### PR TITLE
Restrict /app routes to authenticated users

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,9 +1,17 @@
 import { getEvents, getOrders } from '@/data'
 import { ApplicationLayout } from './application-layout'
+import { createServerSupabaseClient } from '@/lib/supabase-server'
+import { redirect } from 'next/navigation'
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
-  let events = await getEvents()
-  let orders = await getOrders()
+  const supabase = createServerSupabaseClient()
+  const { data, error } = await supabase.auth.getUser()
+  if (error || !data?.user) {
+    redirect('/auth/login')
+  }
+
+  const events = await getEvents()
+  const orders = await getOrders()
 
   return (
     <ApplicationLayout events={events} orders={orders}>{children}</ApplicationLayout>


### PR DESCRIPTION
## Summary
- check Supabase session in `(app)` layout
- redirect unauthenticated visitors to `/auth/login`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68620259be2c832e959c177fcfb58604