### PR TITLE
Refactor auth routes

### DIFF
--- a/src/app/(auth)/auth/login/page.tsx
+++ b/src/app/(auth)/auth/login/page.tsx
@@ -30,7 +30,7 @@ export default function Login() {
           <Label>Remember me</Label>
         </CheckboxField>
         <Text>
-          <TextLink href="/forgot-password">
+          <TextLink href="/auth/password">
             <Strong>Forgot password?</Strong>
           </TextLink>
         </Text>
@@ -40,7 +40,7 @@ export default function Login() {
       </Button>
       <Text>
         Don’t have an account?{' '}
-        <TextLink href="/register">
+        <TextLink href="/auth/signup">
           <Strong>Sign up</Strong>
         </TextLink>
       </Text>

--- a/src/app/(auth)/auth/page.tsx
+++ b/src/app/(auth)/auth/page.tsx
@@ -1,37 +1,5 @@
-'use client'
-
-import { useState } from 'react'
-import LoginForm from '@/components/auth/LoginForm'
-import RegisterForm from '@/components/auth/RegisterForm'
-import ForgotPasswordForm from '@/components/auth/ForgotPasswordForm'
-
-type AuthMode = 'login' | 'register' | 'forgot-password'
+import { redirect } from 'next/navigation'
 
 export default function AuthPage() {
-  const [mode, setMode] = useState<AuthMode>('login')
-
-  const renderForm = () => {
-    switch (mode) {
-      case 'login':
-        return (
-          <LoginForm
-            onRegisterClick={() => setMode('register')}
-            onForgotPasswordClick={() => setMode('forgot-password')}
-          />
-        )
-      case 'register':
-        return <RegisterForm onLoginClick={() => setMode('login')} />
-      case 'forgot-password':
-        return <ForgotPasswordForm onLoginClick={() => setMode('login')} />
-      default:
-        return (
-          <LoginForm
-            onRegisterClick={() => setMode('register')}
-            onForgotPasswordClick={() => setMode('forgot-password')}
-          />
-        )
-    }
-  }
-
-  return <div className="flex w-full justify-center">{renderForm()}</div>
+  redirect('/auth/login')
 }

--- a/src/app/(auth)/auth/password/page.tsx
+++ b/src/app/(auth)/auth/password/page.tsx
@@ -25,7 +25,7 @@ export default function Login() {
       </Button>
       <Text>
         Don’t have an account?{' '}
-        <TextLink href="/register">
+        <TextLink href="/auth/signup">
           <Strong>Sign up</Strong>
         </TextLink>
       </Text>

--- a/src/app/(auth)/auth/signup/page.tsx
+++ b/src/app/(auth)/auth/signup/page.tsx
@@ -46,7 +46,7 @@ export default function Login() {
       </Button>
       <Text>
         Already have an account?{' '}
-        <TextLink href="/auth">
+        <TextLink href="/auth/login">
           <Strong>Sign in</Strong>
         </TextLink>
       </Text>


### PR DESCRIPTION
## Summary
- move standalone login/signup/password routes under `/auth`
- update links accordingly
- redirect `/auth` to `/auth/login`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*
- `npx prettier` *(fails: cannot find plugin)*

------
https://chatgpt.com/codex/tasks/task_e_685cd67b0388832eaad3759512a6f5ff