### PR TITLE
Add collapsible sidebar

### DIFF
--- a/src/app/(app)/application-layout.tsx
+++ b/src/app/(app)/application-layout.tsx
@@ -65,59 +65,57 @@ export function ApplicationLayout({
       }
       sidebar={
         <Sidebar collapsed={collapsed}>
-          <SidebarHeader className="flex items-center gap-2">
+          <SidebarHeader className="flex-row items-center gap-2">
             {!collapsed && inSettings && (
               <SidebarItem href="/">
                 <ChevronLeftIcon />
                 <SidebarLabel>Back to app</SidebarLabel>
               </SidebarItem>
             )}
-
-            <div className="flex items-center gap-2">
-              {!collapsed && !inSettings && (
-                <Dropdown>
-                  <DropdownButton as={SidebarItem}>
-                    <Avatar src="/teams/catalyst.svg" />
-                    <SidebarLabel>Catalyst</SidebarLabel>
-                    <ChevronDownIcon />
-                  </DropdownButton>
-                  <DropdownMenu className="min-w-80 lg:min-w-64" anchor="bottom start">
-                    <DropdownItem href="/settings">
-                      <Cog8ToothIcon />
-                      <DropdownLabel>Settings</DropdownLabel>
-                    </DropdownItem>
-                    <DropdownDivider />
-                    <DropdownItem href="#">
-                      <ShieldCheckIcon />
-                      <DropdownLabel>Privacy policy</DropdownLabel>
-                    </DropdownItem>
-                    <DropdownItem href="#">
-                      <LightBulbIcon />
-                      <DropdownLabel>Share feedback</DropdownLabel>
-                    </DropdownItem>
-                    <DropdownItem href="#">
-                      <QuestionMarkCircleIcon />
-                      <DropdownLabel>Support</DropdownLabel>
-                    </DropdownItem>
-                    <DropdownItem href="#">
-                      <SparklesIcon />
-                      <DropdownLabel>Changelog</DropdownLabel>
-                    </DropdownItem>
-                    <DropdownDivider />
-                    <DropdownItem href="/login">
-                      <ArrowRightStartOnRectangleIcon />
-                      <DropdownLabel>Sign out</DropdownLabel>
-                    </DropdownItem>
-                  </DropdownMenu>
-                </Dropdown>
-              )}
-              <NavbarItem
-                onClick={() => setCollapsed(!collapsed)}
-                aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-              >
-                {collapsed ? <ChevronRightIcon /> : <ChevronLeftIcon />}
-              </NavbarItem>
-            </div>
+            {!collapsed && !inSettings && (
+              <Dropdown>
+                <DropdownButton as={SidebarItem}>
+                  <Avatar src="/teams/catalyst.svg" />
+                  <SidebarLabel>Catalyst</SidebarLabel>
+                  <ChevronDownIcon />
+                </DropdownButton>
+                <DropdownMenu className="min-w-80 lg:min-w-64" anchor="bottom start">
+                  <DropdownItem href="/settings">
+                    <Cog8ToothIcon />
+                    <DropdownLabel>Settings</DropdownLabel>
+                  </DropdownItem>
+                  <DropdownDivider />
+                  <DropdownItem href="#">
+                    <ShieldCheckIcon />
+                    <DropdownLabel>Privacy policy</DropdownLabel>
+                  </DropdownItem>
+                  <DropdownItem href="#">
+                    <LightBulbIcon />
+                    <DropdownLabel>Share feedback</DropdownLabel>
+                  </DropdownItem>
+                  <DropdownItem href="#">
+                    <QuestionMarkCircleIcon />
+                    <DropdownLabel>Support</DropdownLabel>
+                  </DropdownItem>
+                  <DropdownItem href="#">
+                    <SparklesIcon />
+                    <DropdownLabel>Changelog</DropdownLabel>
+                  </DropdownItem>
+                  <DropdownDivider />
+                  <DropdownItem href="/login">
+                    <ArrowRightStartOnRectangleIcon />
+                    <DropdownLabel>Sign out</DropdownLabel>
+                  </DropdownItem>
+                </DropdownMenu>
+              </Dropdown>
+            )}
+            <NavbarItem
+              className="ml-auto"
+              onClick={() => setCollapsed(!collapsed)}
+              aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            >
+              {collapsed ? <ChevronRightIcon /> : <ChevronLeftIcon />}
+            </NavbarItem>
           </SidebarHeader>
 
           <SidebarBody>

--- a/src/app/(app)/application-layout.tsx
+++ b/src/app/(app)/application-layout.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import React, { useState } from 'react'
 import { Avatar } from '@/components/avatar'
 import {
   Dropdown,
@@ -19,6 +20,7 @@ import {
   SidebarLabel,
   SidebarSection,
   SidebarSpacer,
+  SidebarFooter,
 } from '@/components/sidebar'
 import { SidebarLayout } from '@/components/sidebar-layout'
 import { getEvents } from '@/data'
@@ -40,6 +42,7 @@ import {
   Cog6ToothIcon,
   AdjustmentsVerticalIcon,
   ChevronLeftIcon,
+  ChevronRightIcon,
 } from '@heroicons/react/20/solid'
 import { usePathname } from 'next/navigation'
 
@@ -52,6 +55,7 @@ export function ApplicationLayout({
 }) {
   let pathname = usePathname()
   let inSettings = pathname.startsWith('/settings')
+  let [collapsed, setCollapsed] = useState(false)
 
   return (
     <SidebarLayout
@@ -61,7 +65,7 @@ export function ApplicationLayout({
         </Navbar>
       }
       sidebar={
-        <Sidebar>
+        <Sidebar collapsed={collapsed}>
           <SidebarHeader>
             {inSettings ? (
               <SidebarItem href="/">
@@ -179,8 +183,17 @@ export function ApplicationLayout({
 
             <SidebarSpacer />
           </SidebarBody>
+          <SidebarFooter>
+            <SidebarItem
+              onClick={() => setCollapsed(!collapsed)}
+              aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            >
+              {collapsed ? <ChevronRightIcon /> : <ChevronLeftIcon />}
+            </SidebarItem>
+          </SidebarFooter>
         </Sidebar>
       }
+      collapsed={collapsed}
     >
       {children}
     </SidebarLayout>

--- a/src/app/(app)/application-layout.tsx
+++ b/src/app/(app)/application-layout.tsx
@@ -73,7 +73,7 @@ export function ApplicationLayout({
               </SidebarItem>
             )}
 
-            <div className="ml-auto flex items-center gap-2">
+            <div className="flex items-center gap-2">
               {!collapsed && !inSettings && (
                 <Dropdown>
                   <DropdownButton as={SidebarItem}>

--- a/src/app/(app)/application-layout.tsx
+++ b/src/app/(app)/application-layout.tsx
@@ -66,13 +66,15 @@ export function ApplicationLayout({
       sidebar={
         <Sidebar collapsed={collapsed}>
           <SidebarHeader className="flex items-center gap-2">
-            {!collapsed &&
-              (inSettings ? (
-                <SidebarItem href="/">
-                  <ChevronLeftIcon />
-                  <SidebarLabel>Back to app</SidebarLabel>
-                </SidebarItem>
-              ) : (
+            {!collapsed && inSettings && (
+              <SidebarItem href="/">
+                <ChevronLeftIcon />
+                <SidebarLabel>Back to app</SidebarLabel>
+              </SidebarItem>
+            )}
+
+            <div className="ml-auto flex items-center gap-2">
+              {!collapsed && !inSettings && (
                 <Dropdown>
                   <DropdownButton as={SidebarItem}>
                     <Avatar src="/teams/catalyst.svg" />
@@ -108,14 +110,14 @@ export function ApplicationLayout({
                     </DropdownItem>
                   </DropdownMenu>
                 </Dropdown>
-              ))}
-            <NavbarItem
-              onClick={() => setCollapsed(!collapsed)}
-              aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-              className="ml-auto"
-            >
-              {collapsed ? <ChevronRightIcon /> : <ChevronLeftIcon />}
-            </NavbarItem>
+              )}
+              <NavbarItem
+                onClick={() => setCollapsed(!collapsed)}
+                aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+              >
+                {collapsed ? <ChevronRightIcon /> : <ChevronLeftIcon />}
+              </NavbarItem>
+            </div>
           </SidebarHeader>
 
           <SidebarBody>

--- a/src/app/(app)/application-layout.tsx
+++ b/src/app/(app)/application-layout.tsx
@@ -20,7 +20,6 @@ import {
   SidebarLabel,
   SidebarSection,
   SidebarSpacer,
-  SidebarFooter,
 } from '@/components/sidebar'
 import { SidebarLayout } from '@/components/sidebar-layout'
 import { getEvents } from '@/data'
@@ -66,49 +65,57 @@ export function ApplicationLayout({
       }
       sidebar={
         <Sidebar collapsed={collapsed}>
-          <SidebarHeader>
-            {inSettings ? (
-              <SidebarItem href="/">
-                <ChevronLeftIcon />
-                <SidebarLabel>Back to app</SidebarLabel>
-              </SidebarItem>
-            ) : (
-              <Dropdown>
-                <DropdownButton as={SidebarItem}>
-                  <Avatar src="/teams/catalyst.svg" />
-                  <SidebarLabel>Catalyst</SidebarLabel>
-                  <ChevronDownIcon />
-                </DropdownButton>
-                <DropdownMenu className="min-w-80 lg:min-w-64" anchor="bottom start">
-                  <DropdownItem href="/settings">
-                    <Cog8ToothIcon />
-                    <DropdownLabel>Settings</DropdownLabel>
-                  </DropdownItem>
-                  <DropdownDivider />
-                  <DropdownItem href="#">
-                    <ShieldCheckIcon />
-                    <DropdownLabel>Privacy policy</DropdownLabel>
-                  </DropdownItem>
-                  <DropdownItem href="#">
-                    <LightBulbIcon />
-                    <DropdownLabel>Share feedback</DropdownLabel>
-                  </DropdownItem>
-                  <DropdownItem href="#">
-                    <QuestionMarkCircleIcon />
-                    <DropdownLabel>Support</DropdownLabel>
-                  </DropdownItem>
-                  <DropdownItem href="#">
-                    <SparklesIcon />
-                    <DropdownLabel>Changelog</DropdownLabel>
-                  </DropdownItem>
-                  <DropdownDivider />
-                  <DropdownItem href="/login">
-                    <ArrowRightStartOnRectangleIcon />
-                    <DropdownLabel>Sign out</DropdownLabel>
-                  </DropdownItem>
-                </DropdownMenu>
-              </Dropdown>
-            )}
+          <SidebarHeader className="flex items-center gap-2">
+            {!collapsed &&
+              (inSettings ? (
+                <SidebarItem href="/">
+                  <ChevronLeftIcon />
+                  <SidebarLabel>Back to app</SidebarLabel>
+                </SidebarItem>
+              ) : (
+                <Dropdown>
+                  <DropdownButton as={SidebarItem}>
+                    <Avatar src="/teams/catalyst.svg" />
+                    <SidebarLabel>Catalyst</SidebarLabel>
+                    <ChevronDownIcon />
+                  </DropdownButton>
+                  <DropdownMenu className="min-w-80 lg:min-w-64" anchor="bottom start">
+                    <DropdownItem href="/settings">
+                      <Cog8ToothIcon />
+                      <DropdownLabel>Settings</DropdownLabel>
+                    </DropdownItem>
+                    <DropdownDivider />
+                    <DropdownItem href="#">
+                      <ShieldCheckIcon />
+                      <DropdownLabel>Privacy policy</DropdownLabel>
+                    </DropdownItem>
+                    <DropdownItem href="#">
+                      <LightBulbIcon />
+                      <DropdownLabel>Share feedback</DropdownLabel>
+                    </DropdownItem>
+                    <DropdownItem href="#">
+                      <QuestionMarkCircleIcon />
+                      <DropdownLabel>Support</DropdownLabel>
+                    </DropdownItem>
+                    <DropdownItem href="#">
+                      <SparklesIcon />
+                      <DropdownLabel>Changelog</DropdownLabel>
+                    </DropdownItem>
+                    <DropdownDivider />
+                    <DropdownItem href="/login">
+                      <ArrowRightStartOnRectangleIcon />
+                      <DropdownLabel>Sign out</DropdownLabel>
+                    </DropdownItem>
+                  </DropdownMenu>
+                </Dropdown>
+              ))}
+            <NavbarItem
+              onClick={() => setCollapsed(!collapsed)}
+              aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+              className="ml-auto"
+            >
+              {collapsed ? <ChevronRightIcon /> : <ChevronLeftIcon />}
+            </NavbarItem>
           </SidebarHeader>
 
           <SidebarBody>
@@ -183,14 +190,6 @@ export function ApplicationLayout({
 
             <SidebarSpacer />
           </SidebarBody>
-          <SidebarFooter>
-            <SidebarItem
-              onClick={() => setCollapsed(!collapsed)}
-              aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-            >
-              {collapsed ? <ChevronRightIcon /> : <ChevronLeftIcon />}
-            </SidebarItem>
-          </SidebarFooter>
         </Sidebar>
       }
       collapsed={collapsed}

--- a/src/components/sidebar-layout.tsx
+++ b/src/components/sidebar-layout.tsx
@@ -2,6 +2,7 @@
 
 import * as Headless from '@headlessui/react'
 import React, { useState } from 'react'
+import clsx from 'clsx'
 import { NavbarItem } from './navbar'
 
 function OpenMenuIcon() {

--- a/src/components/sidebar-layout.tsx
+++ b/src/components/sidebar-layout.tsx
@@ -48,13 +48,25 @@ export function SidebarLayout({
   navbar,
   sidebar,
   children,
-}: React.PropsWithChildren<{ navbar: React.ReactNode; sidebar: React.ReactNode }>) {
+  collapsed = false,
+}: React.PropsWithChildren<{
+  navbar: React.ReactNode
+  sidebar: React.ReactNode
+  collapsed?: boolean
+}>) {
   let [showSidebar, setShowSidebar] = useState(false)
 
   return (
     <div className="relative isolate flex min-h-svh w-full bg-white max-lg:flex-col lg:bg-zinc-100 dark:bg-zinc-900 dark:lg:bg-zinc-950">
       {/* Sidebar on desktop */}
-      <div className="fixed inset-y-0 left-0 w-64 max-lg:hidden">{sidebar}</div>
+      <div
+        className={clsx(
+          'fixed inset-y-0 left-0 max-lg:hidden transition-all',
+          collapsed ? 'w-16' : 'w-64'
+        )}
+      >
+        {React.isValidElement(sidebar) ? React.cloneElement(sidebar, { collapsed }) : sidebar}
+      </div>
 
       {/* Sidebar on mobile */}
       <MobileSidebar open={showSidebar} close={() => setShowSidebar(false)}>
@@ -72,7 +84,12 @@ export function SidebarLayout({
       </header>
 
       {/* Content */}
-      <main className="flex flex-1 flex-col pb-2 lg:min-w-0 lg:pt-2 lg:pr-2 lg:pl-64">
+      <main
+        className={clsx(
+          'flex flex-1 flex-col pb-2 lg:min-w-0 lg:pt-2 lg:pr-2',
+          collapsed ? 'lg:pl-16' : 'lg:pl-64'
+        )}
+      >
         <div className="grow p-6 lg:rounded-lg lg:bg-white lg:p-10 lg:shadow-xs lg:ring-1 lg:ring-zinc-950/5 dark:lg:bg-zinc-900 dark:lg:ring-white/10">
           <div className="mx-auto max-w-6xl">{children}</div>
         </div>

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -7,8 +7,18 @@ import React, { forwardRef, useId } from 'react'
 import { TouchTarget } from './button'
 import { Link } from './link'
 
-export function Sidebar({ className, ...props }: React.ComponentPropsWithoutRef<'nav'>) {
-  return <nav {...props} className={clsx(className, 'flex h-full min-h-0 flex-col')} />
+export function Sidebar({
+  collapsed = false,
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<'nav'> & { collapsed?: boolean }) {
+  return (
+    <nav
+      {...props}
+      data-collapsed={collapsed ? 'true' : undefined}
+      className={clsx(className, 'group flex h-full min-h-0 flex-col')}
+    />
+  )
 }
 
 export function SidebarHeader({ className, ...props }: React.ComponentPropsWithoutRef<'div'>) {
@@ -86,6 +96,7 @@ export const SidebarItem = forwardRef(function SidebarItem(
   let classes = clsx(
     // Base
     'flex w-full items-center gap-3 rounded-lg px-2 py-2.5 text-left text-base/6 font-medium text-zinc-950 sm:py-2 sm:text-sm/5',
+    'group-data-[collapsed=true]:justify-center group-data-[collapsed=true]:px-2',
     // Leading icon/icon-only
     '*:data-[slot=icon]:size-6 *:data-[slot=icon]:shrink-0 *:data-[slot=icon]:fill-zinc-500 sm:*:data-[slot=icon]:size-5',
     // Trailing icon (down chevron or similar)
@@ -138,5 +149,10 @@ export const SidebarItem = forwardRef(function SidebarItem(
 })
 
 export function SidebarLabel({ className, ...props }: React.ComponentPropsWithoutRef<'span'>) {
-  return <span {...props} className={clsx(className, 'truncate')} />
+  return (
+    <span
+      {...props}
+      className={clsx(className, 'truncate group-data-[collapsed=true]:hidden')}
+    />
+  )
 }


### PR DESCRIPTION
## Summary
- add `collapsed` support to Sidebar component
- support collapsed layout in SidebarLayout
- toggle collapsed state from ApplicationLayout with footer button

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a12db5fcc832e80b5e7d60d672069