### PR TITLE
test(entry): statistics / tag-statistics router に createCaller ベースの回帰テスト

### DIFF
--- a/src/features/entry/server/__tests__/statistics-router.test.ts
+++ b/src/features/entry/server/__tests__/statistics-router.test.ts
@@ -1,0 +1,224 @@
+/**
+ * statistics router 回帰テスト
+ *
+ * createCallerFactory + createMockContext で procedure を直接呼び出し、
+ * RPC 呼び出しの引数組み立て、結果の transformation、エラー時の TRPCError
+ * 変換を検証する。DB RPC 関数自体の集計ロジックは scope 外。
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createMockContext } from '@/lib/test/trpc-test-helpers';
+import { createCallerFactory } from '@/lib/trpc/procedures';
+
+// Sentry の trace は test 中ノイズになるので noop に
+vi.mock('@/lib/sentry/trace', () => ({
+  traceDbQuery: <T>(_op: string, fn: () => Promise<T>) => fn(),
+}));
+
+import { entriesStatisticsRouter } from '../statistics';
+
+const createCaller = createCallerFactory(entriesStatisticsRouter);
+
+function authedCtx(rpcImpl: ReturnType<typeof vi.fn>) {
+  const ctx = createMockContext({ userId: 'user-1' });
+  ctx.supabase.rpc = rpcImpl as never;
+  // proProcedure 用に subscriptionStatus を設定（DB フォールバック回避）
+  return Object.assign(ctx, { subscriptionStatus: 'active' });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// =============================================================================
+// 認証ガード
+// =============================================================================
+
+describe('statistics router: 認証ガード', () => {
+  it('未認証で getTagStats は UNAUTHORIZED', async () => {
+    const ctx = createMockContext({ userId: undefined });
+    const caller = createCaller(ctx);
+    await expect(caller.getTagStats()).rejects.toThrow(
+      expect.objectContaining({ code: 'UNAUTHORIZED' }),
+    );
+  });
+});
+
+// =============================================================================
+// getTagStats: counts / lastUsed への transformation
+// =============================================================================
+
+describe('statistics.getTagStats', () => {
+  it('RPC 結果を { counts, lastUsed } に変換する', async () => {
+    const rpc = vi.fn().mockResolvedValueOnce({
+      data: [
+        { tag_id: 'tag-1', entry_count: 5, last_used: '2026-04-20' },
+        { tag_id: 'tag-2', entry_count: 2, last_used: null },
+      ],
+      error: null,
+    });
+    const caller = createCaller(authedCtx(rpc));
+
+    const result = await caller.getTagStats();
+
+    expect(rpc).toHaveBeenCalledWith('get_tag_stats', { p_user_id: 'user-1' });
+    expect(result).toEqual({
+      counts: { 'tag-1': 5, 'tag-2': 2 },
+      lastUsed: { 'tag-1': '2026-04-20' },
+    });
+  });
+
+  it('data=null でも空のオブジェクトを返す', async () => {
+    const rpc = vi.fn().mockResolvedValueOnce({ data: null, error: null });
+    const caller = createCaller(authedCtx(rpc));
+
+    const result = await caller.getTagStats();
+    expect(result).toEqual({ counts: {}, lastUsed: {} });
+  });
+
+  it('RPC エラーは INTERNAL_SERVER_ERROR に変換される', async () => {
+    const rpc = vi.fn().mockResolvedValueOnce({ data: null, error: { message: 'db down' } });
+    const caller = createCaller(authedCtx(rpc));
+
+    await expect(caller.getTagStats()).rejects.toThrow(
+      expect.objectContaining({ code: 'INTERNAL_SERVER_ERROR' }),
+    );
+  });
+});
+
+// =============================================================================
+// getTimeByTag: row mapping + 期間 filter
+// =============================================================================
+
+describe('statistics.getTimeByTag', () => {
+  it('snake_case row を camelCase に変換する', async () => {
+    const rpc = vi.fn().mockResolvedValueOnce({
+      data: [{ tag_id: 'tag-1', tag_name: 'Deep Work', tag_color: 'blue', hours: 12.5 }],
+      error: null,
+    });
+    const caller = createCaller(authedCtx(rpc));
+
+    const result = await caller.getTimeByTag();
+
+    expect(result).toEqual([{ tagId: 'tag-1', name: 'Deep Work', color: 'blue', hours: 12.5 }]);
+  });
+
+  it('startDate / endDate を p_start_date / p_end_date として送る（stripUndefined 適用）', async () => {
+    const rpc = vi.fn().mockResolvedValueOnce({ data: [], error: null });
+    const caller = createCaller(authedCtx(rpc));
+
+    await caller.getTimeByTag({
+      startDate: '2026-04-01T00:00:00.000Z',
+      endDate: '2026-04-30T23:59:59.000Z',
+    });
+
+    expect(rpc).toHaveBeenCalledWith('get_time_by_tag', {
+      p_user_id: 'user-1',
+      p_start_date: '2026-04-01T00:00:00.000Z',
+      p_end_date: '2026-04-30T23:59:59.000Z',
+    });
+  });
+
+  it('input なしなら p_user_id のみで呼ぶ（undefined params が落ちる）', async () => {
+    const rpc = vi.fn().mockResolvedValueOnce({ data: [], error: null });
+    const caller = createCaller(authedCtx(rpc));
+
+    await caller.getTimeByTag();
+
+    expect(rpc).toHaveBeenCalledWith('get_time_by_tag', { p_user_id: 'user-1' });
+  });
+});
+
+// =============================================================================
+// getDailyHours: input 検証 + pass-through
+// =============================================================================
+
+describe('statistics.getDailyHours', () => {
+  it('year を p_year として送り、結果をそのまま返す', async () => {
+    const rows = [{ date: '2026-04-27', hours: 8 }];
+    const rpc = vi.fn().mockResolvedValueOnce({ data: rows, error: null });
+    const caller = createCaller(authedCtx(rpc));
+
+    const result = await caller.getDailyHours({ year: 2026 });
+
+    expect(rpc).toHaveBeenCalledWith('get_daily_hours', {
+      p_user_id: 'user-1',
+      p_year: 2026,
+    });
+    expect(result).toEqual(rows);
+  });
+
+  it('year が範囲外なら zod バリデーション失敗', async () => {
+    const rpc = vi.fn();
+    const caller = createCaller(authedCtx(rpc));
+
+    await expect(caller.getDailyHours({ year: 1999 })).rejects.toThrow();
+    expect(rpc).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// getHourlyDistribution: 24 時間 → 12 個の 2h スロット集約
+// =============================================================================
+
+describe('statistics.getHourlyDistribution (proProcedure)', () => {
+  it('24 時間データを 12 個の 2h スロットに集約する（minutes → hours 変換）', async () => {
+    const rows = [
+      { hour: 0, total_minutes: 60 }, // 1h
+      { hour: 1, total_minutes: 30 }, // 0.5h
+      { hour: 9, total_minutes: 120 }, // 2h
+      { hour: 23, total_minutes: 60 }, // 1h
+    ];
+    const rpc = vi.fn().mockResolvedValueOnce({ data: rows, error: null });
+    const caller = createCaller(authedCtx(rpc));
+
+    const result = await caller.getHourlyDistribution();
+
+    expect(result).toHaveLength(12);
+    expect(result[0]).toEqual({ timeSlot: '00:00', hours: 1.5 }); // 1+0.5
+    expect(result[4]).toEqual({ timeSlot: '08:00', hours: 2 }); // 9時のみ
+    expect(result[11]).toEqual({ timeSlot: '22:00', hours: 1 }); // 23時のみ
+  });
+
+  it('範囲外 hour（>=24, <0）は無視される', async () => {
+    const rows = [
+      { hour: -1, total_minutes: 60 },
+      { hour: 24, total_minutes: 60 },
+      { hour: 12, total_minutes: 60 },
+    ];
+    const rpc = vi.fn().mockResolvedValueOnce({ data: rows, error: null });
+    const caller = createCaller(authedCtx(rpc));
+
+    const result = await caller.getHourlyDistribution();
+    // 12 時のみ反映（slot 6 = "12:00"）
+    expect(result[6]).toEqual({ timeSlot: '12:00', hours: 1 });
+    // 他の slot は 0
+    expect(result[0]?.hours).toBe(0);
+  });
+});
+
+// =============================================================================
+// getDayOfWeekDistribution: Monday-first 並べ替え
+// =============================================================================
+
+describe('statistics.getDayOfWeekDistribution (proProcedure)', () => {
+  it('日曜始まり (dow=0..6) を月曜始まりに並べ替えて返す', async () => {
+    // dow=0 は Sunday, dow=1 は Monday, ..., dow=6 は Saturday
+    const rows = [
+      { dow: 0, total_minutes: 60 }, // 日: 1h
+      { dow: 1, total_minutes: 120 }, // 月: 2h
+      { dow: 6, total_minutes: 30 }, // 土: 0.5h
+    ];
+    const rpc = vi.fn().mockResolvedValueOnce({ data: rows, error: null });
+    const caller = createCaller(authedCtx(rpc));
+
+    const result = await caller.getDayOfWeekDistribution();
+
+    expect(result).toHaveLength(7);
+    // 月曜が先頭、日曜が末尾
+    expect(result[0]).toEqual({ day: '月', hours: 2 });
+    expect(result[5]).toEqual({ day: '土', hours: 0.5 });
+    expect(result[6]).toEqual({ day: '日', hours: 1 });
+  });
+});

--- a/src/features/entry/server/__tests__/tag-statistics-router.test.ts
+++ b/src/features/entry/server/__tests__/tag-statistics-router.test.ts
@@ -1,0 +1,303 @@
+/**
+ * tag-statistics router 回帰テスト
+ *
+ * createCallerFactory + createMockContext で procedure を直接呼び出し、
+ * 統合 API（getTagOverview / getTagTimeline）の RPC 並列呼び出し、
+ * 結果集約、snake_case → camelCase 変換、null フォールバックを検証する。
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createMockContext } from '@/lib/test/trpc-test-helpers';
+import { createCallerFactory } from '@/lib/trpc/procedures';
+
+vi.mock('@/lib/sentry/trace', () => ({
+  traceDbQuery: <T>(_op: string, fn: () => Promise<T>) => fn(),
+}));
+
+import { entriesTagStatisticsRouter } from '../tag-statistics';
+
+const createCaller = createCallerFactory(entriesTagStatisticsRouter);
+
+function authedCtx(rpcImpl: ReturnType<typeof vi.fn>) {
+  const ctx = createMockContext({ userId: 'user-1' });
+  ctx.supabase.rpc = rpcImpl as never;
+  return Object.assign(ctx, { subscriptionStatus: 'active' });
+}
+
+const TAG_ID = '11111111-1111-1111-1111-111111111111';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// =============================================================================
+// 認証 / Pro guard
+// =============================================================================
+
+describe('tag-statistics router: 認証ガード', () => {
+  it('未認証で getTagOverview は UNAUTHORIZED', async () => {
+    const ctx = createMockContext({ userId: undefined });
+    const caller = createCaller(ctx);
+    await expect(caller.getTagOverview({ tagId: TAG_ID })).rejects.toThrow(
+      expect.objectContaining({ code: 'UNAUTHORIZED' }),
+    );
+  });
+});
+
+// =============================================================================
+// getTagOverview: 7 RPC 並列 + 集約
+// =============================================================================
+
+describe('tag-statistics.getTagOverview (proProcedure)', () => {
+  function setupOverviewRpc(overrides: Record<string, unknown> = {}) {
+    return vi.fn((name: string, _params?: Record<string, unknown>) => {
+      const responses: Record<string, unknown> = {
+        get_tag_cumulative_time: { data: { totalMinutes: 480 }, error: null },
+        get_tag_avg_fulfillment: { data: { avgFulfillment: 2.4, entryCount: 25 }, error: null },
+        get_tag_plan_rate: {
+          data: { totalEntries: 30, plannedEntries: 25, planRate: 0.83 },
+          error: null,
+        },
+        get_tag_fulfillment_distribution: {
+          data: [
+            { score: 1, count: 5 },
+            { score: 2, count: 10 },
+            { score: 3, count: 10 },
+          ],
+          error: null,
+        },
+        get_tag_hourly_distribution: {
+          data: [
+            { hour: 9, total_minutes: 120 },
+            { hour: 14, total_minutes: 60 },
+          ],
+          error: null,
+        },
+        get_tag_dow_distribution: {
+          data: [
+            { dow: 1, total_minutes: 240 },
+            { dow: 5, total_minutes: 60 },
+          ],
+          error: null,
+        },
+        get_child_tag_breakdown: {
+          data: [{ tag_id: 'child-1', tag_name: 'Sub', tag_color: 'blue', hours: 4 }],
+          error: null,
+        },
+        ...overrides,
+      };
+      return Promise.resolve(responses[name] ?? { data: null, error: null });
+    });
+  }
+
+  it('7 RPC が並列に呼ばれ、結果が集約される', async () => {
+    const rpc = setupOverviewRpc();
+    const caller = createCaller(authedCtx(rpc));
+
+    const result = await caller.getTagOverview({ tagId: TAG_ID });
+
+    // 7 RPC 呼ばれた
+    expect(rpc).toHaveBeenCalledTimes(7);
+    expect(result.totalMinutes).toBe(480);
+    expect(result.entryCount).toBe(25);
+    expect(result.avgFulfillment).toBe(2.4);
+    expect(result.totalEntries).toBe(30);
+    expect(result.plannedEntries).toBe(25);
+    expect(result.planRate).toBe(0.83);
+    expect(result.fulfillmentDist).toHaveLength(3);
+  });
+
+  it('hourly は 24 要素配列に展開される', async () => {
+    const rpc = setupOverviewRpc();
+    const caller = createCaller(authedCtx(rpc));
+
+    const result = await caller.getTagOverview({ tagId: TAG_ID });
+
+    expect(result.hourly).toHaveLength(24);
+    expect(result.hourly[9]).toEqual({ hour: 9, minutes: 120 });
+    expect(result.hourly[14]).toEqual({ hour: 14, minutes: 60 });
+    expect(result.hourly[0]).toEqual({ hour: 0, minutes: 0 });
+  });
+
+  it('dow は月曜始まりの 7 要素配列に並べ替えられる', async () => {
+    const rpc = setupOverviewRpc();
+    const caller = createCaller(authedCtx(rpc));
+
+    const result = await caller.getTagOverview({ tagId: TAG_ID });
+
+    expect(result.dow).toHaveLength(7);
+    // dow=1（月）が先頭、dow=0（日）が末尾
+    expect(result.dow[0]).toEqual({ dow: 1, minutes: 240 });
+    expect(result.dow[4]).toEqual({ dow: 5, minutes: 60 });
+    expect(result.dow[6]).toEqual({ dow: 0, minutes: 0 });
+  });
+
+  it('childTags は snake_case → camelCase に変換される', async () => {
+    const rpc = setupOverviewRpc();
+    const caller = createCaller(authedCtx(rpc));
+
+    const result = await caller.getTagOverview({ tagId: TAG_ID });
+
+    expect(result.childTags).toEqual([{ tagId: 'child-1', name: 'Sub', color: 'blue', hours: 4 }]);
+  });
+
+  it('全 RPC が data=null でも形が保たれる（null フォールバック）', async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: null, error: null });
+    const caller = createCaller(authedCtx(rpc));
+
+    const result = await caller.getTagOverview({ tagId: TAG_ID });
+
+    expect(result).toEqual({
+      totalMinutes: 0,
+      entryCount: 0,
+      avgFulfillment: null,
+      totalEntries: 0,
+      plannedEntries: 0,
+      planRate: 0,
+      fulfillmentDist: [],
+      hourly: Array.from({ length: 24 }, (_, hour) => ({ hour, minutes: 0 })),
+      dow: [1, 2, 3, 4, 5, 6, 0].map((dow) => ({ dow, minutes: 0 })),
+      childTags: [],
+    });
+  });
+
+  it('startDate / endDate を全 RPC の引数に含める（buildDateRange）', async () => {
+    const rpc = setupOverviewRpc();
+    const caller = createCaller(authedCtx(rpc));
+
+    await caller.getTagOverview({
+      tagId: TAG_ID,
+      startDate: '2026-04-01T00:00:00.000Z',
+      endDate: '2026-04-30T23:59:59.000Z',
+    });
+
+    // 最初の 6 RPC は p_tag_id を含む
+    const firstCall = rpc.mock.calls[0]?.[1];
+    expect(firstCall).toMatchObject({
+      p_user_id: 'user-1',
+      p_tag_id: TAG_ID,
+      p_start_date: '2026-04-01T00:00:00.000Z',
+      p_end_date: '2026-04-30T23:59:59.000Z',
+    });
+
+    // 7 番目（child breakdown）は p_parent_tag_id
+    const childCall = rpc.mock.calls[6]?.[1];
+    expect(childCall).toMatchObject({
+      p_user_id: 'user-1',
+      p_parent_tag_id: TAG_ID,
+      p_start_date: '2026-04-01T00:00:00.000Z',
+      p_end_date: '2026-04-30T23:59:59.000Z',
+    });
+  });
+
+  it('startDate / endDate なしなら p_start_date / p_end_date を含めない', async () => {
+    const rpc = setupOverviewRpc();
+    const caller = createCaller(authedCtx(rpc));
+
+    await caller.getTagOverview({ tagId: TAG_ID });
+
+    const firstCall = rpc.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(firstCall).not.toHaveProperty('p_start_date');
+    expect(firstCall).not.toHaveProperty('p_end_date');
+  });
+});
+
+// =============================================================================
+// getTagTimeline: 2 RPC 並列 + bucket / recentLimit パラメータ
+// =============================================================================
+
+describe('tag-statistics.getTagTimeline (proProcedure)', () => {
+  it('trend と recentEntries が camelCase に変換される', async () => {
+    const rpc = vi.fn((name: string) => {
+      if (name === 'get_tag_accuracy_trend') {
+        return Promise.resolve({
+          data: [{ bucket: '2026-04', avg_deviation: -5.2, entry_count: 10 }],
+          error: null,
+        });
+      }
+      if (name === 'get_tag_recent_entries') {
+        return Promise.resolve({
+          data: [
+            {
+              entry_id: 'e1',
+              title: 'Meeting',
+              start_time: '2026-04-27T01:00:00.000Z',
+              end_time: '2026-04-27T02:00:00.000Z',
+              duration_minutes: 60,
+              planned_minutes: 60,
+              fulfillment_score: 3,
+            },
+          ],
+          error: null,
+        });
+      }
+      return Promise.resolve({ data: null, error: null });
+    });
+    const caller = createCaller(authedCtx(rpc));
+
+    const result = await caller.getTagTimeline({ tagId: TAG_ID });
+
+    expect(result.trend).toEqual([{ bucket: '2026-04', avgDeviation: -5.2, entryCount: 10 }]);
+    expect(result.recentEntries).toEqual([
+      {
+        entryId: 'e1',
+        title: 'Meeting',
+        startTime: '2026-04-27T01:00:00.000Z',
+        endTime: '2026-04-27T02:00:00.000Z',
+        durationMinutes: 60,
+        plannedMinutes: 60,
+        fulfillmentScore: 3,
+      },
+    ]);
+  });
+
+  it('bucket / recentLimit が指定された時のみ p_bucket / p_limit が送られる', async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: [], error: null });
+    const caller = createCaller(authedCtx(rpc));
+
+    await caller.getTagTimeline({ tagId: TAG_ID, bucket: 'week', recentLimit: 5 });
+
+    const trendCall = rpc.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(trendCall.p_bucket).toBe('week');
+
+    const recentCall = rpc.mock.calls[1]?.[1] as Record<string, unknown>;
+    expect(recentCall.p_limit).toBe(5);
+  });
+
+  it('bucket / recentLimit なしなら p_bucket / p_limit を含めない', async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: [], error: null });
+    const caller = createCaller(authedCtx(rpc));
+
+    await caller.getTagTimeline({ tagId: TAG_ID });
+
+    const trendCall = rpc.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(trendCall).not.toHaveProperty('p_bucket');
+
+    const recentCall = rpc.mock.calls[1]?.[1] as Record<string, unknown>;
+    expect(recentCall).not.toHaveProperty('p_limit');
+  });
+
+  it('recentLimit は zod で 1..50 の範囲外を拒否する', async () => {
+    const rpc = vi.fn();
+    const caller = createCaller(authedCtx(rpc));
+
+    await expect(caller.getTagTimeline({ tagId: TAG_ID, recentLimit: 100 })).rejects.toThrow();
+    expect(rpc).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// 単発 procedure: getTagCumulativeTime のエラーハンドリング
+// =============================================================================
+
+describe('tag-statistics.getTagCumulativeTime', () => {
+  it('RPC エラーは INTERNAL_SERVER_ERROR に変換される', async () => {
+    const rpc = vi.fn().mockResolvedValueOnce({ data: null, error: { message: 'db down' } });
+    const caller = createCaller(authedCtx(rpc));
+
+    await expect(caller.getTagCumulativeTime({ tagId: TAG_ID })).rejects.toThrow(
+      expect.objectContaining({ code: 'INTERNAL_SERVER_ERROR' }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- 統計系 tRPC router 2 つに createCallerFactory ベースの回帰テストを追加
- 2 ファイル / +527 行 / 25 cases
- 実装コード変更ゼロ

## なぜこの PR か

PR #1085 の優先順位リストでは statistics.ts (1008 LOC) と tag-statistics.ts (658 LOC) を「tRPC router で集計は DB RPC 側、helper は internal で test には refactor が必要」として deferred にしていた。

billing-router で確立済みの **`createCallerFactory` + `createMockContext`** パターンを使えば refactor 不要で procedure を直接呼び出して isolation テストできることが分かったので、この層も保護する。

## アプローチ

```ts
const ctx = createMockContext({ userId: 'user-1' });
ctx.supabase.rpc = vi.fn().mockResolvedValueOnce({ data: ..., error: null });
const caller = createCaller({ ...ctx, subscriptionStatus: 'active' });
const result = await caller.getTagOverview({ tagId });
```

DB RPC は mock し、router 層の責務（引数組み立て / 結果集約 / 変換 / エラー TRPCError 化）のみを検証する。DB 関数自体の集計ロジックは scope 外。

## カバレッジ

| Router | Procedure | 検証内容 |
|---|---|---|
| statistics | getTagStats | counts/lastUsed transformation、null fallback、INTERNAL_SERVER_ERROR |
| statistics | getTimeByTag | snake→camel、stripUndefined（startDate/endDate あり/なし） |
| statistics | getDailyHours | zod range（2000-2100）、p_year pass-through |
| statistics | getHourlyDistribution (proProcedure) | 24h → 12 個 2h スロット集約、minutes→hours 変換、範囲外無視 |
| statistics | getDayOfWeekDistribution (proProcedure) | 日曜始まり → 月曜始まり並べ替え |
| statistics | 認証 | UNAUTHORIZED ガード |
| tag-statistics | getTagOverview (proProcedure) | 7 RPC 並列、null fallback で形維持、hourly 24 配列展開、dow 月曜始まり、childTags camelCase、buildDateRange の有無 |
| tag-statistics | getTagTimeline (proProcedure) | 2 RPC 並列、bucket/recentLimit 条件付き、zod range（1-50） |
| tag-statistics | getTagCumulativeTime | RPC エラー → INTERNAL_SERVER_ERROR |
| tag-statistics | 認証 | UNAUTHORIZED ガード |

## Test plan

- [x] `npm run typecheck` pass
- [x] `npm run lint:boundaries` pass
- [x] calendar / entry / tags suite 705 cases pass
- [ ] CI 通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
