### PR TITLE
chore(deps): dependabot dev グループをエコシステム単位に細分化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,8 @@ updates:
       time: '09:00'
       timezone: 'Asia/Tokyo'
 
-    # PR数の制限（3件まで並列処理）
-    open-pull-requests-limit: 3
+    # PR数の制限（grouping を細分化したため少し増やす）
+    open-pull-requests-limit: 6
 
     # ラベル設定（securityは自動付与に任せる）
     labels:
@@ -29,7 +29,10 @@ updates:
       prefix: 'chore'
       include: 'scope'
 
-    # グループ化設定（minor/patchをまとめる）
+    # グループ化設定
+    # development を 1 グループにまとめると 30+ 件の bundle になり、storybook /
+    # playwright / tailwindcss など互いに無関係な breaking が混ざって blast radius
+    # を読めなくなるため、エコシステム単位で細分化する。
     groups:
       production:
         dependency-type: 'production'
@@ -37,8 +40,76 @@ updates:
           - 'minor'
           - 'patch'
 
-      development:
+      # storybook は addon 同士の version を揃える必要があるためまとめる
+      development-storybook:
+        patterns:
+          - '@storybook/*'
+          - 'storybook'
+          - 'eslint-plugin-storybook'
+        update-types:
+          - 'minor'
+          - 'patch'
+
+      # テストランナー / E2E ツールは互いに依存があるためまとめる
+      development-testing:
+        patterns:
+          - '@playwright/*'
+          - 'playwright'
+          - '@axe-core/*'
+          - 'vitest'
+          - '@vitest/*'
+          - 'happy-dom'
+          - '@testing-library/*'
+        update-types:
+          - 'minor'
+          - 'patch'
+
+      # lint / format / type ツール群
+      development-linting:
+        patterns:
+          - 'eslint'
+          - 'eslint-*'
+          - '@eslint/*'
+          - 'typescript-eslint'
+          - '@typescript-eslint/*'
+          - 'prettier'
+          - 'prettier-plugin-*'
+          - '@commitlint/*'
+        update-types:
+          - 'minor'
+          - 'patch'
+
+      # @types/* は受け身の型更新で blast radius が小さい
+      development-types:
+        patterns:
+          - '@types/*'
+        update-types:
+          - 'minor'
+          - 'patch'
+
+      # 上記グループに属さない残りの dev deps
+      development-other:
         dependency-type: 'development'
+        exclude-patterns:
+          - '@storybook/*'
+          - 'storybook'
+          - 'eslint-plugin-storybook'
+          - '@playwright/*'
+          - 'playwright'
+          - '@axe-core/*'
+          - 'vitest'
+          - '@vitest/*'
+          - 'happy-dom'
+          - '@testing-library/*'
+          - 'eslint'
+          - 'eslint-*'
+          - '@eslint/*'
+          - 'typescript-eslint'
+          - '@typescript-eslint/*'
+          - 'prettier'
+          - 'prettier-plugin-*'
+          - '@commitlint/*'
+          - '@types/*'
         update-types:
           - 'minor'
           - 'patch'


### PR DESCRIPTION
## Why

development グループを 1 つにまとめている現状の設定では、weekly run で 37 件超の bundle PR (#1049 / #1064 / #1065) が生まれ、互いに無関係な breaking change (storybook minor + playwright minor + tailwindcss minor 等) が混在して blast radius を読めない状態になっていた。

## What

`.github/dependabot.yml` の development group を 5 つに分割:

- **development-storybook**: `@storybook/*` / `storybook` / `eslint-plugin-storybook` (addon 間の version 整合性が必要なためグループ化を維持)
- **development-testing**: `@playwright/*` / `playwright` / `vitest` / `@vitest/*` / `@testing-library/*` / `@axe-core/*` / `happy-dom`
- **development-linting**: `eslint` / `eslint-*` / `@eslint/*` / `typescript-eslint` / `@typescript-eslint/*` / `prettier` / `prettier-plugin-*` / `@commitlint/*`
- **development-types**: `@types/*` (型のみ、blast radius 最小)
- **development-other**: 上記以外の dev deps (build tools 等)

`open-pull-requests-limit` を 3 → 6 に拡張 (production + dev 5 グループ + GH actions のため)。

## Test plan

- [ ] dependabot config 自体に CI は走らない (yaml syntax のみ)
- [ ] merge 後、次回 dependabot run で 5 つの細分化された dev グループ PR が生まれることを確認
- [ ] 既存の #1065 (development 37 件 bundle) はクローズして dependabot に再生成させる

## Related

37 件 bundle で発生していた問題:
- storybook 10.2 → 10.3 で `experimentalComponentsManifest` 型が消えて TS 失敗
- prettier plugin 関連の reformat 5 ファイル fail
- 個別に判断したい playwright / tailwindcss minor が混在
