### PR TITLE
feat(deploy): タグベースの本番デプロイを実装

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -8,10 +8,52 @@ on:
 permissions:
   contents: write
 
+env:
+  VERCEL_ORG_ID: ${{ secrets.ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.PROJECT_ID }}
+
 jobs:
+  # 本番デプロイ（タグ作成時のみ）
+  deploy-production:
+    name: Deploy to Production
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel@latest
+
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build Project Artifacts
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy to Vercel Production
+        id: deploy
+        run: |
+          DEPLOYMENT_URL=$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})
+          echo "url=$DEPLOYMENT_URL" >> $GITHUB_OUTPUT
+          echo "✅ Deployed to: $DEPLOYMENT_URL"
+
+      - name: Output Deployment URL
+        run: |
+          echo "🚀 Production deployment complete!"
+          echo "URL: ${{ steps.deploy.outputs.url }}"
+
+  # GitHub Release作成
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    needs: deploy-production
 
     steps:
       - name: Checkout code

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,12 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "npm run build:fallback",
   "devCommand": "npm run dev:fallback",
   "installCommand": "npm ci",
-  "framework": "nextjs"
+  "framework": "nextjs",
+  "git": {
+    "deploymentEnabled": {
+      "main": false
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- タグ（`v*.*.*`）push時のみVercel本番デプロイを実行するように変更
- mainブランチへのpushでは本番デプロイしない（Previewのみ）

## 変更内容
### `.github/workflows/create-release.yml`
- `deploy-production`ジョブを追加
- タグ作成 → 本番デプロイ → GitHub Release の順で実行

### `vercel.json`
- `git.deploymentEnabled.main: false` を追加
- mainブランチの自動本番デプロイを無効化

## 新しいデプロイフロー
| 環境 | URL | トリガー |
|------|-----|----------|
| Development | `localhost:3000` | ローカル |
| Preview | `boxlog-app-git-*.vercel.app` | PR/Push |
| Production | `boxlog-app.vercel.app` | **タグのみ** |

## 使い方
```bash
# 本番デプロイ
git tag v0.7.0
git push origin v0.7.0
# → GitHub Actions起動 → Vercel本番デプロイ → GitHub Release作成
```

## Test plan
- [ ] PRマージ後、mainへのpushで本番デプロイされないこと確認
- [ ] タグ作成後、本番デプロイとGitHub Releaseが作成されること確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)