### PR TITLE
Add tag sidebar on calendar page

### DIFF
--- a/src/app/(calendar)/layout.tsx
+++ b/src/app/(calendar)/layout.tsx
@@ -1,0 +1,16 @@
+import { SWRConfig } from 'swr'
+import { getTags } from '@/data'
+import TagSidebar from '@/components/tag-sidebar'
+import React from 'react'
+
+export default async function CalendarLayout({ children }: { children: React.ReactNode }) {
+  const tags = await getTags()
+  return (
+    <SWRConfig value={{ fallback: { '/api/tags': tags } }}>
+      <div className="flex">
+        <TagSidebar />
+        <div className="flex-1">{children}</div>
+      </div>
+    </SWRConfig>
+  )
+}

--- a/src/app/(calendar)/page.tsx
+++ b/src/app/(calendar)/page.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Calendar',
+}
+
+export default function CalendarPage() {
+  return <div className="p-4">Calendar page</div>
+}

--- a/src/app/api/tags/route.ts
+++ b/src/app/api/tags/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server'
+import { getTags } from '@/data'
+
+export async function GET() {
+  const tags = await getTags()
+  return NextResponse.json(tags)
+}

--- a/src/components/badge.tsx
+++ b/src/components/badge.tsx
@@ -34,16 +34,21 @@ const colors = {
   zinc: 'bg-zinc-600/10 text-zinc-700 group-data-hover:bg-zinc-600/20 dark:bg-white/5 dark:text-zinc-400 dark:group-data-hover:bg-white/10',
 }
 
-type BadgeProps = { color?: keyof typeof colors }
+function isPredefinedColor(color: string): color is keyof typeof colors {
+  return color in colors
+}
 
-export function Badge({ color = 'zinc', className, ...props }: BadgeProps & React.ComponentPropsWithoutRef<'span'>) {
+type BadgeProps = { color?: keyof typeof colors | string }
+
+export function Badge({ color = 'zinc', className, style, ...props }: BadgeProps & React.ComponentPropsWithoutRef<'span'>) {
   return (
     <span
       {...props}
+      style={!isPredefinedColor(color) ? { backgroundColor: color, ...style } : style}
       className={clsx(
         className,
         'inline-flex items-center gap-x-1.5 rounded-md px-1.5 py-0.5 text-sm/5 font-medium sm:text-xs/5 forced-colors:outline',
-        colors[color]
+        isPredefinedColor(color) ? colors[color] : undefined
       )}
     />
   )

--- a/src/components/tag-sidebar.tsx
+++ b/src/components/tag-sidebar.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useState } from 'react'
+import useSWR from 'swr'
+import { ChevronDown } from 'lucide-react'
+import { Badge } from '@/components/badge'
+import clsx from 'clsx'
+
+export type Tag = {
+  id: number | string
+  name: string
+  color: string
+  children?: Tag[]
+}
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json())
+
+function TagNode({ tag, level = 0 }: { tag: Tag; level?: number }) {
+  const [open, setOpen] = useState(true)
+  const hasChildren = !!tag.children && tag.children.length > 0
+
+  return (
+    <li className={clsx(level > 0 && 'ml-4')}>
+      <div
+        className="flex items-center gap-1 rounded-md px-2 py-1 cursor-pointer hover:ring-2 hover:ring-primary/40"
+        onClick={() => hasChildren && setOpen(!open)}
+      >
+        {hasChildren && (
+          <ChevronDown className={clsx('h-4 w-4 transition-transform', open ? 'rotate-0' : '-rotate-90')} />
+        )}
+        <Badge color={tag.color} style={{ backgroundColor: tag.color }}>
+          {tag.name}
+        </Badge>
+        <span className="ml-auto text-xs text-zinc-500">0</span>
+      </div>
+      {hasChildren && open && (
+        <ul className="mt-1">
+          {tag.children!.map((child) => (
+            <TagNode key={child.id} tag={child} level={level + 1} />
+          ))}
+        </ul>
+      )}
+    </li>
+  )
+}
+
+export default function TagSidebar() {
+  const { data } = useSWR<Tag[]>("/api/tags", fetcher, { suspense: true })
+
+  return (
+    <aside className="w-60 bg-muted/50 h-[100vh] overflow-y-auto p-2">
+      <ul>{data?.map((tag) => <TagNode key={tag.id} tag={tag} />)}</ul>
+    </aside>
+  )
+}

--- a/src/data.ts
+++ b/src/data.ts
@@ -930,3 +930,28 @@ export function getCountries() {
     },
   ]
 }
+
+export async function getTags() {
+  return [
+    {
+      id: 1,
+      name: 'Work',
+      color: '#f87171',
+      children: [
+        {
+          id: 2,
+          name: 'Project',
+          color: '#60a5fa',
+          children: [
+            { id: 3, name: 'Task', color: '#4ade80' }
+          ],
+        },
+      ],
+    },
+    {
+      id: 4,
+      name: 'Personal',
+      color: '#a78bfa',
+    },
+  ]
+}


### PR DESCRIPTION
## Summary
- implement `/api/tags` endpoint providing sample nested tag data
- extend `Badge` to allow custom background colors
- add `TagSidebar` client component with collapsible tag tree
- create Calendar layout/page using `TagSidebar` and SWR

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864704cad40832e9bf5a5e38ca688be