### PR TITLE
fix(vercel): apps/web の docs feature を deploy 対象に戻す

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -10,7 +10,7 @@ apps/storybook/
 /supabase/
 
 # ドキュメント
-docs/
+/docs/
 
 # テスト・Story ファイル
 *.test.ts


### PR DESCRIPTION
## Summary

- .vercelignore の docs/ を /docs/ に変更
- root docs だけを除外し、apps/web/src/features/docs は Vercel deploy に含める

## Why

Vercel web project を monorepo root から deploy したところ、apps/web/src/features/docs が除外され、@/features/docs が解決できず build が失敗したため。

## Validation

- pnpm build:web