### PR TITLE
fix(notifications): silent な mutation 失敗を toast で通知 (P0-5)

### DIFF
--- a/messages/en/notification.json
+++ b/messages/en/notification.json
@@ -31,7 +31,11 @@
     "errors": {
       "notSupported": "This browser does not support notifications",
       "permissionFailed": "Failed to obtain notification permission",
-      "displayFailed": "Failed to display browser notification"
+      "displayFailed": "Failed to display browser notification",
+      "markAsReadFailed": "Could not mark as read. Please try again",
+      "markAllAsReadFailed": "Could not mark all as read. Please try again",
+      "deleteFailed": "Could not delete the notification. Please try again",
+      "deleteAllReadFailed": "Could not delete read notifications. Please try again"
     },
     "types": {
       "all": "All",

--- a/messages/ja/notification.json
+++ b/messages/ja/notification.json
@@ -31,7 +31,11 @@
     "errors": {
       "notSupported": "このブラウザは通知をサポートしていません",
       "permissionFailed": "通知許可を取得できませんでした",
-      "displayFailed": "ブラウザ通知を表示できませんでした"
+      "displayFailed": "ブラウザ通知を表示できませんでした",
+      "markAsReadFailed": "既読にできませんでした。もう一度お試しください",
+      "markAllAsReadFailed": "すべて既読にできませんでした。もう一度お試しください",
+      "deleteFailed": "通知を削除できませんでした。もう一度お試しください",
+      "deleteAllReadFailed": "既読の通知を削除できませんでした。もう一度お試しください"
     },
     "types": {
       "all": "すべて",

--- a/src/features/notifications/hooks/useNotificationsData.ts
+++ b/src/features/notifications/hooks/useNotificationsData.ts
@@ -11,6 +11,9 @@
  * ```
  */
 
+import { useTranslations } from 'next-intl';
+
+import { handleMutationError } from '@/lib/errors';
 import { cacheStrategies } from '@/lib/tanstack-query/cache-config';
 import { api } from '@/lib/trpc';
 
@@ -65,6 +68,7 @@ export function useNotification(id: string) {
  */
 export function useNotificationMutations() {
   const utils = api.useUtils();
+  const t = useTranslations('notification.errors');
 
   /**
    * キャッシュ無効化（通知関連の全クエリ）
@@ -97,13 +101,17 @@ export function useNotificationMutations() {
 
       return { previousList, previousCount };
     },
-    onError: (_err, _input, context) => {
+    onError: (err, _input, context) => {
       if (context?.previousList) {
         utils.notifications.list.setData(undefined, context.previousList);
       }
       if (context?.previousCount !== undefined) {
         utils.notifications.unreadCount.setData(undefined, context.previousCount);
       }
+      handleMutationError(err, {
+        fallback: t('markAsReadFailed'),
+        scope: 'notification.markAsRead',
+      });
     },
     onSettled: invalidateNotifications,
   });
@@ -128,13 +136,17 @@ export function useNotificationMutations() {
 
       return { previousList, previousCount };
     },
-    onError: (_err, _input, context) => {
+    onError: (err, _input, context) => {
       if (context?.previousList) {
         utils.notifications.list.setData(undefined, context.previousList);
       }
       if (context?.previousCount !== undefined) {
         utils.notifications.unreadCount.setData(undefined, context.previousCount);
       }
+      handleMutationError(err, {
+        fallback: t('markAllAsReadFailed'),
+        scope: 'notification.markAllAsRead',
+      });
     },
     onSettled: invalidateNotifications,
   });
@@ -168,13 +180,14 @@ export function useNotificationMutations() {
 
       return { previousList, previousCount };
     },
-    onError: (_err, _input, context) => {
+    onError: (err, _input, context) => {
       if (context?.previousList) {
         utils.notifications.list.setData(undefined, context.previousList);
       }
       if (context?.previousCount !== undefined) {
         utils.notifications.unreadCount.setData(undefined, context.previousCount);
       }
+      handleMutationError(err, { fallback: t('deleteFailed'), scope: 'notification.delete' });
     },
     onSettled: invalidateNotifications,
   });
@@ -194,10 +207,14 @@ export function useNotificationMutations() {
 
       return { previousList };
     },
-    onError: (_err, _input, context) => {
+    onError: (err, _input, context) => {
       if (context?.previousList) {
         utils.notifications.list.setData(undefined, context.previousList);
       }
+      handleMutationError(err, {
+        fallback: t('deleteAllReadFailed'),
+        scope: 'notification.deleteAllRead',
+      });
     },
     onSettled: invalidateNotifications,
   });

--- a/src/lib/errors/handle-mutation-error.ts
+++ b/src/lib/errors/handle-mutation-error.ts
@@ -1,0 +1,39 @@
+import { logger } from '@/lib/logger';
+import { toast } from '@/lib/toast';
+
+import { getErrorMessage } from './get-error-message';
+
+interface HandleMutationErrorOptions {
+  /** toast に表示するフォールバック文言（既に翻訳済み） */
+  fallback: string;
+  /** logger に記録するコンテキスト名（既定: 'mutation'） */
+  scope?: string;
+}
+
+/**
+ * mutation の onError で共通的に呼ぶ失敗ハンドラ。
+ *
+ * - `logger.warn` で構造化ログに残す
+ * - ユーザーには `toast.error` で通知する（silent 失敗を防ぐ）
+ *
+ * tRPC / TanStack Query の onError は楽観的更新のロールバックのために使われる
+ * ことが多いが、rollback だけで終わってユーザーに失敗が伝わらないケースが
+ * 散見される。この helper を呼ぶことで「ロールバックした後、ユーザーにも
+ * 伝える」を一行で揃えられる。
+ *
+ * @example
+ * ```ts
+ * onError: (err, _vars, context) => {
+ *   rollbackCache(context);
+ *   handleMutationError(err, { fallback: t('toast.updateFailed'), scope: 'tag.update' });
+ * }
+ * ```
+ */
+export function handleMutationError(
+  error: unknown,
+  { fallback, scope = 'mutation' }: HandleMutationErrorOptions,
+): void {
+  const message = getErrorMessage(error, fallback);
+  logger.warn({ scope, error: message }, fallback);
+  toast.error(message || fallback);
+}

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -3,3 +3,4 @@
  */
 
 export { getErrorMessage } from './get-error-message';
+export { handleMutationError } from './handle-mutation-error';


### PR DESCRIPTION
## Summary

- `src/lib/errors/handle-mutation-error.ts` を新設 (logger + toast の共通 wrapper)
- notifications の 4 mutation (markAsRead / markAllAsRead / delete / deleteAllRead) が optimistic rollback のみで silent だったため toast 追加
- messages/{en,ja}/notification.json に error キー 4 件追加

## Context

[P0 audit plan](../../plans/app-agent-claude-code-ok-delightful-valley.md) の P0-5。

audit 時に懸念した他の箇所は全て既に toast 済みで silent ではなかったため今回対象外:
- `InlineTagPalette.tsx` — hook-level (useEntryMutations) の onError で toast
- `createEntityTagsHook.ts` — `mutateAsync` wrapper の try/catch で toast
- `useTagMergeMutation.ts` — 本体で toast.error 済み
- `useEntryMutations.ts` / `useTagCrudMutations.ts` — 各 mutation で toast 済み

今後 mutation を追加する際は `@/lib/errors` の `handleMutationError` を使うことで silent を防げる。

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run lint:boundaries`
- [x] `npm run lint:i18n`
- [x] `npm run test:run` (95 / 1424 passed)
- [ ] 手動: notifications 画面で markAsRead / markAllAsRead / delete / deleteAllRead を network offline で失敗させ、toast が出るか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)