### PR TITLE
chore(storybook): withWrapper の取り逃がし 3 箇所を共通化 (round 2)

### DIFF
--- a/src/lib/components/common/EmptyState.stories.tsx
+++ b/src/lib/components/common/EmptyState.stories.tsx
@@ -49,13 +49,7 @@ export const Default: Story = {
 
 /** テーブル内（size="sm" + centered + actions）。実使用: TableEmptyState, PlanTableEmptyState */
 export const TableEmpty: Story = {
-  decorators: [
-    (Story) => (
-      <div className="border-border h-[300px] w-[400px] rounded-2xl border">
-        <Story />
-      </div>
-    ),
-  ],
+  decorators: [withWrapper('border-border h-[300px] w-[400px] rounded-2xl border')],
   args: {
     icon: Inbox,
     title: 'アイテムがありません',

--- a/src/lib/components/ui/mini-calendar.stories.tsx
+++ b/src/lib/components/ui/mini-calendar.stories.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 
 import { Button } from '@/lib/components/ui/button';
 import { MiniCalendar } from '@/lib/components/ui/mini-calendar';
+import { withWrapper } from '../../../../.storybook/decorators';
 
 const meta = {
   title: 'Components/UI/MiniCalendar',
@@ -25,13 +26,7 @@ const meta = {
       description: '「日付なし」ボタンを表示するか',
     },
   },
-  decorators: [
-    (Story) => (
-      <div className="w-72">
-        <Story />
-      </div>
-    ),
-  ],
+  decorators: [withWrapper('w-72')],
 } satisfies Meta<typeof MiniCalendar>;
 
 export default meta;

--- a/src/lib/components/ui/separator.stories.tsx
+++ b/src/lib/components/ui/separator.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
+import { withWrapper } from '../../../../.storybook/decorators';
 import { Separator } from './separator';
 
 const meta = {
@@ -24,13 +25,7 @@ export const Vertical: Story = {
   args: {
     orientation: 'vertical',
   },
-  decorators: [
-    (Story) => (
-      <div className="flex h-8 items-center">
-        <Story />
-      </div>
-    ),
-  ],
+  decorators: [withWrapper('flex h-8 items-center')],
 };
 
 /** 全パターン一覧。 */


### PR DESCRIPTION
## Summary

PR #1088 の追加調査で見つかった「withWrapper にまとめられるが取り逃がした」 3 箇所を共通化。

- 3 ファイル / 3 箇所 / **−21 / +5 = 実質 −16 行**
- 見た目・既存 API・routing いずれも変更なし

## 変更点

| File | Story | Before | After |
|---|---|---|---|
| `ui/mini-calendar.stories.tsx` | meta | inline `w-72` | `withWrapper('w-72')` |
| `ui/separator.stories.tsx` | Vertical | inline `flex h-8 items-center` | `withWrapper('flex h-8 items-center')` |
| `common/EmptyState.stories.tsx` | TableEmpty | inline `border-border h-[300px] w-[400px] rounded-2xl border` | `withWrapper('border-border h-[300px] w-[400px] rounded-2xl border')` |

## 検討して見送ったもの

調査で他にも候補が出たが、ROI または安全性の観点で本 PR では除外:

| 候補 | 理由 |
|---|---|
| `tags: ['autodocs']` の global preview 設定（49 stories で繰り返し） | Storybook 10 の tag negation 挙動を別途検証する必要あり、オプトアウト story (`alert-dialog`) の挙動が変わるリスク |
| `selectControl` factory（argTypes の繰り返し） | DRY だが explicit な argTypes object のほうが Storybook 開発者にとって読みやすい。可読性 vs LOC の tradeoff で見送り |
| `bg-card border-border rounded-2xl border` の CSS class 化 | 9 箇所あるが application code 側でも使うパターンで、storybook 専用の semantic class を追加する正当性が弱い |
| `space-y-4` などの AllPatterns 内 layout container | layout 意図そのものなので decorator にすると意図が読み取りにくくなる |

## Test plan

- [x] `npm run typecheck` pass
- [x] `npm run lint:boundaries` pass
- [x] withWrapper は PR #1088 で導入済みのため API 追加なし
- [x] 既存 inline decorator と JSX 完全一致 → 視覚的に identical
- [ ] CI 通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
