### PR TITLE
fix(#389): usePerformanceMonitor.tsの型エラーを修正

### DIFF
--- a/src/hooks/usePerformanceMonitor.ts
+++ b/src/hooks/usePerformanceMonitor.ts
@@ -1,5 +1,15 @@
-// @ts-nocheck TODO(#389): 型エラー1件を段階的に修正する
 import { useEffect, useRef } from 'react'
+
+// Chrome固有のperformance.memory API用の型定義
+interface PerformanceMemory {
+  usedJSHeapSize: number
+  totalJSHeapSize: number
+  jsHeapSizeLimit: number
+}
+
+interface PerformanceWithMemory extends Performance {
+  memory?: PerformanceMemory
+}
 
 export const usePerformanceMonitor = (componentName: string, enabled = false) => {
   const renderStartTime = useRef<number>()
@@ -45,12 +55,12 @@ export const useMemoryMonitor = (componentName: string, enabled = false) => {
   useEffect(() => {
     if (!enabled || !('memory' in performance)) return
 
-    const { memory } = performance as unknown
-    if (memory) {
+    const perfWithMemory = performance as PerformanceWithMemory
+    if (perfWithMemory.memory) {
       console.log(`💾 ${componentName} memory usage:`, {
-        used: `${(memory.usedJSHeapSize / 1024 / 1024).toFixed(2)}MB`,
-        total: `${(memory.totalJSHeapSize / 1024 / 1024).toFixed(2)}MB`,
-        limit: `${(memory.jsHeapSizeLimit / 1024 / 1024).toFixed(2)}MB`,
+        used: `${(perfWithMemory.memory.usedJSHeapSize / 1024 / 1024).toFixed(2)}MB`,
+        total: `${(perfWithMemory.memory.totalJSHeapSize / 1024 / 1024).toFixed(2)}MB`,
+        limit: `${(perfWithMemory.memory.jsHeapSizeLimit / 1024 / 1024).toFixed(2)}MB`,
       })
     }
   })


### PR DESCRIPTION
## Summary
- `usePerformanceMonitor.ts`の`@ts-nocheck`を削除し、型エラーを修正
- Chrome固有の`performance.memory` APIに対して適切な型定義（`PerformanceMemory`, `PerformanceWithMemory`）を追加
- `as unknown`を型安全な`as PerformanceWithMemory`に変更

## Test plan
- [ ] `npm run typecheck`が通ることを確認
- [ ] パフォーマンスモニタリング機能が正常に動作することを確認

Closes #389 (partial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)