### PR TITLE
fix(mcp): vercel rewrite を bypass して /api/mcp を直接 advertise

### DIFF
--- a/src/features/settings/components/data-settings.tsx
+++ b/src/features/settings/components/data-settings.tsx
@@ -261,7 +261,9 @@ function McpApiSection() {
 
   // OAuth 接続のため client (Claude.ai etc.) に渡すのはこの URL のみ。
   // API key 入力欄は Phase 1.5 で「接続済み client 一覧」に置換する vestige。
-  const mcpServerUrl = 'https://mcp.dayopt.app/mcp';
+  // 暫定: `/mcp` の vercel.json rewrite が Next.js 404 に捕まる挙動のため
+  // `/api/mcp` を直接 advertise。Phase 1.5 で rewrite を直して `/mcp` に戻す。
+  const mcpServerUrl = 'https://mcp.dayopt.app/api/mcp';
 
   const handleCopy = useCallback(
     (text: string, type: 'url' | 'key') => {

--- a/src/lib/oauth-server/metadata.ts
+++ b/src/lib/oauth-server/metadata.ts
@@ -23,7 +23,11 @@ export function buildAuthorizationServerMetadata() {
   return {
     issuer: AUTHORIZATION_SERVER_URL,
     authorization_endpoint: `${AUTHORIZATION_SERVER_URL}/oauth/authorize`,
-    token_endpoint: `${AUTHORIZATION_SERVER_URL}/oauth/token`,
+    // NOTE: 設計上は `/oauth/token` (vercel.json rewrite で /api/oauth/token に飛ぶ予定)
+    // だが、Vercel rewrite が `/oauth/token` を Next.js 404 にキャッチされる挙動になっており
+    // 動かないため、暫定で `/api/oauth/token` (実体 path) を直接 advertise する。
+    // Phase 1.5 で rewrite の根本対処を試みる。
+    token_endpoint: `${AUTHORIZATION_SERVER_URL}/api/oauth/token`,
     response_types_supported: ['code'],
     grant_types_supported: ['authorization_code', 'refresh_token'],
     code_challenge_methods_supported: ['S256'],


### PR DESCRIPTION
## Summary

設計では `mcp.dayopt.app/mcp → /api/mcp` の vercel.json rewrite を意図していたが、production smoke test で:

- ✅ `mcp.dayopt.app/.well-known/oauth-protected-resource` rewrite 動作
- ✅ `app.dayopt.app/.well-known/oauth-authorization-server` rewrite 動作
- ✅ `app.dayopt.app/oauth/authorize` (Next.js page) 動作
- ❌ `mcp.dayopt.app/mcp` rewrite が Next.js 404 (cache HIT) に取られる
- ❌ `app.dayopt.app/oauth/token` rewrite も同様

`vercel cache purge --yes` 実行後も再現。Next.js dynamic [locale] route または Vercel CDN が `/mcp` / `/oauth/token` を先取りしている可能性。

## Workaround

- `metadata.ts`: `token_endpoint` を `/api/oauth/token` に変更
- `McpApiSection`: MCP URL を `https://mcp.dayopt.app/api/mcp` に変更
- `/oauth/authorize` は page なのでそのまま

ユーザー視点での MCP URL は `/api` prefix が付くが、機能的には完全に動作する。

## Phase 1.5 deferral

vercel rewrite の根本対処は Phase 1.5 で。proxy.ts middleware で rewrite するか、URL contract を見直す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)