### PR TITLE
chore: bump version to v0.8.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boxlog-app",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boxlog-app",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/openai": "^2.0.75",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boxlog-app",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "private": true,
   "sideEffects": [
     "*.css",


### PR DESCRIPTION
## Summary

- Bump version to v0.8.4 for testing the updated create-release workflow

## Test Plan

After merging, create v0.8.4 tag to verify the workflow runs successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)