### PR TITLE
fix(ci): supabase migration workflow の environment 名を Production に揃える

### DIFF
--- a/.github/workflows/supabase-migration.yml
+++ b/.github/workflows/supabase-migration.yml
@@ -35,7 +35,7 @@ jobs:
     name: 🗃️ Push Migrations to Production
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    environment: production
+    environment: Production
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       SUPABASE_DB_PASSWORD: ${{ secrets.PRODUCTION_DB_PASSWORD }}


### PR DESCRIPTION
## Summary

GitHub の environment 名は case-sensitive。repo の environment 設定は `Production` (大文字 P) だが、workflow が `environment: production` (小文字) を参照していたため過去 4 回連続で startup_failure になっていた。

このため Phase 1 PoC (#1117 / #1118) で追加した migration 3 件が production DB に未適用のまま:
- `20260501000000_oauth_tokens_from_api_keys.sql`
- `20260501000100_oauth_authorization_codes.sql`
- `20260501000200_drop_oauth_tokens_user_update.sql`

merge 後、自動で workflow が走り migration が適用される想定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)