### PR TITLE
Implement AntiValues page

### DIFF
--- a/src/app/(app)/review/antivalues/page.tsx
+++ b/src/app/(app)/review/antivalues/page.tsx
@@ -1,4 +1,10 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/button'
 import { Heading } from '@/components/heading'
+import { Textarea } from '@/components/textarea'
+import { Toast } from '@/components/toast'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
@@ -6,5 +12,33 @@ export const metadata: Metadata = {
 }
 
 export default function AntiValuesPage() {
-  return <Heading>AntiValues</Heading>
+  const [value, setValue] = useState('')
+  const [showToast, setShowToast] = useState(false)
+
+  const handleSave = (e: React.FormEvent) => {
+    e.preventDefault()
+    // TODO: connect to backend
+    setShowToast(true)
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6">
+      <Heading>AntiValues</Heading>
+      <form onSubmit={handleSave} className="space-y-4 rounded-lg border border-zinc-950/5 p-4 dark:border-white/10">
+        <p className="text-sm text-zinc-500 dark:text-zinc-400">
+          苦手な価値観、嫌悪感を覚える考え方を列挙してください（例：責任のなすりつけ、思考停止、形式主義）
+        </p>
+        <Textarea
+          aria-label="AntiValues"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          className="min-h-40"
+        />
+        <div className="flex justify-end">
+          <Button type="submit">Save</Button>
+        </div>
+      </form>
+      <Toast message="Saved" show={showToast} onClose={() => setShowToast(false)} />
+    </div>
+  )
 }

--- a/src/components/toast.tsx
+++ b/src/components/toast.tsx
@@ -1,0 +1,24 @@
+'use client'
+import clsx from 'clsx'
+import { useEffect } from 'react'
+
+export function Toast({ message, show, onClose }: { message: string; show: boolean; onClose: () => void }) {
+  useEffect(() => {
+    if (!show) return
+    const t = setTimeout(onClose, 3000)
+    return () => clearTimeout(t)
+  }, [show, onClose])
+
+  return (
+    <div
+      aria-live="polite"
+      aria-atomic="true"
+      className={clsx(
+        'fixed bottom-4 right-4 z-50 rounded-lg bg-zinc-800 px-4 py-2 text-sm text-white shadow transition-opacity',
+        show ? 'opacity-100' : 'pointer-events-none opacity-0'
+      )}
+    >
+      {message}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a simple Toast component
- implement AntiValues page with card layout and toast-based save feedback

## Testing
- `npx prettier -w src/components/toast.tsx src/app/(app)/review/antivalues/page.tsx` *(fails: Cannot find package 'prettier-plugin-organize-imports')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686364dc94dc832eb7ccd9b7cf874300