### PR TITLE
Add search modal

### DIFF
--- a/src/app/(app)/application-layout.tsx
+++ b/src/app/(app)/application-layout.tsx
@@ -22,6 +22,7 @@ import {
   SidebarSpacer,
 } from '@/components/sidebar'
 import { SidebarLayout } from '@/components/sidebar-layout'
+import SearchModal from '@/components/SearchModal'
 import { getEvents, getOrders } from '@/data'
 import { useAuthContext } from '@/contexts/AuthContext'
 import { useRouter } from 'next/navigation'
@@ -73,7 +74,8 @@ export function ApplicationLayout({
   }
 
   return (
-    <SidebarLayout
+    <>
+      <SidebarLayout
       navbar={
         <Navbar>
           <NavbarSpacer />
@@ -247,5 +249,7 @@ export function ApplicationLayout({
     >
       {children}
     </SidebarLayout>
+    <SearchModal />
+  </>
   )
 }

--- a/src/components/LogSearchResult.tsx
+++ b/src/components/LogSearchResult.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { Badge } from './badge'
+import { Link } from './link'
+import { LogEntry } from '@/hooks/useLogSearch'
+
+export default function LogSearchResult({ log, onSelect }: { log: LogEntry; onSelect?: () => void }) {
+  return (
+    <li className="py-3">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="font-semibold text-base/6">
+            <Link href={log.url ?? '#'} onClick={onSelect} className="text-zinc-950 dark:text-white">
+              {log.title}
+            </Link>
+          </div>
+          <p className="mt-1 text-sm/6 text-zinc-600 dark:text-zinc-400">{log.memo}</p>
+          <div className="mt-2 flex flex-wrap gap-1">
+            {log.tags.map((tag) => (
+              <Badge key={tag}>{tag}</Badge>
+            ))}
+          </div>
+        </div>
+        <div className="shrink-0 text-xs/6 text-zinc-500 dark:text-zinc-400">{log.date}</div>
+      </div>
+    </li>
+  )
+}

--- a/src/components/SearchModal.tsx
+++ b/src/components/SearchModal.tsx
@@ -35,7 +35,7 @@ export default function SearchModal() {
         </InputGroup>
         {loading ? (
           <div className="flex justify-center py-8">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900 dark:border-white" />
+            <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-gray-900 dark:border-white" />
           </div>
         ) : results.length > 0 ? (
           <ul className="mt-6 divide-y divide-zinc-950/10 dark:divide-white/10">
@@ -44,8 +44,10 @@ export default function SearchModal() {
             ))}
           </ul>
         ) : (
-          <p className="mt-6 text-center text-sm/6 text-zinc-500 dark:text-zinc-400">No logs found.</p>
-        )
+          <p className="mt-6 text-center text-sm/6 text-zinc-500 dark:text-zinc-400">
+            No logs found.
+          </p>
+        )}
       </DialogBody>
     </Dialog>
   )

--- a/src/components/SearchModal.tsx
+++ b/src/components/SearchModal.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { useEffect } from 'react'
+import { Dialog, DialogBody } from './dialog'
+import { InputGroup, Input } from './input'
+import { MagnifyingGlassIcon } from '@heroicons/react/16/solid'
+import LogSearchResult from './LogSearchResult'
+import { useLogSearch } from '@/hooks/useLogSearch'
+
+export default function SearchModal() {
+  const { open, setOpen, query, setQuery, results, loading } = useLogSearch()
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault()
+        setOpen(true)
+      }
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [setOpen])
+
+  return (
+    <Dialog open={open} onClose={setOpen} size="md">
+      <DialogBody>
+        <InputGroup>
+          <MagnifyingGlassIcon />
+          <Input
+            autoFocus
+            placeholder="Search logs..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+        </InputGroup>
+        {loading ? (
+          <div className="flex justify-center py-8">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900 dark:border-white" />
+          </div>
+        ) : results.length > 0 ? (
+          <ul className="mt-6 divide-y divide-zinc-950/10 dark:divide-white/10">
+            {results.map((log) => (
+              <LogSearchResult key={log.id} log={log} onSelect={() => setOpen(false)} />
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-6 text-center text-sm/6 text-zinc-500 dark:text-zinc-400">No logs found.</p>
+        )
+      </DialogBody>
+    </Dialog>
+  )
+}

--- a/src/hooks/useLogSearch.ts
+++ b/src/hooks/useLogSearch.ts
@@ -1,0 +1,131 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export interface LogEntry {
+  id: number
+  title: string
+  tags: string[]
+  memo: string
+  date: string // YYYY-MM-DD
+  url?: string
+}
+
+const logs: LogEntry[] = [
+  {
+    id: 1,
+    title: 'Morning Workout',
+    tags: ['work'],
+    memo: 'Deadlifts and squats',
+    date: '2025-06-28',
+  },
+  {
+    id: 2,
+    title: 'Study React Hooks',
+    tags: ['study'],
+    memo: 'Read about useEffect and custom hooks',
+    date: '2025-06-29',
+  },
+  {
+    id: 3,
+    title: 'Client Meeting',
+    tags: ['work'],
+    memo: 'Discussed project requirements',
+    date: '2025-06-30',
+  },
+  {
+    id: 4,
+    title: 'Grocery Shopping',
+    tags: ['personal'],
+    memo: 'Bought vegetables and fruits',
+    date: '2025-06-30',
+  },
+  {
+    id: 5,
+    title: 'Write Blog Post',
+    tags: ['study', 'work'],
+    memo: 'Drafted article about TypeScript',
+    date: '2025-07-01',
+  },
+]
+
+interface QueryFilters {
+  text: string
+  tag?: string
+  startDate?: string
+  endDate?: string
+}
+
+function parseQuery(query: string): QueryFilters {
+  const tokens = query.trim().split(/\s+/)
+  const result: QueryFilters = { text: '' }
+  const remaining: string[] = []
+
+  for (const token of tokens) {
+    if (token.startsWith('tag:')) {
+      result.tag = token.slice(4)
+    } else if (token.startsWith('date:')) {
+      const value = token.slice(5)
+      if (value === 'today') {
+        const today = new Date().toISOString().slice(0, 10)
+        result.startDate = today
+        result.endDate = today
+      } else if (value.includes('~')) {
+        const [start, end] = value.split('~')
+        result.startDate = start
+        result.endDate = end
+      } else {
+        result.startDate = value
+        result.endDate = value
+      }
+    } else {
+      remaining.push(token)
+    }
+  }
+
+  result.text = remaining.join(' ')
+  return result
+}
+
+function matchLog(log: LogEntry, filters: QueryFilters) {
+  if (filters.tag && !log.tags.some((t) => t.toLowerCase().includes(filters.tag!.toLowerCase()))) {
+    return false
+  }
+  if (filters.startDate && filters.endDate) {
+    if (log.date < filters.startDate || log.date > filters.endDate) {
+      return false
+    }
+  }
+  const text = filters.text.toLowerCase()
+  if (text) {
+    return (
+      log.title.toLowerCase().includes(text) ||
+      log.memo.toLowerCase().includes(text) ||
+      log.tags.some((t) => t.toLowerCase().includes(text))
+    )
+  }
+  return true
+}
+
+export function useLogSearch() {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<LogEntry[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+
+    setLoading(true)
+    const handle = setTimeout(() => {
+      const filters = parseQuery(query)
+      const filtered = logs.filter((log) => matchLog(log, filters))
+      setResults(filtered)
+      setLoading(false)
+    }, 300)
+
+    return () => clearTimeout(handle)
+  }, [query, open])
+
+  return { open, setOpen, query, setQuery, results, loading }
+}


### PR DESCRIPTION
## Summary
- implement `useLogSearch` hook with placeholder log entries and filtering logic
- create `LogSearchResult` and `SearchModal` components for a command style palette
- mount the modal inside `ApplicationLayout` and open it with `Cmd/Ctrl + K`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686318cd6818832e8ecd88fb0f915808