### PR TITLE
fix(mcp): oauth_tokens user update policy を drop (RLS 強化)

### DIFF
--- a/src/app/[locale]/oauth/authorize/page.tsx
+++ b/src/app/[locale]/oauth/authorize/page.tsx
@@ -54,6 +54,10 @@ export default async function AuthorizePage({ searchParams }: AuthorizePageProps
   });
 
   if (!validation.ok) {
+    // NOTE (Phase 1.5): RFC 6749 §4.1.2.1 では client_id / redirect_uri が valid な
+    // ときは error params を query に乗せて redirect_uri へ redirect すべき
+    // (unsupported_response_type / invalid_scope / missing_pkce 等)。Phase 1 は安全側に
+    // 振って常時 inline render している。Phase 1.5 で trustedRedirect を判定して分岐する。
     const t = await getTranslations('oauth.error');
     return <OAuthErrorPanel message={t(ERROR_MESSAGE_KEY[validation.error])} />;
   }

--- a/src/lib/oauth-server/code-exchange.ts
+++ b/src/lib/oauth-server/code-exchange.ts
@@ -129,6 +129,12 @@ interface IssueTokenPairInput {
   parentRefreshTokenId: string | null;
 }
 
+/**
+ * NOTE (Phase 1.5): refresh + access の 2 つの insert が atomic ではないため、
+ * 第二の insert が失敗すると orphan refresh が DB に残る。client は token を
+ * 受け取らないので security 的な漏洩はないが衛生面で気持ち悪い。Phase 1.5 で
+ * `issue_oauth_token_pair(...)` という Postgres RPC (1 transaction) に置換する。
+ */
 async function issueTokenPair(input: IssueTokenPairInput): Promise<TokenResponse> {
   const db = createOAuthDbClient();
   const access = generateOpaqueToken('access');

--- a/supabase/migrations/20260501000200_drop_oauth_tokens_user_update.sql
+++ b/supabase/migrations/20260501000200_drop_oauth_tokens_user_update.sql
@@ -1,0 +1,17 @@
+-- ============================================================
+-- oauth_tokens の user UPDATE policy を削除
+--
+-- 経緯:
+--   20260501000000 で UPDATE policy を `user_id = auth.uid()` で
+--   付与したが、PostgreSQL RLS は column-level 制限ができないため
+--   user 自身が token_hash / scopes / expires_at / parent_token_id まで
+--   書き換えられる穴になっていた (codex review P1 指摘)。
+--
+--   Phase 1 で user-initiated revoke の UI / mutation も無いので、
+--   user の UPDATE は完全に閉じる。Phase 1.5 で revoke を実装する際は
+--   service-role で動く tRPC mutation 経由で UPDATE する。
+--
+-- See: docs/design/mcp-server/overview.md (Phase 1.5)
+-- ============================================================
+
+DROP POLICY IF EXISTS "Users can update own oauth_tokens" ON public.oauth_tokens;

--- a/supabase/schemas/030_rls_policies.sql
+++ b/supabase/schemas/030_rls_policies.sql
@@ -15,7 +15,8 @@
 
 -- ■ mfa_recovery_codes: SELECT/INSERT/DELETE は user_id = auth.uid()、UPDATE不可
 -- ■ reports: SELECT/DELETE は user_id = auth.uid()、INSERT は service_role のみ
--- ■ oauth_tokens: SELECT/UPDATE は user_id = auth.uid()、INSERT/DELETE 不可 (service-role のみ)
+-- ■ oauth_tokens: SELECT のみ user_id = auth.uid()、UPDATE/INSERT/DELETE は service-role のみ
+--   (column-level RLS が無いため user UPDATE は閉じている。revoke は service-role 経由)
 -- ■ oauth_authorization_codes: 全 user-facing policy 無し (service-role のみ)
 
 -- 詳細は baseline.sql の RLS Policies セクションを参照


### PR DESCRIPTION
## Summary

#1117 (Phase 1 PoC) で merge した `oauth_tokens` の RLS policy が、`user_id = auth.uid()` のみで UPDATE を許可しており、column-level RLS が無いため user 自身が `token_hash` / `scopes` / `expires_at` まで書き換えられる穴になっていた (codex review P1 指摘)。

## Changes

- 新規 migration `20260501000200_drop_oauth_tokens_user_update.sql` で UPDATE policy を drop
- Phase 1 は user-initiated revoke の UI / mutation も無いので user UPDATE は完全に閉じる
- Phase 1.5 で revoke を実装する際は service-role 経由の tRPC mutation で行う
- `supabase/schemas/030_rls_policies.sql` の doc も同期
- `code-exchange.ts` / `authorize/page.tsx` に Phase 1.5 deferral コメント追加 (atomic insert と redirect-based error)

## Background

#1117 の merge 直前に codex から複数の review コメントがあり、round 1-2 の fix は merge に含めたが、round 3 (このブランチ) は push 漏れで取り残されていた。

🤖 Generated with [Claude Code](https://claude.com/claude-code)