### PR TITLE
fix(ci): リリースノートのパスを修正

### DIFF
--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -84,6 +84,7 @@ cp docs/releases/template.md docs/releases/RELEASE_NOTES_v${VERSION}.md
 ```
 
 **必須項目**:
+
 - [ ] 全PRが含まれている
 - [ ] Full Changelogリンクがある
 - [ ] カテゴリ別に整理（Added, Changed, Fixed等）
@@ -94,17 +95,23 @@ cp docs/releases/template.md docs/releases/RELEASE_NOTES_v${VERSION}.md
 
 ## よくある失敗
 
-| 失敗 | 対策 |
-|------|------|
-| バージョン重複 | Phase 0.1で必ず `gh release view` |
-| package.json更新忘れ | Phase 0.3でPRマージ前に更新 |
-| Full Changelog抜け | template.mdをコピーして使用 |
-| 一部PRのみ記載 | `gh pr list --state merged` で全件取得 |
+| 失敗                 | 対策                                   |
+| -------------------- | -------------------------------------- |
+| バージョン重複       | Phase 0.1で必ず `gh release view`      |
+| package.json更新忘れ | Phase 0.3でPRマージ前に更新            |
+| Full Changelog抜け   | template.mdをコピーして使用            |
+| 一部PRのみ記載       | `gh pr list --state merged` で全件取得 |
 
 ## スクリプト
 
 ### バージョン重複チェック
 
 ```bash
-./scripts/check-version.sh 0.X.0
+.claude/skills/releasing/scripts/check-version.sh 0.X.0
+```
+
+### マージ済みPR取得
+
+```bash
+.claude/skills/releasing/scripts/get-merged-prs.sh
 ```

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Check if release notes exist
         id: check_notes
         run: |
-          NOTES_FILE="RELEASE_NOTES_${{ steps.version.outputs.version }}.md"
+          NOTES_FILE="docs/releases/RELEASE_NOTES_${{ steps.version.outputs.version }}.md"
           if [ -f "$NOTES_FILE" ]; then
             echo "exists=true" >> $GITHUB_OUTPUT
             echo "file=$NOTES_FILE" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- `create-release.yml`: リリースノートファイルのパスを `docs/releases/` に修正
- `SKILL.md`: スクリプトパスを正しいパスに修正、`get-merged-prs.sh` を追加

## 背景
v0.9.0 で自動生成ノートになった原因：
- ワークフローがルートで `RELEASE_NOTES_vX.Y.Z.md` を探していた
- 実際のファイルは `docs/releases/RELEASE_NOTES_vX.Y.Z.md` に配置

## Test plan
- [ ] 次回リリース時に正しいノートが使用されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)