### PR TITLE
fix(inspector): actual time変更後に古いfetchで値が戻るレースコンディションを修正

### DIFF
--- a/src/features/entry/components/inspector/hooks/useTimeFields.ts
+++ b/src/features/entry/components/inspector/hooks/useTimeFields.ts
@@ -234,6 +234,7 @@ export function useTimeFields({ entry, entryId, save, saveImmediate }: UseTimeFi
   // 記録時間: 即時保存（サーバー側で隣接auto-shrink）
   const handleActualStartChange = useCallback(
     (time: string | null) => {
+      localDirtyRef.current = true;
       setActualStartTime(time);
       if (!scheduleDate) return;
 
@@ -252,6 +253,7 @@ export function useTimeFields({ entry, entryId, save, saveImmediate }: UseTimeFi
 
   const handleActualEndChange = useCallback(
     (time: string | null) => {
+      localDirtyRef.current = true;
       setActualEndTime(time);
       if (!scheduleDate) return;
 

--- a/src/features/entry/hooks/useEntryMutations.ts
+++ b/src/features/entry/hooks/useEntryMutations.ts
@@ -184,6 +184,7 @@ export function useEntryMutations(options?: { suppressCreateToast?: boolean }) {
       // 1. 進行中のクエリをキャンセル（競合回避）
       await utils.entries.list.cancel();
       await utils.entries.getById.cancel({ id });
+      await utils.entries.getById.cancel({ id, include: { tags: true } });
 
       // 2. 現在のデータをスナップショット（ロールバック用）
       type EntryListData = Awaited<ReturnType<typeof utils.entries.list.fetch>>;


### PR DESCRIPTION
## Summary

Inspector で actual_start_time / actual_end_time を変更しても元に戻る問題を修正。

**根本原因**: 2つのバグが複合していた。

### Bug 1 — `getById { include: { tags: true } }` がキャンセルされない
Inspector 初回表示時、`useEntry(id, { includeTags: true })` が `getById { id, include: { tags: true } }` をフェッチし始める。このフェッチが完了する前に actual time を変更すると：

1. `onMutate` が楽観的更新をキャッシュに書き込む
2. ただし `utils.entries.getById.cancel({ id })` は `{ id }` のみキャンセルし、`{ id, include: { tags: true } }` はキャンセルしない
3. 飛行中のフェッチが完了し、古いデータでキャッシュを上書きする

### Bug 2 — actual time ハンドラーが `localDirtyRef` を立てない
`handleStartTimeChange` / `handleEndTimeChange` は `localDirtyRef.current = true` で entry sync effect による上書きを防いでいるが、`handleActualStartChange` / `handleActualEndChange` はこのフラグを設定していなかった。

Bug 1 でキャッシュが古いデータに戻ると、Bug 2 のせいで sync effect がそのまま走り `actualStartTime` が null にリセットされる。

## Changes

- `useEntryMutations.ts`: `onMutate` で `getById { id, include: { tags: true } }` もキャンセル（+1行）
- `useTimeFields.ts`: `handleActualStartChange` / `handleActualEndChange` で `localDirtyRef.current = true` を設定（+2行）

## Test plan

- [ ] Inspector を開いてすぐ actual start/end time を変更 → 変更が保持される
- [ ] Network タブで `entries.update` が `actual_start_time` / `actual_end_time` を含んで送信される
- [ ] `npm run typecheck` ✓
- [ ] `npm run lint` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)