### PR TITLE
Implement tags CRUD API with Supabase types

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.4",
@@ -16,7 +17,8 @@
     "framer-motion": "^11.2.6",
     "next": "14.2.3",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.7",
@@ -29,7 +31,9 @@
     "prettier": "^3.3.2",
     "prettier-plugin-organize-imports": "^4.0.0",
     "prettier-plugin-tailwindcss": "^0.6.11",
+    "supertest": "^6.3.3",
     "tailwindcss": "^4.1.7",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/app/api/tags/[id]/route.ts
+++ b/src/app/api/tags/[id]/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { z } from 'zod'
+import { createServerSupabaseClient } from '@/lib/supabase-server'
+import type { Database } from '@/lib/database.types'
+
+const tagSchema = z.object({
+  name: z.string().optional(),
+  color: z.string().optional(),
+  parent_id: z.string().uuid().nullable().optional(),
+})
+
+async function getDepth(id: string, supabase: ReturnType<typeof createServerSupabaseClient>): Promise<number | null> {
+  let depth = 1
+  let current = id
+  for (let i = 0; i < 4; i++) {
+    const { data, error } = await supabase
+      .from('tags')
+      .select('parent_id')
+      .eq('id', current)
+      .maybeSingle()
+    if (error) return null
+    if (!data?.parent_id) return depth
+    current = data.parent_id
+    depth++
+  }
+  return depth
+}
+
+export async function GET(_request: NextRequest, { params }: { params: { id: string } }) {
+  const supabase = createServerSupabaseClient()
+  const { data, error } = await supabase.from('tags').select('*').eq('id', params.id).maybeSingle()
+  if (error || !data) {
+    return NextResponse.json({ error: 'not found' }, { status: 404 })
+  }
+  return NextResponse.json(data)
+}
+
+export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
+  const body = await request.json().catch(() => null)
+  const parsed = tagSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.message }, { status: 400 })
+  }
+
+  const supabase = createServerSupabaseClient()
+  const updates = parsed.data
+
+  if (updates.parent_id) {
+    const depth = await getDepth(updates.parent_id, supabase)
+    if (!depth || depth >= 3) {
+      return NextResponse.json({ error: 'depth' }, { status: 422 })
+    }
+  }
+
+  if (updates.name) {
+    const { data: existing } = await supabase
+      .from('tags')
+      .select('id')
+      .eq('name', updates.name)
+      .neq('id', params.id)
+      .maybeSingle()
+    if (existing) {
+      return NextResponse.json({ error: 'duplicate' }, { status: 409 })
+    }
+  }
+
+  const { data, error } = await supabase
+    .from('tags')
+    .update(updates as Database['public']['Tables']['tags']['Update'])
+    .eq('id', params.id)
+    .select()
+    .single()
+
+  if (error || !data) {
+    return NextResponse.json({ error: error?.message }, { status: 500 })
+  }
+
+  return NextResponse.json(data)
+}
+
+export async function DELETE(_request: NextRequest, { params }: { params: { id: string } }) {
+  const supabase = createServerSupabaseClient()
+  const { error } = await supabase.from('tags').delete().eq('id', params.id)
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return new NextResponse(null, { status: 204 })
+}

--- a/src/app/api/tags/route.ts
+++ b/src/app/api/tags/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { createServerSupabaseClient } from '@/lib/supabase-server'
+import type { Database } from '@/lib/database.types'
+
+type TagsRow = Database['public']['Tables']['tags']['Row']
+type TagsInsert = Database['public']['Tables']['tags']['Insert']
+
+const tagSchema = z.object({
+  name: z.string().min(1),
+  color: z.string().optional(),
+  parent_id: z.string().uuid().nullable().optional(),
+})
+
+async function getDepth(id: string, supabase: ReturnType<typeof createServerSupabaseClient>): Promise<number | null> {
+  let depth = 1
+  let current = id
+  for (let i = 0; i < 4; i++) {
+    const { data, error } = await supabase
+      .from('tags')
+      .select('parent_id')
+      .eq('id', current)
+      .maybeSingle()
+    if (error) return null
+    if (!data?.parent_id) return depth
+    current = data.parent_id
+    depth++
+  }
+  return depth
+}
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null)
+  const parsed = tagSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.message }, { status: 400 })
+  }
+
+  const supabase = createServerSupabaseClient()
+  const { name, color, parent_id } = parsed.data
+
+  if (parent_id) {
+    const depth = await getDepth(parent_id, supabase)
+    if (!depth || depth >= 3) {
+      return NextResponse.json({ error: 'depth' }, { status: 422 })
+    }
+  }
+
+  const { data: existing } = await supabase
+    .from('tags')
+    .select('id')
+    .eq('name', name)
+    .maybeSingle()
+
+  if (existing) {
+    return NextResponse.json({ error: 'duplicate' }, { status: 409 })
+  }
+
+  const { data, error } = await supabase
+    .from('tags')
+    .insert({ name, color, parent_id } as TagsInsert)
+    .select()
+    .single()
+
+  if (error || !data) {
+    return NextResponse.json({ error: error?.message }, { status: 500 })
+  }
+
+  return NextResponse.json(data, { status: 201 })
+}

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -1,0 +1,38 @@
+export interface Database {
+  public: {
+    Tables: {
+      tags: {
+        Row: {
+          id: string
+          name: string
+          color: string | null
+          parent_id: string | null
+          depth: number | null
+          created_at: string | null
+        }
+        Insert: {
+          id?: string
+          name: string
+          color?: string | null
+          parent_id?: string | null
+          created_at?: string | null
+        }
+        Update: {
+          id?: string
+          name?: string
+          color?: string | null
+          parent_id?: string | null
+          created_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'tags_parent_id_fkey'
+            columns: ['parent_id']
+            referencedRelation: 'tags'
+            referencedColumns: ['id']
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/lib/supabase-browser.ts
+++ b/src/lib/supabase-browser.ts
@@ -1,4 +1,5 @@
 import { createClient as createSupabaseClient } from '@supabase/supabase-js'
+import type { Database } from './database.types'
 
 export function createClient() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -8,8 +9,8 @@ export function createClient() {
     if (process.env.NODE_ENV === 'development') {
       console.warn('Supabase environment variables are missing')
     }
-    return createSupabaseClient('https://placeholder.supabase.co', 'placeholder')
+    return createSupabaseClient<Database>('https://placeholder.supabase.co', 'placeholder')
   }
 
-  return createSupabaseClient(url, key)
+  return createSupabaseClient<Database>(url, key)
 }

--- a/src/lib/supabase-server.ts
+++ b/src/lib/supabase-server.ts
@@ -1,4 +1,5 @@
 import { createClient as createSupabaseClient } from '@supabase/supabase-js'
+import type { Database } from './database.types'
 
 export function createServerSupabaseClient() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -8,8 +9,8 @@ export function createServerSupabaseClient() {
     if (process.env.NODE_ENV === 'development') {
       console.warn('Supabase environment variables are missing')
     }
-    return createSupabaseClient('https://placeholder.supabase.co', 'placeholder')
+    return createSupabaseClient<Database>('https://placeholder.supabase.co', 'placeholder')
   }
 
-  return createSupabaseClient(url, key)
+  return createSupabaseClient<Database>(url, key)
 }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,34 @@
+create table tags (
+  id uuid primary key default uuid_generate_v4(),
+  name text not null,
+  color text default '#3b82f6',
+  parent_id uuid references tags(id) on delete cascade,
+  depth smallint generated always as (
+    coalesce(
+      (with recursive cte as (
+        select id, parent_id, 1 as d from tags where id = tags.id
+        union all
+        select t.id, t.parent_id, d + 1 from tags t join cte on t.id = cte.parent_id
+      ) select max(d) from cte), 1)
+  ) stored,
+  created_at timestamptz default now()
+);
+create index on tags(parent_id);
+-- policy should be adjusted to existing RLS settings
+-- placeholder for row level security policy
+create policy "individual_access" on tags for all using (auth.uid() = auth.uid());
+
+-- function to prevent depth >= 4
+create or replace function check_tag_depth()
+returns trigger as $$
+begin
+  if (new.depth >= 4) then
+    raise exception 'Tag depth cannot exceed 3';
+  end if;
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger tags_depth_trigger
+  before insert or update on tags
+  for each row execute function check_tag_depth();

--- a/tests/api/tags.test.ts
+++ b/tests/api/tags.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { POST } from '@/app/api/tags/route'
+
+vi.mock('@/lib/supabase-server')
+
+interface SupabaseCall {
+  type: 'select' | 'insert'
+  args?: any
+}
+
+describe('POST /api/tags', () => {
+  const module = await import('@/lib/supabase-server')
+  const mockClient = { from: vi.fn() }
+  ;(module as any).createServerSupabaseClient = () => mockClient
+
+  beforeEach(() => {
+    mockClient.from.mockReset()
+  })
+
+  it('returns 201 on success', async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({ data: null, error: null })
+    const insertSingle = vi
+      .fn()
+      .mockResolvedValue({ data: { id: '1', name: 'Tag1' }, error: null })
+
+    mockClient.from.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({ maybeSingle }),
+      }),
+      insert: vi.fn().mockReturnValue({
+        select: () => ({ single: insertSingle }),
+      }),
+    })
+
+    const res = await POST(new Request('http://test', { method: 'POST', body: JSON.stringify({ name: 'Tag1' }) }))
+    expect(res.status).toBe(201)
+  })
+
+  it('returns 422 when depth too deep', async () => {
+    const maybeSingle = vi
+      .fn()
+      .mockResolvedValueOnce({ data: { parent_id: 'p2' }, error: null })
+      .mockResolvedValueOnce({ data: { parent_id: 'p3' }, error: null })
+      .mockResolvedValueOnce({ data: { parent_id: null }, error: null })
+      .mockResolvedValueOnce({ data: null, error: null })
+    mockClient.from.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({ maybeSingle }),
+      }),
+      insert: vi.fn(),
+    })
+
+    const res = await POST(
+      new Request('http://test', { method: 'POST', body: JSON.stringify({ name: 'deep', parent_id: 'p1' }) })
+    )
+    expect(res.status).toBe(422)
+  })
+
+  it('returns 409 when name duplicated', async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({ data: { id: 'x' }, error: null })
+    mockClient.from.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({ maybeSingle }),
+      }),
+      insert: vi.fn(),
+    })
+
+    const res = await POST(new Request('http://test', { method: 'POST', body: JSON.stringify({ name: 'dup' }) }))
+    expect(res.status).toBe(409)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+import path from 'node:path'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  test: {
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
## Summary
- define Supabase schema for `tags`
- generate typed Supabase client
- implement POST/GET/PUT/DELETE API handlers for `tags`
- add unit tests with Vitest and mock Supabase

## Testing
- `npm test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6864700bad20832e8d103dcee9c11675