### PR TITLE
Dynamic sidebar items

### DIFF
--- a/src/app/(app)/application-layout.tsx
+++ b/src/app/(app)/application-layout.tsx
@@ -69,14 +69,14 @@ export function ApplicationLayout({
         <Sidebar collapsed={collapsed}>
           <SidebarHeader className="flex-row items-center gap-2">
             {!collapsed && inSettings && (
-              <SidebarItem href="/">
+              <SidebarItem href="/" indicator={false}>
                 <ChevronLeftIcon />
                 <SidebarLabel>Back to app</SidebarLabel>
               </SidebarItem>
             )}
             {!collapsed && !inSettings && (
               <Dropdown>
-                <DropdownButton as={SidebarItem}>
+                <DropdownButton as={SidebarItem} indicator={false}>
                   <Avatar src="/teams/catalyst.svg" />
                   <SidebarLabel>Catalyst</SidebarLabel>
                   <ChevronDownIcon />
@@ -126,13 +126,18 @@ export function ApplicationLayout({
             {!inSettings && (
               <>
                 <SidebarSection>
-                  <SidebarItem href="/add" current={pathname.startsWith('/add')}>
+                  <SidebarItem
+                    href="/add"
+                    current={pathname.startsWith('/add')}
+                    indicator={false}
+                  >
                     <PlusIcon />
                     <SidebarLabel>Add</SidebarLabel>
                   </SidebarItem>
                   <SidebarItem
                     href="/search"
                     current={pathname.startsWith('/search')}
+                    indicator={false}
                   >
                     <MagnifyingGlassIcon />
                     <SidebarLabel>Search</SidebarLabel>
@@ -172,6 +177,7 @@ export function ApplicationLayout({
                           key={order.id}
                           href={order.url}
                           current={pathname === order.url}
+                          indicator={false}
                         >
                           Order #{order.id}
                         </SidebarItem>
@@ -181,6 +187,7 @@ export function ApplicationLayout({
                           key={event.id}
                           href={event.url}
                           current={pathname === event.url}
+                          indicator={false}
                         >
                           {event.name}
                         </SidebarItem>
@@ -194,6 +201,7 @@ export function ApplicationLayout({
               <SidebarItem
                   href="/settings/general"
                   current={pathname.startsWith('/settings/general')}
+                  indicator={false}
                 >
                   <Cog6ToothIcon />
                   <SidebarLabel>General</SidebarLabel>
@@ -201,6 +209,7 @@ export function ApplicationLayout({
               <SidebarItem
                   href="/settings/preferences"
                   current={pathname.startsWith('/settings/preferences')}
+                  indicator={false}
                 >
                   <AdjustmentsVerticalIcon />
                   <SidebarLabel>Preferences</SidebarLabel>

--- a/src/app/(app)/application-layout.tsx
+++ b/src/app/(app)/application-layout.tsx
@@ -168,12 +168,20 @@ export function ApplicationLayout({
                   </SidebarHeading>
                   {pathname.startsWith('/orders')
                     ? orders.slice(0, 5).map((order) => (
-                        <SidebarItem key={order.id} href={order.url}>
+                        <SidebarItem
+                          key={order.id}
+                          href={order.url}
+                          current={pathname === order.url}
+                        >
                           Order #{order.id}
                         </SidebarItem>
                       ))
                     : events.map((event) => (
-                        <SidebarItem key={event.id} href={event.url}>
+                        <SidebarItem
+                          key={event.id}
+                          href={event.url}
+                          current={pathname === event.url}
+                        >
                           {event.name}
                         </SidebarItem>
                       ))}

--- a/src/app/(app)/application-layout.tsx
+++ b/src/app/(app)/application-layout.tsx
@@ -168,20 +168,12 @@ export function ApplicationLayout({
                   </SidebarHeading>
                   {pathname.startsWith('/orders')
                     ? orders.slice(0, 5).map((order) => (
-                        <SidebarItem
-                          key={order.id}
-                          href={order.url}
-                          current={pathname === order.url}
-                        >
+                        <SidebarItem key={order.id} href={order.url}>
                           Order #{order.id}
                         </SidebarItem>
                       ))
                     : events.map((event) => (
-                        <SidebarItem
-                          key={event.id}
-                          href={event.url}
-                          current={pathname === event.url}
-                        >
+                        <SidebarItem key={event.id} href={event.url}>
                           {event.name}
                         </SidebarItem>
                       ))}

--- a/src/app/(app)/application-layout.tsx
+++ b/src/app/(app)/application-layout.tsx
@@ -22,7 +22,7 @@ import {
   SidebarSpacer,
 } from '@/components/sidebar'
 import { SidebarLayout } from '@/components/sidebar-layout'
-import { getEvents } from '@/data'
+import { getEvents, getOrders } from '@/data'
 import {
   ArrowRightStartOnRectangleIcon,
   ChevronDownIcon,
@@ -47,9 +47,11 @@ import { usePathname } from 'next/navigation'
 
 export function ApplicationLayout({
   events,
+  orders,
   children,
 }: {
   events: Awaited<ReturnType<typeof getEvents>>
+  orders: Awaited<ReturnType<typeof getOrders>>
   children: React.ReactNode
 }) {
   let pathname = usePathname()
@@ -161,12 +163,20 @@ export function ApplicationLayout({
                 </SidebarSection>
 
                 <SidebarSection className="max-lg:hidden">
-                  <SidebarHeading>Upcoming Events</SidebarHeading>
-                  {events.map((event) => (
-                    <SidebarItem key={event.id} href={event.url}>
-                      {event.name}
-                    </SidebarItem>
-                  ))}
+                  <SidebarHeading>
+                    {pathname.startsWith('/orders') ? 'Recent Orders' : 'Upcoming Events'}
+                  </SidebarHeading>
+                  {pathname.startsWith('/orders')
+                    ? orders.slice(0, 5).map((order) => (
+                        <SidebarItem key={order.id} href={order.url}>
+                          Order #{order.id}
+                        </SidebarItem>
+                      ))
+                    : events.map((event) => (
+                        <SidebarItem key={event.id} href={event.url}>
+                          {event.name}
+                        </SidebarItem>
+                      ))}
                 </SidebarSection>
               </>
             )}

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,8 +1,9 @@
-import { getEvents } from '@/data'
+import { getEvents, getOrders } from '@/data'
 import { ApplicationLayout } from './application-layout'
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   let events = await getEvents()
+  let orders = await getOrders()
 
-  return <ApplicationLayout events={events}>{children}</ApplicationLayout>
+  return <ApplicationLayout events={events} orders={orders}>{children}</ApplicationLayout>
 }

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -84,10 +84,16 @@ export function SidebarHeading({ className, ...props }: React.ComponentPropsWith
 export const SidebarItem = forwardRef(function SidebarItem(
   {
     current,
+    indicator = true,
     className,
     children,
     ...props
-  }: { current?: boolean; className?: string; children: React.ReactNode } & (
+  }: {
+    current?: boolean
+    indicator?: boolean
+    className?: string
+    children: React.ReactNode
+  } & (
     | Omit<Headless.ButtonProps, 'as' | 'className'>
     | Omit<Headless.ButtonProps<typeof Link>, 'as' | 'className'>
   ),
@@ -118,7 +124,7 @@ export const SidebarItem = forwardRef(function SidebarItem(
 
   return (
     <span className={clsx(className, 'relative')}>
-      {current && (
+      {indicator && current && (
         <motion.span
           layoutId="current-indicator"
           className="absolute inset-y-2 -left-4 w-0.5 rounded-full bg-zinc-950 dark:bg-white"

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -108,12 +108,12 @@ export const SidebarItem = forwardRef(function SidebarItem(
     // Active
     'data-active:bg-zinc-950/5 data-active:*:data-[slot=icon]:fill-zinc-950',
     // Current
-    'data-current:*:data-[slot=icon]:fill-zinc-950',
+    'data-current:bg-zinc-950/5 data-current:*:data-[slot=icon]:fill-zinc-950',
     // Dark mode
     'dark:text-white dark:*:data-[slot=icon]:fill-zinc-400',
     'dark:data-hover:bg-white/5 dark:data-hover:*:data-[slot=icon]:fill-white',
     'dark:data-active:bg-white/5 dark:data-active:*:data-[slot=icon]:fill-white',
-    'dark:data-current:*:data-[slot=icon]:fill-white'
+    'dark:data-current:bg-white/5 dark:data-current:*:data-[slot=icon]:fill-white'
   )
 
   return (

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -99,6 +99,16 @@ export const SidebarItem = forwardRef(function SidebarItem(
   ),
   ref: React.ForwardedRef<HTMLAnchorElement | HTMLButtonElement>
 ) {
+  let currentClasses = indicator
+    ? clsx(
+        'data-current:*:data-[slot=icon]:fill-zinc-950',
+        'dark:data-current:*:data-[slot=icon]:fill-white'
+      )
+    : clsx(
+        'data-current:bg-zinc-950/5 data-current:*:data-[slot=icon]:fill-zinc-950',
+        'dark:data-current:bg-white/5 dark:data-current:*:data-[slot=icon]:fill-white'
+      )
+
   let classes = clsx(
     // Base
     'flex w-full items-center gap-3 rounded-lg px-2 py-2.5 text-left text-base/6 font-medium text-zinc-950 sm:py-2 sm:text-sm/5',
@@ -113,13 +123,11 @@ export const SidebarItem = forwardRef(function SidebarItem(
     'data-hover:bg-zinc-950/5 data-hover:*:data-[slot=icon]:fill-zinc-950',
     // Active
     'data-active:bg-zinc-950/5 data-active:*:data-[slot=icon]:fill-zinc-950',
-    // Current
-    'data-current:bg-zinc-950/5 data-current:*:data-[slot=icon]:fill-zinc-950',
     // Dark mode
     'dark:text-white dark:*:data-[slot=icon]:fill-zinc-400',
     'dark:data-hover:bg-white/5 dark:data-hover:*:data-[slot=icon]:fill-white',
     'dark:data-active:bg-white/5 dark:data-active:*:data-[slot=icon]:fill-white',
-    'dark:data-current:bg-white/5 dark:data-current:*:data-[slot=icon]:fill-white'
+    currentClasses
   )
 
   return (


### PR DESCRIPTION
## Summary
- tweak root layout to fetch orders in addition to events
- update ApplicationLayout to accept orders and display recent orders in the sidebar when viewing `/orders`

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b2ed133c8832e99fd93994243b08e