### PR TITLE
Add Identity page with Card

### DIFF
--- a/src/app/(app)/review/identity/page.tsx
+++ b/src/app/(app)/review/identity/page.tsx
@@ -1,4 +1,10 @@
+'use client'
+
+import { useEffect, useState } from 'react'
 import { Heading } from '@/components/heading'
+import { Textarea } from '@/components/textarea'
+import { Button } from '@/components/button'
+import { Card, CardContent, CardFooter } from '@/components/ui/card'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
@@ -6,5 +12,49 @@ export const metadata: Metadata = {
 }
 
 export default function IdentityPage() {
-  return <Heading>Identity</Heading>
+  const [value, setValue] = useState('')
+  const [showToast, setShowToast] = useState(false)
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('identity')
+      if (stored) setValue(stored)
+    }
+  }, [])
+
+  const handleSave = () => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('identity', value)
+    }
+    setShowToast(true)
+    setTimeout(() => setShowToast(false), 3000)
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-6 py-10">
+      <Heading>Identity</Heading>
+      <Card className="w-full max-w-xl">
+        <CardContent className="space-y-4">
+          <p className="text-sm text-zinc-500 dark:text-zinc-400">
+            あなたが自分自身をどう定義するか、自由に書いてください（例：好奇心旺盛な探究者。父であり、ものづくり好きな起業家）
+          </p>
+          <Textarea
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            className="min-h-40"
+          />
+        </CardContent>
+        <CardFooter className="flex justify-end">
+          <Button type="button" onClick={handleSave}>
+            保存
+          </Button>
+        </CardFooter>
+      </Card>
+      {showToast && (
+        <div className="fixed bottom-4 right-4 rounded-md bg-zinc-800 px-4 py-2 text-white shadow">
+          ✅ 保存しました
+        </div>
+      )}
+    </div>
+  )
 }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,32 @@
+import clsx from 'clsx'
+import React, { forwardRef } from 'react'
+
+export const Card = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<'div'>>(function Card(
+  { className, ...props },
+  ref
+) {
+  return (
+    <div
+      ref={ref}
+      className={clsx(
+        'rounded-lg border border-zinc-200 bg-white shadow-sm dark:border-zinc-700 dark:bg-zinc-800',
+        className
+      )}
+      {...props}
+    />
+  )
+})
+
+export const CardContent = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<'div'>>(function CardContent(
+  { className, ...props },
+  ref
+) {
+  return <div ref={ref} className={clsx('p-6', className)} {...props} />
+})
+
+export const CardFooter = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<'div'>>(function CardFooter(
+  { className, ...props },
+  ref
+) {
+  return <div ref={ref} className={clsx('p-6 pt-0', className)} {...props} />
+})


### PR DESCRIPTION
## Summary
- create simple Card UI component
- implement Identity page with editable textarea stored in localStorage
- show toast on save

## Testing
- `npm run lint` *(fails: next not found)*
- `npx prettier -w src/components/ui/card.tsx src/app/(app)/review/identity/page.tsx` *(fails: cannot find plugin)*

------
https://chatgpt.com/codex/tasks/task_e_686364d2cadc832e82f562121a39d9b3