### PR TITLE
chore: v0.8.0以降のワークフロー修正をすべて取り消し

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,14 +5,15 @@ on:
     tags:
       - 'v*.*.*'
 
-env:
-  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-
 permissions:
   contents: write
 
+env:
+  VERCEL_ORG_ID: ${{ secrets.ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.PROJECT_ID }}
+
 jobs:
+  # 本番デプロイ（タグ作成時のみ）
   deploy-production:
     name: Deploy to Production
     runs-on: ubuntu-latest
@@ -20,6 +21,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
 
       - name: Install Vercel CLI
         run: npm install -g vercel@latest
@@ -31,8 +38,18 @@ jobs:
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy to Vercel Production
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        id: deploy
+        run: |
+          DEPLOYMENT_URL=$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})
+          echo "url=$DEPLOYMENT_URL" >> $GITHUB_OUTPUT
+          echo "✅ Deployed to: $DEPLOYMENT_URL"
 
+      - name: Output Deployment URL
+        run: |
+          echo "🚀 Production deployment complete!"
+          echo "URL: ${{ steps.deploy.outputs.url }}"
+
+  # GitHub Release作成
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
@@ -54,7 +71,7 @@ jobs:
       - name: Check if release notes exist
         id: check_notes
         run: |
-          NOTES_FILE="docs/releases/RELEASE_NOTES_${{ steps.version.outputs.version }}.md"
+          NOTES_FILE="RELEASE_NOTES_${{ steps.version.outputs.version }}.md"
           if [ -f "$NOTES_FILE" ]; then
             echo "exists=true" >> $GITHUB_OUTPUT
             echo "file=$NOTES_FILE" >> $GITHUB_OUTPUT
@@ -68,11 +85,11 @@ jobs:
           TAG_VERSION="${{ steps.version.outputs.version_number }}"
 
           if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
-            echo "Error: package.json version ($PACKAGE_VERSION) does not match tag version ($TAG_VERSION)"
+            echo "❌ Error: package.json version ($PACKAGE_VERSION) does not match tag version ($TAG_VERSION)"
             exit 1
           fi
 
-          echo "Version match: $PACKAGE_VERSION"
+          echo "✅ Version match: $PACKAGE_VERSION"
 
       - name: Create Release with notes file
         if: steps.check_notes.outputs.exists == 'true'
@@ -90,9 +107,9 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           body: |
-            ## Release ${{ steps.version.outputs.version }}
+            ## 🎉 Release ${{ steps.version.outputs.version }}
 
-            Release notes file was not found.
+            **⚠️ Note**: This release was created automatically. Release notes file was not found.
 
             Please see the [Full Changelog](${{ github.server_url }}/${{ github.repository }}/compare/${{ steps.version.outputs.version }}...${{ steps.version.outputs.version }}) for details.
           draft: false
@@ -100,3 +117,15 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Notify on success
+        if: success()
+        run: |
+          echo "✅ Release ${{ steps.version.outputs.version }} created successfully!"
+          echo "🔗 View at: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ steps.version.outputs.version }}"
+
+      - name: Notify on failure
+        if: failure()
+        run: |
+          echo "❌ Failed to create release ${{ steps.version.outputs.version }}"
+          echo "Please check the workflow logs and create the release manually if needed."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boxlog-app",
-  "version": "0.8.4",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boxlog-app",
-      "version": "0.8.4",
+      "version": "0.7.0",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/openai": "^2.0.75",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boxlog-app",
-  "version": "0.8.4",
+  "version": "0.8.0",
   "private": true,
   "sideEffects": [
     "*.css",

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,8 @@
   "installCommand": "npm ci",
   "framework": "nextjs",
   "git": {
-    "deploymentEnabled": false
+    "deploymentEnabled": {
+      "main": false
+    }
   }
 }


### PR DESCRIPTION
## Summary

v0.8.0リリース以降に行ったワークフロー修正（v0.8.1〜v0.8.4）をすべて取り消し、v0.8.0の状態に戻します。

### 取り消した変更
- PR #798: シークレット名の変更
- PR #800: env配置の変更
- PR #802: シークレット名を元に戻す
- PR #804: step-level envへの変更
- PR #805: Vercel公式ガイドに従った変更

### 削除済みのリモートタグ
- v0.8.1
- v0.8.2
- v0.8.3
- v0.8.4

## Reason

すべての修正で`startup_failure`エラーが解消されなかったため、一度クリーンな状態に戻して再検討します。

## Test plan

- [ ] マージ後、`package.json`のバージョンが`0.8.0`であることを確認
- [ ] `.github/workflows/create-release.yml`がv0.8.0の状態に戻っていることを確認
- [ ] `vercel.json`がv0.8.0の状態に戻っていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)