### PR TITLE
chore: bump version to v0.8.1 for deployment test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boxlog-app",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "sideEffects": [
     "*.css",


### PR DESCRIPTION
## Summary
- Vercel デプロイのテスト用バージョンバンプ
- `softprops/*` を Actions 許可リストに追加した後の動作確認

## Test plan
- [ ] PR マージ後、`v0.8.1` タグを作成
- [ ] GitHub Actions ワークフローが正常に起動するか確認
- [ ] Vercel Production デプロイが成功するか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)