### PR TITLE
fix(ci): move secrets from global env to job-level env

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -8,15 +8,14 @@ on:
 permissions:
   contents: write
 
-env:
-  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-
 jobs:
   # 本番デプロイ（タグ作成時のみ）
   deploy-production:
     name: Deploy to Production
     runs-on: ubuntu-latest
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

- グローバル`env`でシークレットを参照すると`startup_failure`になる問題を修正
- シークレットをジョブレベルの`env`に移動

## Root Cause

GitHub Actionsでは、ワークフローのグローバル`env`ブロックでシークレットを参照すると、ワークフローが起動時に失敗（`startup_failure`）することがあります。

## Test plan

- [ ] PRマージ後、v0.8.2タグを作成してワークフローをテスト
- [ ] `startup_failure`が解消されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)