### PR TITLE
Fix login wording

### DIFF
--- a/src/app/(auth)/auth/callback/page.tsx
+++ b/src/app/(auth)/auth/callback/page.tsx
@@ -68,7 +68,7 @@ export default function AuthCallback() {
           onClick={() => router.push('/auth')}
           className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition-colors"
         >
-          Back to sign in
+          Back to login
         </button>
       </div>
     )

--- a/src/app/(auth)/auth/login/page.tsx
+++ b/src/app/(auth)/auth/login/page.tsx
@@ -15,7 +15,7 @@ export default function Login() {
   return (
     <form action="" method="POST" className="grid w-full max-w-sm grid-cols-1 gap-8">
       <Logo className="h-6 text-zinc-950 dark:text-white forced-colors:text-[CanvasText]" />
-      <Heading>Sign in to your account</Heading>
+      <Heading>Log in to your account</Heading>
       <Field>
         <Label>Email</Label>
         <Input type="email" name="email" />

--- a/src/app/(auth)/auth/reset-password/page.tsx
+++ b/src/app/(auth)/auth/reset-password/page.tsx
@@ -107,7 +107,7 @@ export default function ResetPassword() {
         {loading ? 'Updating...' : 'Update Password'}
       </Button>
       <button type="button" onClick={() => router.push('/auth')} className="text-blue-600 hover:text-blue-700 text-sm">
-        Back to sign in
+        Back to login
       </button>
     </form>
   )

--- a/src/app/(auth)/auth/signup/page.tsx
+++ b/src/app/(auth)/auth/signup/page.tsx
@@ -4,7 +4,6 @@ import { Checkbox, CheckboxField } from '@/components/checkbox'
 import { Field, Label } from '@/components/fieldset'
 import { Heading } from '@/components/heading'
 import { Input } from '@/components/input'
-import { Select } from '@/components/select'
 import { Strong, Text, TextLink } from '@/components/text'
 import type { Metadata } from 'next'
 
@@ -29,14 +28,6 @@ export default function Login() {
         <Label>Password</Label>
         <Input type="password" name="password" autoComplete="new-password" />
       </Field>
-      <Field>
-        <Label>Country</Label>
-        <Select name="country">
-          <option>Canada</option>
-          <option>Mexico</option>
-          <option>United States</option>
-        </Select>
-      </Field>
       <CheckboxField>
         <Checkbox name="remember" />
         <Label>Get emails about product updates and news.</Label>
@@ -47,7 +38,7 @@ export default function Login() {
       <Text>
         Already have an account?{' '}
         <TextLink href="/auth/login">
-          <Strong>Sign in</Strong>
+          <Strong>Login</Strong>
         </TextLink>
       </Text>
     </form>

--- a/src/components/auth/ForgotPasswordForm.tsx
+++ b/src/components/auth/ForgotPasswordForm.tsx
@@ -70,7 +70,7 @@ export default function ForgotPasswordForm({
       </Button>
       <Text className="text-center">
         <TextLink href="#" onClick={onLoginClick}>
-          <Strong>Back to sign in</Strong>
+          <Strong>Back to login</Strong>
         </TextLink>
       </Text>
     </form>

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -35,7 +35,7 @@ export default function LoginForm({
         setError(error.message)
       }
     } catch (err) {
-      setError('An error occurred during sign in')
+      setError('An error occurred during login')
     } finally {
       setLoading(false)
     }
@@ -54,7 +54,7 @@ export default function LoginForm({
   return (
     <form onSubmit={handleSubmit} className="grid w-full max-w-sm grid-cols-1 gap-8">
       <Logo className="h-6 text-zinc-950 dark:text-white forced-colors:text-[CanvasText]" />
-      <Heading>Sign in</Heading>
+      <Heading>Login</Heading>
       <div className="mb-6 flex flex-col gap-2">
         <Button
           type="button"
@@ -108,7 +108,7 @@ export default function LoginForm({
         </Text>
       </div>
       <Button type="submit" disabled={loading} className="w-full">
-        {loading ? 'Signing in...' : 'Sign in'}
+        {loading ? 'Logging in...' : 'Login'}
       </Button>
       <Text className="text-center">
         Don’t have an account?{' '}

--- a/src/components/auth/RegisterForm.tsx
+++ b/src/components/auth/RegisterForm.tsx
@@ -132,7 +132,7 @@ export default function RegisterForm({
       <Text className="text-center">
         Already have an account?{' '}
         <TextLink href="#" onClick={onLoginClick}>
-          <Strong>Sign in</Strong>
+          <Strong>Login</Strong>
         </TextLink>
       </Text>
     </form>

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -160,7 +160,7 @@ export function useAuth() {
       setAuthState((prev) => ({ ...prev, loading: false }))
       return { data, error: null }
     } catch (error) {
-      const errorMessage = 'OAuth sign in failed'
+      const errorMessage = 'OAuth login failed'
       setAuthState((prev) => ({ ...prev, error: errorMessage, loading: false }))
       return { data: null, error: errorMessage }
     }


### PR DESCRIPTION
## Summary
- replace various 'Sign in' labels with 'Login'
- update error messages
- remove country field from signup form

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cdc8207c0832ebf92a5a4f46ea8aa