### PR TITLE
Remove sidebar collapse control on settings

### DIFF
--- a/src/app/(app)/application-layout.tsx
+++ b/src/app/(app)/application-layout.tsx
@@ -109,13 +109,15 @@ export function ApplicationLayout({
                 </DropdownMenu>
               </Dropdown>
             )}
-            <NavbarItem
-              className="ml-auto"
-              onClick={() => setCollapsed(!collapsed)}
-              aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-            >
-              {collapsed ? <ChevronRightIcon /> : <ChevronLeftIcon />}
-            </NavbarItem>
+            {!inSettings && (
+              <NavbarItem
+                className="ml-auto"
+                onClick={() => setCollapsed(!collapsed)}
+                aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+              >
+                {collapsed ? <ChevronRightIcon /> : <ChevronLeftIcon />}
+              </NavbarItem>
+            )}
           </SidebarHeader>
 
           <SidebarBody>


### PR DESCRIPTION
## Summary
- disable sidebar collapse button when viewing Settings

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a61fdfa1c832e9977a676ffbf4097