### PR TITLE
refactor: 再利用可能コンポーネントとユーティリティの追加

### DIFF
--- a/src/components/common/ConfirmDialog.tsx
+++ b/src/components/common/ConfirmDialog.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import { type ReactNode, useCallback, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import { Button } from '@/components/ui/button';
+import { useDialogKeyboard } from '@/hooks/useDialogKeyboard';
+import { AlertTriangle, type LucideIcon } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+type ConfirmDialogVariant = 'destructive' | 'warning' | 'default';
+
+interface ConfirmDialogProps {
+  /** ダイアログが開いているかどうか */
+  open: boolean;
+  /** ダイアログを閉じるコールバック */
+  onClose: () => void;
+  /** 確認時のコールバック（非同期可） */
+  onConfirm: () => void | Promise<void>;
+  /** タイトル */
+  title: string;
+  /** 説明文（省略可、childrenがある場合） */
+  description?: string;
+  /** カスタムコンテンツ（description の代わりに使用） */
+  children?: ReactNode;
+  /** 確認ボタンのラベル（省略時は翻訳キーから取得） */
+  confirmLabel?: string;
+  /** キャンセルボタンのラベル（省略時は翻訳キーから取得） */
+  cancelLabel?: string;
+  /** バリアント: destructive（削除等）, warning（警告）, default */
+  variant?: ConfirmDialogVariant;
+  /** カスタムアイコン（省略時はバリアントに応じたデフォルト） */
+  icon?: LucideIcon;
+  /** ローディング中のラベル */
+  loadingLabel?: string;
+  /** ダイアログの最大幅（px単位、省略時は448px） */
+  maxWidth?: number;
+}
+
+/**
+ * 汎用確認ダイアログ
+ *
+ * Figma的な運用: このコンポーネントを大元として、オプション（variant, icon等）で
+ * 削除確認、警告確認などの用途に対応する。
+ *
+ * スタイルガイド準拠:
+ * - 8pxグリッドシステム（p-6, gap-4, mb-6等）
+ * - 角丸: rounded-xl（16px）for ダイアログ
+ * - Card: bg-card（カード、ダイアログ用）
+ * - セマンティックカラー: destructive系トークン使用
+ *
+ * @example
+ * ```tsx
+ * // 削除確認
+ * <ConfirmDialog
+ *   open={isOpen}
+ *   onClose={handleClose}
+ *   onConfirm={handleDelete}
+ *   title="Delete item?"
+ *   description="This action cannot be undone."
+ *   variant="destructive"
+ * />
+ *
+ * // カスタムアイコン
+ * <ConfirmDialog
+ *   open={isOpen}
+ *   onClose={handleClose}
+ *   onConfirm={handleConfirm}
+ *   title="Archive item?"
+ *   description="Item will be moved to archive."
+ *   variant="warning"
+ *   icon={Archive}
+ * />
+ * ```
+ */
+export function ConfirmDialog({
+  open,
+  onClose,
+  onConfirm,
+  title,
+  description,
+  children,
+  confirmLabel,
+  cancelLabel,
+  variant = 'default',
+  icon: Icon = AlertTriangle,
+  loadingLabel,
+  maxWidth = 448,
+}: ConfirmDialogProps) {
+  const t = useTranslations();
+  const [isLoading, setIsLoading] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  // クライアントサイドでのみマウント
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // ESCキーでダイアログを閉じる
+  useDialogKeyboard(open, isLoading, onClose);
+
+  const handleConfirm = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      await onConfirm();
+    } finally {
+      setIsLoading(false);
+    }
+  }, [onConfirm]);
+
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget && !isLoading) {
+        onClose();
+      }
+    },
+    [isLoading, onClose],
+  );
+
+  if (!mounted || !open) return null;
+
+  // バリアントに応じたスタイル
+  const iconContainerClass =
+    variant === 'destructive'
+      ? 'bg-destructive-container'
+      : variant === 'warning'
+        ? 'bg-warning-container'
+        : 'bg-muted';
+
+  const iconClass =
+    variant === 'destructive'
+      ? 'text-destructive'
+      : variant === 'warning'
+        ? 'text-warning'
+        : 'text-foreground';
+
+  const confirmButtonVariant = variant === 'destructive' ? 'destructive' : 'primary';
+  const confirmButtonClass =
+    variant === 'destructive'
+      ? 'hover:bg-destructive-hover'
+      : variant === 'warning'
+        ? 'bg-warning text-warning-foreground hover:bg-warning-hover'
+        : undefined;
+
+  // ラベルの決定
+  const resolvedConfirmLabel =
+    confirmLabel ?? (variant === 'destructive' ? t('actions.delete') : t('common.confirm'));
+  const resolvedCancelLabel = cancelLabel ?? t('actions.cancel');
+  const resolvedLoadingLabel =
+    loadingLabel ?? (variant === 'destructive' ? t('common.deleting') : t('common.loading'));
+
+  const dialog = (
+    <div
+      className="animate-in fade-in bg-overlay-heavy fixed inset-0 z-[250] flex items-center justify-center duration-150"
+      onClick={handleBackdropClick}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-dialog-title"
+      aria-describedby="confirm-dialog-description"
+    >
+      {/* ダイアログコンテンツ: bg-card, rounded-xl, p-6 */}
+      <div
+        className="animate-in zoom-in-95 fade-in bg-card text-foreground border-border rounded-xl border p-6 shadow-lg duration-150"
+        style={{ width: `min(calc(100vw - 32px), ${maxWidth}px)` }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header: gap-4準拠 */}
+        <div className={children ? 'mb-6' : ''}>
+          <div className="flex items-start gap-4">
+            {/* アイコン */}
+            <div
+              className={`flex size-10 shrink-0 items-center justify-center rounded-full ${iconContainerClass}`}
+            >
+              <Icon className={`size-5 ${iconClass}`} />
+            </div>
+            <div className="flex-1">
+              <h2 id="confirm-dialog-title" className="text-lg leading-tight font-bold">
+                {title}
+              </h2>
+              {description && (
+                <p id="confirm-dialog-description" className="text-muted-foreground mt-2 text-sm">
+                  {description}
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Custom content */}
+        {children && <div className="mt-6">{children}</div>}
+
+        {/* Footer: gap-2, justify-end */}
+        <div className="mt-6 flex justify-end gap-2">
+          <Button
+            variant="outline"
+            onClick={onClose}
+            disabled={isLoading}
+            className="hover:bg-state-hover"
+          >
+            {resolvedCancelLabel}
+          </Button>
+          <Button
+            variant={confirmButtonVariant}
+            onClick={handleConfirm}
+            disabled={isLoading}
+            className={confirmButtonClass}
+          >
+            {isLoading ? resolvedLoadingLabel : resolvedConfirmLabel}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(dialog, document.body);
+}

--- a/src/components/common/DeleteConfirmDialog.tsx
+++ b/src/components/common/DeleteConfirmDialog.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
-import { createPortal } from 'react-dom';
-
-import { Button } from '@/components/ui/button';
-import { AlertTriangle } from 'lucide-react';
-import { useTranslations } from 'next-intl';
+import { ConfirmDialog } from './ConfirmDialog';
 
 interface DeleteConfirmDialogProps {
   /** ダイアログが開いているかどうか */
@@ -23,13 +18,19 @@ interface DeleteConfirmDialogProps {
 /**
  * 汎用削除確認ダイアログ
  *
- * ReactのcreatePortalを使用してdocument.bodyに直接レンダリング
+ * ConfirmDialog の destructive バリアントをラップした薄いコンポーネント。
+ * 後方互換性のために維持。新規実装では ConfirmDialog を直接使用することを推奨。
  *
- * スタイルガイド準拠:
- * - 8pxグリッドシステム（p-6, gap-4, mb-6等）
- * - 角丸: rounded-xl（16px）for ダイアログ
- * - Card: bg-card（カード、ダイアログ用）
- * - セマンティックカラー: destructive系トークン使用
+ * @example
+ * ```tsx
+ * <DeleteConfirmDialog
+ *   open={isOpen}
+ *   onClose={handleClose}
+ *   onConfirm={handleDelete}
+ *   title="Delete item?"
+ *   description="This action cannot be undone."
+ * />
+ * ```
  */
 export function DeleteConfirmDialog({
   open,
@@ -38,102 +39,14 @@ export function DeleteConfirmDialog({
   title,
   description,
 }: DeleteConfirmDialogProps) {
-  const t = useTranslations();
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [mounted, setMounted] = useState(false);
-
-  // クライアントサイドでのみマウント
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  // ESCキーでダイアログを閉じる
-  useEffect(() => {
-    if (!open) return;
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && !isDeleting) {
-        onClose();
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [open, isDeleting, onClose]);
-
-  const handleConfirm = useCallback(async () => {
-    setIsDeleting(true);
-    try {
-      await onConfirm();
-    } finally {
-      setIsDeleting(false);
-    }
-  }, [onConfirm]);
-
-  const handleBackdropClick = useCallback(
-    (e: React.MouseEvent) => {
-      if (e.target === e.currentTarget && !isDeleting) {
-        onClose();
-      }
-    },
-    [isDeleting, onClose],
+  return (
+    <ConfirmDialog
+      open={open}
+      onClose={onClose}
+      onConfirm={onConfirm}
+      title={title}
+      description={description}
+      variant="destructive"
+    />
   );
-
-  if (!mounted || !open) return null;
-
-  const dialog = (
-    <div
-      className="animate-in fade-in bg-overlay-heavy fixed inset-0 z-[250] flex items-center justify-center duration-150"
-      onClick={handleBackdropClick}
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="delete-dialog-title"
-      aria-describedby="delete-dialog-description"
-    >
-      {/* ダイアログコンテンツ: bg-card, rounded-xl, p-6 */}
-      <div
-        className="animate-in zoom-in-95 fade-in bg-card text-foreground border-border rounded-xl border p-6 shadow-lg duration-150"
-        style={{ width: 'min(calc(100vw - 32px), 448px)' }}
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* Header: gap-4準拠 */}
-        <div className="mb-6 flex items-start gap-4">
-          {/* 警告アイコン: destructive系カラー */}
-          <div className="bg-destructive-container flex size-10 shrink-0 items-center justify-center rounded-full">
-            <AlertTriangle className="text-destructive size-5" />
-          </div>
-          <div className="flex-1">
-            <h2 id="delete-dialog-title" className="text-lg leading-tight font-bold">
-              {title}
-            </h2>
-            <p id="delete-dialog-description" className="text-muted-foreground mt-2 text-sm">
-              {description}
-            </p>
-          </div>
-        </div>
-
-        {/* Footer: gap-2, justify-end */}
-        <div className="flex justify-end gap-2">
-          <Button
-            variant="outline"
-            onClick={onClose}
-            disabled={isDeleting}
-            className="hover:bg-state-hover"
-          >
-            {t('actions.cancel')}
-          </Button>
-          <Button
-            variant="destructive"
-            onClick={handleConfirm}
-            disabled={isDeleting}
-            className="hover:bg-destructive-hover"
-          >
-            {isDeleting ? t('common.deleting') : t('actions.delete')}
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
-
-  return createPortal(dialog, document.body);
 }

--- a/src/components/common/FormDialog.tsx
+++ b/src/components/common/FormDialog.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { type ReactNode, useCallback, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useTranslations } from 'next-intl';
+
+interface FormDialogProps {
+  /** ダイアログが開いているかどうか */
+  open: boolean;
+  /** ダイアログの開閉状態が変わった時のコールバック */
+  onOpenChange: (open: boolean) => void;
+  /** フォーム送信時のコールバック（非同期可） */
+  onSubmit: () => void | Promise<void>;
+  /** タイトル */
+  title: string;
+  /** 説明文（省略可） */
+  description?: string;
+  /** フォーム内容（children） */
+  children: ReactNode;
+  /** 送信ボタンのラベル（省略時は翻訳キーから取得） */
+  submitLabel?: string;
+  /** キャンセルボタンのラベル（省略時は翻訳キーから取得） */
+  cancelLabel?: string;
+  /** 送信ボタンを無効化するかどうか */
+  submitDisabled?: boolean;
+  /** ダイアログの最大幅（省略時は 'md'） */
+  maxWidth?: 'sm' | 'md' | 'lg' | 'xl';
+  /** 閉じるボタン（×）を表示するかどうか */
+  showCloseButton?: boolean;
+}
+
+const maxWidthClasses = {
+  sm: 'max-w-sm',
+  md: 'max-w-md',
+  lg: 'max-w-lg',
+  xl: 'max-w-xl',
+} as const;
+
+/**
+ * フォーム付きダイアログの共通基盤
+ *
+ * Figma的な運用: このコンポーネントを大元として、children でフォーム内容を
+ * カスタマイズする。ローディング状態、キャンセル/保存ボタンは共通化。
+ *
+ * 基盤: shadcn/ui Dialog（Radix UI）
+ * - アクセシビリティ完備（フォーカストラップ、ESCで閉じる等）
+ * - アニメーション対応
+ *
+ * @example
+ * ```tsx
+ * <FormDialog
+ *   open={isOpen}
+ *   onOpenChange={setIsOpen}
+ *   onSubmit={handleSubmit}
+ *   title="Edit Name"
+ *   description="Enter your new display name."
+ * >
+ *   <div className="space-y-4 py-4">
+ *     <Input value={name} onChange={(e) => setName(e.target.value)} />
+ *   </div>
+ * </FormDialog>
+ * ```
+ */
+export function FormDialog({
+  open,
+  onOpenChange,
+  onSubmit,
+  title,
+  description,
+  children,
+  submitLabel,
+  cancelLabel,
+  submitDisabled = false,
+  maxWidth = 'md',
+  showCloseButton = true,
+}: FormDialogProps) {
+  const t = useTranslations();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      setIsLoading(true);
+      try {
+        await onSubmit();
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [onSubmit],
+  );
+
+  const handleClose = useCallback(() => {
+    if (!isLoading) {
+      onOpenChange(false);
+    }
+  }, [isLoading, onOpenChange]);
+
+  const handleOpenChange = useCallback(
+    (isOpen: boolean) => {
+      if (!isLoading) {
+        onOpenChange(isOpen);
+      }
+    },
+    [isLoading, onOpenChange],
+  );
+
+  const resolvedSubmitLabel = submitLabel ?? t('common.confirm');
+  const resolvedCancelLabel = cancelLabel ?? t('common.cancel');
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className={maxWidthClasses[maxWidth]} showCloseButton={showCloseButton}>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          {description && <DialogDescription>{description}</DialogDescription>}
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit}>
+          {children}
+
+          <DialogFooter className="mt-6">
+            <Button type="button" variant="outline" onClick={handleClose} disabled={isLoading}>
+              {resolvedCancelLabel}
+            </Button>
+            <Button type="submit" disabled={isLoading || submitDisabled}>
+              {isLoading ? t('common.loading') : resolvedSubmitLabel}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/calendar/components/sidebar/CalendarSidebar.tsx
+++ b/src/features/calendar/components/sidebar/CalendarSidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from 'react';
 
-import { addDays, endOfWeek, startOfDay, startOfWeek, subDays } from 'date-fns';
+import { addDays, endOfWeek, startOfDay, startOfWeek, subDays } from '@/lib/date';
 
 import { MiniCalendar } from '@/components/common/MiniCalendar';
 import { useCalendarNavigation } from '@/features/calendar/contexts/CalendarNavigationContext';

--- a/src/features/calendar/components/views/AgendaView/AgendaView.tsx
+++ b/src/features/calendar/components/views/AgendaView/AgendaView.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from 'react';
 
-import { addDays, isSameDay, startOfDay } from 'date-fns';
+import { addDays, isSameDay, startOfDay } from '@/lib/date';
 import { CalendarDays } from 'lucide-react';
 
 import { cn } from '@/lib/utils';

--- a/src/features/calendar/components/views/shared/hooks/useDateUtilities.ts
+++ b/src/features/calendar/components/views/shared/hooks/useDateUtilities.ts
@@ -5,7 +5,7 @@
 
 import { useMemo } from 'react';
 
-import { addDays, startOfWeek, subDays } from 'date-fns';
+import { addDays, startOfWeek, subDays } from '@/lib/date';
 
 export interface UseDateUtilitiesOptions {
   referenceDate: Date;

--- a/src/features/calendar/components/views/shared/utils/dateHelpers.ts
+++ b/src/features/calendar/components/views/shared/utils/dateHelpers.ts
@@ -1,45 +1,62 @@
 /**
  * 日付操作ヘルパー関数
+ *
+ * @deprecated 新しいコードでは `@/lib/date` を直接使用してください。
+ * このファイルは後方互換性のため維持されています。
+ *
+ * @example
+ * ```typescript
+ * // 推奨: 新しいライブラリを使用
+ * import { startOfDay, addDays, formatTime } from '@/lib/date';
+ *
+ * // 非推奨: このファイルからのインポート
+ * import { startOfDay, addDays } from './dateHelpers';
+ * ```
  */
 
-import { MS_PER_DAY } from '@/constants/time';
+// ========================================
+// @/lib/date から再エクスポート（共通関数）
+// ========================================
+export {
+  // 日付加算
+  addDays,
+  addMinutes,
+  endOfDay,
+  // 配列生成
+  generateDateRange,
+  // キー生成
+  getDateKey,
+  // 差分計算
+  getDaysDifference,
+  endOfMonth as getMonthEnd,
+  // 月の境界
+  startOfMonth as getMonthStart,
+  endOfWeek as getWeekEnd,
+  // 週の境界
+  startOfWeek as getWeekStart,
+  // 比較・判定
+  isSameDay,
+  isToday,
+  isWeekend,
+  // パース
+  normalizeDate as normalizeEventDate,
+  // 日の境界
+  startOfDay,
+} from '@/lib/date';
+
+// ========================================
+// カレンダー固有のフォーマット関数
+// ========================================
+import {
+  formatTime as formatTimeBase,
+  formatTimeRange as formatTimeRangeBase,
+  type TimeFormat,
+} from '@/lib/date';
 
 /**
- * 今日かどうか判定
- */
-export function isToday(date: Date): boolean {
-  const today = new Date();
-  return date.toDateString() === today.toDateString();
-}
-
-/**
- * 週末かどうか判定（土日）
- */
-export function isWeekend(date: Date): boolean {
-  const day = date.getDay();
-  return day === 0 || day === 6;
-}
-
-/**
- * 日付を日の開始時刻に設定
- */
-export function startOfDay(date: Date): Date {
-  const result = new Date(date);
-  result.setHours(0, 0, 0, 0);
-  return result;
-}
-
-/**
- * 日付を日の終了時刻に設定
- */
-export function endOfDay(date: Date): Date {
-  const result = new Date(date);
-  result.setHours(23, 59, 59, 999);
-  return result;
-}
-
-/**
- * 日付をフォーマット
+ * 日付をフォーマット（カレンダービュー用）
+ *
+ * 日本語固有のフォーマット（「1日(月)」など）
  */
 export function formatDate(date: Date, format: 'short' | 'long' | 'numeric' = 'short'): string {
   const weekdays = ['日', '月', '火', '水', '木', '金', '土'];
@@ -77,128 +94,20 @@ export function formatDate(date: Date, format: 'short' | 'long' | 'numeric' = 's
 /**
  * 時刻をフォーマット
  */
-export function formatTime(date: Date, format: '12h' | '24h' = '24h'): string {
-  const hours = date.getHours();
-  const minutes = date.getMinutes();
-
-  if (format === '24h') {
-    return `${hours}:${minutes.toString().padStart(2, '0')}`;
-  } else {
-    const period = hours >= 12 ? 'PM' : 'AM';
-    const displayHours = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours;
-    return `${displayHours}:${minutes.toString().padStart(2, '0')} ${period}`;
-  }
+export function formatTime(date: Date, format: TimeFormat = '24h'): string {
+  return formatTimeBase(date, format);
 }
 
 /**
  * 時間範囲をフォーマット
  */
-export function formatTimeRange(start: Date, end: Date, format: '12h' | '24h' = '24h'): string {
-  return `${formatTime(start, format)} - ${formatTime(end, format)}`;
+export function formatTimeRange(start: Date, end: Date, format: TimeFormat = '24h'): string {
+  return formatTimeRangeBase(start, end, format);
 }
 
-/**
- * 同じ日かどうか判定
- */
-export function isSameDay(date1: Date, date2: Date): boolean {
-  return date1.toDateString() === date2.toDateString();
-}
-
-/**
- * 日付の差を日数で取得
- */
-export function getDaysDifference(date1: Date, date2: Date): number {
-  const d1 = startOfDay(date1);
-  const d2 = startOfDay(date2);
-  return Math.floor((d2.getTime() - d1.getTime()) / MS_PER_DAY);
-}
-
-/**
- * 日付配列を生成
- */
-export function generateDateRange(startDate: Date, endDate: Date): Date[] {
-  const dates: Date[] = [];
-  const current = new Date(startDate);
-
-  while (current <= endDate) {
-    dates.push(new Date(current));
-    current.setDate(current.getDate() + 1);
-  }
-
-  return dates;
-}
-
-/**
- * 週の開始日を取得（月曜日）
- */
-export function getWeekStart(date: Date): Date {
-  const result = new Date(date);
-  const day = result.getDay();
-  const diff = result.getDate() - day + (day === 0 ? -6 : 1);
-  result.setDate(diff);
-  result.setHours(0, 0, 0, 0);
-  return result;
-}
-
-/**
- * 週の終了日を取得（日曜日）
- */
-export function getWeekEnd(date: Date): Date {
-  const start = getWeekStart(date);
-  const end = new Date(start);
-  end.setDate(start.getDate() + 6);
-  end.setHours(23, 59, 59, 999);
-  return end;
-}
-
-/**
- * 月の開始日を取得
- */
-export function getMonthStart(date: Date): Date {
-  const result = new Date(date);
-  result.setDate(1);
-  result.setHours(0, 0, 0, 0);
-  return result;
-}
-
-/**
- * 月の終了日を取得
- */
-export function getMonthEnd(date: Date): Date {
-  const result = new Date(date);
-  result.setMonth(result.getMonth() + 1, 0); // 次の月の0日 = 今月の最終日
-  result.setHours(23, 59, 59, 999);
-  return result;
-}
-
-/**
- * 日付を指定日数分移動
- */
-export function addDays(date: Date, days: number): Date {
-  const result = new Date(date);
-  result.setDate(result.getDate() + days);
-  return result;
-}
-
-/**
- * 時刻を指定分数分移動
- */
-export function addMinutes(date: Date, minutes: number): Date {
-  const result = new Date(date);
-  result.setMinutes(result.getMinutes() + minutes);
-  return result;
-}
-
-/**
- * 日付キー生成（yyyy-MM-dd形式）
- * 全ビューで共通使用
- */
-export function getDateKey(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-}
+// ========================================
+// カレンダー固有のユーティリティ
+// ========================================
 
 /**
  * イベントの妥当性をチェック
@@ -212,19 +121,9 @@ export function isValidEvent<T extends { startDate?: Date | string | null }>(eve
 }
 
 /**
- * イベントの日付を正規化（DateまたはstringをDateに変換）
- */
-export function normalizeEventDate(eventDate: Date | string | null | undefined): Date | null {
-  if (!eventDate) return null;
-
-  const date = eventDate instanceof Date ? eventDate : new Date(eventDate);
-  return isNaN(date.getTime()) ? null : date;
-}
-
-/**
  * 今日のインデックスを取得（日付配列内での位置）
  */
 export function getTodayIndex(dates: Date[]): number {
   const today = new Date();
-  return dates.findIndex((date) => isSameDay(date, today));
+  return dates.findIndex((date) => date.toDateString() === today.toDateString());
 }

--- a/src/features/calendar/utils/dateUtils.ts
+++ b/src/features/calendar/utils/dateUtils.ts
@@ -11,7 +11,10 @@
  * - Date(year, month, day) コンストラクタを使用（月は0始まり）
  */
 
-import { fromZonedTime, toZonedTime } from 'date-fns-tz';
+// ========================================
+// @/lib/date からの再エクスポート
+// ========================================
+export { localTimeToUTCISO, parseISOToUserTimezone } from '@/lib/date';
 
 /**
  * YYYY-MM-DD文字列をローカルタイムゾーンのDateオブジェクトに変換
@@ -109,68 +112,4 @@ export function parseDatetimeString(datetimeString: string, _targetTimezone?: st
   // ただし、現在の実装ではローカルタイムゾーンとして解釈
   // （注: date-fns-tzを使う完全な実装は後で追加）
   return new Date(year, month, day, hour, minute, second);
-}
-
-/**
- * ISO 8601 datetime文字列をユーザーのタイムゾーンで解釈したDateオブジェクトに変換
- *
- * **重要**: この関数は「表示用」の時刻を返す。
- * 返されたDateオブジェクトの getHours() 等は、指定タイムゾーンでの時刻を返す。
- *
- * @param isoString - ISO 8601形式の日時文字列（例: "2025-01-22T14:30:00+09:00" or "2025-01-22T05:30:00Z"）
- * @param timezone - ユーザーのタイムゾーン（例: 'Asia/Tokyo'）
- * @returns ユーザーのタイムゾーンで解釈されたDateオブジェクト
- *
- * @example
- * ```typescript
- * // UTCの05:30をJSTで表示
- * const date = parseISOToUserTimezone('2025-01-22T05:30:00Z', 'Asia/Tokyo');
- * date.getHours() // => 14 (JST 14:30)
- * ```
- */
-export function parseISOToUserTimezone(isoString: string, timezone: string): Date {
-  const utcDate = new Date(isoString);
-  if (isNaN(utcDate.getTime())) {
-    throw new Error(`Invalid ISO datetime: ${isoString}`);
-  }
-  // UTCからユーザーのタイムゾーンに変換
-  return toZonedTime(utcDate, timezone);
-}
-
-/**
- * ユーザーのタイムゾーンの時刻をUTC ISO文字列に変換
- *
- * **重要**: この関数は「保存用」のISO文字列を返す。
- *
- * @param localDate - ユーザーのタイムゾーンでの日付
- * @param hours - 時（0-23）
- * @param minutes - 分（0-59）
- * @param timezone - ユーザーのタイムゾーン（例: 'Asia/Tokyo'）
- * @returns UTC ISO 8601文字列（例: "2025-01-22T05:30:00.000Z"）
- *
- * @example
- * ```typescript
- * // JST 14:30 をUTC ISO文字列に変換
- * const iso = localTimeToUTCISO(new Date(2025, 0, 22), 14, 30, 'Asia/Tokyo');
- * // => "2025-01-22T05:30:00.000Z"
- * ```
- */
-export function localTimeToUTCISO(
-  localDate: Date,
-  hours: number,
-  minutes: number,
-  timezone: string,
-): string {
-  // ローカル日付から年月日を取得
-  const year = localDate.getFullYear();
-  const month = localDate.getMonth();
-  const day = localDate.getDate();
-
-  // ユーザーのタイムゾーンでの時刻として新しいDateを作成
-  const zonedDate = new Date(year, month, day, hours, minutes, 0, 0);
-
-  // ユーザーのタイムゾーンからUTCに変換
-  const utcDate = fromZonedTime(zonedDate, timezone);
-
-  return utcDate.toISOString();
 }

--- a/src/features/plans/components/PlanDeleteConfirmDialog.tsx
+++ b/src/features/plans/components/PlanDeleteConfirmDialog.tsx
@@ -1,132 +1,46 @@
 'use client';
 
-import { Button } from '@/components/ui/button';
-import { AlertTriangle } from 'lucide-react';
+import { useCallback } from 'react';
+
+import { ConfirmDialog } from '@/components/common/ConfirmDialog';
 import { useTranslations } from 'next-intl';
-import { useCallback, useEffect, useState } from 'react';
-import { createPortal } from 'react-dom';
+
 import { useDeleteConfirmStore } from '../stores/useDeleteConfirmStore';
 
 /**
  * プラン削除確認ダイアログ
  *
- * ReactのcreatePortalを使用してdocument.bodyに直接レンダリング
- * shadcn/uiのAlertDialogの代わりにシンプルなdiv実装
- *
- * スタイルガイド準拠:
- * - 8pxグリッドシステム（p-6, gap-4, mb-4等）
- * - 角丸: rounded-xl（16px）for ダイアログ
- * - Card: bg-card（カード、ダイアログ用）
- * - セマンティックカラー: destructive系トークン使用
+ * Zustand ストアと連携する ConfirmDialog のラッパー。
+ * グローバルに配置し、ストア経由で開閉を制御する。
  */
 export function PlanDeleteConfirmDialog() {
   const t = useTranslations();
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [mounted, setMounted] = useState(false);
 
   const isOpen = useDeleteConfirmStore((state) => state.isOpen);
   const planTitle = useDeleteConfirmStore((state) => state.planTitle);
   const onConfirm = useDeleteConfirmStore((state) => state.onConfirm);
   const closeDialog = useDeleteConfirmStore((state) => state.closeDialog);
 
-  // クライアントサイドでのみマウント
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  // ESCキーでダイアログを閉じる
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && !isDeleting) {
-        closeDialog();
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, isDeleting, closeDialog]);
-
-  const handleConfirm = useCallback(async () => {
-    if (!onConfirm) return;
-    setIsDeleting(true);
-    try {
-      await onConfirm();
-    } finally {
-      setIsDeleting(false);
-      closeDialog();
-    }
-  }, [onConfirm, closeDialog]);
-
-  const handleBackdropClick = useCallback(
-    (e: React.MouseEvent) => {
-      if (e.target === e.currentTarget && !isDeleting) {
-        closeDialog();
-      }
-    },
-    [isDeleting, closeDialog],
-  );
-
-  if (!mounted || !isOpen) return null;
-
   const title = planTitle
     ? t('common.plan.delete.confirmTitleWithName', { name: planTitle })
     : t('common.plan.delete.confirmTitle');
 
-  const dialog = (
-    <div
-      className="animate-in fade-in bg-overlay-heavy fixed inset-0 z-[250] flex items-center justify-center duration-150"
-      onClick={handleBackdropClick}
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="delete-dialog-title"
-      aria-describedby="delete-dialog-description"
-    >
-      {/* ダイアログコンテンツ: bg-card, rounded-xl, p-6 */}
-      <div
-        className="animate-in zoom-in-95 fade-in bg-card text-foreground border-border rounded-xl border p-6 shadow-lg duration-150"
-        style={{ width: 'min(calc(100vw - 32px), 448px)' }}
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* Header: gap-4準拠 */}
-        <div className="mb-6 flex items-start gap-4">
-          {/* 警告アイコン: destructive系カラー */}
-          <div className="bg-destructive-container flex size-10 shrink-0 items-center justify-center rounded-full">
-            <AlertTriangle className="text-destructive size-5" />
-          </div>
-          <div className="flex-1">
-            <h2 id="delete-dialog-title" className="text-lg leading-tight font-bold">
-              {title}
-            </h2>
-            <p id="delete-dialog-description" className="text-muted-foreground mt-2 text-sm">
-              {t('common.plan.delete.description')}
-            </p>
-          </div>
-        </div>
+  const handleConfirm = useCallback(async () => {
+    if (!onConfirm) return;
+    await onConfirm();
+    closeDialog();
+  }, [onConfirm, closeDialog]);
 
-        {/* Footer: gap-2, justify-end */}
-        <div className="flex justify-end gap-2">
-          <Button
-            variant="outline"
-            onClick={closeDialog}
-            disabled={isDeleting}
-            className="hover:bg-state-hover"
-          >
-            {t('actions.cancel')}
-          </Button>
-          <Button
-            variant="destructive"
-            onClick={handleConfirm}
-            disabled={isDeleting}
-            className="hover:bg-destructive-hover"
-          >
-            {isDeleting ? t('common.plan.delete.deleting') : t('common.plan.delete.confirm')}
-          </Button>
-        </div>
-      </div>
-    </div>
+  return (
+    <ConfirmDialog
+      open={isOpen}
+      onClose={closeDialog}
+      onConfirm={handleConfirm}
+      title={title}
+      description={t('common.plan.delete.description')}
+      variant="destructive"
+      confirmLabel={t('common.plan.delete.confirm')}
+      loadingLabel={t('common.plan.delete.deleting')}
+    />
   );
-
-  return createPortal(dialog, document.body);
 }

--- a/src/features/settings/components/display-name-dialog.tsx
+++ b/src/features/settings/components/display-name-dialog.tsx
@@ -4,15 +4,7 @@ import { useCallback, useState } from 'react';
 
 import { useTranslations } from 'next-intl';
 
-import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+import { FormDialog } from '@/components/common/FormDialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useAuthStore } from '@/features/auth/stores/useAuthStore';
@@ -27,6 +19,8 @@ interface DisplayNameDialogProps {
 
 /**
  * 表示名変更ダイアログ
+ *
+ * FormDialog を使用したシンプルな入力ダイアログ。
  */
 export function DisplayNameDialog({ open, onOpenChange, currentName }: DisplayNameDialogProps) {
   const t = useTranslations();
@@ -34,55 +28,41 @@ export function DisplayNameDialog({ open, onOpenChange, currentName }: DisplayNa
   const supabase = createClient();
 
   const [displayName, setDisplayName] = useState(currentName);
-  const [isLoading, setIsLoading] = useState(false);
 
-  const handleSubmit = useCallback(
-    async (e: React.FormEvent) => {
-      e.preventDefault();
+  const handleSubmit = useCallback(async () => {
+    if (!user?.id) return;
+    if (!displayName.trim()) return;
 
-      if (!user?.id) return;
-      if (!displayName.trim()) return;
+    try {
+      // Update profile
+      const { error: profileError } = await supabase
+        .from('profiles')
+        .update({
+          username: displayName.trim(),
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', user.id);
 
-      setIsLoading(true);
-      try {
-        // Update profile
-        const { error: profileError } = await supabase
-          .from('profiles')
-          .update({
-            username: displayName.trim(),
-            updated_at: new Date().toISOString(),
-          })
-          .eq('id', user.id);
-
-        if (profileError) {
-          throw new Error(profileError.message);
-        }
-
-        // Update auth metadata
-        const { error: authError } = await supabase.auth.updateUser({
-          data: { username: displayName.trim() },
-        });
-
-        if (authError) {
-          console.error('Auth metadata update error:', authError);
-        }
-
-        toast.success(t('settings.account.profileUpdated'));
-        onOpenChange(false);
-      } catch (error) {
-        console.error('Display name update error:', error);
-        toast.error(t('errors.generic'));
-      } finally {
-        setIsLoading(false);
+      if (profileError) {
+        throw new Error(profileError.message);
       }
-    },
-    [displayName, user?.id, supabase, t, onOpenChange],
-  );
 
-  const handleClose = useCallback(() => {
-    setDisplayName(currentName);
-    onOpenChange(false);
-  }, [currentName, onOpenChange]);
+      // Update auth metadata
+      const { error: authError } = await supabase.auth.updateUser({
+        data: { username: displayName.trim() },
+      });
+
+      if (authError) {
+        console.error('Auth metadata update error:', authError);
+      }
+
+      toast.success(t('settings.account.profileUpdated'));
+      onOpenChange(false);
+    } catch (error) {
+      console.error('Display name update error:', error);
+      toast.error(t('errors.generic'));
+    }
+  }, [displayName, user?.id, supabase, t, onOpenChange]);
 
   // Reset form when dialog opens
   const handleOpenChange = useCallback(
@@ -96,38 +76,27 @@ export function DisplayNameDialog({ open, onOpenChange, currentName }: DisplayNa
   );
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-w-md">
-        <DialogHeader>
-          <DialogTitle>{t('settings.account.displayName')}</DialogTitle>
-          <DialogDescription>{t('settings.account.displayNameDesc')}</DialogDescription>
-        </DialogHeader>
-
-        <form onSubmit={handleSubmit}>
-          <div className="space-y-4 py-4">
-            <div className="space-y-2">
-              <Label htmlFor="display-name">{t('settings.account.displayName')}</Label>
-              <Input
-                id="display-name"
-                value={displayName}
-                onChange={(e) => setDisplayName(e.target.value)}
-                placeholder={t('settings.account.displayNamePlaceholder')}
-                required
-                autoComplete="name"
-              />
-            </div>
-          </div>
-
-          <DialogFooter>
-            <Button type="button" variant="outline" onClick={handleClose} disabled={isLoading}>
-              {t('common.cancel')}
-            </Button>
-            <Button type="submit" disabled={isLoading || !displayName.trim()}>
-              {isLoading ? t('common.loading') : t('common.confirm')}
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
+    <FormDialog
+      open={open}
+      onOpenChange={handleOpenChange}
+      onSubmit={handleSubmit}
+      title={t('settings.account.displayName')}
+      description={t('settings.account.displayNameDesc')}
+      submitDisabled={!displayName.trim()}
+    >
+      <div className="space-y-4 py-4">
+        <div className="space-y-2">
+          <Label htmlFor="display-name">{t('settings.account.displayName')}</Label>
+          <Input
+            id="display-name"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            placeholder={t('settings.account.displayNamePlaceholder')}
+            required
+            autoComplete="name"
+          />
+        </div>
+      </div>
+    </FormDialog>
   );
 }

--- a/src/features/tags/components/TagMergeDialog.tsx
+++ b/src/features/tags/components/TagMergeDialog.tsx
@@ -9,6 +9,7 @@ import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { DEFAULT_TAG_COLOR } from '@/config/ui/colors';
 import { useMergeTag, useTags } from '@/features/tags/hooks';
 import type { Tag } from '@/features/tags/types';
+import { useDialogKeyboard } from '@/hooks/useDialogKeyboard';
 import { logger } from '@/lib/logger';
 import { cn } from '@/lib/utils';
 import { AlertCircle, GitMerge } from 'lucide-react';
@@ -23,8 +24,8 @@ interface TagMergeDialogProps {
 /**
  * タグマージダイアログ
  *
- * ReactのcreatePortalを使用してdocument.bodyに直接レンダリング
- * TagDeleteDialogと同じ構造
+ * タグを別のタグに統合するダイアログ。
+ * ラジオボタンでターゲットタグを選択し、統合を実行する。
  */
 export function TagMergeDialog({ tag, onClose }: TagMergeDialogProps) {
   const t = useTranslations();
@@ -48,6 +49,9 @@ export function TagMergeDialog({ tag, onClose }: TagMergeDialogProps) {
       setError(null);
     }
   }, [tag]);
+
+  // ESCキーでダイアログを閉じる
+  useDialogKeyboard(!!tag, isMerging, () => onClose());
 
   // ソースタグを除外（フラット構造なので自分自身のみ除外）
   const availableTags = tags.filter((t) => {
@@ -97,20 +101,6 @@ export function TagMergeDialog({ tag, onClose }: TagMergeDialogProps) {
     },
     [isMerging, onClose],
   );
-
-  // ESCキーでダイアログを閉じる
-  useEffect(() => {
-    if (!tag) return;
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && !isMerging) {
-        onClose();
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [tag, isMerging, onClose]);
 
   if (!mounted || !tag) return null;
 

--- a/src/features/tags/components/tag-note-dialog.tsx
+++ b/src/features/tags/components/tag-note-dialog.tsx
@@ -6,6 +6,7 @@ import { createPortal } from 'react-dom';
 import { Button } from '@/components/ui/button';
 import { Field, FieldError } from '@/components/ui/field';
 import { Textarea } from '@/components/ui/textarea';
+import { useDialogKeyboard } from '@/hooks/useDialogKeyboard';
 import { useTranslations } from 'next-intl';
 
 const MAX_LENGTH = 100;
@@ -40,18 +41,7 @@ export function TagNoteDialog({ isOpen, onClose, onSave, currentNote }: TagNoteD
   }, [isOpen, currentNote]);
 
   // ESCキーでダイアログを閉じる
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && !isLoading) {
-        onClose();
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, isLoading, onClose]);
+  useDialogKeyboard(isOpen, isLoading, onClose);
 
   const handleSubmit = useCallback(async () => {
     const trimmedNote = note.trim();
@@ -99,7 +89,7 @@ export function TagNoteDialog({ isOpen, onClose, onSave, currentNote }: TagNoteD
 
   const dialog = (
     <div
-      className="fixed inset-0 z-[250] flex items-center justify-center bg-black/50"
+      className="bg-overlay-heavy fixed inset-0 z-[250] flex items-center justify-center"
       onClick={handleBackdropClick}
       role="dialog"
       aria-modal="true"

--- a/src/features/tags/components/tag-rename-dialog.tsx
+++ b/src/features/tags/components/tag-rename-dialog.tsx
@@ -8,6 +8,7 @@ import { Field, FieldError } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import { TAG_NAME_MAX_LENGTH } from '@/features/tags/constants/colors';
 import { useTags } from '@/features/tags/hooks';
+import { useDialogKeyboard } from '@/hooks/useDialogKeyboard';
 import { useTranslations } from 'next-intl';
 
 interface TagRenameDialogProps {
@@ -62,18 +63,7 @@ export function TagRenameDialog({
   }, [isOpen, currentName]);
 
   // ESCキーでダイアログを閉じる
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && !isLoading) {
-        onClose();
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, isLoading, onClose]);
+  useDialogKeyboard(isOpen, isLoading, onClose);
 
   const handleSubmit = useCallback(async () => {
     const trimmedName = name.trim();
@@ -157,7 +147,7 @@ export function TagRenameDialog({
 
   const dialog = (
     <div
-      className="fixed inset-0 z-[250] flex items-center justify-center bg-black/50"
+      className="bg-overlay-heavy fixed inset-0 z-[250] flex items-center justify-center"
       onClick={handleBackdropClick}
       role="dialog"
       aria-modal="true"

--- a/src/hooks/useDialogKeyboard.ts
+++ b/src/hooks/useDialogKeyboard.ts
@@ -1,0 +1,64 @@
+'use client';
+
+import { useEffect } from 'react';
+
+interface UseDialogKeyboardOptions {
+  /** captureフェーズで処理するかどうか（他のハンドラより先に処理） */
+  capture?: boolean;
+  /** イベントの伝播を停止するかどうか */
+  stopPropagation?: boolean;
+  /** デフォルトの動作を防止するかどうか */
+  preventDefault?: boolean;
+}
+
+/**
+ * ダイアログのキーボードイベントを処理するフック
+ *
+ * - ESCキーでダイアログを閉じる
+ * - ローディング中は無効化
+ *
+ * @param isOpen - ダイアログが開いているかどうか
+ * @param isLoading - ローディング中かどうか（true の場合、ESCキーは無視される）
+ * @param onClose - ダイアログを閉じるコールバック
+ * @param options - オプション設定
+ *
+ * @example
+ * ```tsx
+ * // 基本的な使用法
+ * function MyDialog({ isOpen, onClose }) {
+ *   const [isLoading, setIsLoading] = useState(false);
+ *   useDialogKeyboard(isOpen, isLoading, onClose);
+ *   // ...
+ * }
+ *
+ * // captureフェーズで処理（他のハンドラより先に処理）
+ * useDialogKeyboard(isOpen, isLoading, onClose, {
+ *   capture: true,
+ *   stopPropagation: true,
+ *   preventDefault: true,
+ * });
+ * ```
+ */
+export function useDialogKeyboard(
+  isOpen: boolean,
+  isLoading: boolean,
+  onClose: () => void,
+  options: UseDialogKeyboardOptions = {},
+): void {
+  const { capture = false, stopPropagation = false, preventDefault = false } = options;
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !isLoading) {
+        if (stopPropagation) e.stopPropagation();
+        if (preventDefault) e.preventDefault();
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown, capture);
+    return () => document.removeEventListener('keydown', handleKeyDown, capture);
+  }, [isOpen, isLoading, onClose, capture, stopPropagation, preventDefault]);
+}

--- a/src/lib/date/core.ts
+++ b/src/lib/date/core.ts
@@ -1,0 +1,343 @@
+/**
+ * 日付操作コアユーティリティ
+ *
+ * 基本的な日付計算を提供。外部ライブラリなしでネイティブDateを使用。
+ * タイムゾーン考慮が必要な場合は ./timezone.ts を使用すること。
+ *
+ * @example
+ * ```typescript
+ * import { startOfDay, addDays, isSameDay } from '@/lib/date';
+ *
+ * const today = startOfDay(new Date());
+ * const tomorrow = addDays(today, 1);
+ * console.log(isSameDay(today, new Date())); // true
+ * ```
+ */
+
+import { MS_PER_DAY } from '@/constants/time';
+
+// ========================================
+// 日の境界
+// ========================================
+
+/**
+ * 日付を日の開始時刻（00:00:00.000）に設定
+ */
+export function startOfDay(date: Date): Date {
+  const result = new Date(date);
+  result.setHours(0, 0, 0, 0);
+  return result;
+}
+
+/**
+ * 日付を日の終了時刻（23:59:59.999）に設定
+ */
+export function endOfDay(date: Date): Date {
+  const result = new Date(date);
+  result.setHours(23, 59, 59, 999);
+  return result;
+}
+
+// ========================================
+// 週の境界
+// ========================================
+
+interface WeekOptions {
+  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+}
+
+/**
+ * 週の開始日を取得
+ * @param date 基準日
+ * @param options.weekStartsOn 週の開始曜日（0=日曜, 1=月曜, ...）デフォルトは月曜(1)
+ */
+export function startOfWeek(date: Date, options?: WeekOptions): Date {
+  const weekStartsOn = options?.weekStartsOn ?? 1; // デフォルト: 月曜始まり
+  const result = new Date(date);
+  const day = result.getDay();
+  const diff = (day - weekStartsOn + 7) % 7;
+  result.setDate(result.getDate() - diff);
+  result.setHours(0, 0, 0, 0);
+  return result;
+}
+
+/**
+ * 週の終了日を取得
+ * @param date 基準日
+ * @param options.weekStartsOn 週の開始曜日（0=日曜, 1=月曜, ...）デフォルトは月曜(1)
+ */
+export function endOfWeek(date: Date, options?: WeekOptions): Date {
+  const start = startOfWeek(date, options);
+  const end = new Date(start);
+  end.setDate(start.getDate() + 6);
+  end.setHours(23, 59, 59, 999);
+  return end;
+}
+
+// ========================================
+// 月の境界
+// ========================================
+
+/**
+ * 月の開始日を取得（1日 00:00:00）
+ */
+export function startOfMonth(date: Date): Date {
+  const result = new Date(date);
+  result.setDate(1);
+  result.setHours(0, 0, 0, 0);
+  return result;
+}
+
+/**
+ * 月の終了日を取得（月末 23:59:59）
+ */
+export function endOfMonth(date: Date): Date {
+  const result = new Date(date);
+  result.setMonth(result.getMonth() + 1, 0); // 次の月の0日 = 今月の最終日
+  result.setHours(23, 59, 59, 999);
+  return result;
+}
+
+// ========================================
+// 日付加算
+// ========================================
+
+/**
+ * 日付を指定日数分移動
+ */
+export function addDays(date: Date, days: number): Date {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+}
+
+/**
+ * 日付を指定日数分戻す
+ */
+export function subDays(date: Date, days: number): Date {
+  return addDays(date, -days);
+}
+
+/**
+ * 日付を指定週数分移動
+ */
+export function addWeeks(date: Date, weeks: number): Date {
+  return addDays(date, weeks * 7);
+}
+
+/**
+ * 日付を指定月数分移動
+ */
+export function addMonths(date: Date, months: number): Date {
+  const result = new Date(date);
+  result.setMonth(result.getMonth() + months);
+  return result;
+}
+
+/**
+ * 時刻を指定分数分移動
+ */
+export function addMinutes(date: Date, minutes: number): Date {
+  const result = new Date(date);
+  result.setMinutes(result.getMinutes() + minutes);
+  return result;
+}
+
+/**
+ * 時刻を指定時間数分移動
+ */
+export function addHours(date: Date, hours: number): Date {
+  const result = new Date(date);
+  result.setHours(result.getHours() + hours);
+  return result;
+}
+
+// ========================================
+// 比較・判定
+// ========================================
+
+/**
+ * 同じ日かどうか判定
+ */
+export function isSameDay(date1: Date, date2: Date): boolean {
+  return date1.toDateString() === date2.toDateString();
+}
+
+/**
+ * 今日かどうか判定
+ */
+export function isToday(date: Date): boolean {
+  return isSameDay(date, new Date());
+}
+
+/**
+ * 明日かどうか判定
+ */
+export function isTomorrow(date: Date): boolean {
+  return isSameDay(date, addDays(new Date(), 1));
+}
+
+/**
+ * 昨日かどうか判定
+ */
+export function isYesterday(date: Date): boolean {
+  return isSameDay(date, addDays(new Date(), -1));
+}
+
+/**
+ * 週末かどうか判定（土日）
+ */
+export function isWeekend(date: Date): boolean {
+  const day = date.getDay();
+  return day === 0 || day === 6;
+}
+
+/**
+ * date1がdate2より前かどうか
+ */
+export function isBefore(date1: Date, date2: Date): boolean {
+  return date1.getTime() < date2.getTime();
+}
+
+/**
+ * date1がdate2より後かどうか
+ */
+export function isAfter(date1: Date, date2: Date): boolean {
+  return date1.getTime() > date2.getTime();
+}
+
+/**
+ * 日付がrangeの範囲内かどうか
+ */
+export function isWithinRange(date: Date, start: Date, end: Date): boolean {
+  const time = date.getTime();
+  return time >= start.getTime() && time <= end.getTime();
+}
+
+// ========================================
+// 差分計算
+// ========================================
+
+/**
+ * 日付の差を日数で取得
+ */
+export function getDaysDifference(date1: Date, date2: Date): number {
+  const d1 = startOfDay(date1);
+  const d2 = startOfDay(date2);
+  return Math.floor((d2.getTime() - d1.getTime()) / MS_PER_DAY);
+}
+
+/**
+ * ミリ秒差を取得
+ */
+export function getTimeDifference(date1: Date, date2: Date): number {
+  return date2.getTime() - date1.getTime();
+}
+
+// ========================================
+// 配列生成
+// ========================================
+
+/**
+ * 日付配列を生成
+ */
+export function generateDateRange(startDate: Date, endDate: Date): Date[] {
+  const dates: Date[] = [];
+  const current = new Date(startDate);
+
+  while (current <= endDate) {
+    dates.push(new Date(current));
+    current.setDate(current.getDate() + 1);
+  }
+
+  return dates;
+}
+
+/**
+ * 週の日付配列を生成（月曜〜日曜）
+ */
+export function getWeekDates(date: Date): Date[] {
+  const start = startOfWeek(date);
+  return generateDateRange(start, addDays(start, 6));
+}
+
+/**
+ * 月の日付配列を生成
+ */
+export function getMonthDates(date: Date): Date[] {
+  const start = startOfMonth(date);
+  const end = endOfMonth(date);
+  return generateDateRange(start, end);
+}
+
+// ========================================
+// キー生成
+// ========================================
+
+/**
+ * 日付キー生成（YYYY-MM-DD形式）
+ * キャッシュキーやMapのキーとして使用
+ */
+export function getDateKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * 月キー生成（YYYY-MM形式）
+ */
+export function getMonthKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  return `${year}-${month}`;
+}
+
+// ========================================
+// パース
+// ========================================
+
+/**
+ * YYYY-MM-DD文字列をローカルタイムゾーンのDateオブジェクトに変換
+ *
+ * **注意**: `new Date('YYYY-MM-DD')`はUTCとして解釈されるため、
+ * ローカルタイムゾーンでは前日になることがある。この関数はその問題を回避。
+ *
+ * @example
+ * ```typescript
+ * const date = parseDateString('2025-01-22');
+ * // 日本時間: 2025-01-22 00:00:00（前日にならない）
+ * ```
+ */
+export function parseDateString(dateString: string): Date {
+  const match = dateString.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) {
+    throw new Error(`Invalid date format: ${dateString}. Expected YYYY-MM-DD.`);
+  }
+
+  const [, yearStr, monthStr, dayStr] = match;
+  const year = parseInt(yearStr!, 10);
+  const month = parseInt(monthStr!, 10) - 1; // 0始まり
+  const day = parseInt(dayStr!, 10);
+
+  return new Date(year, month, day);
+}
+
+/**
+ * 日付を検証してDateオブジェクトに変換
+ * Date, string, null/undefined に対応
+ */
+export function normalizeDate(value: Date | string | null | undefined): Date | null {
+  if (!value) return null;
+
+  const date = value instanceof Date ? value : new Date(value);
+  return isNaN(date.getTime()) ? null : date;
+}
+
+/**
+ * 日付が有効かどうか判定
+ */
+export function isValidDate(date: Date): boolean {
+  return date instanceof Date && !isNaN(date.getTime());
+}

--- a/src/lib/date/format.ts
+++ b/src/lib/date/format.ts
@@ -1,0 +1,320 @@
+/**
+ * 日付フォーマットユーティリティ
+ *
+ * ロケール対応のフォーマッティングを提供。
+ * タイムゾーン対応フォーマットは ./timezone.ts を使用。
+ *
+ * @example
+ * ```typescript
+ * import { formatDate, formatTime, formatRelativeTime } from '@/lib/date';
+ *
+ * formatDate(new Date(), 'ja'); // "2025年1月22日"
+ * formatTime(new Date(), '24h'); // "14:30"
+ * formatRelativeTime(new Date(Date.now() - 3600000)); // "1時間前"
+ * ```
+ */
+
+import { MS_PER_DAY, MS_PER_HOUR, MS_PER_MINUTE } from '@/constants/time';
+
+// ========================================
+// 日付フォーマット
+// ========================================
+
+/** 日付フォーマットオプション */
+export interface DateFormatOptions {
+  /** 年を含めるか（デフォルト: true） */
+  includeYear?: boolean;
+  /** 曜日を含めるか（デフォルト: false） */
+  includeWeekday?: boolean;
+  /** フォーマットスタイル（デフォルト: 'medium'） */
+  style?: 'short' | 'medium' | 'long';
+}
+
+/**
+ * 日付をロケールに応じてフォーマット
+ *
+ * @param date - フォーマットする日付
+ * @param locale - ロケール（例: 'ja', 'en', 'en-US'）
+ * @param options - フォーマットオプション
+ * @returns フォーマットされた日付文字列
+ *
+ * @example
+ * ```typescript
+ * formatDate(new Date(), 'ja'); // "2025年1月22日"
+ * formatDate(new Date(), 'en'); // "January 22, 2025"
+ * formatDate(new Date(), 'ja', { includeWeekday: true }); // "2025年1月22日(水)"
+ * ```
+ */
+export function formatDate(
+  date: Date,
+  locale: string = 'ja',
+  options: DateFormatOptions = {},
+): string {
+  const { includeYear = true, includeWeekday = false, style = 'medium' } = options;
+
+  const intlOptions: Intl.DateTimeFormatOptions = {
+    year: includeYear ? 'numeric' : undefined,
+    month: style === 'short' ? 'numeric' : style === 'long' ? 'long' : 'short',
+    day: 'numeric',
+    weekday: includeWeekday ? 'short' : undefined,
+  };
+
+  return new Intl.DateTimeFormat(locale, intlOptions).format(date);
+}
+
+/**
+ * 日付を短形式でフォーマット（M/D または MM/DD）
+ */
+export function formatDateShort(date: Date, locale: string = 'ja'): string {
+  return new Intl.DateTimeFormat(locale, {
+    month: 'numeric',
+    day: 'numeric',
+  }).format(date);
+}
+
+/**
+ * 日付をISO形式（YYYY-MM-DD）でフォーマット
+ */
+export function formatDateISO(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+// ========================================
+// 時刻フォーマット
+// ========================================
+
+/** 時刻フォーマット */
+export type TimeFormat = '12h' | '24h';
+
+/**
+ * 時刻をフォーマット
+ *
+ * @param date - フォーマットする日付
+ * @param format - 12h または 24h
+ * @returns フォーマットされた時刻文字列
+ *
+ * @example
+ * ```typescript
+ * formatTime(new Date('2025-01-22T14:30:00'), '24h'); // "14:30"
+ * formatTime(new Date('2025-01-22T14:30:00'), '12h'); // "2:30 PM"
+ * ```
+ */
+export function formatTime(date: Date, format: TimeFormat = '24h'): string {
+  const hours = date.getHours();
+  const minutes = date.getMinutes();
+  const paddedMinutes = minutes.toString().padStart(2, '0');
+
+  if (format === '24h') {
+    return `${hours}:${paddedMinutes}`;
+  }
+
+  const period = hours >= 12 ? 'PM' : 'AM';
+  const displayHours = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours;
+  return `${displayHours}:${paddedMinutes} ${period}`;
+}
+
+/**
+ * 時間（0-23）を時刻文字列としてフォーマット
+ *
+ * @example
+ * ```typescript
+ * formatHour(14, '24h'); // "14:00"
+ * formatHour(14, '12h'); // "2:00 PM"
+ * ```
+ */
+export function formatHour(hour: number, format: TimeFormat = '24h'): string {
+  if (format === '24h') {
+    return `${hour}:00`;
+  }
+
+  if (hour === 0) return '12:00 AM';
+  if (hour === 12) return '12:00 PM';
+  if (hour < 12) return `${hour}:00 AM`;
+  return `${hour - 12}:00 PM`;
+}
+
+/**
+ * 時間範囲をフォーマット
+ *
+ * @example
+ * ```typescript
+ * formatTimeRange(start, end, '24h'); // "9:00 - 17:00"
+ * ```
+ */
+export function formatTimeRange(start: Date, end: Date, format: TimeFormat = '24h'): string {
+  return `${formatTime(start, format)} - ${formatTime(end, format)}`;
+}
+
+// ========================================
+// 日時フォーマット
+// ========================================
+
+/**
+ * 日時をフォーマット
+ *
+ * @example
+ * ```typescript
+ * formatDateTime(new Date(), 'ja', '24h'); // "2025年1月22日 14:30"
+ * ```
+ */
+export function formatDateTime(
+  date: Date,
+  locale: string = 'ja',
+  timeFormat: TimeFormat = '24h',
+): string {
+  return `${formatDate(date, locale)} ${formatTime(date, timeFormat)}`;
+}
+
+// ========================================
+// 相対時間フォーマット
+// ========================================
+
+/** 相対時間フォーマットオプション */
+export interface RelativeTimeOptions {
+  /** 基準日時（デフォルト: now） */
+  baseDate?: Date;
+  /** ロケール（デフォルト: 'ja'） */
+  locale?: string;
+}
+
+/**
+ * 相対時間をフォーマット（〜前、〜後）
+ *
+ * @param date - フォーマットする日付
+ * @param options - オプション
+ * @returns 相対時間文字列
+ *
+ * @example
+ * ```typescript
+ * formatRelativeTime(new Date(Date.now() - 60000)); // "1分前"
+ * formatRelativeTime(new Date(Date.now() - 3600000)); // "1時間前"
+ * formatRelativeTime(new Date(Date.now() - 86400000)); // "1日前"
+ * ```
+ */
+export function formatRelativeTime(date: Date, options: RelativeTimeOptions = {}): string {
+  const { baseDate = new Date(), locale = 'ja' } = options;
+  const diffMs = baseDate.getTime() - date.getTime();
+  const absDiffMs = Math.abs(diffMs);
+  const isPast = diffMs > 0;
+
+  // Intl.RelativeTimeFormat を使用
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
+
+  if (absDiffMs < MS_PER_MINUTE) {
+    // 1分未満
+    const seconds = Math.floor(absDiffMs / 1000);
+    return rtf.format(isPast ? -seconds : seconds, 'second');
+  }
+
+  if (absDiffMs < MS_PER_HOUR) {
+    // 1時間未満
+    const minutes = Math.floor(absDiffMs / MS_PER_MINUTE);
+    return rtf.format(isPast ? -minutes : minutes, 'minute');
+  }
+
+  if (absDiffMs < MS_PER_DAY) {
+    // 1日未満
+    const hours = Math.floor(absDiffMs / MS_PER_HOUR);
+    return rtf.format(isPast ? -hours : hours, 'hour');
+  }
+
+  if (absDiffMs < MS_PER_DAY * 30) {
+    // 30日未満
+    const days = Math.floor(absDiffMs / MS_PER_DAY);
+    return rtf.format(isPast ? -days : days, 'day');
+  }
+
+  if (absDiffMs < MS_PER_DAY * 365) {
+    // 1年未満
+    const months = Math.floor(absDiffMs / (MS_PER_DAY * 30));
+    return rtf.format(isPast ? -months : months, 'month');
+  }
+
+  // 1年以上
+  const years = Math.floor(absDiffMs / (MS_PER_DAY * 365));
+  return rtf.format(isPast ? -years : years, 'year');
+}
+
+// ========================================
+// 期間フォーマット
+// ========================================
+
+/**
+ * 期間（ミリ秒）を人間が読める形式にフォーマット
+ *
+ * @example
+ * ```typescript
+ * formatDuration(3661000); // "1時間1分1秒"
+ * formatDuration(3600000); // "1時間"
+ * formatDuration(90000); // "1分30秒"
+ * ```
+ */
+export function formatDuration(ms: number, locale: string = 'ja'): string {
+  const hours = Math.floor(ms / MS_PER_HOUR);
+  const minutes = Math.floor((ms % MS_PER_HOUR) / MS_PER_MINUTE);
+  const seconds = Math.floor((ms % MS_PER_MINUTE) / 1000);
+
+  const parts: string[] = [];
+
+  if (locale === 'ja') {
+    if (hours > 0) parts.push(`${hours}時間`);
+    if (minutes > 0) parts.push(`${minutes}分`);
+    if (seconds > 0 || parts.length === 0) parts.push(`${seconds}秒`);
+    return parts.join('');
+  }
+
+  // English format
+  if (hours > 0) parts.push(`${hours}h`);
+  if (minutes > 0) parts.push(`${minutes}m`);
+  if (seconds > 0 || parts.length === 0) parts.push(`${seconds}s`);
+  return parts.join(' ');
+}
+
+/**
+ * 期間（分）を簡潔にフォーマット
+ *
+ * @example
+ * ```typescript
+ * formatDurationMinutes(90); // "1h 30m"
+ * formatDurationMinutes(45); // "45m"
+ * ```
+ */
+export function formatDurationMinutes(totalMinutes: number): string {
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (hours === 0) return `${minutes}m`;
+  if (minutes === 0) return `${hours}h`;
+  return `${hours}h ${minutes}m`;
+}
+
+// ========================================
+// 曜日
+// ========================================
+
+/**
+ * 曜日を取得
+ */
+export function getWeekdayName(
+  date: Date,
+  locale: string = 'ja',
+  format: 'long' | 'short' = 'short',
+): string {
+  return new Intl.DateTimeFormat(locale, { weekday: format }).format(date);
+}
+
+/**
+ * 曜日インデックス（0=日曜, 1=月曜, ...）から曜日名を取得
+ */
+export function getWeekdayNameByIndex(
+  index: number,
+  locale: string = 'ja',
+  format: 'long' | 'short' = 'short',
+): string {
+  // 2024-01-07 は日曜日
+  const baseDate = new Date(2024, 0, 7 + index);
+  return getWeekdayName(baseDate, locale, format);
+}

--- a/src/lib/date/index.ts
+++ b/src/lib/date/index.ts
@@ -1,0 +1,158 @@
+/**
+ * 日付ユーティリティライブラリ
+ *
+ * アプリ全体で統一された日付操作を提供
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   // 日付計算
+ *   startOfDay, endOfDay, addDays, isSameDay,
+ *   // フォーマット
+ *   formatDate, formatTime, formatRelativeTime,
+ *   // タイムゾーン
+ *   convertToTimezone, formatInTimezone, getUserTimezone,
+ * } from '@/lib/date';
+ * ```
+ *
+ * ## 使い分けガイド
+ *
+ * ### 基本的な日付計算（core.ts）
+ * - 日の境界: `startOfDay`, `endOfDay`
+ * - 週の境界: `startOfWeek`, `endOfWeek`
+ * - 月の境界: `startOfMonth`, `endOfMonth`
+ * - 日付加算: `addDays`, `addWeeks`, `addMonths`
+ * - 比較: `isSameDay`, `isToday`, `isBefore`
+ * - キー生成: `getDateKey`, `getMonthKey`
+ *
+ * ### フォーマット（format.ts）
+ * - 日付: `formatDate`, `formatDateShort`, `formatDateISO`
+ * - 時刻: `formatTime`, `formatHour`, `formatTimeRange`
+ * - 相対時間: `formatRelativeTime`
+ * - 期間: `formatDuration`, `formatDurationMinutes`
+ *
+ * ### タイムゾーン（timezone.ts）
+ * - 変換: `convertToTimezone`, `convertFromTimezone`
+ * - フォーマット: `formatInTimezone`, `formatTimeWithTimezone`
+ * - ユーザーTZ: `getUserTimezone`, `getTimezoneAbbreviation`
+ * - ISO変換: `localTimeToUTCISO`, `parseISOToUserTimezone`
+ */
+
+// ========================================
+// Core - 基本的な日付計算
+// ========================================
+export {
+  // 日付加算・減算
+  addDays,
+  addHours,
+  addMinutes,
+  addMonths,
+  addWeeks,
+  endOfDay,
+  endOfMonth,
+  endOfWeek,
+  // 配列生成
+  generateDateRange,
+  // キー生成
+  getDateKey,
+  // 差分計算
+  getDaysDifference,
+  getMonthDates,
+  getMonthKey,
+  getTimeDifference,
+  getWeekDates,
+  isAfter,
+  isBefore,
+  // 比較・判定
+  isSameDay,
+  isToday,
+  isTomorrow,
+  isValidDate,
+  isWeekend,
+  isWithinRange,
+  isYesterday,
+  normalizeDate,
+  // パース
+  parseDateString,
+  // 日の境界
+  startOfDay,
+  // 月の境界
+  startOfMonth,
+  // 週の境界
+  startOfWeek,
+  subDays,
+} from './core';
+
+// ========================================
+// Format - フォーマット
+// ========================================
+export {
+  // 日付フォーマット
+  formatDate,
+  formatDateISO,
+  formatDateShort,
+  // 日時フォーマット
+  formatDateTime,
+  // 期間
+  formatDuration,
+  formatDurationMinutes,
+  formatHour,
+  // 相対時間
+  formatRelativeTime,
+  // 時刻フォーマット
+  formatTime,
+  formatTimeRange,
+  // 曜日
+  getWeekdayName,
+  getWeekdayNameByIndex,
+  type DateFormatOptions,
+  type RelativeTimeOptions,
+  // 型
+  type TimeFormat,
+} from './format';
+
+// ========================================
+// Timezone - タイムゾーン
+// ========================================
+export {
+  convertFromTimezone,
+  // 変換
+  convertToTimezone,
+  formatDateWithTimezone,
+  // フォーマット
+  formatInTimezone,
+  formatTimeWithTimezone,
+  // タイムゾーンリスト
+  getCommonTimezones,
+  getTimezoneAbbreviation,
+  getTimezoneOffset,
+  // ユーザータイムゾーン
+  getUserTimezone,
+  // ISO変換
+  localTimeToUTCISO,
+  parseISOToUserTimezone,
+  type TimezoneInfo,
+} from './timezone';
+
+// ========================================
+// 定数の再エクスポート
+// ========================================
+export {
+  MINUTES_PER_DAY,
+  MINUTES_PER_HOUR,
+  MS_PER_DAY,
+  MS_PER_HOUR,
+  MS_PER_MINUTE,
+  MS_PER_SECOND,
+  MS_PER_WEEK,
+  SECONDS_PER_DAY,
+  SECONDS_PER_HOUR,
+  SECONDS_PER_MINUTE,
+  daysToMs,
+  hoursToMs,
+  minutesToMs,
+  msToDays,
+  msToHours,
+  msToMinutes,
+  msToSeconds,
+} from '@/constants/time';

--- a/src/lib/date/timezone.ts
+++ b/src/lib/date/timezone.ts
@@ -1,0 +1,270 @@
+/**
+ * タイムゾーンユーティリティ
+ *
+ * date-fns-tz をベースにしたタイムゾーン変換・フォーマット。
+ * アプリ全体で統一されたタイムゾーン処理を提供。
+ *
+ * @example
+ * ```typescript
+ * import { convertToTimezone, formatInTimezone, getUserTimezone } from '@/lib/date';
+ *
+ * const userTz = getUserTimezone();
+ * const localDate = convertToTimezone(utcDate, userTz);
+ * const formatted = formatInTimezone(utcDate, userTz, 'yyyy-MM-dd HH:mm');
+ * ```
+ */
+
+import { format } from 'date-fns';
+import { formatInTimeZone, fromZonedTime, toZonedTime } from 'date-fns-tz';
+
+// ========================================
+// タイムゾーン変換
+// ========================================
+
+/**
+ * UTC時刻を指定タイムゾーンの時刻に変換
+ *
+ * **注意**: 返されるDateオブジェクトのgetHours()等は指定TZでの値を返す
+ *
+ * @param utcDate - UTC日時
+ * @param timezone - 変換先タイムゾーン（例: 'Asia/Tokyo'）
+ * @returns タイムゾーン変換されたDateオブジェクト
+ *
+ * @example
+ * ```typescript
+ * // UTC 05:00 → JST 14:00
+ * const jstDate = convertToTimezone(new Date('2025-01-22T05:00:00Z'), 'Asia/Tokyo');
+ * jstDate.getHours(); // => 14
+ * ```
+ */
+export function convertToTimezone(utcDate: Date, timezone: string): Date {
+  return toZonedTime(utcDate, timezone);
+}
+
+/**
+ * 指定タイムゾーンの時刻をUTCに変換
+ *
+ * @param zonedDate - タイムゾーン付き日時
+ * @param timezone - 元のタイムゾーン（例: 'Asia/Tokyo'）
+ * @returns UTC Dateオブジェクト
+ *
+ * @example
+ * ```typescript
+ * // JST 14:00 → UTC 05:00
+ * const utcDate = convertFromTimezone(localDate, 'Asia/Tokyo');
+ * ```
+ */
+export function convertFromTimezone(zonedDate: Date, timezone: string): Date {
+  return fromZonedTime(zonedDate, timezone);
+}
+
+// ========================================
+// タイムゾーン対応フォーマット
+// ========================================
+
+/**
+ * 日時を指定タイムゾーンでフォーマット
+ *
+ * @param date - フォーマットする日時
+ * @param timezone - タイムゾーン
+ * @param formatString - フォーマット文字列（date-fns形式）
+ * @returns フォーマットされた文字列
+ *
+ * @example
+ * ```typescript
+ * formatInTimezone(new Date(), 'Asia/Tokyo', 'yyyy-MM-dd HH:mm');
+ * // => "2025-01-22 14:30"
+ * ```
+ */
+export function formatInTimezone(date: Date, timezone: string, formatString: string): string {
+  return formatInTimeZone(date, timezone, formatString);
+}
+
+/**
+ * 日時をフォーマット（タイムゾーンオプション付き）
+ *
+ * @param date - フォーマットする日時
+ * @param formatString - フォーマット文字列
+ * @param timezone - オプションのタイムゾーン（省略時はローカル）
+ */
+export function formatDateWithTimezone(
+  date: Date,
+  formatString: string,
+  timezone?: string,
+): string {
+  if (timezone) {
+    return formatInTimeZone(date, timezone, formatString);
+  }
+  return format(date, formatString);
+}
+
+/**
+ * 時刻をタイムゾーン対応でフォーマット
+ *
+ * @param date - フォーマットする日時
+ * @param timeFormat - '12h' または '24h'
+ * @param timezone - オプションのタイムゾーン
+ */
+export function formatTimeWithTimezone(
+  date: Date,
+  timeFormat: '12h' | '24h',
+  timezone?: string,
+): string {
+  const formatString = timeFormat === '24h' ? 'HH:mm' : 'h:mm a';
+
+  if (timezone) {
+    return formatInTimeZone(date, timezone, formatString);
+  }
+  return format(date, formatString);
+}
+
+// ========================================
+// ユーザータイムゾーン
+// ========================================
+
+/**
+ * ユーザーのブラウザタイムゾーンを取得
+ *
+ * @returns タイムゾーン文字列（例: 'Asia/Tokyo'）
+ */
+export function getUserTimezone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone;
+}
+
+/**
+ * タイムゾーンの略称を取得
+ *
+ * @param timezone - タイムゾーン（例: 'Asia/Tokyo'）
+ * @returns 略称（例: 'JST'）
+ */
+export function getTimezoneAbbreviation(timezone: string): string {
+  // よく使われるタイムゾーンの略称マッピング
+  const abbreviations: Record<string, string> = {
+    'Asia/Tokyo': 'JST',
+    'America/New_York': 'EST',
+    'America/Los_Angeles': 'PST',
+    'America/Chicago': 'CST',
+    'America/Denver': 'MST',
+    'Europe/London': 'GMT',
+    'Europe/Paris': 'CET',
+    'Australia/Sydney': 'AEDT',
+    'Pacific/Auckland': 'NZDT',
+  };
+
+  if (abbreviations[timezone]) {
+    return abbreviations[timezone];
+  }
+
+  // マッピングにない場合は Intl API で取得
+  try {
+    const formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      timeZoneName: 'short',
+    });
+    const parts = formatter.formatToParts(new Date());
+    const tzPart = parts.find((part) => part.type === 'timeZoneName');
+    return tzPart?.value || 'UTC';
+  } catch {
+    return 'UTC';
+  }
+}
+
+/**
+ * タイムゾーンのオフセットを取得（時間単位）
+ *
+ * @param timezone - タイムゾーン
+ * @param date - 基準日時（DST考慮）
+ * @returns オフセット（例: 9 for JST）
+ */
+export function getTimezoneOffset(timezone: string, date: Date = new Date()): number {
+  const utcDate = new Date(date.toLocaleString('en-US', { timeZone: 'UTC' }));
+  const tzDate = new Date(date.toLocaleString('en-US', { timeZone: timezone }));
+  return (tzDate.getTime() - utcDate.getTime()) / (1000 * 60 * 60);
+}
+
+// ========================================
+// ISO変換
+// ========================================
+
+/**
+ * ユーザーのタイムゾーンの時刻をUTC ISO文字列に変換
+ *
+ * @param localDate - ローカル日付
+ * @param hours - 時（0-23）
+ * @param minutes - 分（0-59）
+ * @param timezone - ユーザーのタイムゾーン
+ * @returns UTC ISO 8601文字列
+ *
+ * @example
+ * ```typescript
+ * // JST 14:30 → UTC ISO
+ * localTimeToUTCISO(new Date(2025, 0, 22), 14, 30, 'Asia/Tokyo');
+ * // => "2025-01-22T05:30:00.000Z"
+ * ```
+ */
+export function localTimeToUTCISO(
+  localDate: Date,
+  hours: number,
+  minutes: number,
+  timezone: string,
+): string {
+  const year = localDate.getFullYear();
+  const month = localDate.getMonth();
+  const day = localDate.getDate();
+
+  const zonedDate = new Date(year, month, day, hours, minutes, 0, 0);
+  const utcDate = fromZonedTime(zonedDate, timezone);
+
+  return utcDate.toISOString();
+}
+
+/**
+ * ISO 8601文字列をユーザーのタイムゾーンで解釈したDateに変換
+ *
+ * @param isoString - ISO 8601形式の日時文字列
+ * @param timezone - ユーザーのタイムゾーン
+ * @returns タイムゾーン変換されたDateオブジェクト
+ */
+export function parseISOToUserTimezone(isoString: string, timezone: string): Date {
+  const utcDate = new Date(isoString);
+  if (isNaN(utcDate.getTime())) {
+    throw new Error(`Invalid ISO datetime: ${isoString}`);
+  }
+  return toZonedTime(utcDate, timezone);
+}
+
+// ========================================
+// タイムゾーンリスト
+// ========================================
+
+/** タイムゾーン情報 */
+export interface TimezoneInfo {
+  value: string;
+  label: string;
+  offset: number;
+}
+
+/**
+ * よく使われるタイムゾーンのリストを取得
+ */
+export function getCommonTimezones(): TimezoneInfo[] {
+  return [
+    { value: 'Pacific/Honolulu', label: 'Honolulu (GMT-10)', offset: -10 },
+    { value: 'America/Anchorage', label: 'Anchorage (GMT-9)', offset: -9 },
+    { value: 'America/Los_Angeles', label: 'Los Angeles (GMT-8)', offset: -8 },
+    { value: 'America/Denver', label: 'Denver (GMT-7)', offset: -7 },
+    { value: 'America/Chicago', label: 'Chicago (GMT-6)', offset: -6 },
+    { value: 'America/New_York', label: 'New York (GMT-5)', offset: -5 },
+    { value: 'America/Sao_Paulo', label: 'São Paulo (GMT-3)', offset: -3 },
+    { value: 'Europe/London', label: 'London (GMT+0)', offset: 0 },
+    { value: 'Europe/Paris', label: 'Paris (GMT+1)', offset: 1 },
+    { value: 'Europe/Moscow', label: 'Moscow (GMT+3)', offset: 3 },
+    { value: 'Asia/Dubai', label: 'Dubai (GMT+4)', offset: 4 },
+    { value: 'Asia/Kolkata', label: 'Kolkata (GMT+5:30)', offset: 5.5 },
+    { value: 'Asia/Singapore', label: 'Singapore (GMT+8)', offset: 8 },
+    { value: 'Asia/Shanghai', label: 'Shanghai (GMT+8)', offset: 8 },
+    { value: 'Asia/Tokyo', label: 'Tokyo (GMT+9)', offset: 9 },
+    { value: 'Australia/Sydney', label: 'Sydney (GMT+10)', offset: 10 },
+    { value: 'Pacific/Auckland', label: 'Auckland (GMT+12)', offset: 12 },
+  ].sort((a, b) => a.offset - b.offset);
+}

--- a/src/lib/supabase/realtime/createRealtimeHook.ts
+++ b/src/lib/supabase/realtime/createRealtimeHook.ts
@@ -1,0 +1,115 @@
+/**
+ * Realtimeフック生成ファクトリー
+ *
+ * 共通パターンを抽出し、feature固有のRealtime購読フックを簡潔に作成できる
+ *
+ * @example
+ * ```typescript
+ * // feature固有のフックを簡潔に定義
+ * export const usePlanRealtime = createRealtimeHook({
+ *   name: 'plan',
+ *   table: 'plans',
+ *   useMutationGuard: () => usePlanCacheStore((s) => s.isMutating),
+ *   onInvalidate: (utils, payload) => {
+ *     void utils.plans.list.invalidate();
+ *     const id = payload.new?.id ?? payload.old?.id;
+ *     if (id) void utils.plans.getById.invalidate({ id });
+ *   },
+ * });
+ * ```
+ */
+
+'use client';
+
+import { logger } from '@/lib/logger';
+import { api } from '@/lib/trpc';
+
+import { useRealtimeSubscription } from './useRealtimeSubscription';
+
+import type { AppRouter } from '@/server/api/root';
+import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
+
+// tRPC Utils の型
+type RouterInputs = inferRouterInputs<AppRouter>;
+type RouterOutputs = inferRouterOutputs<AppRouter>;
+type TRPCUtils = ReturnType<typeof api.useUtils>;
+
+/** Realtimeイベントペイロード */
+export interface RealtimePayload<T = Record<string, unknown>> {
+  eventType: 'INSERT' | 'UPDATE' | 'DELETE';
+  new: T | null;
+  old: T | null;
+}
+
+/** Realtimeフックオプション */
+export interface RealtimeHookOptions {
+  /** 購読を有効化するか（デフォルト: true） */
+  enabled?: boolean;
+}
+
+/** createRealtimeHook の設定 */
+export interface RealtimeHookConfig<T = { id: string }> {
+  /** フック名（ログ用、チャンネル名に使用） */
+  name: string;
+  /** 購読対象のテーブル名 */
+  table: string;
+  /** mutation中かどうかを返すフック（二重更新防止） */
+  useMutationGuard: () => boolean;
+  /** キャッシュ無効化処理 */
+  onInvalidate: (utils: TRPCUtils, payload: RealtimePayload<T>) => void;
+  /** エラー時の処理（オプション） */
+  onError?: (error: Error) => void;
+}
+
+/**
+ * Realtimeフックを生成するファクトリー関数
+ *
+ * 共通パターン:
+ * 1. userId + enabledオプション
+ * 2. mutation中はイベントをスキップ
+ * 3. キャッシュ無効化
+ * 4. ログ出力
+ */
+export function createRealtimeHook<T extends { id?: string } = { id: string }>(
+  config: RealtimeHookConfig<T>,
+) {
+  const { name, table, useMutationGuard, onInvalidate, onError } = config;
+
+  return function useRealtimeHook(userId: string | undefined, options: RealtimeHookOptions = {}) {
+    const { enabled = true } = options;
+    const utils = api.useUtils();
+    const isMutating = useMutationGuard();
+
+    useRealtimeSubscription<T>({
+      channelName: `${name}-changes-${userId}`,
+      table,
+      event: '*', // INSERT, UPDATE, DELETE すべて
+      ...(userId && { filter: `user_id=eq.${userId}` }),
+      enabled,
+      onEvent: (payload) => {
+        const typedPayload = payload as unknown as RealtimePayload<T>;
+        const recordId = typedPayload.new?.id ?? typedPayload.old?.id;
+
+        logger.debug(`[${name} Realtime] Event detected:`, typedPayload.eventType, recordId);
+
+        // 自分のmutation中はRealtime経由の更新をスキップ（二重更新防止）
+        if (isMutating) {
+          logger.debug(`[${name} Realtime] Skipping invalidation (mutation in progress)`);
+          return;
+        }
+
+        // キャッシュ無効化
+        onInvalidate(utils, typedPayload);
+      },
+      onError: (error) => {
+        logger.error(`[${name} Realtime] Subscription error:`, error);
+        onError?.(error);
+      },
+    });
+  };
+}
+
+// ========================================
+// 型エクスポート
+// ========================================
+export type { RouterInputs, RouterOutputs, TRPCUtils };

--- a/src/lib/supabase/realtime/index.ts
+++ b/src/lib/supabase/realtime/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Supabase Realtime ユーティリティ
+ *
+ * @example
+ * ```typescript
+ * // 汎用購読フック
+ * import { useRealtimeSubscription } from '@/lib/supabase/realtime';
+ *
+ * // ファクトリーでカスタムフックを作成
+ * import { createRealtimeHook } from '@/lib/supabase/realtime';
+ *
+ * export const useMyRealtime = createRealtimeHook({
+ *   name: 'my-entity',
+ *   table: 'my_table',
+ *   useMutationGuard: () => useMyStore((s) => s.isMutating),
+ *   onInvalidate: (utils) => void utils.myEntity.list.invalidate(),
+ * });
+ * ```
+ */
+
+// 汎用購読フック
+export { useRealtimeSubscription } from './useRealtimeSubscription';
+
+// ファクトリー
+export {
+  createRealtimeHook,
+  type RealtimeHookConfig,
+  type RealtimeHookOptions,
+  type RealtimePayload,
+} from './createRealtimeHook';
+
+// 型定義
+export {
+  RealtimeSubscriptionError,
+  type PostgresChangeEvent,
+  type RealtimeChannelManager,
+  type RealtimeChannelStatus,
+  type RealtimeSubscriptionConfig,
+} from './types';

--- a/src/lib/tanstack-query/index.ts
+++ b/src/lib/tanstack-query/index.ts
@@ -1,0 +1,48 @@
+/**
+ * TanStack Query ユーティリティ
+ *
+ * キャッシュ設定、エラーハンドリング、楽観的更新ヘルパーをエクスポート
+ */
+
+// キャッシュ設定
+export {
+  cacheStrategies,
+  getCacheStrategy,
+  realtimeCache,
+  shortTermCache,
+  standardCache,
+  staticCache,
+} from './cache-config';
+
+// エラーハンドリング
+export {
+  getRetryDelay,
+  handleQueryError,
+  logMutationSuccess,
+  logQueryError,
+  shouldRetry,
+  type ErrorContext,
+} from './error-handler';
+
+// 楽観的更新ヘルパー
+export {
+  addToList,
+  addToPaginatedList,
+  // スナップショット・ロールバック
+  createSnapshot,
+  // プレーンリスト操作
+  filterList,
+  // ページネーション付きリスト操作
+  filterPaginatedList,
+  // 一時ID
+  generateTempId,
+  isTempId,
+  removeFromList,
+  removeFromPaginatedList,
+  replaceInPaginatedList,
+  snapshotQuery,
+  updateList,
+  updatePaginatedList,
+  type PaginatedList,
+  type Snapshot,
+} from './optimistic-mutation';

--- a/src/lib/tanstack-query/optimistic-mutation.ts
+++ b/src/lib/tanstack-query/optimistic-mutation.ts
@@ -1,0 +1,351 @@
+/**
+ * 楽観的更新ユーティリティ
+ *
+ * tRPC mutationの楽観的更新パターンを簡素化するヘルパー関数
+ *
+ * @example
+ * ```typescript
+ * const mutation = api.tags.delete.useMutation({
+ *   onMutate: async ({ id }) => {
+ *     const snapshot = await createSnapshot(utils, [
+ *       { query: utils.tags.list, key: undefined },
+ *       { query: utils.tags.getById, key: { id } },
+ *     ]);
+ *
+ *     // 楽観的更新
+ *     updateListCache(utils.tags.list, undefined, (old) =>
+ *       filterFromList(old, (item) => item.id !== id)
+ *     );
+ *
+ *     return { snapshot };
+ *   },
+ *   onError: (_err, _input, context) => {
+ *     context?.snapshot?.restore();
+ *   },
+ *   onSettled: () => {
+ *     void utils.tags.list.invalidate();
+ *   },
+ * });
+ * ```
+ */
+
+// ========================================
+// 型定義
+// ========================================
+
+/** ページネーション付きリストデータ（tags形式） */
+export interface PaginatedList<T> {
+  data: T[];
+  count: number;
+}
+
+/** tRPCのキャッシュ操作インターフェース */
+interface CacheOperations<TData, TInput = undefined> {
+  cancel: (input?: TInput) => Promise<void>;
+  getData: (input?: TInput) => TData | undefined;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  setData: (input: any, updater: any) => void;
+  invalidate: (input?: TInput, options?: { refetchType?: 'active' | 'all' }) => Promise<void>;
+}
+
+/** スナップショットアイテム */
+interface SnapshotItem<TData, TInput = undefined> {
+  query: CacheOperations<TData, TInput>;
+  key: TInput;
+}
+
+/** スナップショット結果 */
+export interface Snapshot {
+  restore: () => void;
+}
+
+// ========================================
+// スナップショット・ロールバック
+// ========================================
+
+/**
+ * 複数クエリのスナップショットを作成し、ロールバック関数を返す
+ *
+ * @example
+ * ```typescript
+ * const snapshot = await createSnapshot(utils, [
+ *   { query: utils.tags.list, key: undefined },
+ *   { query: utils.tags.getById, key: { id } },
+ * ]);
+ *
+ * // エラー時にロールバック
+ * snapshot.restore();
+ * ```
+ */
+export async function createSnapshot<T extends SnapshotItem<unknown, unknown>[]>(
+  _utils: unknown,
+  queries: T,
+): Promise<Snapshot> {
+  // 全クエリをキャンセル
+  await Promise.all(queries.map((q) => q.query.cancel(q.key)));
+
+  // スナップショットを取得
+  const snapshots = queries.map((q) => ({
+    query: q.query,
+    key: q.key,
+    data: q.query.getData(q.key),
+  }));
+
+  return {
+    restore: () => {
+      for (const snap of snapshots) {
+        snap.query.setData(snap.key, snap.data);
+      }
+    },
+  };
+}
+
+/**
+ * 単一クエリのスナップショットを作成
+ *
+ * @example
+ * ```typescript
+ * const { previous, restore } = await snapshotQuery(utils.tags.list);
+ * ```
+ */
+export async function snapshotQuery<TData, TInput = undefined>(
+  query: CacheOperations<TData, TInput>,
+  key?: TInput,
+): Promise<{ previous: TData | undefined; restore: () => void }> {
+  await query.cancel(key);
+  const previous = query.getData(key);
+
+  return {
+    previous,
+    restore: () => {
+      query.setData(key, previous);
+    },
+  };
+}
+
+// ========================================
+// リスト操作ヘルパー（プレーンリスト用）
+// ========================================
+
+/**
+ * プレーンリストからアイテムをフィルタリング
+ *
+ * @example
+ * ```typescript
+ * utils.plans.list.setData(undefined, (old) =>
+ *   filterList(old, (plan) => plan.id !== deletedId)
+ * );
+ * ```
+ */
+export function filterList<T>(
+  list: T[] | undefined,
+  predicate: (item: T) => boolean,
+): T[] | undefined {
+  if (!list) return list;
+  return list.filter(predicate);
+}
+
+/**
+ * プレーンリストのアイテムを更新
+ *
+ * @example
+ * ```typescript
+ * utils.plans.list.setData(undefined, (old) =>
+ *   updateList(old, (plan) =>
+ *     plan.id === id ? { ...plan, title: newTitle } : plan
+ *   )
+ * );
+ * ```
+ */
+export function updateList<T>(list: T[] | undefined, mapper: (item: T) => T): T[] | undefined {
+  if (!list) return list;
+  return list.map(mapper);
+}
+
+/**
+ * プレーンリストにアイテムを追加
+ *
+ * @example
+ * ```typescript
+ * utils.plans.list.setData(undefined, (old) =>
+ *   addToList(old, newPlan)
+ * );
+ * ```
+ */
+export function addToList<T>(
+  list: T[] | undefined,
+  item: T,
+  position: 'start' | 'end' = 'end',
+): T[] {
+  if (!list) return [item];
+  return position === 'start' ? [item, ...list] : [...list, item];
+}
+
+/**
+ * プレーンリストからアイテムを削除
+ *
+ * @example
+ * ```typescript
+ * utils.plans.list.setData(undefined, (old) =>
+ *   removeFromList(old, 'id', deletedId)
+ * );
+ * ```
+ */
+export function removeFromList<T, K extends keyof T>(
+  list: T[] | undefined,
+  key: K,
+  value: T[K],
+): T[] | undefined {
+  if (!list) return list;
+  return list.filter((item) => item[key] !== value);
+}
+
+// ========================================
+// リスト操作ヘルパー（ページネーション付きリスト用）
+// ========================================
+
+/**
+ * ページネーション付きリストからアイテムをフィルタリング
+ *
+ * @example
+ * ```typescript
+ * utils.tags.list.setData(undefined, (old) =>
+ *   filterPaginatedList(old, (tag) => tag.id !== deletedId)
+ * );
+ * ```
+ */
+export function filterPaginatedList<T>(
+  list: PaginatedList<T> | undefined,
+  predicate: (item: T) => boolean,
+): PaginatedList<T> | undefined {
+  if (!list) return list;
+  const filtered = list.data.filter(predicate);
+  return {
+    ...list,
+    data: filtered,
+    count: filtered.length,
+  };
+}
+
+/**
+ * ページネーション付きリストのアイテムを更新
+ *
+ * @example
+ * ```typescript
+ * utils.tags.list.setData(undefined, (old) =>
+ *   updatePaginatedList(old, (tag) =>
+ *     tag.id === id ? { ...tag, name: newName } : tag
+ *   )
+ * );
+ * ```
+ */
+export function updatePaginatedList<T>(
+  list: PaginatedList<T> | undefined,
+  mapper: (item: T) => T,
+): PaginatedList<T> | undefined {
+  if (!list) return list;
+  return {
+    ...list,
+    data: list.data.map(mapper),
+  };
+}
+
+/**
+ * ページネーション付きリストにアイテムを追加
+ *
+ * @example
+ * ```typescript
+ * utils.tags.list.setData(undefined, (old) =>
+ *   addToPaginatedList(old, newTag, 'start')
+ * );
+ * ```
+ */
+export function addToPaginatedList<T>(
+  list: PaginatedList<T> | undefined,
+  item: T,
+  position: 'start' | 'end' = 'end',
+): PaginatedList<T> {
+  if (!list) return { data: [item], count: 1 };
+  return {
+    ...list,
+    data: position === 'start' ? [item, ...list.data] : [...list.data, item],
+    count: list.count + 1,
+  };
+}
+
+/**
+ * ページネーション付きリストからアイテムを削除
+ *
+ * @example
+ * ```typescript
+ * utils.tags.list.setData(undefined, (old) =>
+ *   removeFromPaginatedList(old, 'id', deletedId)
+ * );
+ * ```
+ */
+export function removeFromPaginatedList<T, K extends keyof T>(
+  list: PaginatedList<T> | undefined,
+  key: K,
+  value: T[K],
+): PaginatedList<T> | undefined {
+  if (!list) return list;
+  const filtered = list.data.filter((item) => item[key] !== value);
+  return {
+    ...list,
+    data: filtered,
+    count: list.count - 1,
+  };
+}
+
+/**
+ * ページネーション付きリスト内のアイテムを置換
+ *
+ * @example
+ * ```typescript
+ * utils.tags.list.setData(undefined, (old) =>
+ *   replaceInPaginatedList(old, 'id', tempId, actualTag)
+ * );
+ * ```
+ */
+export function replaceInPaginatedList<T, K extends keyof T>(
+  list: PaginatedList<T> | undefined,
+  key: K,
+  oldValue: T[K],
+  newItem: T,
+): PaginatedList<T> | undefined {
+  if (!list) return list;
+  return {
+    ...list,
+    data: list.data.map((item) => (item[key] === oldValue ? newItem : item)),
+  };
+}
+
+// ========================================
+// 一時ID生成
+// ========================================
+
+/**
+ * 楽観的更新用の一時IDを生成
+ *
+ * @example
+ * ```typescript
+ * const tempId = generateTempId();
+ * // => "temp-1234567890123"
+ * ```
+ */
+export function generateTempId(prefix = 'temp'): string {
+  return `${prefix}-${Date.now()}`;
+}
+
+/**
+ * IDが一時IDかどうかを判定
+ *
+ * @example
+ * ```typescript
+ * isTempId('temp-1234567890123'); // true
+ * isTempId('uuid-xxx-xxx'); // false
+ * ```
+ */
+export function isTempId(id: string, prefix = 'temp'): boolean {
+  return id.startsWith(`${prefix}-`);
+}


### PR DESCRIPTION
## Summary
- 共通ダイアログコンポーネント（ConfirmDialog, FormDialog）の追加
- 楽観的更新ユーティリティ（optimistic-mutation）の追加
- 日付ユーティリティライブラリ（@/lib/date）の追加
- Realtimeフックファクトリパターンの導入
- useDialogKeyboardフックの追加
- date-fns importの統一

## Test plan
- [ ] 型チェック（npm run typecheck）が通ること
- [ ] Lint（npm run lint）が通ること
- [ ] 各ダイアログが正常に動作すること
- [ ] 日付関連の表示が正しいこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)