### PR TITLE
chore(release): v0.28.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,9 @@ yarn.lock
 # Next.js build output
 .next
 
+# Turborepo cache
+.turbo/
+
 # Nuxt.js build / generate output
 .nuxt
 dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dayopt-app",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dayopt-app",
-      "version": "0.27.0",
+      "version": "0.28.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dayopt-app",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "private": true,
   "sideEffects": [
     "*.css",


### PR DESCRIPTION
## Summary

- `package.json` を v0.28.0 に bump
- `.turbo/` を `.gitignore` に追加（Turborepo cache を untracked から除外）

## Test plan

- [x] typecheck
- [x] unit tests (1651/1651 passed)
- [ ] CI green
- [ ] tag後、本番デプロイ確認