### PR TITLE
fix(tags): codex レビュー P1+P2 x2 を修正

### DIFF
--- a/src/features/calendar/components/tag-filter/components/TagFlatList.tsx
+++ b/src/features/calendar/components/tag-filter/components/TagFlatList.tsx
@@ -529,9 +529,10 @@ function SortableParentBlock({
   const groupVisibility = getGroupVisibility(groupTagIds);
   const headerIcon = node.tag.icon ?? node.children[0]?.icon ?? null;
   const isPopoverOpen = openPopoverTagId === node.tag.id;
-  const shouldShowChildContainer = !collapsed;
   const canDropChildHere =
     !!activeTreeTag && activeTreeTag.tag.id !== node.tag.id && canBecomeChild(activeTreeTag);
+  // collapsed でも drag 中は drop 先として残す（reparent を ungroup と誤認させない）
+  const shouldShowChildContainer = !collapsed || (!!activeDragId && canDropChildHere);
 
   const style = isMobile
     ? undefined

--- a/src/features/tags/components/TagQuickSelector.tsx
+++ b/src/features/tags/components/TagQuickSelector.tsx
@@ -103,10 +103,12 @@ function TagQuickSelectorContent({
     closeSelf();
     openTagCreateModal({
       onCreated: (tag) => {
-        onCreateAndSelect(tag.name, tag.color, tag.icon, tag.parent_id);
+        // tag は modal 側で作成済み。caller の onCreateAndSelect は再度 mutation
+        // を呼んで duplicate-name で fail するので、id を直接 onSelect に渡す。
+        onSelect(tag.id, tag.name);
       },
     });
-  }, [closeSelf, openTagCreateModal, onCreateAndSelect]);
+  }, [closeSelf, openTagCreateModal, onSelect]);
 
   const isTagZero = sortedTags.length === 0;
 

--- a/src/features/tags/components/tag-create-modal.tsx
+++ b/src/features/tags/components/tag-create-modal.tsx
@@ -119,23 +119,36 @@ export function TagCreateModal({ open, onClose, initialParentId, onCreated }: Ta
   );
 
   const trimmedDebounced = debouncedName.trim();
-
-  const duplicate = useMemo(() => {
-    if (!trimmedDebounced) return false;
-    const lower = trimmedDebounced.toLowerCase();
-    return allTags.some(
-      (tag) =>
-        tag.is_active !== false && tag.parent_id === parentId && tag.name.toLowerCase() === lower,
-    );
-  }, [allTags, parentId, trimmedDebounced]);
-
   const trimmedLive = name.trim();
+
+  const checkDuplicate = useCallback(
+    (value: string) => {
+      if (!value) return false;
+      const lower = value.toLowerCase();
+      return allTags.some(
+        (tag) =>
+          tag.is_active !== false && tag.parent_id === parentId && tag.name.toLowerCase() === lower,
+      );
+    },
+    [allTags, parentId],
+  );
+
+  const duplicate = useMemo(
+    () => checkDuplicate(trimmedDebounced),
+    [checkDuplicate, trimmedDebounced],
+  );
+
   const canSubmit = trimmedLive.length > 0 && !duplicate && !submitting;
 
   const errorMessage = duplicate ? t('duplicateName') : null;
 
   const handleSubmit = useCallback(async () => {
-    if (!canSubmit) return;
+    if (submitting || trimmedLive.length === 0) return;
+    // debounce (200ms) より早く submit された場合に備え、live name で同期再チェック
+    if (checkDuplicate(trimmedLive)) {
+      setDebouncedName(trimmedLive);
+      return;
+    }
     setSubmitting(true);
     try {
       const created = await createTagMutation.mutateAsync({
@@ -157,7 +170,17 @@ export function TagCreateModal({ open, onClose, initialParentId, onCreated }: Ta
     } finally {
       setSubmitting(false);
     }
-  }, [canSubmit, createTagMutation, trimmedLive, color, icon, parentId, onCreated, onClose]);
+  }, [
+    submitting,
+    trimmedLive,
+    checkDuplicate,
+    createTagMutation,
+    color,
+    icon,
+    parentId,
+    onCreated,
+    onClose,
+  ]);
 
   const handleNameKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Summary

PR #1081 (v0.27.0) の Codex 自動レビューで検出された 3 件のバグに対応。

リリースノートでは「v0.27.1 で対応予定」と記載していたものを前倒しで修正。

## Fixes

### P1: TagQuickSelector の double-create バグ
[`src/features/tags/components/TagQuickSelector.tsx`](src/features/tags/components/TagQuickSelector.tsx)

`TagCreateModal` が既にタグを作成済みなのに、`onCreated` ハンドラが `onCreateAndSelect(...)` を呼んでおり、caller (`EntryInspectorForm` / `InlineTagPalette`) が二度目の `useCreateTag` mutation を走らせていた。これにより：

- duplicate-name エラーが発生
- 新規作成タグが未選択のまま残る (EntryInspectorForm 経由)

**Fix**: 作成済み tag の id を直接 `onSelect(tag.id, tag.name)` に渡すように変更。`onCreateAndSelect` は zero-tag empty state のサンプルチップ経由でのみ呼ばれる形になる。

### P2: tag-create-modal の duplicate check timing
[`src/features/tags/components/tag-create-modal.tsx`](src/features/tags/components/tag-create-modal.tsx)

duplicate 判定が `debouncedName` (200ms lag) ベースだったため、素早く submit するとサーバー側で重複検出されて fail していた。

**Fix**: `checkDuplicate(value)` 関数化し、`handleSubmit` で live `trimmedLive` を使って同期再検査。重複なら `setDebouncedName` で error message を即時表示して return。

### P2: collapsed group へのタグドロップ regression
[`src/features/calendar/components/tag-filter/components/TagFlatList.tsx`](src/features/calendar/components/tag-filter/components/TagFlatList.tsx)

`shouldShowChildContainer = !collapsed` だったため、collapsed group の `children:<groupId>` droppable が消失。`moveTagTree` が drop を root-level reorder と解釈し、reparent ではなく ungroup として処理されていた。

**Fix**: drag 中 (`activeDragId && canDropChildHere`) は collapsed でも drop 先として残すように条件を緩和。

## Quality Checks

- ✅ `npm run typecheck`
- ✅ `npm run lint`
- ✅ `npm run test:run -- src/features/tags` (61/61)

## 既知の限界

InlineTagPalette の modal 経由フローでは、`closeSelf()` 時に `pendingSelection` が clear されるため、modal 完了後の `handleCreate` が pendingSelection 不在で early return する。**duplicate エラーは出なくなるが、エントリ作成は silent に skip される**。これは pre-existing な orthogonal な問題であり、別 PR で `pendingSelection` の保持タイミングを再設計する予定。EntryInspectorForm 経由のフローはこの PR で完全に動作する。

## Test plan

- [ ] EntryInspectorForm から TagQuickSelector → 「+」→ modal で新規タグ作成 → 該当 entry に新規タグが選択されることを確認
- [ ] tag-create-modal で既存名を素早く入力して submit → サーバーリクエスト前に inline error が表示されることを確認
- [ ] collapsed group にタグを drag → 子として reparent されることを確認 (root-level reorder にならないこと)

🤖 Generated with [Claude Code](https://claude.com/claude-code)