### PR TITLE
Fix auth flow redirect

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key

--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@ To run the Catalyst demo, first install the npm dependencies:
 npm install
 ```
 
+Create a `.env.local` file with your Supabase credentials:
+
+```bash
+cp .env.example .env.local
+# then edit .env.local with your values
+```
+
+- `NEXT_PUBLIC_SUPABASE_URL` should be the URL of your Supabase project
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY` is the anonymous API key
+
+Make sure the Site URL and Redirect URLs in Supabase match your local URL, e.g. `http://localhost:3000/auth/callback`.
+
 Next, run the development server:
 
 ```bash

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { useRouter } from 'next/navigation'
 import { useAuthContext } from '@/contexts/AuthContext'
 import { Logo } from '@/app/logo'
 import { Button } from '@/components/button'
@@ -23,6 +24,7 @@ export default function LoginForm({
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const { signIn, signInWithOAuth } = useAuthContext()
+  const router = useRouter()
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -33,6 +35,8 @@ export default function LoginForm({
       const { error } = await signIn(email, password)
       if (error) {
         setError(error.message)
+      } else {
+        router.push('/calender')
       }
     } catch (err) {
       setError('An error occurred during sign in')
@@ -47,6 +51,8 @@ export default function LoginForm({
     const { error } = await signInWithOAuth(provider)
     if (error) {
       setError(error)
+    } else {
+      router.push('/calender')
     }
     setLoading(false)
   }


### PR DESCRIPTION
## Summary
- ensure login redirects to the calendar page when sign in succeeds
- handle OAuth login in the same way

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cc61c7ec4832e9c303c6722620703