### PR TITLE
feat(entry): entry 時間モデルの domain 層を新設

### DIFF
--- a/apps/app/src/features/calendar/lib/entry-adapter.ts
+++ b/apps/app/src/features/calendar/lib/entry-adapter.ts
@@ -6,7 +6,7 @@
  */
 
 import type { EntryWithTags } from '@/features/entry';
-import { getEntryState } from '@/features/entry';
+import { getEntryState, isPlannedEntry, isUnplannedEntry } from '@/features/entry';
 import { tzIsSameDay } from '@/lib/date/timezone';
 import type { CalendarEvent } from '../types/calendar.types';
 
@@ -39,8 +39,8 @@ export function entryToCalendarEvent(entry: EntryWithTags, timezone: string): Ca
     return null;
   }
 
-  const isUnplanned = entry.origin === 'unplanned';
-  const isPlanned = entry.origin === 'planned';
+  const isUnplanned = isUnplannedEntry(entry);
+  const isPlanned = isPlannedEntry(entry);
 
   if (isPlanned && (!entry.start_time || !entry.end_time)) {
     return null;

--- a/apps/app/src/features/entry/domain/__tests__/entry-time-model.test.ts
+++ b/apps/app/src/features/entry/domain/__tests__/entry-time-model.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  determineEntryOrigin,
+  getActualMinutes,
+  getActualRange,
+  getDiffMinutes,
+  getPlannedMinutes,
+  getPlannedRange,
+  hasPlannedActualDiff,
+  isPlannedEntry,
+  isUnplannedEntry,
+} from '../entry-time-model';
+
+const NOW = new Date('2026-03-12T12:00:00Z');
+const PAST = '2026-03-12T11:00:00Z'; // 1h before NOW
+const FUTURE = '2026-03-12T13:00:00Z'; // 1h after NOW
+
+describe('determineEntryOrigin', () => {
+  it('end が now より前なら unplanned', () => {
+    expect(determineEntryOrigin(PAST, NOW)).toBe('unplanned');
+  });
+
+  it('end が now と同時刻なら unplanned（境界値）', () => {
+    expect(determineEntryOrigin(NOW, NOW)).toBe('unplanned');
+  });
+
+  it('end が now より後なら planned', () => {
+    expect(determineEntryOrigin(FUTURE, NOW)).toBe('planned');
+  });
+
+  it('Date オブジェクトでも動作する', () => {
+    const past = new Date('2026-03-12T10:00:00Z');
+    expect(determineEntryOrigin(past, NOW)).toBe('unplanned');
+    const future = new Date('2026-03-12T14:00:00Z');
+    expect(determineEntryOrigin(future, NOW)).toBe('planned');
+  });
+});
+
+describe('isPlannedEntry / isUnplannedEntry', () => {
+  it('origin が planned なら isPlannedEntry = true', () => {
+    expect(isPlannedEntry({ origin: 'planned' })).toBe(true);
+    expect(isUnplannedEntry({ origin: 'planned' })).toBe(false);
+  });
+
+  it('origin が unplanned なら isUnplannedEntry = true', () => {
+    expect(isUnplannedEntry({ origin: 'unplanned' })).toBe(true);
+    expect(isPlannedEntry({ origin: 'unplanned' })).toBe(false);
+  });
+
+  it('origin が null なら両方 false', () => {
+    expect(isPlannedEntry({ origin: null })).toBe(false);
+    expect(isUnplannedEntry({ origin: null })).toBe(false);
+  });
+
+  it('origin が undefined なら両方 false', () => {
+    expect(isPlannedEntry({})).toBe(false);
+    expect(isUnplannedEntry({})).toBe(false);
+  });
+});
+
+describe('getPlannedRange', () => {
+  it('start_time / end_time が揃っていれば TimeRange を返す', () => {
+    const entry = {
+      start_time: '2026-03-12T09:00:00Z',
+      end_time: '2026-03-12T10:00:00Z',
+    };
+    const range = getPlannedRange(entry);
+    expect(range).not.toBeNull();
+    expect(range!.start).toEqual(new Date('2026-03-12T09:00:00Z'));
+    expect(range!.end).toEqual(new Date('2026-03-12T10:00:00Z'));
+  });
+
+  it('start_time が null なら null', () => {
+    expect(getPlannedRange({ start_time: null, end_time: '2026-03-12T10:00:00Z' })).toBeNull();
+  });
+
+  it('end_time が null なら null', () => {
+    expect(getPlannedRange({ start_time: '2026-03-12T09:00:00Z', end_time: null })).toBeNull();
+  });
+
+  it('両方 undefined なら null', () => {
+    expect(getPlannedRange({})).toBeNull();
+  });
+});
+
+describe('getActualRange', () => {
+  it('actual_start / actual_end が揃っていれば TimeRange を返す', () => {
+    const entry = {
+      actual_start_time: '2026-03-12T09:05:00Z',
+      actual_end_time: '2026-03-12T10:10:00Z',
+    };
+    const range = getActualRange(entry);
+    expect(range).not.toBeNull();
+    expect(range!.start).toEqual(new Date('2026-03-12T09:05:00Z'));
+    expect(range!.end).toEqual(new Date('2026-03-12T10:10:00Z'));
+  });
+
+  it('actual_start_time が null なら null', () => {
+    expect(
+      getActualRange({ actual_start_time: null, actual_end_time: '2026-03-12T10:00:00Z' }),
+    ).toBeNull();
+  });
+
+  it('両方なければ null', () => {
+    expect(getActualRange({})).toBeNull();
+  });
+});
+
+describe('getPlannedMinutes', () => {
+  it('duration_minutes が保存済みなら優先して返す', () => {
+    const entry = {
+      start_time: '2026-03-12T09:00:00Z',
+      end_time: '2026-03-12T10:00:00Z',
+      duration_minutes: 45, // range は 60 分だが保存値を優先
+    };
+    expect(getPlannedMinutes(entry)).toBe(45);
+  });
+
+  it('duration_minutes が null なら range から算出', () => {
+    const entry = {
+      start_time: '2026-03-12T09:00:00Z',
+      end_time: '2026-03-12T10:30:00Z',
+      duration_minutes: null,
+    };
+    expect(getPlannedMinutes(entry)).toBe(90);
+  });
+
+  it('planned range がなければ null', () => {
+    expect(getPlannedMinutes({ start_time: null, end_time: null })).toBeNull();
+  });
+});
+
+describe('getActualMinutes', () => {
+  it('actual range から分数を算出する', () => {
+    const entry = {
+      actual_start_time: '2026-03-12T09:00:00Z',
+      actual_end_time: '2026-03-12T10:15:00Z',
+    };
+    expect(getActualMinutes(entry)).toBe(75);
+  });
+
+  it('duration_minutes は無視して actual range を使う', () => {
+    const entry = {
+      actual_start_time: '2026-03-12T09:00:00Z',
+      actual_end_time: '2026-03-12T10:00:00Z',
+      duration_minutes: 999,
+    };
+    expect(getActualMinutes(entry)).toBe(60);
+  });
+
+  it('actual range がなければ null', () => {
+    expect(getActualMinutes({})).toBeNull();
+  });
+});
+
+describe('getDiffMinutes', () => {
+  it('actual - planned を返す（actual が長い → 正）', () => {
+    const entry = {
+      start_time: '2026-03-12T09:00:00Z',
+      end_time: '2026-03-12T10:00:00Z',
+      actual_start_time: '2026-03-12T09:00:00Z',
+      actual_end_time: '2026-03-12T10:30:00Z',
+      duration_minutes: null,
+    };
+    expect(getDiffMinutes(entry)).toBe(30);
+  });
+
+  it('actual が短ければ負の値', () => {
+    const entry = {
+      start_time: '2026-03-12T09:00:00Z',
+      end_time: '2026-03-12T10:00:00Z',
+      actual_start_time: '2026-03-12T09:00:00Z',
+      actual_end_time: '2026-03-12T09:45:00Z',
+      duration_minutes: null,
+    };
+    expect(getDiffMinutes(entry)).toBe(-15);
+  });
+
+  it('planned がなければ null', () => {
+    const entry = {
+      actual_start_time: '2026-03-12T09:00:00Z',
+      actual_end_time: '2026-03-12T10:00:00Z',
+    };
+    expect(getDiffMinutes(entry)).toBeNull();
+  });
+
+  it('actual がなければ null', () => {
+    const entry = {
+      start_time: '2026-03-12T09:00:00Z',
+      end_time: '2026-03-12T10:00:00Z',
+    };
+    expect(getDiffMinutes(entry)).toBeNull();
+  });
+});
+
+describe('hasPlannedActualDiff', () => {
+  it('差分がある場合は true', () => {
+    const entry = {
+      start_time: '2026-03-12T09:00:00Z',
+      end_time: '2026-03-12T10:00:00Z',
+      actual_start_time: '2026-03-12T09:00:00Z',
+      actual_end_time: '2026-03-12T10:30:00Z',
+      duration_minutes: null,
+    };
+    expect(hasPlannedActualDiff(entry)).toBe(true);
+  });
+
+  it('planned と actual が同じ時間なら false', () => {
+    const entry = {
+      start_time: '2026-03-12T09:00:00Z',
+      end_time: '2026-03-12T10:00:00Z',
+      actual_start_time: '2026-03-12T09:00:00Z',
+      actual_end_time: '2026-03-12T10:00:00Z',
+      duration_minutes: null,
+    };
+    expect(hasPlannedActualDiff(entry)).toBe(false);
+  });
+
+  it('planned range がなければ false', () => {
+    const entry = {
+      actual_start_time: '2026-03-12T09:00:00Z',
+      actual_end_time: '2026-03-12T10:00:00Z',
+    };
+    expect(hasPlannedActualDiff(entry)).toBe(false);
+  });
+
+  it('actual range がなければ false', () => {
+    const entry = {
+      start_time: '2026-03-12T09:00:00Z',
+      end_time: '2026-03-12T10:00:00Z',
+    };
+    expect(hasPlannedActualDiff(entry)).toBe(false);
+  });
+});

--- a/apps/app/src/features/entry/domain/entry-time-model.ts
+++ b/apps/app/src/features/entry/domain/entry-time-model.ts
@@ -1,0 +1,68 @@
+import type { EntryOrigin } from '@/lib/types/entry';
+
+export type EntryLike = {
+  origin?: string | null;
+  start_time?: string | null;
+  end_time?: string | null;
+  actual_start_time?: string | null;
+  actual_end_time?: string | null;
+  duration_minutes?: number | null;
+};
+
+export type TimeRange = { start: Date; end: Date };
+
+/** end <= now なら 'unplanned'、それ以外は 'planned'。now を注入できるのでテストが決定論的になる。 */
+export function determineEntryOrigin(end: Date | string, now: Date = new Date()): EntryOrigin {
+  return new Date(end).getTime() <= now.getTime() ? 'unplanned' : 'planned';
+}
+
+export function isPlannedEntry(entry: EntryLike): boolean {
+  return entry.origin === 'planned';
+}
+
+export function isUnplannedEntry(entry: EntryLike): boolean {
+  return entry.origin === 'unplanned';
+}
+
+export function getPlannedRange(entry: EntryLike): TimeRange | null {
+  if (!entry.start_time || !entry.end_time) return null;
+  return { start: new Date(entry.start_time), end: new Date(entry.end_time) };
+}
+
+export function getActualRange(entry: EntryLike): TimeRange | null {
+  if (!entry.actual_start_time || !entry.actual_end_time) return null;
+  return { start: new Date(entry.actual_start_time), end: new Date(entry.actual_end_time) };
+}
+
+/**
+ * planned 所要時間（分）。
+ * duration_minutes が保存済みなら優先、なければ planned range の差分から算出する。
+ */
+export function getPlannedMinutes(entry: EntryLike): number | null {
+  const range = getPlannedRange(entry);
+  if (!range) return null;
+  return (
+    entry.duration_minutes ?? Math.round((range.end.getTime() - range.start.getTime()) / 60000)
+  );
+}
+
+/** actual 所要時間（分）。常に actual_start/actual_end から算出する。 */
+export function getActualMinutes(entry: EntryLike): number | null {
+  const range = getActualRange(entry);
+  if (!range) return null;
+  return Math.round((range.end.getTime() - range.start.getTime()) / 60000);
+}
+
+/** actual - planned（分）。正 = actual が長い、負 = actual が短い。どちらかがない場合は null。 */
+export function getDiffMinutes(entry: EntryLike): number | null {
+  const planned = getPlannedMinutes(entry);
+  const actual = getActualMinutes(entry);
+  if (planned === null || actual === null) return null;
+  return actual - planned;
+}
+
+/** planned と actual に差分があるかどうか。 */
+export function hasPlannedActualDiff(entry: EntryLike): boolean {
+  const diff = getDiffMinutes(entry);
+  return diff !== null && diff !== 0;
+}

--- a/apps/app/src/features/entry/domain/index.ts
+++ b/apps/app/src/features/entry/domain/index.ts
@@ -1,0 +1,12 @@
+export {
+  determineEntryOrigin,
+  getActualMinutes,
+  getActualRange,
+  getDiffMinutes,
+  getPlannedMinutes,
+  getPlannedRange,
+  hasPlannedActualDiff,
+  isPlannedEntry,
+  isUnplannedEntry,
+} from './entry-time-model';
+export type { EntryLike, TimeRange } from './entry-time-model';

--- a/apps/app/src/features/entry/hooks/useEntryMutations.ts
+++ b/apps/app/src/features/entry/hooks/useEntryMutations.ts
@@ -15,6 +15,7 @@ import { api } from '@/lib/trpc';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslations } from 'next-intl';
 import { useRef } from 'react';
+import { determineEntryOrigin } from '../domain';
 import { clearNew, markNew } from '../lib/new-entry-tracker';
 import type { UpdateEntryInput } from '../schemas/entry';
 import { useEntryInspectorStore } from '../stores/useEntryInspectorStore';
@@ -78,8 +79,7 @@ export function useEntryMutations(options?: {
       const tempId = createTempId();
       const selectedStart = input.start_time ?? input.actual_start_time ?? null;
       const selectedEnd = input.end_time ?? input.actual_end_time ?? null;
-      const origin =
-        selectedEnd && new Date(selectedEnd).getTime() <= Date.now() ? 'unplanned' : 'planned';
+      const origin = selectedEnd ? determineEntryOrigin(selectedEnd) : 'planned';
       const tempEntry: Awaited<ReturnType<typeof utils.entries.list.fetch>>[number] = {
         id: tempId,
         title: input.title,

--- a/apps/app/src/features/entry/index.ts
+++ b/apps/app/src/features/entry/index.ts
@@ -26,6 +26,22 @@ export { useEntryInspectorStore } from './stores/useEntryInspectorStore';
 export { computeActualTimeDiffOverlay } from './lib/actual-time-overlay';
 
 // =============================================================================
+// Domain (Entry 時間モデル — 純粋関数、DB/tRPC/React 非依存)
+// =============================================================================
+export {
+  determineEntryOrigin,
+  getActualMinutes,
+  getActualRange,
+  getDiffMinutes,
+  getPlannedMinutes,
+  getPlannedRange,
+  hasPlannedActualDiff,
+  isPlannedEntry,
+  isUnplannedEntry,
+} from './domain';
+export type { EntryLike, TimeRange } from './domain';
+
+// =============================================================================
 // Lib (entry-status utilities)
 // =============================================================================
 export { getEntryState } from './lib/entry-status';

--- a/apps/app/src/features/entry/server/entry-service.ts
+++ b/apps/app/src/features/entry/server/entry-service.ts
@@ -9,6 +9,7 @@ import 'server-only';
 import type { TablesInsert, TablesUpdate } from '@/lib/database.types';
 import { logger } from '@/lib/logger';
 import { ServiceError } from '@/lib/trpc/errors';
+import { determineEntryOrigin } from '../domain';
 import { normalizeDateTimeConsistency, removeUndefinedFields } from '../lib/entry-normalization';
 
 import type {
@@ -508,8 +509,7 @@ export class EntryService {
     timezone?: string,
   ): NormalizedEntryInput {
     const selectedRange = this.resolveCreateRange(input, timezone);
-    const isUnplanned = new Date(selectedRange.end).getTime() <= Date.now();
-    const origin = isUnplanned ? 'unplanned' : 'planned';
+    const origin = determineEntryOrigin(selectedRange.end);
 
     const normalized: NormalizedEntryInput = {
       user_id: userId,


### PR DESCRIPTION
## Summary

- `features/entry/domain/entry-time-model.ts` を新設し、Entry 時間モデルの基本ルールを純粋関数として一箇所に集約
- `entry-service.ts` と `useEntryMutations.ts` で重複していた planned/unplanned 自動判定を `determineEntryOrigin` に統一
- `entry-adapter.ts` のインライン origin 判定を `isPlannedEntry` / `isUnplannedEntry` に置き換え

## 追加した関数

| 関数 | 説明 |
|------|------|
| `determineEntryOrigin(end, now?)` | end <= now → unplanned、それ以外 → planned |
| `isPlannedEntry(entry)` | origin === 'planned' |
| `isUnplannedEntry(entry)` | origin === 'unplanned' |
| `getPlannedRange(entry)` | start_time / end_time → TimeRange |
| `getActualRange(entry)` | actual_start_time / actual_end_time → TimeRange |
| `getPlannedMinutes(entry)` | duration_minutes 優先、なければ planned range 差分 |
| `getActualMinutes(entry)` | actual range から算出（duration_minutes 非参照） |
| `getDiffMinutes(entry)` | actual - planned（正 = actual が長い） |
| `hasPlannedActualDiff(entry)` | diff !== null && diff !== 0 |

## 制約

- DB / tRPC / React / Zustand に依存しない純粋関数のみ
- 仕様変更なし、既存挙動を維持
- statistics.ts / normalizeDateTimeConsistency / computeTimeDiff は対象外

## Test plan

- [ ] `domain/__tests__/entry-time-model.test.ts` 29テスト green
- [ ] `pnpm typecheck` エラーなし
- [ ] `pnpm lint` 0 warnings
- [ ] `pnpm lint:boundaries` cross-feature import なし
- [ ] `pnpm test:run` 1680テスト全通過（既存 regression なし）

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJpXiezizyYGPSWMtD1pLK)_