### PR TITLE
Fix auth pages

### DIFF
--- a/src/app/(auth)/auth/login/page.tsx
+++ b/src/app/(auth)/auth/login/page.tsx
@@ -1,10 +1,9 @@
-import { Logo } from '@/app/logo'
-import { Button } from '@/components/button'
-import { Checkbox, CheckboxField } from '@/components/checkbox'
-import { Field, Label } from '@/components/fieldset'
-import { Heading } from '@/components/heading'
-import { Input } from '@/components/input'
-import { Strong, Text, TextLink } from '@/components/text'
+"use client"
+
+import { useRouter } from 'next/navigation'
+import LoginForm from '@/components/auth/LoginForm'
+import { useAuthContext } from '@/contexts/AuthContext'
+import { useEffect } from 'react'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
@@ -12,38 +11,19 @@ export const metadata: Metadata = {
 }
 
 export default function Login() {
+  const router = useRouter()
+  const { user } = useAuthContext()
+
+  useEffect(() => {
+    if (user) {
+      router.push('/calender')
+    }
+  }, [user, router])
+
   return (
-    <form action="" method="POST" className="grid w-full max-w-sm grid-cols-1 gap-8">
-      <Logo className="h-6 text-zinc-950 dark:text-white forced-colors:text-[CanvasText]" />
-      <Heading>Sign in to your account</Heading>
-      <Field>
-        <Label>Email</Label>
-        <Input type="email" name="email" />
-      </Field>
-      <Field>
-        <Label>Password</Label>
-        <Input type="password" name="password" />
-      </Field>
-      <div className="flex items-center justify-between">
-        <CheckboxField>
-          <Checkbox name="remember" />
-          <Label>Remember me</Label>
-        </CheckboxField>
-        <Text>
-          <TextLink href="/auth/password">
-            <Strong>Forgot password?</Strong>
-          </TextLink>
-        </Text>
-      </div>
-      <Button type="submit" className="w-full">
-        Login
-      </Button>
-      <Text>
-        Don’t have an account?{' '}
-        <TextLink href="/auth/signup">
-          <Strong>Sign up</Strong>
-        </TextLink>
-      </Text>
-    </form>
+    <LoginForm
+      onRegisterClick={() => router.push('/auth/signup')}
+      onForgotPasswordClick={() => router.push('/auth/password')}
+    />
   )
 }

--- a/src/app/(auth)/auth/password/page.tsx
+++ b/src/app/(auth)/auth/password/page.tsx
@@ -1,9 +1,9 @@
-import { Logo } from '@/app/logo'
-import { Button } from '@/components/button'
-import { Field, Label } from '@/components/fieldset'
-import { Heading } from '@/components/heading'
-import { Input } from '@/components/input'
-import { Strong, Text, TextLink } from '@/components/text'
+"use client"
+
+import { useRouter } from 'next/navigation'
+import ForgotPasswordForm from '@/components/auth/ForgotPasswordForm'
+import { useAuthContext } from '@/contexts/AuthContext'
+import { useEffect } from 'react'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
@@ -11,24 +11,16 @@ export const metadata: Metadata = {
 }
 
 export default function Login() {
+  const router = useRouter()
+  const { user } = useAuthContext()
+
+  useEffect(() => {
+    if (user) {
+      router.push('/calender')
+    }
+  }, [user, router])
+
   return (
-    <form action="" method="POST" className="grid w-full max-w-sm grid-cols-1 gap-8">
-      <Logo className="h-6 text-zinc-950 dark:text-white forced-colors:text-[CanvasText]" />
-      <Heading>Reset your password</Heading>
-      <Text>Enter your email and we’ll send you a link to reset your password.</Text>
-      <Field>
-        <Label>Email</Label>
-        <Input type="email" name="email" />
-      </Field>
-      <Button type="submit" className="w-full">
-        Reset password
-      </Button>
-      <Text>
-        Don’t have an account?{' '}
-        <TextLink href="/auth/signup">
-          <Strong>Sign up</Strong>
-        </TextLink>
-      </Text>
-    </form>
+    <ForgotPasswordForm onLoginClick={() => router.push('/auth/login')} />
   )
 }

--- a/src/app/(auth)/auth/signup/page.tsx
+++ b/src/app/(auth)/auth/signup/page.tsx
@@ -1,11 +1,9 @@
-import { Logo } from '@/app/logo'
-import { Button } from '@/components/button'
-import { Checkbox, CheckboxField } from '@/components/checkbox'
-import { Field, Label } from '@/components/fieldset'
-import { Heading } from '@/components/heading'
-import { Input } from '@/components/input'
-import { Select } from '@/components/select'
-import { Strong, Text, TextLink } from '@/components/text'
+"use client"
+
+import { useRouter } from 'next/navigation'
+import RegisterForm from '@/components/auth/RegisterForm'
+import { useAuthContext } from '@/contexts/AuthContext'
+import { useEffect } from 'react'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
@@ -13,43 +11,16 @@ export const metadata: Metadata = {
 }
 
 export default function Login() {
+  const router = useRouter()
+  const { user } = useAuthContext()
+
+  useEffect(() => {
+    if (user) {
+      router.push('/calender')
+    }
+  }, [user, router])
+
   return (
-    <form action="" method="POST" className="grid w-full max-w-sm grid-cols-1 gap-8">
-      <Logo className="h-6 text-zinc-950 dark:text-white forced-colors:text-[CanvasText]" />
-      <Heading>Create your account</Heading>
-      <Field>
-        <Label>Email</Label>
-        <Input type="email" name="email" />
-      </Field>
-      <Field>
-        <Label>Full name</Label>
-        <Input name="name" />
-      </Field>
-      <Field>
-        <Label>Password</Label>
-        <Input type="password" name="password" autoComplete="new-password" />
-      </Field>
-      <Field>
-        <Label>Country</Label>
-        <Select name="country">
-          <option>Canada</option>
-          <option>Mexico</option>
-          <option>United States</option>
-        </Select>
-      </Field>
-      <CheckboxField>
-        <Checkbox name="remember" />
-        <Label>Get emails about product updates and news.</Label>
-      </CheckboxField>
-      <Button type="submit" className="w-full">
-        Create account
-      </Button>
-      <Text>
-        Already have an account?{' '}
-        <TextLink href="/auth/login">
-          <Strong>Sign in</Strong>
-        </TextLink>
-      </Text>
-    </form>
+    <RegisterForm onLoginClick={() => router.push('/auth/login')} />
   )
 }


### PR DESCRIPTION
## Summary
- mount auth form components in login/signup/password pages
- redirect to calendar on successful auth

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cdb4bedbc832e9734598221b560d3