### PR TITLE
chore: bump version to 0.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "boxlog-app",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "boxlog-app",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.44",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boxlog-app",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "private": true,
   "sideEffects": [
     "*.css",


### PR DESCRIPTION
## Summary
- package.jsonのバージョンを0.16.0→0.17.0に更新

## Test plan
- [x] package.jsonのversionフィールドが0.17.0になっていることを確認
- [x] package-lock.jsonも同期されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)