### PR TITLE
Add account settings page

### DIFF
--- a/src/app/(app)/application-layout.tsx
+++ b/src/app/(app)/application-layout.tsx
@@ -41,6 +41,7 @@ import {
   MagnifyingGlassIcon,
   PlusIcon,
   Cog6ToothIcon,
+  UserIcon,
   AdjustmentsVerticalIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
@@ -218,6 +219,14 @@ export function ApplicationLayout({
                 >
                   <Cog6ToothIcon />
                   <SidebarLabel>General</SidebarLabel>
+                </SidebarItem>
+              <SidebarItem
+                  href="/settings/account"
+                  current={pathname.startsWith('/settings/account')}
+                  indicator={false}
+                >
+                  <UserIcon />
+                  <SidebarLabel>Account</SidebarLabel>
                 </SidebarItem>
               <SidebarItem
                   href="/settings/preferences"

--- a/src/app/(app)/settings/account/page.tsx
+++ b/src/app/(app)/settings/account/page.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/button'
+import { Heading, Subheading } from '@/components/heading'
+import { Input } from '@/components/input'
+import { Text } from '@/components/text'
+import { SettingSection } from '@/components/settings-section'
+import { Switch } from '@/components/switch'
+
+export default function AccountSettingsPage() {
+  const [name, setName] = useState('')
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [passwordError, setPasswordError] = useState<string | null>(null)
+  const [twoFactorEnabled, setTwoFactorEnabled] = useState(false)
+
+  const handleNameSave = (e: React.FormEvent) => {
+    e.preventDefault()
+    // TODO: connect to backend
+  }
+
+  const handlePasswordSave = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (newPassword !== confirmPassword) {
+      setPasswordError('Passwords do not match')
+      return
+    }
+    setPasswordError(null)
+    // TODO: connect to backend
+  }
+
+  return (
+    <div className="space-y-10">
+      <Heading>Account</Heading>
+
+      <SettingSection title="Profile" description="Update your personal information.">
+        <form onSubmit={handleNameSave} className="space-y-4 px-4 py-4">
+          <Input
+            aria-label="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Your name"
+            required
+          />
+          <div className="flex justify-end">
+            <Button type="submit">Save name</Button>
+          </div>
+        </form>
+      </SettingSection>
+
+      <SettingSection title="Password" description="Change your account password.">
+        <form onSubmit={handlePasswordSave} className="space-y-4 px-4 py-4">
+          <Input
+            type="password"
+            aria-label="Current password"
+            value={currentPassword}
+            onChange={(e) => setCurrentPassword(e.target.value)}
+            placeholder="Current password"
+            required
+          />
+          <Input
+            type="password"
+            aria-label="New password"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            placeholder="New password"
+            required
+          />
+          <Input
+            type="password"
+            aria-label="Confirm new password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            placeholder="Confirm new password"
+            required
+          />
+          {passwordError && <Text className="text-red-600">{passwordError}</Text>}
+          <div className="flex justify-end">
+            <Button type="submit">Update password</Button>
+          </div>
+        </form>
+      </SettingSection>
+
+      <SettingSection
+        title="Two-Factor Authentication"
+        description="Add an extra layer of security to your account."
+      >
+        <div className="flex items-center justify-between px-4 py-4">
+          <div>
+            <Subheading level={3} className="!text-base">
+              Enable 2FA
+            </Subheading>
+            <Text className="mt-1">Require a second step to sign in.</Text>
+          </div>
+          <Switch checked={twoFactorEnabled} onChange={setTwoFactorEnabled} />
+        </div>
+        {twoFactorEnabled && (
+          <div className="flex justify-end px-4 pb-4">
+            <Button type="button">Set up 2FA</Button>
+          </div>
+        )}
+      </SettingSection>
+    </div>
+  )
+}

--- a/src/app/(app)/settings/account/page.tsx
+++ b/src/app/(app)/settings/account/page.tsx
@@ -32,7 +32,7 @@ export default function AccountSettingsPage() {
   }
 
   return (
-    <div className="space-y-10">
+    <div className="mx-auto max-w-4xl space-y-10">
       <Heading>Account</Heading>
 
       <SettingSection title="Profile" description="Update your personal information.">

--- a/src/app/(app)/settings/preferences/page.tsx
+++ b/src/app/(app)/settings/preferences/page.tsx
@@ -9,7 +9,7 @@ export default function PreferencesPage() {
   const [theme, setTheme] = useState('light')
   const [language, setLanguage] = useState('en')
   return (
-    <div className="space-y-10">
+    <div className="mx-auto max-w-4xl space-y-10">
       <Heading>Preferences</Heading>
       <SettingSection title="General" description="Basic application options.">
         <ToggleItem


### PR DESCRIPTION
## Summary
- add account settings section with name, password and 2FA controls
- update sidebar navigation to include new page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68625026a624832e991ee88de55228a6