### PR TITLE
Add calendar UI with FullCalendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ npm run dev
 ```
 
 Finally, open [http://localhost:3000](http://localhost:3000) in your browser to view the website.
+
+If `npm run lint` or other scripts fail with errors such as `next: not found` or "Module not found: Can't resolve '@fullcalendar/react'", ensure that the npm dependencies are installed successfully. Run `npm install` again and verify that your environment allows network access to the npm registry.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,12 @@ dependencies before they were added, run `npm install` again or add them
 explicitly:
 
 ```bash
-npm install @fullcalendar/react @fullcalendar/daygrid @fullcalendar/timegrid @fullcalendar/interaction
+npm install \
+  @fullcalendar/react \
+  @fullcalendar/daygrid \
+  @fullcalendar/timegrid \
+  @fullcalendar/interaction \
+  @fullcalendar/core
 ```
 
 Ensure your environment has network access to the npm registry so these

--- a/README.md
+++ b/README.md
@@ -14,4 +14,19 @@ npm run dev
 
 Finally, open [http://localhost:3000](http://localhost:3000) in your browser to view the website.
 
-If `npm run lint` or other scripts fail with errors such as `next: not found` or "Module not found: Can't resolve '@fullcalendar/react'", ensure that the npm dependencies are installed successfully. Run `npm install` again and verify that your environment allows network access to the npm registry.
+If `npm run lint` or other scripts fail with errors such as `next: not found` or
+"Module not found: Can't resolve '@fullcalendar/react'", make sure all
+dependencies have been installed. After pulling the repository, run:
+
+```bash
+npm install
+```
+
+If the error persists you may need to explicitly install the calendar packages:
+
+```bash
+npm install @fullcalendar/react @fullcalendar/daygrid @fullcalendar/timegrid @fullcalendar/interaction
+```
+
+Ensure your environment has network access to the npm registry so these
+packages can be downloaded successfully.

--- a/README.md
+++ b/README.md
@@ -15,14 +15,16 @@ npm run dev
 Finally, open [http://localhost:3000](http://localhost:3000) in your browser to view the website.
 
 If `npm run lint` or other scripts fail with errors such as `next: not found` or
-"Module not found: Can't resolve '@fullcalendar/react'", make sure all
-dependencies have been installed. After pulling the repository, run:
+"Module not found: Can't resolve '@fullcalendar/react'", ensure that all
+dependencies are installed:
 
 ```bash
 npm install
 ```
 
-If the error persists you may need to explicitly install the calendar packages:
+The FullCalendar packages are listed in `package.json`. If you installed
+dependencies before they were added, run `npm install` again or add them
+explicitly:
 
 ```bash
 npm install @fullcalendar/react @fullcalendar/daygrid @fullcalendar/timegrid @fullcalendar/interaction

--- a/package.json
+++ b/package.json
@@ -15,7 +15,11 @@
     "framer-motion": "^11.2.6",
     "next": "14.2.3",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "@fullcalendar/react": "^6.1.10",
+    "@fullcalendar/daygrid": "^6.1.10",
+    "@fullcalendar/timegrid": "^6.1.10",
+    "@fullcalendar/interaction": "^6.1.10"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.7",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "@fullcalendar/react": "^6.1.10",
     "@fullcalendar/daygrid": "^6.1.10",
     "@fullcalendar/timegrid": "^6.1.10",
-    "@fullcalendar/interaction": "^6.1.10"
+    "@fullcalendar/interaction": "^6.1.10",
+    "@fullcalendar/core": "^6.1.10"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.7",

--- a/src/app/(app)/application-layout.tsx
+++ b/src/app/(app)/application-layout.tsx
@@ -149,7 +149,7 @@ export function ApplicationLayout({
                 <SidebarSection>
                   <SidebarItem href="/calender" current={pathname === '/calender'}>
                     <CalendarIcon />
-                    <SidebarLabel>Calender</SidebarLabel>
+                    <SidebarLabel>Calendar</SidebarLabel>
                   </SidebarItem>
                   <SidebarItem
                     href="/box"

--- a/src/app/(app)/calender/calendar-client.tsx
+++ b/src/app/(app)/calender/calendar-client.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import FullCalendar from '@fullcalendar/react'
+import dayGridPlugin from '@fullcalendar/daygrid'
+import timeGridPlugin from '@fullcalendar/timegrid'
+import interactionPlugin from '@fullcalendar/interaction'
+
+import '@fullcalendar/core/index.css'
+import '@fullcalendar/daygrid/index.css'
+import '@fullcalendar/timegrid/index.css'
+
+export default function CalendarClient() {
+  return (
+    <FullCalendar
+      plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin]}
+      initialView="timeGridWeek"
+      headerToolbar={{
+        left: 'prev,next today',
+        center: 'title',
+        right: 'timeGridDay,timeGridWeek,twoWeek,dayGridMonth',
+      }}
+      views={{
+        twoWeek: {
+          type: 'timeGrid',
+          duration: { weeks: 2 },
+          buttonText: '2 week',
+        },
+      }}
+      height="auto"
+    />
+  )
+}

--- a/src/app/(app)/calender/page.tsx
+++ b/src/app/(app)/calender/page.tsx
@@ -1,61 +1,20 @@
-import { Stat } from '@/app/stat'
-import { Avatar } from '@/components/avatar'
-import { Heading, Subheading } from '@/components/heading'
-import { Select } from '@/components/select'
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/table'
-import { getRecentOrders } from '@/data'
+import dynamic from 'next/dynamic'
+import { Heading } from '@/components/heading'
+import type { Metadata } from 'next'
 
-export default async function Home() {
-  let orders = await getRecentOrders()
+export const metadata: Metadata = {
+  title: 'Calendar',
+}
 
+const Calendar = dynamic(() => import('./calendar-client'), { ssr: false })
+
+export default function CalendarPage() {
   return (
     <>
-      <Heading>Good afternoon, Erica</Heading>
-      <div className="mt-8 flex items-end justify-between">
-        <Subheading>Overview</Subheading>
-        <div>
-          <Select name="period">
-            <option value="last_week">Last week</option>
-            <option value="last_two">Last two weeks</option>
-            <option value="last_month">Last month</option>
-            <option value="last_quarter">Last quarter</option>
-          </Select>
-        </div>
+      <Heading>Calendar</Heading>
+      <div className="mt-8">
+        <Calendar />
       </div>
-      <div className="mt-4 grid gap-8 sm:grid-cols-2 xl:grid-cols-4">
-        <Stat title="Total revenue" value="$2.6M" change="+4.5%" />
-        <Stat title="Average order value" value="$455" change="-0.5%" />
-        <Stat title="Tickets sold" value="5,888" change="+4.5%" />
-        <Stat title="Pageviews" value="823,067" change="+21.2%" />
-      </div>
-      <Subheading className="mt-14">Recent orders</Subheading>
-      <Table className="mt-4 [--gutter:--spacing(6)] lg:[--gutter:--spacing(10)]">
-        <TableHead>
-          <TableRow>
-            <TableHeader>Order number</TableHeader>
-            <TableHeader>Purchase date</TableHeader>
-            <TableHeader>Customer</TableHeader>
-            <TableHeader>Event</TableHeader>
-            <TableHeader className="text-right">Amount</TableHeader>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {orders.map((order) => (
-            <TableRow key={order.id} href={order.url} title={`Order #${order.id}`}>
-              <TableCell>{order.id}</TableCell>
-              <TableCell className="text-zinc-500">{order.date}</TableCell>
-              <TableCell>{order.customer.name}</TableCell>
-              <TableCell>
-                <div className="flex items-center gap-2">
-                  <Avatar src={order.event.thumbUrl} className="size-6" />
-                  <span>{order.event.name}</span>
-                </div>
-              </TableCell>
-              <TableCell className="text-right">US{order.amount.usd}</TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
     </>
   )
 }


### PR DESCRIPTION
## Summary
- add FullCalendar dependencies
- implement `CalendarPage` using dynamic client component
- add `CalendarClient` component with day/week/2week/month views

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c816be9a8832ebd5b19d11062c5f0