### PR TITLE
test(calendar): medium priority — interaction / cache hook / CRUD 橋渡しの回帰テスト

### DIFF
--- a/src/features/calendar/components/views/shared/utils/__tests__/interactionHelpers.test.ts
+++ b/src/features/calendar/components/views/shared/utils/__tests__/interactionHelpers.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+
+import type { InteractionState } from '../../../../../interaction';
+
+import { getAdjustedStyle, getPreviewTime } from '../interactionHelpers';
+
+const idle: InteractionState = { mode: 'idle' };
+
+const dragging: InteractionState = {
+  mode: 'dragging',
+  entryId: 'plan-1',
+  startPoint: { x: 0, y: 0 },
+  currentPoint: { x: 100, y: 200 },
+  originalPosition: { top: 0, height: 60, left: 0, width: 100 },
+  dateIndex: 0,
+  targetDateIndex: 0,
+  snappedTop: 60,
+  previewTime: {
+    start: new Date('2026-04-27T01:00:00.000Z'),
+    end: new Date('2026-04-27T02:00:00.000Z'),
+  },
+  isOverlapping: false,
+};
+
+const resizing: InteractionState = {
+  mode: 'resizing',
+  entryId: 'plan-1',
+  startPoint: { x: 0, y: 0 },
+  currentPoint: { x: 0, y: 100 },
+  originalPosition: { top: 0, height: 60, left: 0, width: 100 },
+  direction: 'bottom',
+  snappedHeight: 120,
+  previewTime: {
+    start: new Date('2026-04-27T01:00:00.000Z'),
+    end: new Date('2026-04-27T03:00:00.000Z'),
+  },
+  isOverlapping: false,
+};
+
+const baseStyle: React.CSSProperties = {
+  top: 0,
+  height: 60,
+  background: 'red',
+};
+
+describe('getAdjustedStyle', () => {
+  it('idle 状態では元のスタイルをそのまま返す', () => {
+    const result = getAdjustedStyle(baseStyle, 'plan-1', idle);
+    expect(result).toEqual(baseStyle);
+  });
+
+  describe('dragging', () => {
+    it('対象 plan には opacity=0.3 / zIndex=1 を付与', () => {
+      const result = getAdjustedStyle(baseStyle, 'plan-1', dragging);
+      expect(result).toMatchObject({
+        ...baseStyle,
+        opacity: 0.3,
+        zIndex: 1,
+      });
+    });
+
+    it('別の plan は影響を受けない（元スタイルそのまま）', () => {
+      const result = getAdjustedStyle(baseStyle, 'plan-2', dragging);
+      expect(result).toEqual(baseStyle);
+      expect(result).not.toHaveProperty('opacity');
+    });
+  });
+
+  describe('resizing', () => {
+    it('対象 plan には snappedHeight を反映 / zIndex=1000 を付与', () => {
+      const result = getAdjustedStyle(baseStyle, 'plan-1', resizing);
+      expect(result).toMatchObject({
+        ...baseStyle,
+        height: '120px',
+        zIndex: 1000,
+      });
+    });
+
+    it('別の plan は影響を受けない', () => {
+      const result = getAdjustedStyle(baseStyle, 'plan-2', resizing);
+      expect(result).toEqual(baseStyle);
+    });
+  });
+
+  it('元のスタイル を mutate しない', () => {
+    const original = { ...baseStyle };
+    getAdjustedStyle(original, 'plan-1', dragging);
+    expect(original).toEqual(baseStyle);
+  });
+});
+
+describe('getPreviewTime', () => {
+  it('idle / dragging では null を返す（resize 時のみ表示）', () => {
+    expect(getPreviewTime('plan-1', idle)).toBeNull();
+    expect(getPreviewTime('plan-1', dragging)).toBeNull();
+  });
+
+  it('resizing 中で対象 plan なら previewTime を返す', () => {
+    const result = getPreviewTime('plan-1', resizing);
+    expect(result).toEqual(resizing.previewTime);
+  });
+
+  it('resizing 中でも別 plan の場合は null', () => {
+    expect(getPreviewTime('plan-2', resizing)).toBeNull();
+  });
+});

--- a/src/features/calendar/components/views/shared/utils/__tests__/interactionHelpers.test.ts
+++ b/src/features/calendar/components/views/shared/utils/__tests__/interactionHelpers.test.ts
@@ -9,8 +9,8 @@ const idle: InteractionState = { mode: 'idle' };
 const dragging: InteractionState = {
   mode: 'dragging',
   entryId: 'plan-1',
-  startPoint: { x: 0, y: 0 },
-  currentPoint: { x: 100, y: 200 },
+  startPoint: { clientX: 0, clientY: 0 },
+  currentPoint: { clientX: 100, clientY: 200 },
   originalPosition: { top: 0, height: 60, left: 0, width: 100 },
   dateIndex: 0,
   targetDateIndex: 0,
@@ -22,18 +22,19 @@ const dragging: InteractionState = {
   isOverlapping: false,
 };
 
-const resizing: InteractionState = {
+const resizingPreviewTime = {
+  start: new Date('2026-04-27T01:00:00.000Z'),
+  end: new Date('2026-04-27T03:00:00.000Z'),
+};
+const resizing: Extract<InteractionState, { mode: 'resizing' }> = {
   mode: 'resizing',
   entryId: 'plan-1',
-  startPoint: { x: 0, y: 0 },
-  currentPoint: { x: 0, y: 100 },
+  startPoint: { clientX: 0, clientY: 0 },
+  currentPoint: { clientX: 0, clientY: 100 },
   originalPosition: { top: 0, height: 60, left: 0, width: 100 },
   direction: 'bottom',
   snappedHeight: 120,
-  previewTime: {
-    start: new Date('2026-04-27T01:00:00.000Z'),
-    end: new Date('2026-04-27T03:00:00.000Z'),
-  },
+  previewTime: resizingPreviewTime,
   isOverlapping: false,
 };
 

--- a/src/features/calendar/hooks/operations/__tests__/useEntryOperations.test.tsx
+++ b/src/features/calendar/hooks/operations/__tests__/useEntryOperations.test.tsx
@@ -1,0 +1,215 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CalendarEvent } from '@/lib/types/calendar-event';
+
+const updateMutate = vi.fn();
+const deleteMutate = vi.fn();
+const getByIdGetData = vi.fn();
+const toastSuccess = vi.fn();
+const loggerError = vi.fn();
+
+vi.mock('@/features/entry', () => ({
+  useEntryMutations: () => ({
+    updateEntry: { mutate: updateMutate },
+    deleteEntry: { mutate: deleteMutate },
+  }),
+}));
+
+vi.mock('@/lib/trpc', () => ({
+  api: {
+    useUtils: () => ({
+      entries: {
+        getById: { getData: getByIdGetData },
+      },
+    }),
+  },
+}));
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: (msg: string, opts: unknown) => toastSuccess(msg, opts),
+  },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: loggerError, info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+const { useEntryOperations } = await import('../useEntryOperations');
+
+function makeEvent(overrides: Partial<CalendarEvent> & { id: string }): CalendarEvent {
+  const start = new Date('2026-04-27T01:00:00.000Z');
+  const end = new Date('2026-04-27T02:00:00.000Z');
+  return {
+    title: 'Sample',
+    startDate: start,
+    endDate: end,
+    status: 'open',
+    color: '',
+    createdAt: start,
+    updatedAt: start,
+    displayStartDate: start,
+    displayEndDate: end,
+    duration: 60,
+    isMultiDay: false,
+    ...overrides,
+  };
+}
+
+describe('useEntryOperations', () => {
+  beforeEach(() => {
+    updateMutate.mockReset();
+    deleteMutate.mockReset();
+    getByIdGetData.mockReset();
+    toastSuccess.mockReset();
+    loggerError.mockReset();
+  });
+
+  describe('handleEntryDelete', () => {
+    it('deleteEntry.mutate を {id} で呼ぶ', async () => {
+      const { result } = renderHook(() => useEntryOperations());
+      await result.current.handleEntryDelete('entry-1');
+
+      expect(deleteMutate).toHaveBeenCalledWith({ id: 'entry-1' });
+    });
+  });
+
+  describe('handleUpdateEntry: string overload', () => {
+    it('id + updates から start_time / end_time を ISO で渡す', async () => {
+      getByIdGetData.mockReturnValue({
+        id: 'entry-1',
+        start_time: '2026-04-27T00:00:00.000Z',
+        end_time: '2026-04-27T01:00:00.000Z',
+      });
+
+      const { result } = renderHook(() => useEntryOperations());
+      await result.current.handleUpdateEntry('entry-1', {
+        startTime: new Date('2026-04-27T01:00:00.000Z'),
+        endTime: new Date('2026-04-27T02:00:00.000Z'),
+      });
+
+      expect(updateMutate).toHaveBeenCalledWith(
+        {
+          id: 'entry-1',
+          data: {
+            start_time: '2026-04-27T01:00:00.000Z',
+            end_time: '2026-04-27T02:00:00.000Z',
+          },
+        },
+        expect.objectContaining({ onSuccess: expect.any(Function) }),
+      );
+    });
+
+    it('resetActualTime=true なら actual_start_time / actual_end_time も null で送る', async () => {
+      getByIdGetData.mockReturnValue(null);
+
+      const { result } = renderHook(() => useEntryOperations());
+      await result.current.handleUpdateEntry('entry-1', {
+        startTime: new Date('2026-04-27T01:00:00.000Z'),
+        endTime: new Date('2026-04-27T02:00:00.000Z'),
+        resetActualTime: true,
+      });
+
+      const callArgs = updateMutate.mock.calls[0]?.[0] as { data: Record<string, unknown> };
+      expect(callArgs.data).toMatchObject({
+        actual_start_time: null,
+        actual_end_time: null,
+      });
+    });
+
+    it('resetActualTime 未指定なら actual_* フィールドを送らない', async () => {
+      getByIdGetData.mockReturnValue(null);
+
+      const { result } = renderHook(() => useEntryOperations());
+      await result.current.handleUpdateEntry('entry-1', {
+        startTime: new Date('2026-04-27T01:00:00.000Z'),
+        endTime: new Date('2026-04-27T02:00:00.000Z'),
+      });
+
+      const callArgs = updateMutate.mock.calls[0]?.[0] as { data: Record<string, unknown> };
+      expect(callArgs.data).not.toHaveProperty('actual_start_time');
+      expect(callArgs.data).not.toHaveProperty('actual_end_time');
+    });
+
+    it('onSuccess で showTimeChangeUndoToast が呼ばれ、Undo 用に prev 時間が toast.action に格納される', async () => {
+      getByIdGetData.mockReturnValue({
+        id: 'entry-1',
+        start_time: '2026-04-27T00:00:00.000Z',
+        end_time: '2026-04-27T00:30:00.000Z',
+      });
+
+      const { result } = renderHook(() => useEntryOperations());
+      await result.current.handleUpdateEntry('entry-1', {
+        startTime: new Date('2026-04-27T01:00:00.000Z'),
+        endTime: new Date('2026-04-27T02:00:00.000Z'),
+      });
+
+      // mutate に渡された onSuccess を呼んで toast 発火を再現
+      const onSuccess = updateMutate.mock.calls[0]?.[1].onSuccess as () => void;
+      onSuccess();
+
+      expect(toastSuccess).toHaveBeenCalledTimes(1);
+      const [, opts] = toastSuccess.mock.calls[0] as [string, { action: { onClick: () => void } }];
+      // Undo クリックで prev 時間が mutate される
+      opts.action.onClick();
+      expect(updateMutate).toHaveBeenLastCalledWith({
+        id: 'entry-1',
+        data: {
+          start_time: '2026-04-27T00:00:00.000Z',
+          end_time: '2026-04-27T00:30:00.000Z',
+        },
+      });
+    });
+  });
+
+  describe('handleUpdateEntry: object overload (CalendarEvent)', () => {
+    it('startDate が null なら logger.error を出して mutate を呼ばない', async () => {
+      const event = makeEvent({ id: 'e1', startDate: null });
+
+      const { result } = renderHook(() => useEntryOperations());
+      await result.current.handleUpdateEntry(event);
+
+      expect(loggerError).toHaveBeenCalled();
+      expect(updateMutate).not.toHaveBeenCalled();
+    });
+
+    it('CalendarEvent の startDate / endDate を ISO で送り Undo toast を仕込む', async () => {
+      getByIdGetData.mockReturnValue({
+        id: 'e1',
+        start_time: '2026-04-27T00:00:00.000Z',
+        end_time: '2026-04-27T01:00:00.000Z',
+      });
+      const event = makeEvent({ id: 'e1' });
+
+      const { result } = renderHook(() => useEntryOperations());
+      await result.current.handleUpdateEntry(event);
+
+      expect(updateMutate).toHaveBeenCalledWith(
+        {
+          id: 'e1',
+          data: {
+            start_time: '2026-04-27T01:00:00.000Z',
+            end_time: '2026-04-27T02:00:00.000Z',
+          },
+        },
+        expect.objectContaining({ onSuccess: expect.any(Function) }),
+      );
+    });
+
+    it('endDate が undefined でも data.end_time は undefined で問題なし', async () => {
+      getByIdGetData.mockReturnValue(null);
+      const event = makeEvent({ id: 'e1', endDate: null });
+
+      const { result } = renderHook(() => useEntryOperations());
+      await result.current.handleUpdateEntry(event);
+
+      const callArgs = updateMutate.mock.calls[0]?.[0] as { data: Record<string, unknown> };
+      expect(callArgs.data.end_time).toBeUndefined();
+    });
+  });
+});

--- a/src/features/entry/hooks/__tests__/useUpdateEntityTagsInCache.test.tsx
+++ b/src/features/entry/hooks/__tests__/useUpdateEntityTagsInCache.test.tsx
@@ -1,0 +1,174 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const setDataById = vi.fn();
+const setDataByIdWithTags = vi.fn();
+
+vi.mock('@/lib/trpc', () => ({
+  api: {
+    useUtils: () => ({
+      entries: {
+        getById: {
+          setData: vi.fn((input: unknown, updater: unknown) => {
+            const inputObj = input as { id: string; include?: { tags: boolean } };
+            if (inputObj.include?.tags) {
+              setDataByIdWithTags(input, updater);
+            } else {
+              setDataById(input, updater);
+            }
+          }),
+        },
+      },
+    }),
+  },
+}));
+
+const { useUpdateEntityTagsInCache } = await import('../useUpdateEntityTagsInCache');
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return {
+    queryClient,
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  };
+}
+
+describe('useUpdateEntityTagsInCache', () => {
+  beforeEach(() => {
+    setDataById.mockClear();
+    setDataByIdWithTags.mockClear();
+  });
+
+  describe('list キャッシュ更新', () => {
+    it('entries.list キャッシュの該当 entity の tagId を更新する', () => {
+      const { queryClient, wrapper } = createWrapper();
+
+      const seed = [
+        { id: 'e1', tagId: 'tag-old', title: 'A' },
+        { id: 'e2', tagId: 'tag-other', title: 'B' },
+      ];
+      queryClient.setQueryData([['entries', 'list']], seed);
+
+      const { result } = renderHook(() => useUpdateEntityTagsInCache('entries'), { wrapper });
+      result.current('e1', ['tag-new']);
+
+      const updated = queryClient.getQueryData<typeof seed>([['entries', 'list']]);
+      expect(updated?.[0]).toMatchObject({ id: 'e1', tagId: 'tag-new' });
+      // 別 entity は影響を受けない
+      expect(updated?.[1]).toMatchObject({ id: 'e2', tagId: 'tag-other' });
+    });
+
+    it('newTagIds が空配列なら tagId=null に設定する', () => {
+      const { queryClient, wrapper } = createWrapper();
+
+      queryClient.setQueryData([['entries', 'list']], [{ id: 'e1', tagId: 'tag-old' }]);
+
+      const { result } = renderHook(() => useUpdateEntityTagsInCache('entries'), { wrapper });
+      result.current('e1', []);
+
+      const updated = queryClient.getQueryData<{ id: string; tagId: string | null }[]>([
+        ['entries', 'list'],
+      ]);
+      expect(updated?.[0]?.tagId).toBeNull();
+    });
+
+    it('複数の list キャッシュ（input 違い）を全て更新する', () => {
+      const { queryClient, wrapper } = createWrapper();
+
+      queryClient.setQueryData(
+        [['entries', 'list'], { input: { status: 'open' }, type: 'query' }],
+        [{ id: 'e1', tagId: 'tag-old' }],
+      );
+      queryClient.setQueryData(
+        [['entries', 'list'], { input: { status: 'closed' }, type: 'query' }],
+        [{ id: 'e1', tagId: 'tag-old' }],
+      );
+
+      const { result } = renderHook(() => useUpdateEntityTagsInCache('entries'), { wrapper });
+      result.current('e1', ['tag-new']);
+
+      const open = queryClient.getQueryData<{ id: string; tagId: string }[]>([
+        ['entries', 'list'],
+        { input: { status: 'open' }, type: 'query' },
+      ]);
+      const closed = queryClient.getQueryData<{ id: string; tagId: string }[]>([
+        ['entries', 'list'],
+        { input: { status: 'closed' }, type: 'query' },
+      ]);
+      expect(open?.[0]?.tagId).toBe('tag-new');
+      expect(closed?.[0]?.tagId).toBe('tag-new');
+    });
+
+    it('entries.getById のキャッシュは predicate にマッチせず list 経由では触らない', () => {
+      const { queryClient, wrapper } = createWrapper();
+
+      queryClient.setQueryData([['entries', 'getById'], { input: { id: 'e1' }, type: 'query' }], {
+        id: 'e1',
+        tagId: 'tag-old',
+      });
+
+      const { result } = renderHook(() => useUpdateEntityTagsInCache('entries'), { wrapper });
+      result.current('e1', ['tag-new']);
+
+      // setQueriesData の predicate は list だけにマッチするので getById キャッシュはそのまま
+      const got = queryClient.getQueryData<{ tagId: string }>([
+        ['entries', 'getById'],
+        { input: { id: 'e1' }, type: 'query' },
+      ]);
+      expect(got?.tagId).toBe('tag-old');
+    });
+
+    it('対象 list が空配列でも throw しない（no-op）', () => {
+      const { queryClient, wrapper } = createWrapper();
+      queryClient.setQueryData([['entries', 'list']], []);
+
+      const { result } = renderHook(() => useUpdateEntityTagsInCache('entries'), { wrapper });
+      expect(() => result.current('e1', ['tag-new'])).not.toThrow();
+    });
+  });
+
+  describe('getById setData', () => {
+    it('include なし / include={tags:true} の両方を更新する', () => {
+      const { wrapper } = createWrapper();
+      const { result } = renderHook(() => useUpdateEntityTagsInCache('entries'), { wrapper });
+
+      result.current('e1', ['tag-new']);
+
+      expect(setDataById).toHaveBeenCalledWith({ id: 'e1' }, expect.any(Function));
+      expect(setDataByIdWithTags).toHaveBeenCalledWith(
+        { id: 'e1', include: { tags: true } },
+        expect.any(Function),
+      );
+    });
+
+    it('updater は oldData が null/undefined なら同じ値を返す（no-op）', () => {
+      const { wrapper } = createWrapper();
+      const { result } = renderHook(() => useUpdateEntityTagsInCache('entries'), { wrapper });
+
+      result.current('e1', ['tag-new']);
+
+      const updaterCall = setDataById.mock.calls[0]?.[1] as (data: unknown) => unknown;
+      expect(updaterCall(null)).toBeNull();
+      expect(updaterCall(undefined)).toBeUndefined();
+    });
+
+    it('updater は tagId のみ書き換えて他フィールドは保持する', () => {
+      const { wrapper } = createWrapper();
+      const { result } = renderHook(() => useUpdateEntityTagsInCache('entries'), { wrapper });
+
+      result.current('e1', ['tag-new']);
+
+      const updaterCall = setDataById.mock.calls[0]?.[1] as (
+        data: Record<string, unknown> | null,
+      ) => Record<string, unknown> | null;
+      const result2 = updaterCall({ id: 'e1', title: 'A', tagId: 'tag-old' });
+      expect(result2).toEqual({ id: 'e1', title: 'A', tagId: 'tag-new' });
+    });
+  });
+});

--- a/src/features/entry/lib/__tests__/new-entry-tracker.test.ts
+++ b/src/features/entry/lib/__tests__/new-entry-tracker.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { clearNew, isNewEntry, markNew } from '../new-entry-tracker';
+
+// モジュールレベルの Set を共有しているため、各テスト後にクリーンアップする
+const TEST_IDS = ['entry-1', 'entry-2', 'entry-3'];
+
+afterEach(() => {
+  TEST_IDS.forEach(clearNew);
+});
+
+describe('new-entry-tracker', () => {
+  it('markNew で追加した ID は isNewEntry=true', () => {
+    markNew('entry-1');
+    expect(isNewEntry('entry-1')).toBe(true);
+  });
+
+  it('未マーク ID は isNewEntry=false', () => {
+    expect(isNewEntry('entry-2')).toBe(false);
+  });
+
+  it('clearNew でマークが解除される', () => {
+    markNew('entry-1');
+    expect(isNewEntry('entry-1')).toBe(true);
+
+    clearNew('entry-1');
+    expect(isNewEntry('entry-1')).toBe(false);
+  });
+
+  it('複数 ID を独立して扱える', () => {
+    markNew('entry-1');
+    markNew('entry-2');
+
+    expect(isNewEntry('entry-1')).toBe(true);
+    expect(isNewEntry('entry-2')).toBe(true);
+    expect(isNewEntry('entry-3')).toBe(false);
+
+    clearNew('entry-1');
+    expect(isNewEntry('entry-1')).toBe(false);
+    expect(isNewEntry('entry-2')).toBe(true);
+  });
+
+  it('未登録 ID への clearNew は no-op（throw しない）', () => {
+    expect(() => clearNew('entry-3')).not.toThrow();
+    expect(isNewEntry('entry-3')).toBe(false);
+  });
+
+  it('markNew は冪等（同 ID を 2 回追加しても 1 回 clearNew で消える）', () => {
+    markNew('entry-1');
+    markNew('entry-1');
+
+    clearNew('entry-1');
+    expect(isNewEntry('entry-1')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- 計 4 ファイル / +550 行のテスト追加
- pure 関数 2 件 + tRPC を絡めた hook 2 件
- 実装コード変更ゼロ（テスト追加と既存型への narrowing のみ）

## 追加したテスト

| Commit | 対象 | LOC | カバレッジ |
|---|---|---|---|
| c9ced09e7 | [entry/lib/new-entry-tracker.ts](src/features/entry/lib/new-entry-tracker.ts) | 23 | mark / clear / 冪等性 / 複数 ID 独立 |
| e71cf2ecb + f2d710943 | [calendar/components/views/shared/utils/interactionHelpers.ts](src/features/calendar/components/views/shared/utils/interactionHelpers.ts) | 50 | drag opacity/zIndex、resize snappedHeight/zIndex、別 plan 非干渉 |
| 24f98b087 | [entry/hooks/useUpdateEntityTagsInCache.ts](src/features/entry/hooks/useUpdateEntityTagsInCache.ts) | 53 | list cache 更新 / getById include 両 key / null updater no-op |
| 10a689489 | [calendar/hooks/operations/useEntryOperations.ts](src/features/calendar/hooks/operations/useEntryOperations.ts) | 129 | delete 配線、string/object overload、resetActualTime、Undo toast onClick で prev 時刻に rollback |

## なぜこの選択か

PR #1084 で出した優先順位リストの Medium のうち、ROI が見合うものを選定。

- **pure 関数 (#13, #14)**: Set 操作と style merge は silent degrade が起きやすい代表例
- **hook (#11, #10)**: tRPC + QueryClient + toast の配線層。drag/resize で UI と DB が乖離する bug を防ぐ。renderHook + module mock のパターンを確立したので reach できた

## 除外したもの

| # | 対象 | 理由 |
|---|---|---|
| #12 | entry-status.ts | 既に充実したテスト済み（survey 段階で誤識別） |
| #9 | useEntryMutations.ts (538 LOC) | 楽観的更新 + onMutate/onError/onSettled + Inspector store + Realtime 競合と密結合。テスト setup が hook 量を超えるため別 PR が clean |

## Test plan

- [x] `npm run typecheck` pass
- [x] `npm run lint:boundaries` pass
- [x] calendar / entry / tags unit suite 566 cases pass
- [x] 既存テストへの破壊的変更なし
- [ ] CI 通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
