### PR TITLE
Fix build error and optimize sidebar animation

### DIFF
--- a/src/components/sidebar-layout.tsx
+++ b/src/components/sidebar-layout.tsx
@@ -26,11 +26,11 @@ function MobileSidebar({ open, close, children }: React.PropsWithChildren<{ open
     <Headless.Dialog open={open} onClose={close} className="lg:hidden">
       <Headless.DialogBackdrop
         transition
-        className="fixed inset-0 bg-black/30 transition data-closed:opacity-0 data-enter:duration-300 data-enter:ease-out data-leave:duration-200 data-leave:ease-in"
+        className="fixed inset-0 bg-black/30 transition data-closed:opacity-0 data-enter:duration-150 data-enter:ease-out data-leave:duration-150 data-leave:ease-in"
       />
       <Headless.DialogPanel
         transition
-        className="fixed inset-y-0 w-full max-w-80 p-2 transition duration-300 ease-in-out data-closed:-translate-x-full"
+        className="fixed inset-y-0 w-full max-w-80 p-2 transition duration-150 ease-in-out data-closed:-translate-x-full"
       >
         <div className="flex h-full flex-col rounded-lg bg-white shadow-xs ring-1 ring-zinc-950/5 dark:bg-zinc-900 dark:ring-white/10">
           <div className="-mb-3 px-4 pt-3">
@@ -62,11 +62,13 @@ export function SidebarLayout({
       {/* Sidebar on desktop */}
       <div
         className={clsx(
-          'fixed inset-y-0 left-0 max-lg:hidden transition-all',
+          'fixed inset-y-0 left-0 max-lg:hidden transition-all duration-150',
           collapsed ? 'w-16' : 'w-64'
         )}
       >
-        {React.isValidElement(sidebar) ? React.cloneElement(sidebar, { collapsed }) : sidebar}
+        {React.isValidElement(sidebar)
+          ? React.cloneElement(sidebar as React.ReactElement, { collapsed })
+          : sidebar}
       </div>
 
       {/* Sidebar on mobile */}

--- a/src/components/stacked-layout.tsx
+++ b/src/components/stacked-layout.tsx
@@ -25,11 +25,11 @@ function MobileSidebar({ open, close, children }: React.PropsWithChildren<{ open
     <Headless.Dialog open={open} onClose={close} className="lg:hidden">
       <Headless.DialogBackdrop
         transition
-        className="fixed inset-0 bg-black/30 transition data-closed:opacity-0 data-enter:duration-300 data-enter:ease-out data-leave:duration-200 data-leave:ease-in"
+        className="fixed inset-0 bg-black/30 transition data-closed:opacity-0 data-enter:duration-150 data-enter:ease-out data-leave:duration-150 data-leave:ease-in"
       />
       <Headless.DialogPanel
         transition
-        className="fixed inset-y-0 w-full max-w-80 p-2 transition duration-300 ease-in-out data-closed:-translate-x-full"
+        className="fixed inset-y-0 w-full max-w-80 p-2 transition duration-150 ease-in-out data-closed:-translate-x-full"
       >
         <div className="flex h-full flex-col rounded-lg bg-white shadow-xs ring-1 ring-zinc-950/5 dark:bg-zinc-900 dark:ring-white/10">
           <div className="-mb-3 px-4 pt-3">


### PR DESCRIPTION
## Summary
- fix TypeScript error in `SidebarLayout` by casting the sidebar element
- reduce animation durations to make sidebar interactions faster

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685b36fca860832eb8a79cb556e54a1e