### PR TITLE
docs: デザインシステム参照先をtheme.tsからglobals.cssに修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,12 +124,13 @@ AIは、コードを書く前に以下を必ず実行すること：
 - [ ] データフェッチングは、どの方法が推奨されているか？
 - [ ] この機能にNext.js組み込みの解決策は存在するか？
 
-### 3. theme.ts適用可能性の確認（所要時間：10秒）
+### 3. globals.css セマンティックトークン確認（所要時間：10秒）
 
 ```typescript
-// 必ず確認：/src/config/ui/theme.ts
-// スタイリングに関わる全ての値はここから取得
+// 必ず確認：/src/styles/globals.css
+// スタイリングは globals.css で定義されたセマンティックトークンを使用
 // 新しい色やサイズを勝手に定義しない
+// 例: bg-card, text-foreground, border-border 等
 ```
 
 ---
@@ -146,8 +147,8 @@ AIは、コードを書く前に以下を必ず実行すること：
 #### 2. スタイリング
 
 - ❌ 禁止: `style`属性、任意のカラーコード、マジックナンバー
-- ❌ 禁止: `className="text-blue-500"`（Tailwindクラスの直接指定）
-- ✅ 必須: `/src/config/ui/theme.ts`の値のみ使用
+- ❌ 禁止: `className="text-blue-500"`（Tailwindカラークラスの直接指定）
+- ✅ 必須: `globals.css` のセマンティックトークン使用（`bg-card`, `text-foreground` 等）
 
 #### 3. コンポーネント作成
 

--- a/docs/design-system/STYLE_GUIDE.md
+++ b/docs/design-system/STYLE_GUIDE.md
@@ -389,7 +389,7 @@ xl: 1280px  // デスクトップ
 
 ## 🔗 関連ドキュメント
 
-- **実装詳細**: `/src/config/ui/theme.ts`
+- **セマンティックトークン定義**: `/src/styles/globals.css`
 - **コンポーネント例**: `/src/components/CLAUDE.md`
 - **テーマ移行**: `docs/design-system/THEME_MIGRATION.md`
 - **統合履歴**: `docs/design-system/INTEGRATION_LOG.md`

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -37,23 +37,24 @@ import { colors } from '@/config/theme'
 - `border-border` / `border-input` - ボーダー
 - `bg-destructive` / `text-destructive-foreground` - 削除ボタン等
 
-**スペーシング・タイポグラフィ・角丸は theme.ts のヘルパーを使用：**
+**スペーシング・タイポグラフィ・角丸も globals.css のユーティリティクラスを使用：**
 
 ```tsx
-import { typography, spacing, rounded } from '@/config/ui/theme'
+// ✅ タイポグラフィ（globals.css で定義されたユーティリティクラス）
+<h1 className="text-heading-h1">  // 48px, bold
+<h2 className="text-heading-h2">  // 32px, bold
+<p className="text-body-base">    // 16px, normal
 
-// ✅ タイポグラフィ
-<h1 className={typography.heading.h1}>
-<p className={typography.body.base}>
+// ✅ スペーシング（Tailwindクラス、8pxグリッド準拠）
+<div className="p-4">   // 16px padding
+<div className="gap-2"> // 8px gap
 
-// ✅ スペーシング（値が必要な場合）
-<div style={{ margin: spacing.md }}>
-
-// ✅ 角丸
-<button className={rounded.component.button.md}>
+// ✅ 角丸（globals.css で定義）
+<button className="rounded-md">  // 8px
+<div className="rounded-xl">     // 16px
 ```
 
-**重要：カラー以外（typography, spacing, rounded）は `/src/config/ui/theme.ts` を参照**
+**重要：すべてのスタイリングは `/src/styles/globals.css` のセマンティックトークンを参照**
 
 #### 1.1 スペーシング：8pxグリッドシステム（必須遵守）
 


### PR DESCRIPTION
## 概要

存在しない `/src/config/ui/theme.ts` への参照を実際のファイル `/src/styles/globals.css` に修正しました。

## 変更内容

### 修正ファイル

1. **CLAUDE.md** (ルート)
   - 実装前チェックリスト（theme.ts適用可能性の確認）
   - スタイリング禁止事項（theme.tsの値のみ使用）
   
2. **src/CLAUDE.md**
   - スタイリングガイド（セマンティックトークン参照先）
   
3. **docs/design-system/STYLE_GUIDE.md**
   - 関連ドキュメント参照先（セマンティックトークン定義）

### 変更統計

- 3ファイル変更
- +19行追加、-17行削除
- 型チェック: ✅ PASS

## 影響範囲

- ドキュメントのみの変更（コード変更なし）
- 開発者がセマンティックトークンの参照先を正しく理解できるようになります

## 検証

```bash
npm run typecheck  # ✅ PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)