### PR TITLE
refactor(stores): useCalendarSettingsStore の persist 削除 + server sync 一本化 (P0-2)

### DIFF
--- a/messages/en/common.json
+++ b/messages/en/common.json
@@ -375,6 +375,7 @@
     },
     "errors": {
       "generic": "An error occurred",
+      "loadFailedDescription": "Could not load your settings. Please try again.",
       "storage": {
         "imageOnly": "Only image files can be uploaded",
         "fileTooLarge": "File size must be 5MB or less",

--- a/messages/ja/common.json
+++ b/messages/ja/common.json
@@ -375,6 +375,7 @@
     },
     "errors": {
       "generic": "問題が起きました。もう一度お試しください",
+      "loadFailedDescription": "設定を読み込めませんでした。もう一度お試しください",
       "storage": {
         "imageOnly": "画像ファイルのみアップロード可能です",
         "fileTooLarge": "ファイルサイズは5MB以下です",

--- a/src/app/[locale]/(app)/_providers/Providers.tsx
+++ b/src/app/[locale]/(app)/_providers/Providers.tsx
@@ -50,6 +50,7 @@ const AxeAccessibilityChecker =
     : () => null;
 
 import { AuthStoreInitializer } from '@/features/auth';
+import { UserSettingsInitializer } from '@/features/settings';
 import { api, getBaseUrl } from '@/lib/trpc';
 import { ThemeProvider } from './theme-provider';
 
@@ -200,6 +201,8 @@ export function Providers({ children }: ProvidersProps) {
       <api.Provider client={trpcClient} queryClient={queryClient}>
         {/* 認証ストア初期化（Contextを提供しないので並列配置可能） */}
         <AuthStoreInitializer />
+        {/* UserSettings を Zustand に hydrate（全ページで常に最新設定が反映されるよう app-level で sync） */}
+        <UserSettingsInitializer />
         <ThemeProvider>
           <SessionMonitorProvider>
             <ServiceWorkerProvider>

--- a/src/app/[locale]/(app)/_providers/Providers.tsx
+++ b/src/app/[locale]/(app)/_providers/Providers.tsx
@@ -201,12 +201,13 @@ export function Providers({ children }: ProvidersProps) {
       <api.Provider client={trpcClient} queryClient={queryClient}>
         {/* 認証ストア初期化（Contextを提供しないので並列配置可能） */}
         <AuthStoreInitializer />
-        {/* UserSettings を Zustand に hydrate（全ページで常に最新設定が反映されるよう app-level で sync） */}
-        <UserSettingsInitializer />
         <ThemeProvider>
           <SessionMonitorProvider>
             <ServiceWorkerProvider>
-              {children}
+              {/* UserSettings の hydration が完了するまで children を render しない。
+                  timezone 等が defaults のまま timezone-dependent mutation が実行
+                  されるのを防ぐ。TanStack Query の永続 cache が効けば体感遅延は極小。 */}
+              <UserSettingsInitializer>{children}</UserSettingsInitializer>
               <GlobalTagMergeModal />
             </ServiceWorkerProvider>
           </SessionMonitorProvider>

--- a/src/features/settings/components/UserSettingsInitializer.tsx
+++ b/src/features/settings/components/UserSettingsInitializer.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useUserSettings } from '../hooks/useUserSettings';
+
+/**
+ * UserSettings 初期化コンポーネント
+ *
+ * Providers ツリーの最上位で一度だけ `useUserSettings` を呼び、
+ * DB から取得したユーザー設定を `useCalendarSettingsStore` に sync する。
+ *
+ * ・useCalendarSettingsStore は persist を持たず、server が単一の source of truth
+ * ・全ページで常に最新設定が反映されるよう、app-level で hydrate する
+ * ・TanStack Query の永続キャッシュ（IndexedDB）と組み合わせて cold load でも
+ *   ほぼ即時に正しい値で hydrate される
+ */
+export function UserSettingsInitializer() {
+  useUserSettings();
+  return null;
+}

--- a/src/features/settings/components/UserSettingsInitializer.tsx
+++ b/src/features/settings/components/UserSettingsInitializer.tsx
@@ -2,6 +2,8 @@
 
 import type { ReactNode } from 'react';
 
+import { useTranslations } from 'next-intl';
+
 import { useUserSettings } from '../hooks/useUserSettings';
 
 interface UserSettingsInitializerProps {
@@ -14,24 +16,69 @@ interface UserSettingsInitializerProps {
  * Providers ツリーの最上位で一度だけ `useUserSettings` を呼び、DB から取得した
  * ユーザー設定を `useCalendarSettingsStore` に sync する。
  *
+ * なぜ gate が必要か:
  * ・useCalendarSettingsStore は persist を持たず、server が単一の source of truth
- * ・timezone / weekStartsOn 等の設定は entry 作成等の timezone-dependent mutation
- *   で読まれるため、hydration 前 (defaults) のまま mutation を許すと UTC 変換
- *   がズレる可能性がある
- * ・そのため DB fetch が完了するまで children を render しない。TanStack Query の
- *   永続キャッシュ (IndexedDB) が効いていれば cold load でもほぼ即時に通過する
- * ・fetch 失敗時 (error) は server row なしとみなし defaults で通過する
- * ・オフライン時 (fetchStatus === 'paused') はネットワーク復帰まで解消しない
- *   ため、defaults で通過させて UI を blocking にしない
+ * ・timezone / weekStartsOn 等は entry 作成等の timezone-dependent mutation で
+ *   読まれる。defaults (browser timezone) のまま mutation が動くと UTC 変換が
+ *   ズレ、誤ったタイムスタンプで server に書き込まれる data integrity 問題になる
+ * ・そのため `dbSettings` が確定するまで children を render しない
+ *
+ * 状態別の扱い:
+ * ・hydrated=true (dbSettings === settings object or null): 通過。null は
+ *   "row なし新規ユーザー" の confirmed state なので defaults で OK
+ * ・loading (pending, online): blocking null render
+ * ・error: 再試行 UI を出す。silent fallback はしない
+ * ・paused (offline) + no cache: オフライン UI。mutation がキューイングされる
+ *   前に「offline で settings 未取得」と明示する
  */
 export function UserSettingsInitializer({ children }: UserSettingsInitializerProps) {
-  const { isPending, isPaused, error } = useUserSettings();
+  const t = useTranslations('common');
+  const { hydrated, isPaused, error } = useUserSettings();
 
-  // 通常の cold load 中は render をブロックする。ただし paused (offline) / error は
-  // 永続ブロックの原因になるため defaults で通過させる
-  if (isPending && !error && !isPaused) {
-    return null;
+  if (hydrated) {
+    return <>{children}</>;
   }
 
-  return <>{children}</>;
+  // 未 hydrate の 3 ケース:
+  // 1. error — 再試行を促す（reload で app 全体を reload する簡易対応）
+  if (error) {
+    return (
+      <div
+        role="alert"
+        className="bg-background text-foreground flex min-h-dvh flex-col items-center justify-center gap-4 p-6 text-center"
+      >
+        <p className="text-sm">{t('errors.loadFailedDescription')}</p>
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          className="bg-primary text-primary-foreground rounded-lg px-4 py-2 text-sm font-medium"
+        >
+          {t('actions.retry')}
+        </button>
+      </div>
+    );
+  }
+
+  // 2. paused (offline) — オフラインで cache もない状態
+  if (isPaused) {
+    return (
+      <div
+        role="status"
+        className="bg-background text-foreground flex min-h-dvh flex-col items-center justify-center gap-4 p-6 text-center"
+      >
+        <p className="text-sm">{t('offline.description')}</p>
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          className="bg-primary text-primary-foreground rounded-lg px-4 py-2 text-sm font-medium"
+        >
+          {t('offline.reload')}
+        </button>
+      </div>
+    );
+  }
+
+  // 3. 通常の loading (pending, online): 通常 TanStack Query の永続 cache が効くため
+  // ms 単位。null を返して描画を遅らせる
+  return null;
 }

--- a/src/features/settings/components/UserSettingsInitializer.tsx
+++ b/src/features/settings/components/UserSettingsInitializer.tsx
@@ -21,12 +21,15 @@ interface UserSettingsInitializerProps {
  * ・そのため DB fetch が完了するまで children を render しない。TanStack Query の
  *   永続キャッシュ (IndexedDB) が効いていれば cold load でもほぼ即時に通過する
  * ・fetch 失敗時 (error) は server row なしとみなし defaults で通過する
+ * ・オフライン時 (fetchStatus === 'paused') はネットワーク復帰まで解消しない
+ *   ため、defaults で通過させて UI を blocking にしない
  */
 export function UserSettingsInitializer({ children }: UserSettingsInitializerProps) {
-  const { isPending, error } = useUserSettings();
+  const { isPending, isPaused, error } = useUserSettings();
 
-  // fetch 完了前 (かつエラーでもない) は render しない。エラー時は defaults で通過
-  if (isPending && !error) {
+  // 通常の cold load 中は render をブロックする。ただし paused (offline) / error は
+  // 永続ブロックの原因になるため defaults で通過させる
+  if (isPending && !error && !isPaused) {
     return null;
   }
 

--- a/src/features/settings/components/UserSettingsInitializer.tsx
+++ b/src/features/settings/components/UserSettingsInitializer.tsx
@@ -1,19 +1,34 @@
 'use client';
 
+import type { ReactNode } from 'react';
+
 import { useUserSettings } from '../hooks/useUserSettings';
 
+interface UserSettingsInitializerProps {
+  children: ReactNode;
+}
+
 /**
- * UserSettings 初期化コンポーネント
+ * UserSettings 初期化 + hydration gate コンポーネント
  *
- * Providers ツリーの最上位で一度だけ `useUserSettings` を呼び、
- * DB から取得したユーザー設定を `useCalendarSettingsStore` に sync する。
+ * Providers ツリーの最上位で一度だけ `useUserSettings` を呼び、DB から取得した
+ * ユーザー設定を `useCalendarSettingsStore` に sync する。
  *
  * ・useCalendarSettingsStore は persist を持たず、server が単一の source of truth
- * ・全ページで常に最新設定が反映されるよう、app-level で hydrate する
- * ・TanStack Query の永続キャッシュ（IndexedDB）と組み合わせて cold load でも
- *   ほぼ即時に正しい値で hydrate される
+ * ・timezone / weekStartsOn 等の設定は entry 作成等の timezone-dependent mutation
+ *   で読まれるため、hydration 前 (defaults) のまま mutation を許すと UTC 変換
+ *   がズレる可能性がある
+ * ・そのため DB fetch が完了するまで children を render しない。TanStack Query の
+ *   永続キャッシュ (IndexedDB) が効いていれば cold load でもほぼ即時に通過する
+ * ・fetch 失敗時 (error) は server row なしとみなし defaults で通過する
  */
-export function UserSettingsInitializer() {
-  useUserSettings();
-  return null;
+export function UserSettingsInitializer({ children }: UserSettingsInitializerProps) {
+  const { isPending, error } = useUserSettings();
+
+  // fetch 完了前 (かつエラーでもない) は render しない。エラー時は defaults で通過
+  if (isPending && !error) {
+    return null;
+  }
+
+  return <>{children}</>;
 }

--- a/src/features/settings/hooks/useUserSettings.ts
+++ b/src/features/settings/hooks/useUserSettings.ts
@@ -38,10 +38,16 @@ export function useUserSettings() {
     refetchOnReconnect: false,
   });
 
-  // networkMode: 'offlineFirst' でオフライン時は fetchStatus === 'paused' になる。
-  // paused はネットワーク復帰まで解消しないため、hydration gate で永続ブロック
-  // の原因になる。UserSettingsInitializer はこの値を使って unblock する
+  // networkMode: 'offlineFirst' でオフライン時は fetchStatus === 'paused' になる
   const isPaused = fetchStatus === 'paused';
+
+  // hydration 判定:
+  // - dbSettings === undefined: response 未取得（未解決）
+  // - dbSettings === null: row なし（server は new user に null を返す）
+  // - dbSettings === object: 既存 settings 取得済み
+  // null も「settings row が無い」という confirmed な情報として扱い、defaults で
+  // 通過させる。hydrated = データに触れた（undefined ではない）かどうか
+  const hydrated = dbSettings !== undefined;
 
   // DB更新用mutation
   const updateMutation = api.userSettings.update.useMutation({
@@ -130,6 +136,7 @@ export function useUserSettings() {
     saveSettings,
     isPending,
     isPaused,
+    hydrated,
     isSaving: updateMutation.isPending,
     error,
   };

--- a/src/features/settings/hooks/useUserSettings.ts
+++ b/src/features/settings/hooks/useUserSettings.ts
@@ -3,7 +3,7 @@
  * TanStack Queryを使用してSupabaseと同期
  */
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { toast } from '@/lib/toast';
 import { useTranslations } from 'next-intl';
@@ -41,13 +41,10 @@ export function useUserSettings() {
   // networkMode: 'offlineFirst' でオフライン時は fetchStatus === 'paused' になる
   const isPaused = fetchStatus === 'paused';
 
-  // hydration 判定:
-  // - dbSettings === undefined: response 未取得（未解決）
-  // - dbSettings === null: row なし（server は new user に null を返す）
-  // - dbSettings === object: 既存 settings 取得済み
-  // null も「settings row が無い」という confirmed な情報として扱い、defaults で
-  // 通過させる。hydrated = データに触れた（undefined ではない）かどうか
-  const hydrated = dbSettings !== undefined;
+  // hydration 判定: データ応答を受け取り、Zustand store への apply が完了したか
+  // dbSettings !== undefined だけでは apply useEffect がまだ走っていない commit
+  // が存在しうるため、Zustand への反映完了を別 state として持つ
+  const [storeHydrated, setStoreHydrated] = useState(false);
 
   // DB更新用mutation
   const updateMutation = api.userSettings.update.useMutation({
@@ -70,9 +67,10 @@ export function useUserSettings() {
   // （メール言語変更時にアプリの日付フォーマットが意図せず変わるのを防ぐ）
   const dateFormatInitializedRef = useRef(false);
 
-  // DBから取得した設定をStoreに反映
+  // DBから取得した設定をStoreに反映。null (row なし) は new user として通過する
   useEffect(() => {
-    if (dbSettings && !isPending) {
+    if (isPending) return;
+    if (dbSettings) {
       updateSettings({
         timezone: dbSettings.timezone,
         timeFormat: dbSettings.timeFormat,
@@ -95,6 +93,9 @@ export function useUserSettings() {
       });
       dateFormatInitializedRef.current = true;
     }
+    // dbSettings が object でも null でも apply は完了扱い
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- query 解決後の 1 回限りの hydration flag
+    setStoreHydrated(true);
   }, [dbSettings, isPending, updateSettings]);
 
   // 設定をDBに保存する関数
@@ -136,7 +137,7 @@ export function useUserSettings() {
     saveSettings,
     isPending,
     isPaused,
-    hydrated,
+    hydrated: storeHydrated,
     isSaving: updateMutation.isPending,
     error,
   };

--- a/src/features/settings/hooks/useUserSettings.ts
+++ b/src/features/settings/hooks/useUserSettings.ts
@@ -29,6 +29,7 @@ export function useUserSettings() {
   const {
     data: dbSettings,
     isPending,
+    fetchStatus,
     error,
   } = api.userSettings.get.useQuery(undefined, {
     staleTime: CACHE_5_MINUTES,
@@ -36,6 +37,11 @@ export function useUserSettings() {
     refetchOnMount: false,
     refetchOnReconnect: false,
   });
+
+  // networkMode: 'offlineFirst' でオフライン時は fetchStatus === 'paused' になる。
+  // paused はネットワーク復帰まで解消しないため、hydration gate で永続ブロック
+  // の原因になる。UserSettingsInitializer はこの値を使って unblock する
+  const isPaused = fetchStatus === 'paused';
 
   // DB更新用mutation
   const updateMutation = api.userSettings.update.useMutation({
@@ -123,6 +129,7 @@ export function useUserSettings() {
     settings,
     saveSettings,
     isPending,
+    isPaused,
     isSaving: updateMutation.isPending,
     error,
   };

--- a/src/features/settings/index.ts
+++ b/src/features/settings/index.ts
@@ -21,6 +21,7 @@ export { SETTINGS_CATEGORIES } from './constants';
 export { SettingsContent, isValidCategory } from './components/SettingsContent';
 export { SettingsDialog } from './components/SettingsDialog';
 export { SettingsSidebar } from './components/SettingsSidebar';
+export { UserSettingsInitializer } from './components/UserSettingsInitializer';
 
 // =============================================================================
 // Hooks

--- a/src/lib/stores/useCalendarSettingsStore.ts
+++ b/src/lib/stores/useCalendarSettingsStore.ts
@@ -1,10 +1,9 @@
 import { create } from 'zustand';
-import { devtools, persist } from 'zustand/middleware';
+import { devtools } from 'zustand/middleware';
 
 import type { CalendarViewType, HourHeightDensity } from '@/lib/calendar-constants';
 import { DEFAULT_CHRONOTYPE_SETTINGS } from '@/lib/chronotype-defaults';
 import type { ChronotypeSettings as ChronotypeSettingsState } from '@/lib/types/chronotype';
-import { platformStorage } from '@/lib/zustand/storage';
 
 export type { CalendarViewType } from '@/lib/calendar-constants';
 
@@ -74,32 +73,27 @@ const defaultSettings: CalendarSettings = {
   hourHeightDensity: 'default',
 };
 
-/** カレンダー設定を管理するZustandストア（localStorageに永続化） */
+/**
+ * カレンダー設定を管理する Zustand ストア
+ *
+ * persist せず、`UserSettingsInitializer` (Providers 直下) が server (user_settings)
+ * から取得した値を hydrate する。multi-tab 間の staleness を避けるため、localStorage
+ * に独自コピーを保持しない。cold load 時は defaultSettings → TanStack Query の
+ * 永続 cache から hydrate される流れでほぼ即時に正しい値になる。
+ */
 export const useCalendarSettingsStore = create<CalendarSettingsStore>()(
   devtools(
-    persist(
-      (set) => {
-        return {
-          ...defaultSettings,
+    (set) => ({
+      ...defaultSettings,
 
-          updateSettings: (newSettings) =>
-            set((state) => ({
-              ...state,
-              ...newSettings,
-            })),
+      updateSettings: (newSettings) =>
+        set((state) => ({
+          ...state,
+          ...newSettings,
+        })),
 
-          resetSettings: () => set({ ...defaultSettings }),
-        };
-      },
-      {
-        name: 'calendar-settings',
-        storage: platformStorage(),
-        partialize: (state) => {
-          const { updateSettings: _u, resetSettings: _r, ...persisted } = state;
-          return persisted;
-        },
-      },
-    ),
+      resetSettings: () => set({ ...defaultSettings }),
+    }),
     {
       name: 'calendar-settings-store',
       enabled: process.env.NODE_ENV !== 'production',


### PR DESCRIPTION
## Summary

- `useCalendarSettingsStore` から `persist(platformStorage())` を削除
- `UserSettingsInitializer` を新設し Providers 直下にマウント
- 全ページで `userSettings.get` を driven とする hydrate-on-mount パターンに
- 他の persist store (useShellStore / useCalendarFilterStore / useTourStore / useEntryFilterStore factory) は UI ephemeral or 端末ローカル性質なので維持

## Context

[P0 audit plan](../../plans/app-agent-claude-code-ok-delightful-valley.md) の P0-2。

### Before
- Zustand が localStorage に独自コピーを persist
- 他タブで timezone 変更 → localStorage と server が不整合 → stale な値で entry 作成
- server-of-truth が 2 箇所（server + localStorage）

### After
- Zustand は in-memory のみ
- `UserSettingsInitializer` が `useUserSettings` を app-level で呼び、server データを hydrate
- TanStack Query の永続 cache (IndexedDB) と組み合わせて cold load でもほぼ即時に正しい値
- multi-tab で常に server と一致

## Trade-off

- **Risk**: cold load 時 TanStack Query cache がまだ hydrate されていない極短時間、Zustand に `defaultSettings` (browser timezone + ISO date format + 月曜開始) が見える可能性
- **Mitigation**: PersistQueryClientProvider が IndexedDB から userSettings.get を instant restore する設計。初回アクセスの user だけが影響（その user はまだ server に settings row がない）

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run lint:boundaries`
- [x] `npm run test:run` (95 files / 1424 tests pass)
- [ ] 手動: calendar / stats / settings 各ページで timezone / weekStartsOn 等が正しく表示されるか
- [ ] 手動: settings で timezone 変更 → 別タブリロードで即反映されるか（multi-tab sync）
- [ ] 手動: 初回ログイン user (user_settings 行なし) が defaults で起動できるか

🤖 Generated with [Claude Code](https://claude.com/claude-code)