### PR TITLE
fix(ci): vercel build:fallbackスクリプトを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dev:kill": "lsof -ti:3000 | xargs kill -9 2>/dev/null || echo 'No server running'",
     "prebuild": "echo 'prebuild: no-op'",
     "build": "NODE_OPTIONS='--max-old-space-size=12288' next build",
+    "build:fallback": "NODE_OPTIONS='--max-old-space-size=12288' next build",
     "start": "next start",
     "check": "npm run typecheck && npm run lint && npm run test:run",
     "lint": "eslint . --max-warnings 34",


### PR DESCRIPTION
## Summary
- Vercel CLIがNext.js 16検知時に`npm run build:fallback`を実行するが、スクリプトが存在せずデプロイが失敗していた
- `build`と同一コマンドのエイリアスとして`build:fallback`を追加

## Context
v0.17.0タグのCreate Releaseワークフローで発生:
```
Detected Next.js version: 16.1.6
Running "npm run build:fallback"
npm error Missing script: "build:fallback"
```

## Test plan
- [ ] CI通過確認
- [ ] マージ後にv0.17.0タグのCreate Releaseを再実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)