### PR TITLE
fix(settings): timezone 更新時に tz cache を即時 invalidate (P0-4)

### DIFF
--- a/src/features/entry/server/router.ts
+++ b/src/features/entry/server/router.ts
@@ -13,6 +13,7 @@ import type { TablesUpdate } from '@/lib/database.types';
 import { logger } from '@/lib/logger';
 import { entryCreateRateLimit } from '@/lib/rate-limit/upstash';
 import { captureBusinessEvent } from '@/lib/sentry';
+import { getUserTimezone } from '@/lib/server/user-timezone-cache';
 import { handleServiceError } from '@/lib/trpc/errors';
 import { createTRPCRouter, protectedProcedure } from '@/lib/trpc/procedures';
 import {
@@ -66,56 +67,12 @@ async function isEntryCreateLimited(userId: string): Promise<boolean> {
 }
 
 // =============================================================================
-// ユーザータイムゾーン取得ヘルパー（短寿命キャッシュ）
+// ユーザータイムゾーン取得ヘルパー（lib/server の共有 cache を利用）
 // =============================================================================
 
-/** TTL付きキャッシュエントリ */
-interface TzCacheEntry {
-  timezone: string;
-  expiresAt: number;
-}
-
-/**
- * ユーザーID → タイムゾーンの短寿命キャッシュ（30秒TTL）
- *
- * デバウンス保存（500ms間隔）で高頻度に呼ばれる getUserTimezone の
- * DBラウンドトリップを削減する。TTLが短いため、ユーザーがタイムゾーンを
- * 変更しても30秒以内に反映される。
- */
-const tzCache = new Map<string, TzCacheEntry>();
-const TZ_CACHE_TTL_MS = 30_000;
-
-/**
- * user_settings からタイムゾーンを取得（失敗時は 'UTC' にフォールバック）
- */
-async function getUserTimezone(
-  supabase: Parameters<typeof createEntryService>[0],
-  userId: string,
-): Promise<string> {
-  const now = Date.now();
-  const cached = tzCache.get(userId);
-  if (cached && cached.expiresAt > now) {
-    return cached.timezone;
-  }
-
-  const { data } = await supabase
-    .from('user_settings')
-    .select('timezone')
-    .eq('user_id', userId)
-    .single();
-  const timezone = (data?.timezone as string | null | undefined) ?? 'UTC';
-
-  tzCache.set(userId, { timezone, expiresAt: now + TZ_CACHE_TTL_MS });
-
-  // キャッシュ肥大化防止（サーバーレス環境では通常不要だが安全策）
-  if (tzCache.size > 1000) {
-    for (const [key, entry] of tzCache) {
-      if (entry.expiresAt <= now) tzCache.delete(key);
-    }
-  }
-
-  return timezone;
-}
+// getUserTimezone / invalidateUserTimezoneCache は `@/lib/server/user-timezone-cache`
+// 側で module-level singleton として管理する。settings 更新時は settings router から
+// invalidateUserTimezoneCache を呼ぶことで即時反映される。
 
 // =============================================================================
 // Inline Schemas

--- a/src/features/settings/server/router.ts
+++ b/src/features/settings/server/router.ts
@@ -14,6 +14,7 @@ import {
 } from '@/features/chronotype';
 import type { Database } from '@/lib/database.types';
 import { logger } from '@/lib/logger';
+import { invalidateUserTimezoneCache } from '@/lib/server/user-timezone-cache';
 import { handleServiceError } from '@/lib/trpc/errors';
 import { createTRPCRouter, protectedProcedure } from '@/lib/trpc/procedures';
 
@@ -201,6 +202,12 @@ export const userSettingsRouter = createTRPCRouter({
           })
           .select()
           .single();
+
+        // timezone を更新した場合は entry router 側の tz cache を即時 invalidate。
+        // 30 秒 TTL を待たずに新しい timezone で entry が作成されるようにする。
+        if (!error && input.timezone !== undefined) {
+          invalidateUserTimezoneCache(userId);
+        }
 
         // personalization は RPC で atomic に部分更新（並行保存の競合を回避）
         if (input.personalizationValues !== undefined) {

--- a/src/lib/server/__tests__/user-timezone-cache.test.ts
+++ b/src/lib/server/__tests__/user-timezone-cache.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getUserTimezone, invalidateUserTimezoneCache } from '@/lib/server/user-timezone-cache';
+
+import type { Database } from '@/lib/database.types';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+type Client = SupabaseClient<Database>;
+
+/**
+ * Supabase client の `from().select().eq().single()` を模す最小限のモック。
+ * 呼び出し回数と返却する timezone を差し込み可能にする。
+ */
+function createMockSupabase(timezone: string | null) {
+  const single = vi.fn().mockResolvedValue({ data: { timezone } });
+  const eq = vi.fn().mockReturnValue({ single });
+  const select = vi.fn().mockReturnValue({ eq });
+  const from = vi.fn().mockReturnValue({ select });
+
+  const client = { from } as unknown as Client;
+  return { client, single, from };
+}
+
+describe('user-timezone-cache', () => {
+  beforeEach(() => {
+    // cache は module-level singleton のため、test ごとにユニーク userId で汚染を避ける
+  });
+
+  it('初回呼び出しで DB を引き、2 回目は cache から返す', async () => {
+    const userId = `user-${crypto.randomUUID()}`;
+    const { client, single } = createMockSupabase('Asia/Tokyo');
+
+    const first = await getUserTimezone(client, userId);
+    expect(first).toBe('Asia/Tokyo');
+    expect(single).toHaveBeenCalledTimes(1);
+
+    const second = await getUserTimezone(client, userId);
+    expect(second).toBe('Asia/Tokyo');
+    expect(single).toHaveBeenCalledTimes(1); // cache hit
+  });
+
+  it('invalidateUserTimezoneCache の後は DB を再度引く', async () => {
+    const userId = `user-${crypto.randomUUID()}`;
+    const { client, single } = createMockSupabase('Asia/Tokyo');
+
+    await getUserTimezone(client, userId);
+    expect(single).toHaveBeenCalledTimes(1);
+
+    invalidateUserTimezoneCache(userId);
+
+    await getUserTimezone(client, userId);
+    expect(single).toHaveBeenCalledTimes(2);
+  });
+
+  it('settings 更新シナリオ: 旧 tz → invalidate → 新 tz が即反映', async () => {
+    const userId = `user-${crypto.randomUUID()}`;
+
+    const oldClient = createMockSupabase('UTC');
+    expect(await getUserTimezone(oldClient.client, userId)).toBe('UTC');
+
+    // settings.update で timezone 変更 → invalidate
+    invalidateUserTimezoneCache(userId);
+
+    // 次の取得は新しい tz を反映（DB 側が Asia/Tokyo を返すよう差し替え）
+    const newClient = createMockSupabase('Asia/Tokyo');
+    expect(await getUserTimezone(newClient.client, userId)).toBe('Asia/Tokyo');
+  });
+
+  it('DB の timezone が null の場合は UTC にフォールバック', async () => {
+    const userId = `user-${crypto.randomUUID()}`;
+    const { client } = createMockSupabase(null);
+
+    expect(await getUserTimezone(client, userId)).toBe('UTC');
+  });
+
+  it('invalidate は存在しない userId でも throw しない', () => {
+    expect(() => invalidateUserTimezoneCache('nonexistent-user')).not.toThrow();
+  });
+});

--- a/src/lib/server/user-timezone-cache.ts
+++ b/src/lib/server/user-timezone-cache.ts
@@ -1,0 +1,67 @@
+/**
+ * ユーザータイムゾーンの短寿命キャッシュ（30秒 TTL）
+ *
+ * エントリ操作（高頻度 mutation）の getUserTimezone 呼び出しで DB ラウンドトリップ
+ * を削減する目的。TTL が短いため、通常運用では設定変更から 30 秒以内に反映される。
+ *
+ * settings の timezone が更新された時は `invalidateUserTimezoneCache(userId)` で
+ * 即時 invalidate して、stale な timezone で entry が作成される事故を防ぐ。
+ *
+ * サーバーレス環境では instance ごとの独立 cache になるため、厳密な一貫性には
+ * 頼らない（cache miss した instance は DB を引く）。
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import type { Database } from '@/lib/database.types';
+
+interface TzCacheEntry {
+  timezone: string;
+  expiresAt: number;
+}
+
+const tzCache = new Map<string, TzCacheEntry>();
+const TZ_CACHE_TTL_MS = 30_000;
+const TZ_CACHE_MAX_SIZE = 1000;
+
+/**
+ * user_settings から timezone を取得（cache 経由、失敗時は 'UTC' にフォールバック）
+ */
+export async function getUserTimezone(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+): Promise<string> {
+  const now = Date.now();
+  const cached = tzCache.get(userId);
+  if (cached && cached.expiresAt > now) {
+    return cached.timezone;
+  }
+
+  const { data } = await supabase
+    .from('user_settings')
+    .select('timezone')
+    .eq('user_id', userId)
+    .single();
+  const timezone = (data?.timezone as string | null | undefined) ?? 'UTC';
+
+  tzCache.set(userId, { timezone, expiresAt: now + TZ_CACHE_TTL_MS });
+
+  // cache 肥大化防止（サーバーレス環境では通常不要だが安全策）
+  if (tzCache.size > TZ_CACHE_MAX_SIZE) {
+    for (const [key, entry] of tzCache) {
+      if (entry.expiresAt <= now) tzCache.delete(key);
+    }
+  }
+
+  return timezone;
+}
+
+/**
+ * ユーザーの timezone cache を即時無効化する。
+ *
+ * settings.timezone 更新 mutation 完了後に呼ぶことで、30 秒 TTL を待たずに
+ * 新しい timezone が即座に反映される。
+ */
+export function invalidateUserTimezoneCache(userId: string): void {
+  tzCache.delete(userId);
+}


### PR DESCRIPTION
## Summary

- entry router の 30 秒 TTL の in-memory tz cache を `@/lib/server/user-timezone-cache` に切り出し
- settings.update mutation で timezone 変更時に `invalidateUserTimezoneCache(userId)` を呼ぶ
- これで timezone 変更が即時に entry 作成に反映される（従来は最大 30 秒 stale）

## Context

[P0 audit plan](../../plans/app-agent-claude-code-ok-delightful-valley.md) の P0-4。
ローンチ前 blocker 6 件のうち 1 件目。

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run lint:boundaries`
- [x] `npm run lint:i18n`
- [x] `npm run test:run` (95 files / 1424 tests pass; +5 new tests for cache)
- [ ] 手動: settings で timezone 変更 → 即座に entry 作成 → 新 tz で timestamp される

🤖 Generated with [Claude Code](https://claude.com/claude-code)