### PR TITLE
fix(calendar): TZ ベースの今日判定 / 取得失敗の再試行 / OAuth callback 失敗通知

### DIFF
--- a/messages/en/auth.json
+++ b/messages/en/auth.json
@@ -23,7 +23,9 @@
       "captchaRequired": "CAPTCHA verification required. Please complete the challenge.",
       "botDetected": "Bot detected. Please wait a moment and try again.",
       "ipBlocked": "Too many attempts from this IP address. Please try again in {minutes} minutes.",
-      "ipBlockedTitle": "IP Address Blocked"
+      "ipBlockedTitle": "IP Address Blocked",
+      "oauthCallbackError": "We couldn't finish signing you in. Please try again.",
+      "oauthCallbackMissingCode": "We couldn't verify your sign-in. Please try again."
     },
     "success": {
       "loginSuccess": "Successfully logged in",

--- a/messages/en/calendar.json
+++ b/messages/en/calendar.json
@@ -60,7 +60,7 @@
         "short": "Short"
       },
       "saved": "Saved",
-      "noEventsOnThisDay": "No events on this day",
+      "noEventsOnThisDay": "A fresh day. Add your first block to begin.",
       "selectEventToEdit": "Select an event to edit",
       "selectEventToDelete": "Select an event to delete",
       "deselected": "Event deselected",

--- a/messages/ja/auth.json
+++ b/messages/ja/auth.json
@@ -23,7 +23,9 @@
       "captchaRequired": "CAPTCHA認証が必要です。チャレンジを完了してください",
       "botDetected": "ボットと判定されました。しばらく待ってから再度お試しください",
       "ipBlocked": "このIPアドレスからの試行が制限されています。{minutes}分後に再試行してください",
-      "ipBlockedTitle": "IPアドレスがブロックされています"
+      "ipBlockedTitle": "IPアドレスがブロックされています",
+      "oauthCallbackError": "ログインを完了できませんでした。もう一度お試しください",
+      "oauthCallbackMissingCode": "認証情報が確認できませんでした。もう一度ログインをお試しください"
     },
     "success": {
       "loginSuccess": "ログインしました",

--- a/src/app/[locale]/(app)/(modes)/calendar/_composition/useCalendarDataLayer.ts
+++ b/src/app/[locale]/(app)/(modes)/calendar/_composition/useCalendarDataLayer.ts
@@ -28,6 +28,8 @@ export interface CalendarDataLayerResult {
   viewDateRange: ViewDateRange;
   filteredEvents: CalendarEvent[];
   allCalendarEvents: CalendarEvent[];
+  /** バックグラウンド再取得を含む取得中フラグ */
+  isFetching: boolean;
   /** ナビゲーション方向に対応する日付範囲を事前取得する */
   prefetchDirection: (direction: 'prev' | 'next' | 'today') => void;
   /** ビュー切り替え先の日付範囲を即座に事前取得する */
@@ -49,6 +51,8 @@ export function useCalendarDataLayer({
     filteredEvents,
     allCalendarEvents,
     entriesError,
+    isEntriesFetching,
+    refetchEntries,
     prefetchDirection,
     prefetchForView,
   } = useCalendarData({
@@ -56,22 +60,37 @@ export function useCalendarDataLayer({
     currentDate,
   });
 
-  // エントリ取得エラー時にtoast通知
+  // エントリ取得エラー時にtoast通知 + 再試行アクション
   useEffect(() => {
     if (entriesError) {
       logger.error('[useCalendarDataLayer] entries fetch error', entriesError);
-      toast.error(tError('entriesLoadFailed'));
+      toast.error(tError('entriesLoadFailed'), {
+        action: {
+          label: tError('retry'),
+          onClick: () => {
+            void refetchEntries();
+          },
+        },
+      });
     }
-  }, [entriesError, tError]);
+  }, [entriesError, tError, refetchEntries]);
 
   return useMemo(
     () => ({
       viewDateRange,
       filteredEvents,
       allCalendarEvents,
+      isFetching: isEntriesFetching,
       prefetchDirection,
       prefetchForView,
     }),
-    [viewDateRange, filteredEvents, allCalendarEvents, prefetchDirection, prefetchForView],
+    [
+      viewDateRange,
+      filteredEvents,
+      allCalendarEvents,
+      isEntriesFetching,
+      prefetchDirection,
+      prefetchForView,
+    ],
   );
 }

--- a/src/app/[locale]/(auth)/auth/callback/route.ts
+++ b/src/app/[locale]/(auth)/auth/callback/route.ts
@@ -15,6 +15,7 @@
 
 import { NextResponse } from 'next/server';
 
+import { logger } from '@/lib/logger';
 import { getSafeRedirectPath } from '@/lib/safe-redirect';
 import { createClient } from '@/lib/supabase/server';
 
@@ -34,10 +35,13 @@ export async function GET(request: Request) {
       return NextResponse.redirect(new URL(next, request.url));
     }
 
-    // エラーが発生した場合はログインページへリダイレクト
+    logger.warn({ message: error.message }, '[auth/callback] exchangeCodeForSession failed');
     return NextResponse.redirect(new URL('/auth/login?error=auth_callback_error', request.url));
   }
 
-  // コードがない場合はログインページへリダイレクト
-  return NextResponse.redirect(new URL('/auth/login', request.url));
+  // コードがない場合はログインページへリダイレクト（理由をユーザーに通知）
+  logger.warn('[auth/callback] missing code parameter');
+  return NextResponse.redirect(
+    new URL('/auth/login?error=auth_callback_missing_code', request.url),
+  );
 }

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Eye, EyeOff } from 'lucide-react';
@@ -51,7 +51,21 @@ export function LoginForm({ className, ...props }: React.ComponentProps<'div'>) 
   const redirectPath = getSafeRedirectPath(searchParams?.get('redirect'));
 
   const [showPassword, setShowPassword] = useState(false);
-  const [serverError, setServerError] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // OAuth/メール確認 callback 失敗時、callback route が ?error= を付けて redirect する。
+  // ユーザーに無言バウンスさせず、対応するメッセージを表示する。
+  const queryError = useMemo(() => {
+    const errorParam = searchParams?.get('error');
+    if (!errorParam) return null;
+    const errorKeyMap: Record<string, string> = {
+      auth_callback_error: 'auth.errors.oauthCallbackError',
+      auth_callback_missing_code: 'auth.errors.oauthCallbackMissingCode',
+    };
+    return t(errorKeyMap[errorParam] ?? 'auth.errors.unexpectedError');
+  }, [searchParams, t]);
+
+  const serverError = submitError ?? queryError;
 
   const {
     register,
@@ -66,7 +80,7 @@ export function LoginForm({ className, ...props }: React.ComponentProps<'div'>) 
   });
 
   const onSubmit = async (data: LoginFormData) => {
-    setServerError(null);
+    setSubmitError(null);
 
     try {
       // ステップ1: ログイン試行（最小依存で実行）
@@ -75,7 +89,7 @@ export function LoginForm({ className, ...props }: React.ComponentProps<'div'>) 
       if (signInError) {
         // ログイン失敗時: OWASP準拠でサニタイズ済みメッセージを表示
         const errorKey = getAuthErrorKey(signInError.message, 'login');
-        setServerError(t(errorKey));
+        setSubmitError(t(errorKey));
       } else if (signInData) {
         // ログイン成功
 
@@ -114,7 +128,7 @@ export function LoginForm({ className, ...props }: React.ComponentProps<'div'>) 
       }
     } catch (err) {
       logger.error('[LoginForm] Unexpected error:', err);
-      setServerError(t('auth.errors.unexpectedError') || 'An unexpected error occurred');
+      setSubmitError(t('auth.errors.unexpectedError') || 'An unexpected error occurred');
     }
   };
 

--- a/src/features/calendar/components/controller/hooks/useCalendarData.ts
+++ b/src/features/calendar/components/controller/hooks/useCalendarData.ts
@@ -59,8 +59,12 @@ interface UseCalendarDataResult {
   entriesData: ReturnType<typeof useEntries>['data'];
   /** エントリ取得エラー */
   entriesError: ReturnType<typeof useEntries>['error'];
-  /** エントリ取得中かどうか */
+  /** エントリ取得中かどうか（初回のみ true） */
   isEntriesLoading: boolean;
+  /** バックグラウンド再取得中も含めて取得中かどうか */
+  isEntriesFetching: boolean;
+  /** エントリ取得を手動で再試行する */
+  refetchEntries: ReturnType<typeof useEntries>['refetch'];
   /** ナビゲーション方向に対応する日付範囲を事前取得する */
   prefetchDirection: (direction: 'prev' | 'next' | 'today') => void;
   /** ビュー切り替え先の日付範囲を即座に事前取得する */
@@ -100,6 +104,8 @@ export function useCalendarData({
     data: entriesData,
     error: entriesError,
     isLoading: isEntriesLoading,
+    isFetching: isEntriesFetching,
+    refetch: refetchEntries,
   } = useEntries(dateFilter);
 
   // タグマスタ取得（EntryCard等で使用するためキャッシュをwarm up + フィルタ初期化）
@@ -286,6 +292,8 @@ export function useCalendarData({
     entriesData,
     entriesError,
     isEntriesLoading,
+    isEntriesFetching,
+    refetchEntries,
     prefetchDirection,
     prefetchForView,
   };

--- a/src/features/calendar/components/layout/Header/MobileCalendarHeader.tsx
+++ b/src/features/calendar/components/layout/Header/MobileCalendarHeader.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { format, getWeek, isSameMonth, isToday } from 'date-fns';
+import { format, getWeek, isSameMonth } from 'date-fns';
 import { enUS, ja } from 'date-fns/locale';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
@@ -8,6 +8,7 @@ import { memo, useCallback, useState } from 'react';
 
 import { AppHeader } from '@/lib/components/shell/AppHeader';
 import { Button } from '@/lib/components/ui/button';
+import { isTodayInTimezone } from '@/lib/date/timezone';
 import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
 import { cn } from '@/lib/utils';
 
@@ -64,13 +65,14 @@ export const MobileCalendarHeader = memo<MobileCalendarHeaderProps>(
     // ヘッダー: 月部分・日番号・接尾辞を分離して今日バッジ + 週数を1行に統合
     const weekStartsOn = useCalendarSettingsStore((s) => s.weekStartsOn);
     const showWeekNumbers = useCalendarSettingsStore((s) => s.showWeekNumbers);
+    const timezone = useCalendarSettingsStore((s) => s.timezone);
     const monthPart = format(currentDate, locale === 'ja' ? 'M月' : 'MMM ', {
       locale: dateFnsLocale,
     });
     const dayNumber = format(currentDate, 'd');
     const daySuffix = locale === 'ja' ? '日' : '';
     const weekdayShort = format(currentDate, 'EEE', { locale: enUS });
-    const today = isToday(currentDate);
+    const today = isTodayInTimezone(currentDate, timezone);
     const weekNumber = getWeek(currentDate, { weekStartsOn });
 
     const handleToggle = useCallback(() => {

--- a/src/features/calendar/components/layout/Header/MobileMonthGrid.tsx
+++ b/src/features/calendar/components/layout/Header/MobileMonthGrid.tsx
@@ -7,7 +7,6 @@ import {
   endOfWeek,
   format,
   getWeek,
-  isSameDay,
   isSameMonth,
   startOfMonth,
   startOfWeek,
@@ -16,6 +15,7 @@ import {
 import { useTranslations } from 'next-intl';
 import { memo, useCallback, useMemo } from 'react';
 
+import { isTodayInTimezone, tzIsSameDay } from '@/lib/date/timezone';
 import { useHasMounted } from '@/lib/hooks/useHasMounted';
 import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
 import { cn } from '@/lib/utils';
@@ -82,17 +82,18 @@ export const MobileMonthGrid = memo<MobileMonthGridProps>(
 
     const { handlers, ref } = useSwipeGesture(handleSwipeLeft, handleSwipeRight);
 
-    // 日付の状態を判定
+    const timezone = useCalendarSettingsStore((state) => state.timezone);
+
+    // 日付の状態を判定（ユーザー TZ ベース）
     const getDayState = useCallback(
       (date: Date) => {
-        const today = new Date();
-        const isToday = isSameDay(date, today);
-        const isSelected = isSameDay(date, selectedDate);
+        const isToday = isTodayInTimezone(date, timezone);
+        const isSelected = tzIsSameDay(date, selectedDate, timezone);
         const isCurrentMonth = isSameMonth(date, viewMonth);
 
         return { isToday, isSelected, isCurrentMonth };
       },
-      [selectedDate, viewMonth],
+      [selectedDate, viewMonth, timezone],
     );
 
     const handleDateClick = useCallback(

--- a/src/features/calendar/components/views/MultiDayView/MultiDayView.tsx
+++ b/src/features/calendar/components/views/MultiDayView/MultiDayView.tsx
@@ -2,11 +2,11 @@
 
 import React, { useMemo } from 'react';
 
-import { format, getWeek, isToday } from 'date-fns';
+import { format, getWeek } from 'date-fns';
 
-import { cn } from '@/lib/utils';
-
+import { isTodayInTimezone } from '@/lib/date/timezone';
 import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import { cn } from '@/lib/utils';
 
 import { CalendarViewAnimation } from '../../animations/ViewTransition';
 import {
@@ -111,7 +111,7 @@ export function MultiDayView({
             showMonthYear={false}
             dayNameFormat="short"
             dateFormat="d"
-            isToday={isToday(date)}
+            isToday={isTodayInTimezone(date, timezone)}
             isSelected={false}
           />
         </div>

--- a/src/features/calendar/components/views/WeekView/components/WeekGrid.tsx
+++ b/src/features/calendar/components/views/WeekView/components/WeekGrid.tsx
@@ -2,11 +2,11 @@
 
 import React from 'react';
 
-import { getWeek, isToday } from 'date-fns';
+import { getWeek } from 'date-fns';
 
-import { cn } from '@/lib/utils';
-
+import { isTodayInTimezone } from '@/lib/date/timezone';
 import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import { cn } from '@/lib/utils';
 
 import {
   CalendarDateHeader,
@@ -122,7 +122,7 @@ export const WeekGrid = ({
             showMonthYear={false}
             dayNameFormat="short"
             dateFormat="d"
-            isToday={isToday(date)}
+            isToday={isTodayInTimezone(date, timezone)}
             isSelected={false}
           />
         </div>

--- a/src/features/calendar/components/views/shared/DateDisplay/DateDisplay.tsx
+++ b/src/features/calendar/components/views/shared/DateDisplay/DateDisplay.tsx
@@ -2,8 +2,10 @@
 
 import React from 'react';
 
-import { format, isToday } from 'date-fns';
+import { format } from 'date-fns';
 
+import { isTodayInTimezone } from '@/lib/date/timezone';
+import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
 import { cn } from '@/lib/utils';
 
 import type { DateDisplayProps } from '../../../../types/date-display.types';
@@ -142,7 +144,8 @@ export const DateDisplay = ({
   onClick,
   onDoubleClick,
 }: DateDisplayProps) => {
-  const today = todayProp ?? isToday(date);
+  const timezone = useCalendarSettingsStore((s) => s.timezone);
+  const today = todayProp ?? isTodayInTimezone(date, timezone);
 
   const { dayName, dateString, monthYear } = useDateFormats(
     date,

--- a/src/features/calendar/components/views/shared/components/DayColumn/DayColumn.tsx
+++ b/src/features/calendar/components/views/shared/components/DayColumn/DayColumn.tsx
@@ -15,7 +15,9 @@ import { useEntryPosition } from '../../hooks/useEntryPosition';
 import { EntryCard, isNewEntry, useEntryInspectorStore } from '@/features/entry';
 import { useTagsMap } from '@/features/tags';
 import { MEDIA_QUERIES } from '@/lib/breakpoints';
+import { isTodayInTimezone } from '@/lib/date/timezone';
 import { useMediaQuery } from '@/lib/hooks/useMediaQuery';
+import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
 import { filterEntriesByDate, sortTimedEntries } from '../../../../../lib/layout';
 
 export const DayColumn = memo<DayColumnProps>(function DayColumn({
@@ -34,6 +36,7 @@ export const DayColumn = memo<DayColumnProps>(function DayColumn({
   const setAnchorRect = useEntryInspectorStore((state) => state.setAnchorRect);
   const isMobile = useMediaQuery(MEDIA_QUERIES.mobile);
   const format = useFormatter();
+  const timezone = useCalendarSettingsStore((state) => state.timezone);
 
   // この日のエントリをフィルタリング
   const dayEntries = useMemo(() => {
@@ -125,12 +128,9 @@ export const DayColumn = memo<DayColumnProps>(function DayColumn({
               onClick={(e) => {
                 e.stopPropagation();
                 if (onTimeClick) {
-                  // 現在時刻 or 9:00 付近にクリックイベントを発火
+                  // 「今日」判定はユーザー TZ に揃える（OS TZ と calendar TZ がズレる場合の崩れを防ぐ）
                   const now = new Date();
-                  const isDateToday =
-                    date.getFullYear() === now.getFullYear() &&
-                    date.getMonth() === now.getMonth() &&
-                    date.getDate() === now.getDate();
+                  const isDateToday = isTodayInTimezone(date, timezone, now);
                   const hour = isDateToday ? Math.max(now.getHours(), 9) : 9;
                   onTimeClick(date, hour, 0);
                 }

--- a/src/features/calendar/components/views/shared/components/DayColumn/DayColumn.tsx
+++ b/src/features/calendar/components/views/shared/components/DayColumn/DayColumn.tsx
@@ -4,6 +4,7 @@
 
 'use client';
 
+import { formatInTimeZone } from 'date-fns-tz';
 import { Plus } from 'lucide-react';
 import { useFormatter, useTranslations } from 'next-intl';
 import React, { memo, useMemo } from 'react';
@@ -128,10 +129,13 @@ export const DayColumn = memo<DayColumnProps>(function DayColumn({
               onClick={(e) => {
                 e.stopPropagation();
                 if (onTimeClick) {
-                  // 「今日」判定はユーザー TZ に揃える（OS TZ と calendar TZ がズレる場合の崩れを防ぐ）
+                  // 「今日」判定 / 現在時 hour の両方をユーザー TZ で評価する。
+                  // `now.getHours()` は OS TZ ベースなので、calendar TZ と乖離していると
+                  // 「今日の今の時刻」を意図したつもりが UTC 深夜などで埋まり得る。
                   const now = new Date();
                   const isDateToday = isTodayInTimezone(date, timezone, now);
-                  const hour = isDateToday ? Math.max(now.getHours(), 9) : 9;
+                  const tzHour = Number(formatInTimeZone(now, timezone, 'H'));
+                  const hour = isDateToday ? Math.max(tzHour, 9) : 9;
                   onTimeClick(date, hour, 0);
                 }
               }}

--- a/src/features/calendar/components/views/shared/hooks/useCurrentPeriod.ts
+++ b/src/features/calendar/components/views/shared/hooks/useCurrentPeriod.ts
@@ -7,6 +7,8 @@ import { useMemo } from 'react';
 
 import { isSameDay, isSameWeek } from 'date-fns';
 
+import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+
 import { getTodayIndex } from '../utils/dateHelpers';
 
 /** useCurrentPeriod フックのオプション */
@@ -40,10 +42,12 @@ export function useCurrentPeriod({
   periodType,
   weekStartsOn = 0,
 }: UseCurrentPeriodOptions): UseCurrentPeriodReturn {
-  // 今日が期間内のどこにあるかを計算
+  const timezone = useCalendarSettingsStore((state) => state.timezone);
+
+  // 今日が期間内のどこにあるかを計算（ユーザー TZ 基準）
   const todayIndex = useMemo(() => {
-    return getTodayIndex(dates);
-  }, [dates]);
+    return getTodayIndex(dates, timezone);
+  }, [dates, timezone]);
 
   // 期間タイプごとの判定
   const isCurrentPeriod = useMemo(() => {

--- a/src/features/calendar/components/views/shared/hooks/useIsToday.ts
+++ b/src/features/calendar/components/views/shared/hooks/useIsToday.ts
@@ -1,14 +1,17 @@
 import { useMemo } from 'react';
 
-import { isToday as dateFnsIsToday } from 'date-fns';
+import { isTodayInTimezone } from '@/lib/date/timezone';
+import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
 
 /**
- * 指定された日付が今日かどうかを判定するフック
- * 全カレンダービューで共通利用可能
+ * 指定された日付が「ユーザーの calendar timezone での今日」かどうかを判定するフック
  *
- * @param date 判定対象の日付
- * @returns 今日の場合true、それ以外はfalse
+ * date-fns の `isToday` はブラウザのローカル TZ で判定するため、ユーザーが
+ * OS TZ と異なる timezone を設定している場合に highlight が 1 日ずれる。
+ * カレンダーは取得・表示の両方を `useCalendarSettingsStore.timezone` で揃えるため、
+ * このフックも同じ timezone を参照する。
  */
 export function useIsToday(date: Date): boolean {
-  return useMemo(() => dateFnsIsToday(date), [date]);
+  const timezone = useCalendarSettingsStore((s) => s.timezone);
+  return useMemo(() => isTodayInTimezone(date, timezone), [date, timezone]);
 }

--- a/src/features/calendar/components/views/shared/utils/dateHelpers.ts
+++ b/src/features/calendar/components/views/shared/utils/dateHelpers.ts
@@ -5,6 +5,8 @@
  * このファイルにはカレンダービュー固有のユーティリティのみ含まれます。
  */
 
+import { tzIsSameDay } from '@/lib/date/timezone';
+
 /**
  * 日付をフォーマット（カレンダービュー用・ロケール対応）
  */
@@ -44,8 +46,17 @@ export function isValidEvent<T extends { startDate?: Date | string | null }>(eve
 
 /**
  * 今日のインデックスを取得（日付配列内での位置）
+ *
+ * timezone を渡した場合はユーザー TZ で「今日」を判定する。
+ * カレンダーは settings の timezone を基準にしているので、
+ * 呼び出し側はできるだけ timezone を渡すこと。省略時はブラウザローカル TZ。
  */
-export function getTodayIndex(dates: Date[]): number {
-  const today = new Date();
-  return dates.findIndex((date) => date.toDateString() === today.toDateString());
+export function getTodayIndex(dates: Date[], timezone?: string): number {
+  const now = new Date();
+
+  if (timezone) {
+    return dates.findIndex((date) => tzIsSameDay(date, now, timezone));
+  }
+
+  return dates.findIndex((date) => date.toDateString() === now.toDateString());
 }

--- a/src/features/calendar/components/views/shared/utils/getTodayIndex.test.ts
+++ b/src/features/calendar/components/views/shared/utils/getTodayIndex.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getTodayIndex } from './dateHelpers';
+
+/**
+ * getTodayIndex の TZ 対応回帰テスト
+ *
+ * Bug 背景: 旧実装は `date.toDateString()` 比較（ブラウザ ローカル TZ）。
+ * カレンダー設定の timezone と OS TZ が異なる場合に「今日」の列が
+ * 1 ずれる事故が起きうるため、明示的に TZ を渡すと TZ 基準で判定する。
+ */
+describe('getTodayIndex', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('timezone を渡すとユーザー TZ で「今日」を判定する', () => {
+    // 現在は UTC 2026-04-28 23:30 (JST 2026-04-29 08:30)
+    vi.setSystemTime(new Date('2026-04-28T23:30:00Z'));
+
+    const dates = [
+      new Date('2026-04-28T00:00:00Z'), // JST 28日 09:00
+      new Date('2026-04-29T00:00:00Z'), // JST 29日 09:00 ← 今日
+      new Date('2026-04-30T00:00:00Z'), // JST 30日 09:00
+    ];
+
+    expect(getTodayIndex(dates, 'Asia/Tokyo')).toBe(1);
+    // UTC 基準では index 0 が今日（28日）
+    expect(getTodayIndex(dates, 'UTC')).toBe(0);
+  });
+
+  it('対象配列に「今日」が含まれない場合 -1 を返す', () => {
+    vi.setSystemTime(new Date('2026-04-28T12:00:00Z'));
+
+    const dates = [
+      new Date('2026-04-25T00:00:00Z'),
+      new Date('2026-04-26T00:00:00Z'),
+      new Date('2026-04-27T00:00:00Z'),
+    ];
+
+    expect(getTodayIndex(dates, 'Asia/Tokyo')).toBe(-1);
+    expect(getTodayIndex(dates)).toBe(-1);
+  });
+
+  it('timezone 未指定はブラウザ TZ にフォールバック (互換挙動)', () => {
+    // どの TZ で動くかは vitest 環境依存だが、 toDateString 比較で動くことだけを確認
+    const today = new Date();
+    const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
+
+    expect(getTodayIndex([today])).toBe(0);
+    expect(getTodayIndex([yesterday])).toBe(-1);
+  });
+});

--- a/src/lib/date/__tests__/isTodayInTimezone.test.ts
+++ b/src/lib/date/__tests__/isTodayInTimezone.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { isTodayInTimezone } from '../timezone';
+
+/**
+ * isTodayInTimezone の回帰テスト
+ *
+ * Bug 背景: date-fns の `isToday` はブラウザ ローカル TZ で判定するため、
+ * ユーザーが OS TZ と異なる timezone を設定している場合、calendar の
+ * 「今日」ハイライトが 1 日ずれる問題があった。
+ * 取得・表示の両方を `useCalendarSettingsStore.timezone` で揃える。
+ */
+describe('isTodayInTimezone', () => {
+  it('UTC 23:30 を JST から見ると「翌日」が今日', () => {
+    // UTC 2026-04-28 23:30 = JST 2026-04-29 08:30
+    const now = new Date('2026-04-28T23:30:00Z');
+    const candidateUtc = new Date('2026-04-29T00:00:00Z'); // JST で 09:00 (29日)
+
+    expect(isTodayInTimezone(candidateUtc, 'Asia/Tokyo', now)).toBe(true);
+    // 28 日始点（UTC midnight）は JST では既に 29 日 09:00 → 28 日キーは false
+    expect(isTodayInTimezone(new Date('2026-04-28T00:00:00Z'), 'Asia/Tokyo', now)).toBe(false);
+  });
+
+  it('UTC 03:00 を NY (EST -5h, 冬) から見ると「前日」が今日', () => {
+    // UTC 2026-01-15 03:00 = EST 2026-01-14 22:00
+    const now = new Date('2026-01-15T03:00:00Z');
+    const candidate14 = new Date('2026-01-14T18:00:00Z'); // EST 13:00 (14日)
+    const candidate15 = new Date('2026-01-15T15:00:00Z'); // EST 10:00 (15日)
+
+    expect(isTodayInTimezone(candidate14, 'America/New_York', now)).toBe(true);
+    expect(isTodayInTimezone(candidate15, 'America/New_York', now)).toBe(false);
+  });
+
+  it('DST spring-forward 当日でも今日判定が壊れない (NY 2026-03-08)', () => {
+    // 2026-03-08 はアメリカ DST 開始日。UTC 12:00 = EDT 08:00
+    const now = new Date('2026-03-08T12:00:00Z');
+    const sameDayMorning = new Date('2026-03-08T06:00:00Z'); // EST 01:00 (DST 前)
+    const sameDayAfternoon = new Date('2026-03-08T20:00:00Z'); // EDT 16:00 (DST 後)
+
+    expect(isTodayInTimezone(sameDayMorning, 'America/New_York', now)).toBe(true);
+    expect(isTodayInTimezone(sameDayAfternoon, 'America/New_York', now)).toBe(true);
+  });
+
+  it('同一 UTC でも timezone が異なると判定が変わる', () => {
+    const now = new Date('2026-04-28T15:00:00Z'); // JST 2026-04-29 00:00 / UTC 28日
+    const candidate = new Date('2026-04-29T00:00:00Z'); // JST 09:00 (29日) / UTC 00:00 (29日)
+
+    // JST では now と同じ 29日
+    expect(isTodayInTimezone(candidate, 'Asia/Tokyo', now)).toBe(true);
+    // UTC では now (28日) と異なる 29日
+    expect(isTodayInTimezone(candidate, 'UTC', now)).toBe(false);
+  });
+});

--- a/src/lib/date/timezone.ts
+++ b/src/lib/date/timezone.ts
@@ -368,6 +368,23 @@ export function tzIsSameDay(a: Date, b: Date, timezone: string): boolean {
 }
 
 /**
+ * 指定 Date がユーザー TZ における「今日」かどうか
+ *
+ * date-fns の `isToday` はブラウザのローカル TZ を基準とするため、
+ * ユーザーが設定した calendar timezone と OS TZ が異なる場合に
+ * 「今日」のハイライトが 1 日ずれる問題が発生する。
+ * カレンダー UI からはこの helper を使うこと。
+ *
+ * @param date - 判定対象（UTC Date）
+ * @param timezone - ユーザーのタイムゾーン
+ * @param now - 比較基準（テスト用）。省略時は現在時刻
+ * @returns ユーザー TZ で今日と同じ日付なら true
+ */
+export function isTodayInTimezone(date: Date, timezone: string, now: Date = new Date()): boolean {
+  return tzIsSameDay(date, now, timezone);
+}
+
+/**
  * ユーザーTZでの日付キー (YYYY-MM-DD)
  *
  * @param date - 対象日時


### PR DESCRIPTION
## Summary

ここまでの 19 ファイル分の変更を 4 つのテーマに整理して 1 PR にまとめた。

### 1. fix(calendar): timezone-aware の今日判定で OS TZ ズレを解消
- date-fns の `isToday` がブラウザの OS TZ で判定するため、ユーザーが calendar settings の timezone を OS TZ と異なる値にしていると「今日」ハイライトが 1 日ずれる事故が起きうる
- `src/lib/date/timezone.ts` に `isTodayInTimezone(date, timezone, now?)` を追加
- Week / MultiDay / DateDisplay / DayColumn / Mobile (Header / MonthGrid) と `getTodayIndex` を全て timezone-aware に統一
- DST spring-forward / TZ 境界をまたぐケースを含む回帰テスト 2 ファイル

### 2. fix(auth): OAuth callback 失敗を i18n メッセージで通知
- `/auth/callback` で code 交換失敗 / code 欠落時に無言で `/auth/login` バウンスしていたのを、`?error=auth_callback_error` / `?error=auth_callback_missing_code` 経由で localized メッセージ表示
- callback route 側で `logger.warn` で構造化ログ（PII を含めない）

### 3. feat(calendar): エントリ取得失敗 toast に再試行アクションを追加
- `useEntries` の `refetch` を `useCalendarData` → `useCalendarDataLayer` 経由で expose
- 取得失敗 toast に「再読み込み」action を追加
- 将来 in-flight UI 用に `isFetching` も併せて返す

### 4. fix(calendar): 空状態コピー (en) を pre-suasion 形式に揃える
- 日本語側は「まっさらな1日です。最初のブロックを追加しましょう」と既に pre-suasion 形式
- 英語の `noEventsOnThisDay` を「A fresh day. Add your first block to begin.」に揃える

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run lint:i18n`
- [x] `npm run test:run` (新規 7 テストケース pass)
- [ ] Settings で timezone を OS TZ と異なる値に変更 → Week / MultiDay / Mobile (header + month grid) で「今日」ハイライトが calendar TZ ベースに揃うこと
- [ ] OAuth callback 失敗 (例: callback URL を直接叩く) → ログイン画面に i18n メッセージが出ること
- [ ] Calendar 表示中に network offline → toast に「再読み込み」が出て、復旧後に押すと再取得されること
- [ ] 1 日も予定が無い日付 (en locale) → 「A fresh day. Add your first block to begin.」が出ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)