### PR TITLE
ci: apps/web build を quality gate に追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,30 @@ jobs:
             apps/app/.next/static/chunks/*.css
           retention-days: 1
 
+  web-build:
+    name: "\U0001F310 Web Build"
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - run: corepack enable
+      - run: pnpm install --frozen-lockfile
+
+      - uses: actions/cache@v5
+        with:
+          path: apps/web/.next/cache
+          key: nextjs-web-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('apps/web/src/**/*.{ts,tsx}', 'apps/web/content/**/*.{md,mdx,json}') }}
+          restore-keys: nextjs-web-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+
+      - name: Build web
+        run: pnpm build:web
+
   bundle-size:
     name: "\U0001F4E6 Bundle Size"
     runs-on: ubuntu-latest
@@ -226,7 +250,7 @@ jobs:
   quality-gate:
     name: "\U0001F6AA Quality Gate"
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, test, build, bundle-size, e2e]
+    needs: [lint, typecheck, test, build, web-build, bundle-size, e2e]
     if: always()
     steps:
       - run: |
@@ -234,6 +258,7 @@ jobs:
              [ "${{ needs.typecheck.result }}" != "success" ] || \
              [ "${{ needs.test.result }}" != "success" ] || \
              [ "${{ needs.build.result }}" != "success" ] || \
+             [ "${{ needs.web-build.result }}" != "success" ] || \
              [ "${{ needs.bundle-size.result }}" != "success" ] || \
              [ "${{ needs.e2e.result }}" != "success" ]; then
             echo "One or more jobs failed"


### PR DESCRIPTION
## Summary

- apps/web の production build を CI の独立 job として追加
- Quality Gate に web-build を含め、monorepo 側で dayopt.app を守れる状態にする

## Validation

- pnpm build:web
- pnpm exec prettier --check .github/workflows/ci.yml

## Notes

Dayopt/web repo を archive/delete する前の guardrail。Vercel web project の monorepo 切り替えは、この check が green になってから進める。