### PR TITLE
chore(storybook): width-only decorator を withWrapper factory に共通化

### DIFF
--- a/.storybook/decorators/index.tsx
+++ b/.storybook/decorators/index.tsx
@@ -16,6 +16,22 @@ import { StoryTRPCProvider } from '../mocks/trpc';
 
 export { storeMockDecorator } from '../mocks/stores';
 
+/**
+ * Story を任意の className でラップする decorator factory
+ *
+ * よくある「固定幅で Story をプレビューする」パターンをまとめる:
+ * `withWrapper('w-[500px]')` で `<div className="w-[500px]"><Story /></div>` 相当。
+ * 既存の inline decorator と完全に同じ JSX を返すため見た目に影響しない。
+ */
+export const withWrapper = (className: string): Decorator => {
+  const WrappedStory: Decorator = (Story) => (
+    <div className={className}>
+      <Story />
+    </div>
+  );
+  return WrappedStory;
+};
+
 // メッセージファイルを自動収集（namespace追加時に変更不要）
 const messageModules = import.meta.glob<Record<string, string>>('../../messages/ja/*.json', {
   eager: true,

--- a/src/lib/components/common/EmptyState.stories.tsx
+++ b/src/lib/components/common/EmptyState.stories.tsx
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { CalendarDays, Inbox } from 'lucide-react';
 
 import { Button } from '@/lib/components/ui/button';
+
+import { withWrapper } from '../../../../.storybook/decorators';
 import { EmptyState } from './EmptyState';
 
 const meta = {
@@ -30,13 +32,7 @@ const meta = {
       description: '親要素内で中央配置',
     },
   },
-  decorators: [
-    (Story) => (
-      <div className="w-[400px]">
-        <Story />
-      </div>
-    ),
-  ],
+  decorators: [withWrapper('w-[400px]')],
 } satisfies Meta<typeof EmptyState>;
 
 export default meta;

--- a/src/lib/components/common/LabeledRow.stories.tsx
+++ b/src/lib/components/common/LabeledRow.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
 import { Switch } from '@/lib/components/ui/switch';
+import { withWrapper } from '../../../../.storybook/decorators';
 
 import { LabeledRow } from './LabeledRow';
 
@@ -8,13 +9,7 @@ const meta = {
   title: 'Components/Common/LabeledRow',
   component: LabeledRow,
   tags: ['autodocs'],
-  decorators: [
-    (Story) => (
-      <div className="w-[500px]">
-        <Story />
-      </div>
-    ),
-  ],
+  decorators: [withWrapper('w-[500px]')],
 } satisfies Meta<typeof LabeledRow>;
 
 export default meta;

--- a/src/lib/components/common/SectionCard.stories.tsx
+++ b/src/lib/components/common/SectionCard.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
 import { Button } from '@/lib/components/ui/button';
 import { Switch } from '@/lib/components/ui/switch';
+import { withWrapper } from '../../../../.storybook/decorators';
 
 import { LabeledRow } from './LabeledRow';
 import { SectionCard } from './SectionCard';
@@ -10,13 +11,7 @@ const meta = {
   title: 'Components/Common/SectionCard',
   component: SectionCard,
   tags: ['autodocs'],
-  decorators: [
-    (Story) => (
-      <div className="w-[500px]">
-        <Story />
-      </div>
-    ),
-  ],
+  decorators: [withWrapper('w-[500px]')],
 } satisfies Meta<typeof SectionCard>;
 
 export default meta;

--- a/src/lib/components/shell/sidebar/BlockItem.stories.tsx
+++ b/src/lib/components/shell/sidebar/BlockItem.stories.tsx
@@ -9,6 +9,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { fn } from 'storybook/test';
 
 import { TagIcon } from '@/features/tags';
+import { withWrapper } from '../../../../../.storybook/decorators';
 
 import { BlockItem } from './BlockItem';
 
@@ -19,13 +20,7 @@ const meta = {
   args: {
     onClick: fn(),
   },
-  decorators: [
-    (Story) => (
-      <div className="w-64">
-        <Story />
-      </div>
-    ),
-  ],
+  decorators: [withWrapper('w-64')],
   tags: ['autodocs'],
 } satisfies Meta<typeof BlockItem>;
 

--- a/src/lib/components/shell/sidebar/Sidebar.stories.tsx
+++ b/src/lib/components/shell/sidebar/Sidebar.stories.tsx
@@ -6,7 +6,9 @@ import { Button } from '@/lib/components/ui/button';
 import { HoverTooltip } from '@/lib/components/ui/tooltip';
 import { useShellStore } from '@/lib/stores/useShellStore';
 
+import { withWrapper } from '../../../../../.storybook/decorators';
 import { PRESET_AUTH } from '../../../../../.storybook/mocks/presets';
+
 import { Sidebar } from './Sidebar';
 
 // ── Mock: サイドバーコンテンツ（SidebarContent の簡易版） ──
@@ -116,13 +118,7 @@ export const Default: Story = {
   args: {
     children: <MockSidebarContent />,
   },
-  decorators: [
-    (Story) => (
-      <div className="h-[500px] w-64">
-        <Story />
-      </div>
-    ),
-  ],
+  decorators: [withWrapper('h-[500px] w-64')],
 };
 
 /** コンテンツなし。children スロットが空の状態。 */
@@ -134,13 +130,7 @@ export const Empty: Story = {
       </div>
     ),
   },
-  decorators: [
-    (Story) => (
-      <div className="h-[400px] w-64">
-        <Story />
-      </div>
-    ),
-  ],
+  decorators: [withWrapper('h-[400px] w-64')],
 };
 
 /**

--- a/src/lib/components/shell/sidebar/SidebarSection.stories.tsx
+++ b/src/lib/components/shell/sidebar/SidebarSection.stories.tsx
@@ -16,6 +16,7 @@ import { getTagColorClasses } from '@/lib/tag-colors';
 
 import { TagIcon } from '@/features/tags';
 
+import { withWrapper } from '../../../../../.storybook/decorators';
 import { BlockItem } from './BlockItem';
 import { SidebarSection } from './SidebarSection';
 
@@ -185,13 +186,7 @@ export const Default: Story = {
       </div>
     ),
   },
-  decorators: [
-    (Story) => (
-      <div className="w-64 px-2">
-        <Story />
-      </div>
-    ),
-  ],
+  decorators: [withWrapper('w-64 px-2')],
 };
 
 /** action スロット付き（+ボタン）。 */
@@ -216,13 +211,7 @@ export const WithAction: Story = {
       </div>
     ),
   },
-  decorators: [
-    (Story) => (
-      <div className="w-64 px-2">
-        <Story />
-      </div>
-    ),
-  ],
+  decorators: [withWrapper('w-64 px-2')],
 };
 
 /** サイドバー全体再現 — ヘッダー + カレンダー + タグ + パレット + 履歴 + テーマ + フッター。 */


### PR DESCRIPTION
## Summary

- common / shell の story で繰り返し書かれていた width-only decorator を `withWrapper(className)` factory に共通化
- 7 ファイル / 8 箇所 / -56 行 +32 行（差分は -24 行）
- 見た目・既存 API・routing いずれも変更なし

## 動機

`common/` と `shell/sidebar/` 配下の 6 story で、Story を固定幅でプレビューするためだけの ほぼ同じ inline decorator が 8 回書かれていた:

```tsx
decorators: [(Story) => <div className="w-[500px]"><Story /></div>]
```

これを `.storybook/decorators` の `withWrapper(className)` factory に集約した。生成される JSX は inline 版と完全一致するため、Storybook 側での見た目は変わらない。

## 変更点

### `.storybook/decorators/index.tsx`

```tsx
export const withWrapper = (className: string): Decorator => {
  const WrappedStory: Decorator = (Story) => (
    <div className={className}>
      <Story />
    </div>
  );
  return WrappedStory;
};
```

### 置換対象（8 箇所）

| File | Before → After |
|---|---|
| `common/EmptyState.stories.tsx` (meta) | inline `w-[400px]` → `withWrapper('w-[400px]')` |
| `common/LabeledRow.stories.tsx` (meta) | inline `w-[500px]` → `withWrapper('w-[500px]')` |
| `common/SectionCard.stories.tsx` (meta) | inline `w-[500px]` → `withWrapper('w-[500px]')` |
| `shell/sidebar/BlockItem.stories.tsx` (meta) | inline `w-64` → `withWrapper('w-64')` |
| `shell/sidebar/Sidebar.stories.tsx` (Default story) | inline `h-[500px] w-64` → `withWrapper('h-[500px] w-64')` |
| `shell/sidebar/Sidebar.stories.tsx` (Empty story) | inline `h-[400px] w-64` → `withWrapper('h-[400px] w-64')` |
| `shell/sidebar/SidebarSection.stories.tsx` (DefaultPalette story) | inline `w-64 px-2` → `withWrapper('w-64 px-2')` |
| `shell/sidebar/SidebarSection.stories.tsx` (WithAction story) | inline `w-64 px-2` → `withWrapper('w-64 px-2')` |

## あえて触らなかったもの

下記 decorator は単純な width 指定を超える responsibility を持つため対象外:

- `EmptyState.stories.tsx` の `TableEmpty` story — border + 高さ + radius 付き container
- `CookieConsentBanner.stories.tsx` — localStorage の事前 setup を含む
- `NavBadge.stories.tsx` — Sparkles アイコン込みの container

## Test plan

- [x] `npm run typecheck` pass
- [x] `npm run lint:boundaries` pass
- [x] unit suite 1228 cases pass
- [x] 既存 inline decorator と JSX 完全一致 → 視覚的に identical
- [ ] CI 通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
