### PR TITLE
fix(web): build時のupstash warningを抑止する

### DIFF
--- a/apps/web/src/platform/security/rate-limit.ts
+++ b/apps/web/src/platform/security/rate-limit.ts
@@ -1,6 +1,7 @@
 import { env } from '@/platform/config/env';
 import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
+import { PHASE_PRODUCTION_BUILD } from 'next/constants';
 
 /**
  * レート制限設定
@@ -10,6 +11,7 @@ import { Redis } from '@upstash/redis';
  */
 
 const hasRedis = !!(env.UPSTASH_REDIS_REST_URL && env.UPSTASH_REDIS_REST_TOKEN);
+const isProductionBuild = process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD;
 
 // Redis クライアント（Upstash 設定時のみ）
 const redis = hasRedis
@@ -19,8 +21,9 @@ const redis = hasRedis
     })
   : undefined;
 
-if (!hasRedis) {
-  // production では env.ts の validateRequiredEnv が起動時に throw するため、ここに到達するのは dev/test のみ
+if (!hasRedis && !isProductionBuild) {
+  // production build では route module 評価時に繰り返し出るため抑止する。
+  // runtime の production secret 検証は instrumentation.ts の assertProductionRuntimeEnv が担当する。
   console.warn(
     '[RateLimit] Upstash is not configured. All rate limits become pass-through (no protection). Set UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN.',
   );


### PR DESCRIPTION
## Summary
- suppress the repeated Upstash-not-configured warning during Next production build module evaluation
- keep runtime behavior unchanged: when Redis env is missing at runtime, the same pass-through limiter and warning behavior remain
- leave the Turbopack content fs trace as a follow-up because it spans blog/release/docs content loaders

## Cause
- `rate-limit.ts` logs at module load, and Next evaluates API route modules while collecting page data during `next build`, so the message appears once per build worker/import.
- The Turbopack NFT trace comes from filesystem-based MDX content loaders imported by routes such as `/blog/feed.xml` and `/api/tags`. Removing it cleanly likely needs a content-loader or manifest-level cleanup.

## Verification
- `pnpm lint:web`
- `pnpm typecheck:web`
- `pnpm build:web`