### PR TITLE
refactor(stores): user preference を useCalendarSettingsStore から分離する

### DIFF
--- a/apps/product/src/app/[locale]/(app)/(modes)/calendar/_composition/useCalendarComposition.ts
+++ b/apps/product/src/app/[locale]/(app)/(modes)/calendar/_composition/useCalendarComposition.ts
@@ -21,7 +21,6 @@ import type { CalendarViewType } from '@/features/calendar';
 import { useEntryInspectorStore } from '@/features/entry';
 import { logger } from '@/lib/logger';
 import { useCalendarNavigationStore } from '@/lib/stores/useCalendarNavigationStore';
-import type { CalendarSettings } from '@/lib/stores/useCalendarSettingsStore';
 
 // Sub-hooks
 import { useCalendarCrudHandlers } from './useCalendarCrudHandlers';
@@ -82,7 +81,7 @@ export interface CalendarCompositionResult {
   onDateSelect: ReturnType<typeof useCalendarNavHandlers>['onDateSelect'];
 
   // === Settings persistence ===
-  onSettingsChange: (settings: Partial<CalendarSettings>) => void;
+  onSettingsChange: (settings: Partial<UserSettings>) => void;
 }
 
 // =============================================================================

--- a/apps/product/src/app/[locale]/(app)/(modes)/calendar/_composition/useCalendarComposition.ts
+++ b/apps/product/src/app/[locale]/(app)/(modes)/calendar/_composition/useCalendarComposition.ts
@@ -21,6 +21,7 @@ import type { CalendarViewType } from '@/features/calendar';
 import { useEntryInspectorStore } from '@/features/entry';
 import { logger } from '@/lib/logger';
 import { useCalendarNavigationStore } from '@/lib/stores/useCalendarNavigationStore';
+import type { UserSettings } from '@/lib/stores/userSettings';
 
 // Sub-hooks
 import { useCalendarCrudHandlers } from './useCalendarCrudHandlers';

--- a/apps/product/src/app/[locale]/(app)/(modes)/calendar/_composition/useCalendarNavHandlers.ts
+++ b/apps/product/src/app/[locale]/(app)/(modes)/calendar/_composition/useCalendarNavHandlers.ts
@@ -13,6 +13,7 @@ import type { CalendarViewType } from '@/features/calendar';
 import { useCalendarNavigationHandlers, useWeekendToggleShortcut } from '@/features/calendar';
 import { useUserSettings } from '@/features/settings';
 import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import type { UserSettings } from '@/lib/stores/userSettings';
 
 // =============================================================================
 // Types

--- a/apps/product/src/app/[locale]/(app)/(modes)/calendar/_composition/useCalendarNavHandlers.ts
+++ b/apps/product/src/app/[locale]/(app)/(modes)/calendar/_composition/useCalendarNavHandlers.ts
@@ -12,7 +12,6 @@ import { useCallback, useMemo } from 'react';
 import type { CalendarViewType } from '@/features/calendar';
 import { useCalendarNavigationHandlers, useWeekendToggleShortcut } from '@/features/calendar';
 import { useUserSettings } from '@/features/settings';
-import type { CalendarSettings } from '@/lib/stores/useCalendarSettingsStore';
 import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
 
 // =============================================================================
@@ -36,7 +35,7 @@ export interface CalendarNavHandlersResult {
   onNavigateToday: () => void;
   onToggleWeekends: () => void;
   onDateSelect: (date: Date) => void;
-  onSettingsChange: (settings: Partial<CalendarSettings>) => void;
+  onSettingsChange: (settings: Partial<UserSettings>) => void;
 }
 
 // =============================================================================
@@ -72,7 +71,7 @@ export function useCalendarNavHandlers({
 
   // Settings persistence（ViewSwitcherからの設定変更をDBに保存）
   const handleSettingsChange = useCallback(
-    (settings: Partial<CalendarSettings>) => {
+    (settings: Partial<UserSettings>) => {
       saveSettings(settings);
     },
     [saveSettings],

--- a/apps/product/src/features/calendar/components/CalendarController.tsx
+++ b/apps/product/src/features/calendar/components/CalendarController.tsx
@@ -20,7 +20,6 @@ import type { CalendarEvent, CalendarViewType, ViewDateRange } from '../types/ca
 import { CalendarViewRenderer } from './controller/components';
 import { initializePreload } from './controller/utils';
 
-import type { CalendarSettings } from '@/lib/stores/useCalendarSettingsStore';
 import { CalendarLayout } from './layout/CalendarLayout';
 import { EventContextMenu, MobileTouchHint } from './views/shared/components';
 
@@ -85,7 +84,7 @@ export interface CalendarControllerProps {
   onPrefetch?: ((direction: 'prev' | 'next' | 'today') => void) | undefined;
 
   // --- Settings persistence ---
-  onSettingsChange?: (settings: Partial<CalendarSettings>) => void;
+  onSettingsChange?: (settings: Partial<UserSettings>) => void;
 
   // --- Slots ---
   className?: string;

--- a/apps/product/src/features/calendar/components/CalendarController.tsx
+++ b/apps/product/src/features/calendar/components/CalendarController.tsx
@@ -20,6 +20,7 @@ import type { CalendarEvent, CalendarViewType, ViewDateRange } from '../types/ca
 import { CalendarViewRenderer } from './controller/components';
 import { initializePreload } from './controller/utils';
 
+import type { UserSettings } from '@/lib/stores/userSettings';
 import { CalendarLayout } from './layout/CalendarLayout';
 import { EventContextMenu, MobileTouchHint } from './views/shared/components';
 

--- a/apps/product/src/features/calendar/components/controller/hooks/useCalendarData.ts
+++ b/apps/product/src/features/calendar/components/controller/hooks/useCalendarData.ts
@@ -8,7 +8,7 @@ import { fromZonedTime } from 'date-fns-tz';
 import type { EntryWithTags } from '@/features/entry';
 import { useEntries } from '@/features/entry';
 import { useTags } from '@/features/tags';
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 import { api } from '@/lib/trpc';
 import { expandEntriesToCalendarEvents } from '../../../lib/entry-adapter';
 
@@ -80,8 +80,8 @@ export function useCalendarData({
   currentDate,
 }: UseCalendarDataOptions): UseCalendarDataResult {
   // 週の開始日設定とタイムゾーンを取得
-  const weekStartsOn = useCalendarSettingsStore((state) => state.weekStartsOn);
-  const timezone = useCalendarSettingsStore((state) => state.timezone);
+  const weekStartsOn = useUserPreferenceStore((state) => state.weekStartsOn);
+  const timezone = useUserPreferenceStore((state) => state.timezone);
 
   // ビューに応じた期間計算（週の開始日設定を反映）
   const viewDateRange = useMemo(() => {

--- a/apps/product/src/features/calendar/components/layout/CalendarLayout.tsx
+++ b/apps/product/src/features/calendar/components/layout/CalendarLayout.tsx
@@ -10,8 +10,6 @@ import { DateNavigator } from '@/lib/components/common/DateNavigator';
 import { AppHeader } from '@/lib/components/shell/AppHeader';
 import { InlineBanner } from '@/lib/components/ui/inline-banner';
 import { useInlineBanner } from '@/lib/hooks/useInlineBanner';
-import type { CalendarSettings } from '@/lib/stores/useCalendarSettingsStore';
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
 import { useSwipeGesture } from '../../hooks/useSwipeGesture';
 import type { CalendarViewType } from '../../types/calendar.types';
 
@@ -46,7 +44,7 @@ export interface CalendarLayoutProps {
   onPrefetch?: ((direction: NavigationDirection) => void) | undefined;
 
   // Settings persistence callback
-  onSettingsChange?: ((settings: Partial<CalendarSettings>) => void) | undefined;
+  onSettingsChange?: ((settings: Partial<UserSettings>) => void) | undefined;
 
   // Header slots
   leftSlot?: React.ReactNode | undefined;
@@ -84,8 +82,8 @@ export const CalendarLayout = memo<CalendarLayoutProps>(
     rightSlot,
   }) => {
     const t = useTranslations('calendar');
-    const showWeekNumbers = useCalendarSettingsStore((s) => s.showWeekNumbers);
-    const weekStartsOn = useCalendarSettingsStore((s) => s.weekStartsOn);
+    const showWeekNumbers = useUserPreferenceStore((s) => s.showWeekNumbers);
+    const weekStartsOn = useUserPreferenceStore((s) => s.weekStartsOn);
     const banner = useInlineBanner();
 
     // ナビゲーション方向 + キーの追跡（スライドアニメーション用）

--- a/apps/product/src/features/calendar/components/layout/CalendarLayout.tsx
+++ b/apps/product/src/features/calendar/components/layout/CalendarLayout.tsx
@@ -10,6 +10,8 @@ import { DateNavigator } from '@/lib/components/common/DateNavigator';
 import { AppHeader } from '@/lib/components/shell/AppHeader';
 import { InlineBanner } from '@/lib/components/ui/inline-banner';
 import { useInlineBanner } from '@/lib/hooks/useInlineBanner';
+import type { UserSettings } from '@/lib/stores/userSettings';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 import { useSwipeGesture } from '../../hooks/useSwipeGesture';
 import type { CalendarViewType } from '../../types/calendar.types';
 

--- a/apps/product/src/features/calendar/components/layout/Header/MobileCalendarHeader.tsx
+++ b/apps/product/src/features/calendar/components/layout/Header/MobileCalendarHeader.tsx
@@ -9,7 +9,7 @@ import { memo, useCallback, useState } from 'react';
 import { AppHeader } from '@/lib/components/shell/AppHeader';
 import { Button } from '@/lib/components/ui/button';
 import { isTodayInTimezone } from '@/lib/date/timezone';
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 import { cn } from '@/lib/utils';
 
 import type { NavigationDirection } from '@/lib/components/common/DateNavigator';
@@ -63,9 +63,9 @@ export const MobileCalendarHeader = memo<MobileCalendarHeaderProps>(
     }
 
     // ヘッダー: 月部分・日番号・接尾辞を分離して今日バッジ + 週数を1行に統合
-    const weekStartsOn = useCalendarSettingsStore((s) => s.weekStartsOn);
-    const showWeekNumbers = useCalendarSettingsStore((s) => s.showWeekNumbers);
-    const timezone = useCalendarSettingsStore((s) => s.timezone);
+    const weekStartsOn = useUserPreferenceStore((s) => s.weekStartsOn);
+    const showWeekNumbers = useUserPreferenceStore((s) => s.showWeekNumbers);
+    const timezone = useUserPreferenceStore((s) => s.timezone);
     const monthPart = format(currentDate, locale === 'ja' ? 'M月' : 'MMM ', {
       locale: dateFnsLocale,
     });

--- a/apps/product/src/features/calendar/components/layout/Header/MobileMonthGrid.tsx
+++ b/apps/product/src/features/calendar/components/layout/Header/MobileMonthGrid.tsx
@@ -17,7 +17,7 @@ import { memo, useCallback, useMemo } from 'react';
 
 import { isTodayInTimezone, tzIsSameDay } from '@/lib/date/timezone';
 import { useHasMounted } from '@/lib/hooks/useHasMounted';
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 import { cn } from '@/lib/utils';
 
 import { useSwipeGesture } from '../../../hooks/useSwipeGesture';
@@ -45,8 +45,8 @@ interface MobileMonthGridProps {
 export const MobileMonthGrid = memo<MobileMonthGridProps>(
   ({ viewMonth, selectedDate, onViewMonthChange, onDateSelect, className }) => {
     const tCommon = useTranslations('common');
-    const weekStartsOn = useCalendarSettingsStore((state) => state.weekStartsOn);
-    const showWeekNumbers = useCalendarSettingsStore((state) => state.showWeekNumbers);
+    const weekStartsOn = useUserPreferenceStore((state) => state.weekStartsOn);
+    const showWeekNumbers = useUserPreferenceStore((state) => state.showWeekNumbers);
     const isMounted = useHasMounted();
 
     const weekdaysRaw = tCommon.raw('dates.weekdaysNarrow') as string[];
@@ -82,7 +82,7 @@ export const MobileMonthGrid = memo<MobileMonthGridProps>(
 
     const { handlers, ref } = useSwipeGesture(handleSwipeLeft, handleSwipeRight);
 
-    const timezone = useCalendarSettingsStore((state) => state.timezone);
+    const timezone = useUserPreferenceStore((state) => state.timezone);
 
     // 日付の状態を判定（ユーザー TZ ベース）
     const getDayState = useCallback(

--- a/apps/product/src/features/calendar/components/layout/Header/ViewSwitcher.tsx
+++ b/apps/product/src/features/calendar/components/layout/Header/ViewSwitcher.tsx
@@ -17,9 +17,11 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@/lib/components/ui/dropdown-menu';
-import type { CalendarSettings } from '@/lib/stores/useCalendarSettingsStore';
 import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import type { UserSettings } from '@/lib/stores/userSettings';
+import { dispatchUserSettings } from '@/lib/stores/userSettings';
 import { useShellStore } from '@/lib/stores/useShellStore';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 import { cn } from '@/lib/utils';
 import type { ShortcutDef } from '../../../hooks/keyboard/shortcut-registry';
 import { registerShortcuts } from '../../../hooks/keyboard/shortcut-registry';
@@ -30,7 +32,7 @@ import { isMultiDayView } from '../../../types/calendar.types';
 interface ViewSwitcherProps {
   currentView: CalendarViewType;
   onChange: (view: CalendarViewType) => void;
-  onSettingsChange?: ((settings: Partial<CalendarSettings>) => void) | undefined;
+  onSettingsChange?: ((settings: Partial<UserSettings>) => void) | undefined;
   className?: string;
 }
 
@@ -66,16 +68,15 @@ export function ViewSwitcher({
 }: ViewSwitcherProps) {
   const t = useTranslations();
   const showWeekends = useCalendarSettingsStore((s) => s.showWeekends);
-  const showWeekNumbers = useCalendarSettingsStore((s) => s.showWeekNumbers);
+  const showWeekNumbers = useUserPreferenceStore((s) => s.showWeekNumbers);
   const hourHeightDensity = useCalendarSettingsStore((s) => s.hourHeightDensity);
-  const updateSettings = useCalendarSettingsStore((s) => s.updateSettings);
 
   const persistSettings = useCallback(
-    (settings: Partial<CalendarSettings>) => {
-      updateSettings(settings);
+    (settings: Partial<UserSettings>) => {
+      dispatchUserSettings(settings);
       onSettingsChange?.(settings);
     },
-    [updateSettings, onSettingsChange],
+    [onSettingsChange],
   );
 
   const currentLabel = isMultiDayView(currentView)

--- a/apps/product/src/features/calendar/components/views/DayView/DayView.tsx
+++ b/apps/product/src/features/calendar/components/views/DayView/DayView.tsx
@@ -6,7 +6,7 @@ import { getWeek } from 'date-fns';
 
 import { cn } from '@/lib/utils';
 
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 
 import { CalendarViewAnimation } from '../../animations/ViewTransition';
 import { CalendarDateHeader, DateDisplay, ScrollableCalendarLayout } from '../shared';
@@ -34,8 +34,8 @@ export const DayView = ({
   onNavigateNext: _onNavigateNext,
   onNavigateToday: _onNavigateToday,
 }: DayViewProps) => {
-  const timezone = useCalendarSettingsStore((s) => s.timezone);
-  const weekStartsOn = useCalendarSettingsStore((s) => s.weekStartsOn);
+  const timezone = useUserPreferenceStore((s) => s.timezone);
+  const weekStartsOn = useUserPreferenceStore((s) => s.weekStartsOn);
 
   // 表示する日付
   const displayDates = useMemo(() => {

--- a/apps/product/src/features/calendar/components/views/MultiDayView/MultiDayView.tsx
+++ b/apps/product/src/features/calendar/components/views/MultiDayView/MultiDayView.tsx
@@ -5,7 +5,7 @@ import React, { useMemo } from 'react';
 import { format, getWeek } from 'date-fns';
 
 import { isTodayInTimezone } from '@/lib/date/timezone';
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 import { cn } from '@/lib/utils';
 
 import { CalendarViewAnimation } from '../../animations/ViewTransition';
@@ -45,8 +45,8 @@ export function MultiDayView({
   onNavigateNext: _onNavigateNext,
   onNavigateToday: _onNavigateToday,
 }: MultiDayViewProps) {
-  const timezone = useCalendarSettingsStore((s) => s.timezone);
-  const weekStartsOn = useCalendarSettingsStore((s) => s.weekStartsOn);
+  const timezone = useUserPreferenceStore((s) => s.timezone);
+  const weekStartsOn = useUserPreferenceStore((s) => s.weekStartsOn);
   const HOUR_HEIGHT = useResponsiveHourHeight();
 
   const displayCenterDate = useMemo(() => {

--- a/apps/product/src/features/calendar/components/views/WeekView/WeekView.tsx
+++ b/apps/product/src/features/calendar/components/views/WeekView/WeekView.tsx
@@ -2,7 +2,7 @@
 
 import { isWeekend } from 'date-fns';
 
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 
 import { CalendarViewAnimation } from '../../animations/ViewTransition';
 
@@ -44,7 +44,7 @@ export const WeekView = ({
   onUpdateEntry,
   onTimeRangeSelect,
 }: WeekViewProps) => {
-  const weekStartsOnSetting = useCalendarSettingsStore((s) => s.weekStartsOn);
+  const weekStartsOnSetting = useUserPreferenceStore((s) => s.weekStartsOn);
   // 設定ストアの値を優先、プロップでオーバーライド可能
   const weekStartsOn = weekStartsOnProp ?? weekStartsOnSetting;
 

--- a/apps/product/src/features/calendar/components/views/WeekView/components/WeekGrid.tsx
+++ b/apps/product/src/features/calendar/components/views/WeekView/components/WeekGrid.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { getWeek } from 'date-fns';
 
 import { isTodayInTimezone } from '@/lib/date/timezone';
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 import { cn } from '@/lib/utils';
 
 import {
@@ -44,8 +44,8 @@ export const WeekGrid = ({
   onTimeRangeSelect,
   className,
 }: WeekGridProps) => {
-  const timezone = useCalendarSettingsStore((s) => s.timezone);
-  const weekStartsOn = useCalendarSettingsStore((s) => s.weekStartsOn);
+  const timezone = useUserPreferenceStore((s) => s.timezone);
+  const weekStartsOn = useUserPreferenceStore((s) => s.weekStartsOn);
 
   // レスポンシブな時間高さ
   const hourHeight = useResponsiveHourHeight();

--- a/apps/product/src/features/calendar/components/views/shared/DateDisplay/DateDisplay.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/DateDisplay/DateDisplay.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { format } from 'date-fns';
 
 import { isTodayInTimezone } from '@/lib/date/timezone';
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 import { cn } from '@/lib/utils';
 
 import type { DateDisplayProps } from '../../../../types/date-display.types';
@@ -144,7 +144,7 @@ export const DateDisplay = ({
   onClick,
   onDoubleClick,
 }: DateDisplayProps) => {
-  const timezone = useCalendarSettingsStore((s) => s.timezone);
+  const timezone = useUserPreferenceStore((s) => s.timezone);
   const today = todayProp ?? isTodayInTimezone(date, timezone);
 
   const { dayName, dateString, monthYear } = useDateFormats(

--- a/apps/product/src/features/calendar/components/views/shared/components/CalendarDragSelection/useDragSelection.ts
+++ b/apps/product/src/features/calendar/components/views/shared/components/CalendarDragSelection/useDragSelection.ts
@@ -14,7 +14,7 @@ import { useCallback, useEffect, useReducer, useRef } from 'react';
 import { useTranslations } from 'next-intl';
 
 import { formatTimeString } from '@/lib/date';
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 import { toast } from '@/lib/toast';
 
 import { useHapticFeedback } from '../../../../../hooks/accessibility/useHapticFeedback';
@@ -219,7 +219,7 @@ export function useDragSelection({
   plans = [],
   hourHeight = HOUR_HEIGHT,
 }: UseDragSelectionOptions): UseDragSelectionReturn {
-  const defaultDuration = useCalendarSettingsStore((state) => state.defaultDuration);
+  const defaultDuration = useUserPreferenceStore((state) => state.defaultDuration);
   const { tap } = useHapticFeedback();
   const t = useTranslations('entry');
 

--- a/apps/product/src/features/calendar/components/views/shared/components/DayColumn/DayColumn.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/DayColumn/DayColumn.tsx
@@ -18,7 +18,7 @@ import { useTagsMap } from '@/features/tags';
 import { MEDIA_QUERIES } from '@/lib/breakpoints';
 import { isTodayInTimezone } from '@/lib/date/timezone';
 import { useMediaQuery } from '@/lib/hooks/useMediaQuery';
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 import { filterEntriesByDate, sortTimedEntries } from '../../../../../lib/layout';
 
 export const DayColumn = memo<DayColumnProps>(function DayColumn({
@@ -37,7 +37,7 @@ export const DayColumn = memo<DayColumnProps>(function DayColumn({
   const setAnchorRect = useEntryInspectorStore((state) => state.setAnchorRect);
   const isMobile = useMediaQuery(MEDIA_QUERIES.mobile);
   const format = useFormatter();
-  const timezone = useCalendarSettingsStore((state) => state.timezone);
+  const timezone = useUserPreferenceStore((state) => state.timezone);
 
   // この日のエントリをフィルタリング
   const dayEntries = useMemo(() => {

--- a/apps/product/src/features/calendar/components/views/shared/components/DraftEntryBlock.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/DraftEntryBlock.tsx
@@ -7,7 +7,7 @@ import { useTranslations } from 'next-intl';
 
 import { ColonTagLabel } from '@/lib/components/ui/colon-tag-label';
 import { formatTimeString } from '@/lib/date';
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 import { getTagColorClasses } from '@/lib/tag-colors';
 import { hasTwoLayerTimeConflict } from '@/lib/time/two-layer-overlap';
 import { cn } from '@/lib/utils';
@@ -45,7 +45,7 @@ interface DraftEntryBlockProps {
  */
 export function DraftEntryBlock({ draft, hourHeight }: DraftEntryBlockProps) {
   const t = useTranslations();
-  const timeFormat = useCalendarSettingsStore((s) => s.timeFormat);
+  const timeFormat = useUserPreferenceStore((s) => s.timeFormat);
   const updateTimes = useTagDraftStore((s) => s.updateTimes);
   const queryClient = useQueryClient();
 

--- a/apps/product/src/features/calendar/components/views/shared/components/InlineTagPalette/InlineTagPalette.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/InlineTagPalette/InlineTagPalette.tsx
@@ -23,8 +23,8 @@ import { ColonTagLabel } from '@/lib/components/ui/colon-tag-label';
 import { formatTimeString } from '@/lib/date';
 import { convertFromTimezone } from '@/lib/date/timezone';
 import { logger } from '@/lib/logger';
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
 import { useShellStore } from '@/lib/stores/useShellStore';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 import { getTagColorClasses, resolveTagColor } from '@/lib/tag-colors';
 import { hasTwoLayerTimeConflict } from '@/lib/time/two-layer-overlap';
 import { cn } from '@/lib/utils';
@@ -60,7 +60,7 @@ export function InlineTagPalette({ hourHeight, date }: InlineTagPaletteProps) {
   const pendingSelection = useInlineCreateStore.use.pendingSelection();
   const clearPendingSelection = useInlineCreateStore.use.clearPendingSelection();
   const updateSelectionTimes = useInlineCreateStore.use.updateSelectionTimes();
-  const timezone = useCalendarSettingsStore((s) => s.timezone);
+  const timezone = useUserPreferenceStore((s) => s.timezone);
   const locale = useLocale();
   const t = useTranslations('tags');
   const tCalendar = useTranslations('calendar');
@@ -264,7 +264,7 @@ export function InlineTagPalette({ hourHeight, date }: InlineTagPaletteProps) {
     return () => clearPendingSelection();
   }, [waitingForModal, clearPendingSelection]);
 
-  const timeFormat = useCalendarSettingsStore((s) => s.timeFormat);
+  const timeFormat = useUserPreferenceStore((s) => s.timeFormat);
   const [nowForPastCheck, setNowForPastCheck] = useState<number | null>(null);
 
   useEffect(() => {

--- a/apps/product/src/features/calendar/components/views/shared/components/ScrollableCalendarLayout.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/ScrollableCalendarLayout.tsx
@@ -67,7 +67,7 @@ export const CalendarDateHeader = ({
   weekNumber,
   className,
 }: CalendarDateHeaderProps) => {
-  const showWeekNumbers = useCalendarSettingsStore((s) => s.showWeekNumbers);
+  const showWeekNumbers = useUserPreferenceStore((s) => s.showWeekNumbers);
 
   // 設定がオンで週番号が渡されている場合のみ表示
   const shouldShowWeekNumber = showWeekNumbers && weekNumber != null;
@@ -155,7 +155,7 @@ export const ScrollableCalendarLayout = ({
   }, [chronotype]);
 
   // 現在時刻のフォーマット（設定に応じて 24h/12h）
-  const timeFormat = useCalendarSettingsStore((s) => s.timeFormat);
+  const timeFormat = useUserPreferenceStore((s) => s.timeFormat);
   const formattedCurrentTime = formatTimeString(
     currentTime.getHours(),
     currentTime.getMinutes(),

--- a/apps/product/src/features/calendar/components/views/shared/components/ScrollableCalendarLayout.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/ScrollableCalendarLayout.tsx
@@ -16,6 +16,7 @@ import { cn } from '@/lib/utils';
 
 import { formatTimeString } from '@/lib/date';
 import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 
 import { TIME_COLUMN_WIDTH, Z_INDEX } from '../constants/grid.constants';
 import { CurrentTimeLine } from '../grid/CurrentTimeLine';

--- a/apps/product/src/features/calendar/components/views/shared/components/TimezoneOffset/TimezoneOffset.stories.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/TimezoneOffset/TimezoneOffset.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 
 import { TimezoneOffset } from './TimezoneOffset';
 
@@ -26,7 +26,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   decorators: [
     (Story) => {
-      useCalendarSettingsStore.setState({ timezone: 'Asia/Tokyo' });
+      useUserPreferenceStore.setState({ timezone: 'Asia/Tokyo' });
       return <Story />;
     },
   ],
@@ -36,7 +36,7 @@ export const Default: Story = {
 export const UTC: Story = {
   decorators: [
     (Story) => {
-      useCalendarSettingsStore.setState({ timezone: 'Europe/London' });
+      useUserPreferenceStore.setState({ timezone: 'Europe/London' });
       return <Story />;
     },
   ],
@@ -46,7 +46,7 @@ export const UTC: Story = {
 export const NewYork: Story = {
   decorators: [
     (Story) => {
-      useCalendarSettingsStore.setState({ timezone: 'America/New_York' });
+      useUserPreferenceStore.setState({ timezone: 'America/New_York' });
       return <Story />;
     },
   ],
@@ -56,7 +56,7 @@ export const NewYork: Story = {
 export const LosAngeles: Story = {
   decorators: [
     (Story) => {
-      useCalendarSettingsStore.setState({ timezone: 'America/Los_Angeles' });
+      useUserPreferenceStore.setState({ timezone: 'America/Los_Angeles' });
       return <Story />;
     },
   ],
@@ -69,7 +69,7 @@ export const WithClassName: Story = {
   },
   decorators: [
     (Story) => {
-      useCalendarSettingsStore.setState({ timezone: 'Asia/Tokyo' });
+      useUserPreferenceStore.setState({ timezone: 'Asia/Tokyo' });
       return <Story />;
     },
   ],
@@ -89,7 +89,7 @@ export const AllPatterns: Story = {
     return (
       <div className="flex flex-col gap-4">
         {timezones.map(({ label, tz }) => {
-          useCalendarSettingsStore.setState({ timezone: tz });
+          useUserPreferenceStore.setState({ timezone: tz });
           return (
             <div key={tz} className="flex items-center gap-4">
               <span className="text-muted-foreground w-52 text-xs">{label}</span>

--- a/apps/product/src/features/calendar/components/views/shared/components/TimezoneOffset/TimezoneOffset.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/TimezoneOffset/TimezoneOffset.tsx
@@ -3,7 +3,6 @@
 import { useTranslations } from 'next-intl';
 
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@/lib/components/ui/select';
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
 import { getTimeZones } from '@/lib/timezone-utils';
 import { api } from '@/lib/trpc';
 import { cn } from '@/lib/utils';
@@ -16,8 +15,8 @@ interface TimezoneOffsetProps {
 /** タイムゾーンを選択するドロップダウンコンポーネント（UTC オフセット表示） */
 export function TimezoneOffset({ className }: TimezoneOffsetProps) {
   const tActions = useTranslations('calendar.actions');
-  const timezone = useCalendarSettingsStore((s) => s.timezone);
-  const updateSettings = useCalendarSettingsStore((s) => s.updateSettings);
+  const timezone = useUserPreferenceStore((s) => s.timezone);
+  const updatePreferences = useUserPreferenceStore((s) => s.updatePreferences);
   const utils = api.useUtils();
   const updateMutation = api.userSettings.update.useMutation({
     onSuccess: () => {
@@ -58,7 +57,7 @@ export function TimezoneOffset({ className }: TimezoneOffsetProps) {
   };
 
   const handleTimezoneChange = (value: string) => {
-    updateSettings({ timezone: value });
+    updatePreferences({ timezone: value });
     updateMutation.mutate({ timezone: value });
   };
 

--- a/apps/product/src/features/calendar/components/views/shared/components/TimezoneOffset/TimezoneOffset.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/TimezoneOffset/TimezoneOffset.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from 'next-intl';
 
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@/lib/components/ui/select';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 import { getTimeZones } from '@/lib/timezone-utils';
 import { api } from '@/lib/trpc';
 import { cn } from '@/lib/utils';

--- a/apps/product/src/features/calendar/components/views/shared/grid/CurrentTimeLine/CurrentTimeLine.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/grid/CurrentTimeLine/CurrentTimeLine.tsx
@@ -14,7 +14,7 @@
 import { memo, useMemo } from 'react';
 
 import { convertToTimezone, tzIsSameDay } from '@/lib/date/timezone';
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 import { timeToPixels } from '../../../../../lib/grid';
 import type { CurrentTimeLineProps } from '../../../../../types/grid.types';
 import { CURRENT_TIME_DOT_SIZE, HOUR_HEIGHT, Z_INDEX } from '../../constants/grid.constants';
@@ -35,7 +35,7 @@ export const CurrentTimeLine = memo<CurrentTimeLineProps>(function CurrentTimeLi
   containerWidth: _containerWidth = 800,
 }) {
   const rawTime = useCurrentTime({ updateInterval });
-  const timezone = useCalendarSettingsStore((state) => state.timezone);
+  const timezone = useUserPreferenceStore((state) => state.timezone);
 
   // ユーザーTZに変換してから位置計算（ブラウザTZと異なる場合に正しい位置を表示）
   const currentTime = useMemo(() => convertToTimezone(rawTime, timezone), [rawTime, timezone]);
@@ -159,7 +159,7 @@ export const CurrentTimeLineForColumn = memo<{
   endHour = 24,
 }) {
   const rawTime = useCurrentTime({ updateInterval: 60000 });
-  const timezone = useCalendarSettingsStore((state) => state.timezone);
+  const timezone = useUserPreferenceStore((state) => state.timezone);
 
   // ユーザーTZに変換
   const currentTime = useMemo(() => convertToTimezone(rawTime, timezone), [rawTime, timezone]);

--- a/apps/product/src/features/calendar/components/views/shared/hooks/useCurrentPeriod.ts
+++ b/apps/product/src/features/calendar/components/views/shared/hooks/useCurrentPeriod.ts
@@ -7,7 +7,7 @@ import { useMemo } from 'react';
 
 import { isSameDay, isSameWeek } from 'date-fns';
 
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 
 import { getTodayIndex } from '../utils/dateHelpers';
 
@@ -42,7 +42,7 @@ export function useCurrentPeriod({
   periodType,
   weekStartsOn = 0,
 }: UseCurrentPeriodOptions): UseCurrentPeriodReturn {
-  const timezone = useCalendarSettingsStore((state) => state.timezone);
+  const timezone = useUserPreferenceStore((state) => state.timezone);
 
   // 今日が期間内のどこにあるかを計算（ユーザー TZ 基準）
   const todayIndex = useMemo(() => {

--- a/apps/product/src/features/calendar/components/views/shared/hooks/useIsToday.ts
+++ b/apps/product/src/features/calendar/components/views/shared/hooks/useIsToday.ts
@@ -1,17 +1,17 @@
 import { useMemo } from 'react';
 
 import { isTodayInTimezone } from '@/lib/date/timezone';
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 
 /**
  * 指定された日付が「ユーザーの calendar timezone での今日」かどうかを判定するフック
  *
  * date-fns の `isToday` はブラウザのローカル TZ で判定するため、ユーザーが
  * OS TZ と異なる timezone を設定している場合に highlight が 1 日ずれる。
- * カレンダーは取得・表示の両方を `useCalendarSettingsStore.timezone` で揃えるため、
+ * カレンダーは取得・表示の両方を `useUserPreferenceStore.timezone` で揃えるため、
  * このフックも同じ timezone を参照する。
  */
 export function useIsToday(date: Date): boolean {
-  const timezone = useCalendarSettingsStore((s) => s.timezone);
+  const timezone = useUserPreferenceStore((s) => s.timezone);
   return useMemo(() => isTodayInTimezone(date, timezone), [date, timezone]);
 }

--- a/apps/product/src/features/calendar/hooks/keyboard/useCalendarEntryKeyboard.ts
+++ b/apps/product/src/features/calendar/hooks/keyboard/useCalendarEntryKeyboard.ts
@@ -5,7 +5,7 @@ import { useEffect, useRef } from 'react';
 import { useEntryInspectorStore, useEntryMutations } from '@/features/entry';
 import { localTimeToUTCISO } from '@/lib/date/timezone';
 import { logger } from '@/lib/logger';
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 import { toast } from '@/lib/toast';
 import { useTranslations } from 'next-intl';
 import { useEntryClipboardStore } from '../../stores/useEntryClipboardStore';
@@ -58,7 +58,7 @@ export function useCalendarEventKeyboard({
   const { isOpen, entryId, openInspector, closeInspector } = useEntryInspectorStore();
   const { createEntry } = useEntryMutations();
   // ユーザーの設定タイムゾーン（ペースト時のUTC変換に使用）
-  const timezone = useCalendarSettingsStore((s: { timezone: string }) => s.timezone);
+  const timezone = useUserPreferenceStore((s: { timezone: string }) => s.timezone);
 
   // コールバックの最新値を参照
   const onDeleteEntryRef = useRef(onDeleteEntry);

--- a/apps/product/src/features/calendar/hooks/keyboard/useWeekendToggleShortcut.ts
+++ b/apps/product/src/features/calendar/hooks/keyboard/useWeekendToggleShortcut.ts
@@ -4,6 +4,7 @@ import { toast } from '@/lib/toast';
 import { useTranslations } from 'next-intl';
 
 import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import type { UserSettings } from '@/lib/stores/userSettings';
 import type { ShortcutDef } from './shortcut-registry';
 import { registerShortcut } from './shortcut-registry';
 

--- a/apps/product/src/features/calendar/hooks/keyboard/useWeekendToggleShortcut.ts
+++ b/apps/product/src/features/calendar/hooks/keyboard/useWeekendToggleShortcut.ts
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useRef } from 'react';
 import { toast } from '@/lib/toast';
 import { useTranslations } from 'next-intl';
 
-import type { CalendarSettings } from '@/lib/stores/useCalendarSettingsStore';
 import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
 import type { ShortcutDef } from './shortcut-registry';
 import { registerShortcut } from './shortcut-registry';
@@ -12,14 +11,14 @@ import { registerShortcut } from './shortcut-registry';
  * 週末表示切り替えのキーボードショートカット（Cmd/Ctrl + W）を管理するフック
  */
 export function useWeekendToggleShortcut(
-  onSettingsChange?: ((settings: Partial<CalendarSettings>) => void) | undefined,
+  onSettingsChange?: ((settings: Partial<UserSettings>) => void) | undefined,
 ) {
   const showWeekends = useCalendarSettingsStore((s) => s.showWeekends);
   const updateSettings = useCalendarSettingsStore((s) => s.updateSettings);
   const t = useTranslations('calendar.toast');
 
   const persistSettings = useCallback(
-    (settings: Partial<CalendarSettings>) => {
+    (settings: Partial<UserSettings>) => {
       updateSettings(settings);
       onSettingsChange?.(settings);
     },

--- a/apps/product/src/features/entry/components/inspector/fields/TimeInput.tsx
+++ b/apps/product/src/features/entry/components/inspector/fields/TimeInput.tsx
@@ -15,7 +15,6 @@ import { Drawer, DrawerContent } from '@/lib/components/ui/drawer';
 import { Popover, PopoverAnchor, PopoverContent } from '@/lib/components/ui/popover';
 import { formatHHmm, formatTimeString, parseTimeString } from '@/lib/date';
 import { useIsMobile } from '@/lib/hooks/useIsMobile';
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
 import { computeDuration, formatDurationDisplay } from '@/lib/time-utils';
 import { cn } from '@/lib/utils';
 
@@ -71,7 +70,7 @@ export function TimeInput({
   testId,
 }: TimeInputProps) {
   const isMobile = useIsMobile();
-  const timeFormat = useCalendarSettingsStore((s) => s.timeFormat);
+  const timeFormat = useUserPreferenceStore((s) => s.timeFormat);
   const [draft, setDraft] = useState(value);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [popoverOpen, setPopoverOpen] = useState(false);

--- a/apps/product/src/features/entry/components/inspector/fields/TimeInput.tsx
+++ b/apps/product/src/features/entry/components/inspector/fields/TimeInput.tsx
@@ -15,6 +15,7 @@ import { Drawer, DrawerContent } from '@/lib/components/ui/drawer';
 import { Popover, PopoverAnchor, PopoverContent } from '@/lib/components/ui/popover';
 import { formatHHmm, formatTimeString, parseTimeString } from '@/lib/date';
 import { useIsMobile } from '@/lib/hooks/useIsMobile';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 import { computeDuration, formatDurationDisplay } from '@/lib/time-utils';
 import { cn } from '@/lib/utils';
 

--- a/apps/product/src/features/entry/components/inspector/hooks/useTimeFields.ts
+++ b/apps/product/src/features/entry/components/inspector/hooks/useTimeFields.ts
@@ -14,7 +14,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { localTimeToUTCISO, parseISOToUserTimezone } from '@/lib/date-utils';
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
 import { hasTwoLayerTimeConflict } from '@/lib/time/two-layer-overlap';
 import type { EntryWithTags } from '../../../types/entry';
 
@@ -55,7 +54,7 @@ function toISOForDate(date: Date, time: string, timezone: string): string | null
  * @returns scheduleDate, startTime, endTime, actualStartTime, actualEndTime および各ハンドラー
  */
 export function useTimeFields({ entry, entryId, save, saveImmediate }: UseTimeFieldsOptions) {
-  const timezone = useCalendarSettingsStore((state) => state.timezone);
+  const timezone = useUserPreferenceStore((state) => state.timezone);
   const queryClient = useQueryClient();
 
   // UI refs

--- a/apps/product/src/features/entry/components/inspector/hooks/useTimeFields.ts
+++ b/apps/product/src/features/entry/components/inspector/hooks/useTimeFields.ts
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { localTimeToUTCISO, parseISOToUserTimezone } from '@/lib/date-utils';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 import { hasTwoLayerTimeConflict } from '@/lib/time/two-layer-overlap';
 import type { EntryWithTags } from '../../../types/entry';
 

--- a/apps/product/src/features/review/components/layout/MobileReviewHeader.tsx
+++ b/apps/product/src/features/review/components/layout/MobileReviewHeader.tsx
@@ -11,6 +11,7 @@ import type { DateRangeDisplayProps } from '@/lib/components/common/DateRangeDis
 import { AppHeader } from '@/lib/components/shell/AppHeader';
 import { MiniCalendar } from '@/lib/components/ui/mini-calendar';
 import { isTodayInTimezone } from '@/lib/date/timezone';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 import { cn } from '@/lib/utils';
 
 import type { NavigationDirection } from '@/lib/components/common/DateNavigator';

--- a/apps/product/src/features/review/components/layout/MobileReviewHeader.tsx
+++ b/apps/product/src/features/review/components/layout/MobileReviewHeader.tsx
@@ -11,7 +11,6 @@ import type { DateRangeDisplayProps } from '@/lib/components/common/DateRangeDis
 import { AppHeader } from '@/lib/components/shell/AppHeader';
 import { MiniCalendar } from '@/lib/components/ui/mini-calendar';
 import { isTodayInTimezone } from '@/lib/date/timezone';
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
 import { cn } from '@/lib/utils';
 
 import type { NavigationDirection } from '@/lib/components/common/DateNavigator';
@@ -45,7 +44,7 @@ export function MobileReviewHeader({
   const t = useTranslations('calendar.actions');
   const locale = useLocale();
   const dateFnsLocale = locale === 'ja' ? ja : enUS;
-  const timezone = useCalendarSettingsStore((s) => s.timezone);
+  const timezone = useUserPreferenceStore((s) => s.timezone);
   const [isExpanded, setIsExpanded] = useState(false);
   const ChevronIcon = isExpanded ? ChevronUp : ChevronDown;
   const currentDate = dateDisplayProps.date;

--- a/apps/product/src/features/review/components/layout/ReviewGranularitySelector.tsx
+++ b/apps/product/src/features/review/components/layout/ReviewGranularitySelector.tsx
@@ -17,7 +17,6 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@/lib/components/ui/dropdown-menu';
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
 import { useShellStore } from '@/lib/stores/useShellStore';
 import { toast } from '@/lib/toast';
 import { api } from '@/lib/trpc';
@@ -49,15 +48,15 @@ export function ReviewGranularitySelector({
   className,
 }: ReviewGranularitySelectorProps) {
   const t = useTranslations();
-  const showWeekNumbers = useCalendarSettingsStore((s) => s.showWeekNumbers);
-  const updateSettings = useCalendarSettingsStore((s) => s.updateSettings);
+  const showWeekNumbers = useUserPreferenceStore((s) => s.showWeekNumbers);
+  const updatePreferences = useUserPreferenceStore((s) => s.updatePreferences);
   const utils = api.useUtils();
 
   const updateMutation = api.userSettings.update.useMutation({
     onMutate: (settings) => {
-      const previousShowWeekNumbers = useCalendarSettingsStore.getState().showWeekNumbers;
+      const previousShowWeekNumbers = useUserPreferenceStore.getState().showWeekNumbers;
       if (typeof settings.showWeekNumbers === 'boolean') {
-        updateSettings({ showWeekNumbers: settings.showWeekNumbers });
+        updatePreferences({ showWeekNumbers: settings.showWeekNumbers });
       }
       return { previousShowWeekNumbers };
     },
@@ -66,7 +65,7 @@ export function ReviewGranularitySelector({
     },
     onError: (_error, _settings, context) => {
       if (context) {
-        updateSettings({ showWeekNumbers: context.previousShowWeekNumbers });
+        updatePreferences({ showWeekNumbers: context.previousShowWeekNumbers });
       }
       toast.error(t('settings.common.saveFailed'));
     },

--- a/apps/product/src/features/review/components/layout/ReviewGranularitySelector.tsx
+++ b/apps/product/src/features/review/components/layout/ReviewGranularitySelector.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuTrigger,
 } from '@/lib/components/ui/dropdown-menu';
 import { useShellStore } from '@/lib/stores/useShellStore';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 import { toast } from '@/lib/toast';
 import { api } from '@/lib/trpc';
 import { cn } from '@/lib/utils';

--- a/apps/product/src/features/review/components/layout/useReviewDateDisplayProps.ts
+++ b/apps/product/src/features/review/components/layout/useReviewDateDisplayProps.ts
@@ -1,14 +1,14 @@
 import { useTranslations } from 'next-intl';
 
 import type { DateRangeDisplayProps } from '@/lib/components/common/DateRangeDisplay';
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 
 import type { ReviewGranularity } from '../../stores/useReviewFilterStore';
 
 /**
  * Review の granularity を共通 DateRangeDisplay の props に変換するフック
  *
- * 週番号表示は useCalendarSettingsStore.showWeekNumbers を参照し、
+ * 週番号表示は useUserPreferenceStore.showWeekNumbers を参照し、
  * Calendar と Review で表示条件を共有する。
  */
 export function useReviewDateDisplayProps(
@@ -16,8 +16,8 @@ export function useReviewDateDisplayProps(
   granularity: ReviewGranularity,
 ): DateRangeDisplayProps {
   const tCommon = useTranslations('common');
-  const showWeekNumbers = useCalendarSettingsStore((s) => s.showWeekNumbers);
-  const weekStartsOn = useCalendarSettingsStore((s) => s.weekStartsOn);
+  const showWeekNumbers = useUserPreferenceStore((s) => s.showWeekNumbers);
+  const weekStartsOn = useUserPreferenceStore((s) => s.weekStartsOn);
 
   const showWeekNumber = showWeekNumbers && (granularity === 'day' || granularity === 'week');
 

--- a/apps/product/src/features/review/hooks/useReviewPageData.ts
+++ b/apps/product/src/features/review/hooks/useReviewPageData.ts
@@ -2,7 +2,7 @@
 
 import { useMemo } from 'react';
 
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 import { api } from '@/lib/trpc';
 
 import {
@@ -23,8 +23,8 @@ import type { StatsPageData } from '../types/metrics.types';
 export function useReviewPageData() {
   const currentDate = useReviewFilterStore((s) => s.currentDate);
   const granularity = useReviewFilterStore((s) => s.granularity);
-  const timezone = useCalendarSettingsStore((s) => s.timezone);
-  const weekStartsOn = useCalendarSettingsStore((s) => s.weekStartsOn);
+  const timezone = useUserPreferenceStore((s) => s.timezone);
+  const weekStartsOn = useUserPreferenceStore((s) => s.weekStartsOn);
 
   const dateRange = useMemo(
     () => computeStatsDateRange(currentDate, granularity, timezone, weekStartsOn),

--- a/apps/product/src/features/review/hooks/useTagDetailData.ts
+++ b/apps/product/src/features/review/hooks/useTagDetailData.ts
@@ -9,7 +9,7 @@
 
 import { useCallback, useMemo, useState } from 'react';
 
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 import { cacheStrategies } from '@/lib/tanstack-query/cache-config';
 import { api } from '@/lib/trpc';
 
@@ -38,8 +38,8 @@ function granularityToBucket(g: ReviewGranularity): 'week' | 'month' | 'day' {
 export function useTagOverviewData(tagId: string) {
   const granularity = useReviewFilterStore((s) => s.granularity);
   const currentDate = useReviewFilterStore((s) => s.currentDate);
-  const timezone = useCalendarSettingsStore((s) => s.timezone);
-  const weekStartsOn = useCalendarSettingsStore((s) => s.weekStartsOn);
+  const timezone = useUserPreferenceStore((s) => s.timezone);
+  const weekStartsOn = useUserPreferenceStore((s) => s.weekStartsOn);
 
   const dateRange = useMemo(
     () => computeStatsDateRange(currentDate, granularity, timezone, weekStartsOn),
@@ -55,8 +55,8 @@ export function useTagOverviewData(tagId: string) {
 export function useTagTimelineData(tagId: string) {
   const granularity = useReviewFilterStore((s) => s.granularity);
   const currentDate = useReviewFilterStore((s) => s.currentDate);
-  const timezone = useCalendarSettingsStore((s) => s.timezone);
-  const weekStartsOn = useCalendarSettingsStore((s) => s.weekStartsOn);
+  const timezone = useUserPreferenceStore((s) => s.timezone);
+  const weekStartsOn = useUserPreferenceStore((s) => s.weekStartsOn);
 
   const dateRange = useMemo(
     () => computeStatsDateRange(currentDate, granularity, timezone, weekStartsOn),
@@ -76,8 +76,8 @@ export function useTagTimelineData(tagId: string) {
 export function useTagDashboardData(tagId: string) {
   const granularity = useReviewFilterStore((s) => s.granularity);
   const currentDate = useReviewFilterStore((s) => s.currentDate);
-  const timezone = useCalendarSettingsStore((s) => s.timezone);
-  const weekStartsOn = useCalendarSettingsStore((s) => s.weekStartsOn);
+  const timezone = useUserPreferenceStore((s) => s.timezone);
+  const weekStartsOn = useUserPreferenceStore((s) => s.weekStartsOn);
 
   const dateRange = useMemo(
     () => computeStatsDateRange(currentDate, granularity, timezone, weekStartsOn),

--- a/apps/product/src/features/review/hooks/useTimePLData.ts
+++ b/apps/product/src/features/review/hooks/useTimePLData.ts
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 
 import { formatInTimeZone } from 'date-fns-tz';
 
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 import { resolveTagColor } from '@/lib/tag-colors';
 import { api } from '@/lib/trpc';
 
@@ -49,8 +49,8 @@ interface TimePLRpcResponse {
 export function useTimePLData() {
   const currentDate = useReviewFilterStore((s) => s.currentDate);
   const granularity = useReviewFilterStore((s) => s.granularity);
-  const timezone = useCalendarSettingsStore((s) => s.timezone);
-  const weekStartsOn = useCalendarSettingsStore((s) => s.weekStartsOn);
+  const timezone = useUserPreferenceStore((s) => s.timezone);
+  const weekStartsOn = useUserPreferenceStore((s) => s.weekStartsOn);
 
   const dateRange = useMemo(
     () => computeStatsDateRange(currentDate, granularity, timezone, weekStartsOn),

--- a/apps/product/src/features/settings/hooks/__tests__/useDateFormat.test.ts
+++ b/apps/product/src/features/settings/hooks/__tests__/useDateFormat.test.ts
@@ -1,13 +1,13 @@
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// カレンダー設定ストアをモック
+// ユーザー嗜好ストアをモック
 let mockDateFormat = 'yyyy-MM-dd';
 let mockTimeFormat: '12h' | '24h' = '24h';
 let mockTimezone = 'Asia/Tokyo';
 
-vi.mock('@/lib/stores/useCalendarSettingsStore', () => ({
-  useCalendarSettingsStore: (selector?: (s: Record<string, unknown>) => unknown) => {
+vi.mock('@/lib/stores/useUserPreferenceStore', () => ({
+  useUserPreferenceStore: (selector?: (s: Record<string, unknown>) => unknown) => {
     const state = {
       dateFormat: mockDateFormat,
       timeFormat: mockTimeFormat,

--- a/apps/product/src/features/settings/hooks/useUserSettings.ts
+++ b/apps/product/src/features/settings/hooks/useUserSettings.ts
@@ -3,7 +3,7 @@
  * TanStack Queryを使用してSupabaseと同期
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { toast } from '@/lib/toast';
 import { useTranslations } from 'next-intl';
@@ -11,8 +11,10 @@ import { useTranslations } from 'next-intl';
 import { CACHE_5_MINUTES } from '@/lib/date';
 import { api } from '@/lib/trpc';
 
-import type { CalendarSettings } from '@/lib/stores/useCalendarSettingsStore';
 import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import type { UserSettings } from '@/lib/stores/userSettings';
+import { dispatchUserSettings } from '@/lib/stores/userSettings';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 
 /**
  * ユーザー設定をDBと同期するhook
@@ -20,8 +22,6 @@ import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore'
  * - 設定変更時: DBに保存（debounce済み）
  */
 export function useUserSettings() {
-  // セレクタで関数のみ購読（saveSettings の deps を安定化）
-  const updateSettings = useCalendarSettingsStore((s) => s.updateSettings);
   const t = useTranslations();
   const utils = api.useUtils();
 
@@ -71,7 +71,7 @@ export function useUserSettings() {
   useEffect(() => {
     if (isPending) return;
     if (dbSettings) {
-      updateSettings({
+      dispatchUserSettings({
         timezone: dbSettings.timezone,
         timeFormat: dbSettings.timeFormat,
         // 初回のみ locale から導出、以降は Store の値を維持
@@ -96,13 +96,13 @@ export function useUserSettings() {
     // dbSettings が object でも null でも apply は完了扱い
     // eslint-disable-next-line react-hooks/set-state-in-effect -- query 解決後の 1 回限りの hydration flag
     setStoreHydrated(true);
-  }, [dbSettings, isPending, updateSettings]);
+  }, [dbSettings, isPending]);
 
   // 設定をDBに保存する関数
   const saveSettings = useCallback(
-    (settings: Partial<CalendarSettings>) => {
+    (settings: Partial<UserSettings>) => {
       // Storeを即座に更新（楽観的更新）
-      updateSettings(settings);
+      dispatchUserSettings(settings);
 
       // DBに保存用のマッピング
       const dbInput: Record<string, unknown> = {};
@@ -126,11 +126,16 @@ export function useUserSettings() {
         updateMutation.mutate(dbInput);
       }
     },
-    [updateSettings, updateMutation],
+    [updateMutation],
   );
 
-  // UI表示用にストア全体を返す（呼び出し元との互換性維持）
-  const settings = useCalendarSettingsStore();
+  // UI表示用に2ストアを merge した shape を返す（既存 consumer との互換性維持）
+  const preferences = useUserPreferenceStore();
+  const calendarSettings = useCalendarSettingsStore();
+  const settings = useMemo<UserSettings>(
+    () => ({ ...preferences, ...calendarSettings }),
+    [preferences, calendarSettings],
+  );
 
   return {
     settings,

--- a/apps/product/src/features/settings/stores/useCalendarSettingsStore.test.ts
+++ b/apps/product/src/features/settings/stores/useCalendarSettingsStore.test.ts
@@ -10,14 +10,9 @@ describe('useCalendarSettingsStore', () => {
   describe('初期状態', () => {
     it('デフォルト値が正しい', () => {
       const state = useCalendarSettingsStore.getState();
-      expect(state.timezone).toBe(Intl.DateTimeFormat().resolvedOptions().timeZone);
-      expect(state.timeFormat).toBe('24h');
-      expect(state.dateFormat).toBe('yyyy-MM-dd');
       expect(state.defaultView).toBe('week');
-      expect(state.weekStartsOn).toBe(1);
-      expect(state.defaultDuration).toBe(60);
-      expect(state.snapInterval).toBe(15);
       expect(state.showWeekends).toBe(true);
+      expect(state.hourHeightDensity).toBe('default');
     });
 
     it('クロノタイプはデフォルト無効（null）', () => {
@@ -36,14 +31,14 @@ describe('useCalendarSettingsStore', () => {
   describe('updateSettings', () => {
     it('一部の設定を更新できる', () => {
       useCalendarSettingsStore.getState().updateSettings({
-        timeFormat: '12h',
-        dateFormat: 'MM/dd/yyyy',
+        defaultView: 'day',
+        hourHeightDensity: 'compact',
       });
       const state = useCalendarSettingsStore.getState();
-      expect(state.timeFormat).toBe('12h');
-      expect(state.dateFormat).toBe('MM/dd/yyyy');
+      expect(state.defaultView).toBe('day');
+      expect(state.hourHeightDensity).toBe('compact');
       // 他は維持
-      expect(state.timezone).toBe(Intl.DateTimeFormat().resolvedOptions().timeZone);
+      expect(state.showWeekends).toBe(true);
     });
 
     it('クロノタイプを有効化できる', () => {
@@ -54,24 +49,24 @@ describe('useCalendarSettingsStore', () => {
       expect(state.chronotype).toEqual({ type: 'lion' });
     });
 
-    it('snapIntervalを変更できる', () => {
-      useCalendarSettingsStore.getState().updateSettings({ snapInterval: 5 });
-      expect(useCalendarSettingsStore.getState().snapInterval).toBe(5);
+    it('showWeekends を切り替えられる', () => {
+      useCalendarSettingsStore.getState().updateSettings({ showWeekends: false });
+      expect(useCalendarSettingsStore.getState().showWeekends).toBe(false);
     });
   });
 
   describe('resetSettings', () => {
     it('全設定をデフォルトに戻す', () => {
       useCalendarSettingsStore.getState().updateSettings({
-        timeFormat: '12h',
-        weekStartsOn: 0,
+        defaultView: 'day',
         showWeekends: false,
+        hourHeightDensity: 'spacious',
       });
       useCalendarSettingsStore.getState().resetSettings();
       const state = useCalendarSettingsStore.getState();
-      expect(state.timeFormat).toBe('24h');
-      expect(state.weekStartsOn).toBe(1);
+      expect(state.defaultView).toBe('week');
       expect(state.showWeekends).toBe(true);
+      expect(state.hourHeightDensity).toBe('default');
     });
   });
 });

--- a/apps/product/src/features/settings/stores/useUserPreferenceStore.test.ts
+++ b/apps/product/src/features/settings/stores/useUserPreferenceStore.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
+
+describe('useUserPreferenceStore', () => {
+  beforeEach(() => {
+    useUserPreferenceStore.getState().resetPreferences();
+  });
+
+  describe('初期状態', () => {
+    it('デフォルト値が正しい', () => {
+      const state = useUserPreferenceStore.getState();
+      expect(state.timezone).toBe(Intl.DateTimeFormat().resolvedOptions().timeZone);
+      expect(state.timeFormat).toBe('24h');
+      expect(state.dateFormat).toBe('yyyy-MM-dd');
+      expect(state.weekStartsOn).toBe(1);
+      expect(state.showWeekNumbers).toBe(false);
+      expect(state.defaultDuration).toBe(60);
+      expect(state.snapInterval).toBe(15);
+    });
+  });
+
+  describe('updatePreferences', () => {
+    it('一部の設定を更新できる', () => {
+      useUserPreferenceStore.getState().updatePreferences({
+        timeFormat: '12h',
+        dateFormat: 'MM/dd/yyyy',
+      });
+      const state = useUserPreferenceStore.getState();
+      expect(state.timeFormat).toBe('12h');
+      expect(state.dateFormat).toBe('MM/dd/yyyy');
+      // 他は維持
+      expect(state.timezone).toBe(Intl.DateTimeFormat().resolvedOptions().timeZone);
+    });
+
+    it('snapInterval を変更できる', () => {
+      useUserPreferenceStore.getState().updatePreferences({ snapInterval: 5 });
+      expect(useUserPreferenceStore.getState().snapInterval).toBe(5);
+    });
+
+    it('showWeekNumbers を切り替えられる', () => {
+      useUserPreferenceStore.getState().updatePreferences({ showWeekNumbers: true });
+      expect(useUserPreferenceStore.getState().showWeekNumbers).toBe(true);
+    });
+  });
+
+  describe('resetPreferences', () => {
+    it('全設定をデフォルトに戻す', () => {
+      useUserPreferenceStore.getState().updatePreferences({
+        timeFormat: '12h',
+        weekStartsOn: 0,
+        showWeekNumbers: true,
+      });
+      useUserPreferenceStore.getState().resetPreferences();
+      const state = useUserPreferenceStore.getState();
+      expect(state.timeFormat).toBe('24h');
+      expect(state.weekStartsOn).toBe(1);
+      expect(state.showWeekNumbers).toBe(false);
+    });
+  });
+});

--- a/apps/product/src/lib/components/ui/mini-calendar.tsx
+++ b/apps/product/src/lib/components/ui/mini-calendar.tsx
@@ -32,6 +32,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/lib/components/ui/select';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 import { cn } from '@/lib/utils';
 
 export interface MiniCalendarProps {

--- a/apps/product/src/lib/components/ui/mini-calendar.tsx
+++ b/apps/product/src/lib/components/ui/mini-calendar.tsx
@@ -32,7 +32,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/lib/components/ui/select';
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
 import { cn } from '@/lib/utils';
 
 export interface MiniCalendarProps {
@@ -99,8 +98,8 @@ export const MiniCalendar = memo<MiniCalendarProps>(
   }) => {
     const tCommon = useTranslations('common');
     const tActions = useTranslations('calendar.actions');
-    const weekStartsOn = useCalendarSettingsStore((state) => state.weekStartsOn);
-    const showWeekNumbers = useCalendarSettingsStore((state) => state.showWeekNumbers);
+    const weekStartsOn = useUserPreferenceStore((state) => state.weekStartsOn);
+    const showWeekNumbers = useUserPreferenceStore((state) => state.showWeekNumbers);
     const isMounted = useHasMounted();
     const [open, setOpen] = useState(false);
     const [viewMonth, setViewMonth] = useState(() => month ?? selectedDate ?? new Date());

--- a/apps/product/src/lib/hooks/useDateFormat.ts
+++ b/apps/product/src/lib/hooks/useDateFormat.ts
@@ -7,8 +7,7 @@ import { useCallback } from 'react';
 
 import { format } from 'date-fns';
 
-import type { DateFormatType } from '@/lib/stores/useCalendarSettingsStore';
-import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
+import type { DateFormatType } from '@/lib/stores/useUserPreferenceStore';
 
 interface UseDateFormatReturn {
   dateFormat: DateFormatType;
@@ -26,9 +25,9 @@ interface UseDateFormatReturn {
  * ユーザー設定に基づいて日付をフォーマットするフック
  */
 export function useDateFormat(): UseDateFormatReturn {
-  const dateFormat = useCalendarSettingsStore((s) => s.dateFormat);
-  const timeFormat = useCalendarSettingsStore((s) => s.timeFormat);
-  const timezone = useCalendarSettingsStore((s) => s.timezone);
+  const dateFormat = useUserPreferenceStore((s) => s.dateFormat);
+  const timeFormat = useUserPreferenceStore((s) => s.timeFormat);
+  const timezone = useUserPreferenceStore((s) => s.timezone);
 
   const formatDate = useCallback(
     (date: Date): string => {

--- a/apps/product/src/lib/hooks/useDateFormat.ts
+++ b/apps/product/src/lib/hooks/useDateFormat.ts
@@ -8,6 +8,7 @@ import { useCallback } from 'react';
 import { format } from 'date-fns';
 
 import type { DateFormatType } from '@/lib/stores/useUserPreferenceStore';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 
 interface UseDateFormatReturn {
   dateFormat: DateFormatType;

--- a/apps/product/src/lib/stores/useCalendarSettingsStore.ts
+++ b/apps/product/src/lib/stores/useCalendarSettingsStore.ts
@@ -7,30 +7,16 @@ import type { ChronotypeSettings as ChronotypeSettingsState } from '@/lib/types/
 
 export type { CalendarViewType } from '@/lib/calendar-constants';
 
-/** 日付フォーマットの種別（日本式・米国式・欧州式・ISO式） */
-export type DateFormatType = 'yyyy/MM/dd' | 'MM/dd/yyyy' | 'dd/MM/yyyy' | 'yyyy-MM-dd';
-
-/** カレンダーの各種設定項目を表すインターフェース */
+/** Calendar 専用の UI 表示設定 */
 export interface CalendarSettings {
-  // タイムゾーン設定
-  timezone: string; // 例: 'Asia/Tokyo', 'America/New_York'
-
-  // 時間表示形式
-  timeFormat: '24h' | '12h';
-
-  // 日付表示形式
-  dateFormat: DateFormatType; // yyyy/MM/dd（日本）, MM/dd/yyyy（米国）, dd/MM/yyyy（欧州）, yyyy-MM-dd（ISO）
-
   // デフォルトビュー設定
   defaultView: CalendarViewType; // 起動時のデフォルトビュー
 
-  // その他の設定
-  weekStartsOn: 0 | 1 | 6; // 日曜、月曜、土曜
-  defaultDuration: number; // デフォルトのタスク時間（分）
-  snapInterval: 5 | 10 | 15 | 30; // ドラッグ&ドロップのスナップ間隔（分）
   // 表示設定
-  showWeekNumbers: boolean;
   showWeekends: boolean;
+
+  // グリッド密度
+  hourHeightDensity: HourHeightDensity;
 
   // クロノタイプ設定
   chronotype: ChronotypeSettingsState | null;
@@ -42,9 +28,6 @@ export interface CalendarSettings {
     bedtime: number; // 就寝時刻（0-23）
     wakeTime: number; // 起床時刻（0-23）
   };
-
-  // グリッド密度
-  hourHeightDensity: HourHeightDensity;
 }
 
 interface CalendarSettingsStore extends CalendarSettings {
@@ -53,16 +36,9 @@ interface CalendarSettingsStore extends CalendarSettings {
 }
 
 const defaultSettings: CalendarSettings = {
-  timezone:
-    typeof window !== 'undefined' ? Intl.DateTimeFormat().resolvedOptions().timeZone : 'UTC',
-  timeFormat: '24h',
-  dateFormat: 'yyyy-MM-dd', // ISO 8601（国際標準）
-  defaultView: 'week', // デフォルトは週表示
-  weekStartsOn: 1, // 月曜始まり
-  defaultDuration: 60,
-  snapInterval: 15, // デフォルトは15分間隔
-  showWeekNumbers: false,
-  showWeekends: true, // デフォルトは週末も表示
+  defaultView: 'week',
+  showWeekends: true,
+  hourHeightDensity: 'default',
   chronotype: DEFAULT_CHRONOTYPE_SETTINGS,
   chronotypeGradient: { light: null, dark: null },
   sleepSchedule: {
@@ -70,16 +46,18 @@ const defaultSettings: CalendarSettings = {
     bedtime: 23,
     wakeTime: 7,
   },
-  hourHeightDensity: 'default',
 };
 
 /**
- * カレンダー設定を管理する Zustand ストア
+ * Calendar UI 設定を管理する Zustand ストア
  *
  * persist せず、`UserSettingsInitializer` (Providers 直下) が server (user_settings)
  * から取得した値を hydrate する。multi-tab 間の staleness を避けるため、localStorage
  * に独自コピーを保持しない。cold load 時は defaultSettings → TanStack Query の
  * 永続 cache から hydrate される流れでほぼ即時に正しい値になる。
+ *
+ * app-wide な user preference (timezone / weekStartsOn 等) は `useUserPreferenceStore`
+ * に分離されている。
  */
 export const useCalendarSettingsStore = create<CalendarSettingsStore>()(
   devtools(

--- a/apps/product/src/lib/stores/useUserPreferenceStore.ts
+++ b/apps/product/src/lib/stores/useUserPreferenceStore.ts
@@ -1,0 +1,71 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+
+/** 日付フォーマットの種別（日本式・米国式・欧州式・ISO式） */
+export type DateFormatType = 'yyyy/MM/dd' | 'MM/dd/yyyy' | 'dd/MM/yyyy' | 'yyyy-MM-dd';
+
+/**
+ * app-wide なユーザー嗜好（locale / 表示形式 / 入力既定値）
+ *
+ * Calendar feature に閉じない、複数 feature が参照する設定をここに集約する。
+ * `useCalendarSettingsStore` には Calendar UI 専用の state のみを残す。
+ */
+export interface UserPreference {
+  /** タイムゾーン（例: 'Asia/Tokyo'） */
+  timezone: string;
+  /** 時刻表示形式 */
+  timeFormat: '24h' | '12h';
+  /** 日付表示形式 */
+  dateFormat: DateFormatType;
+  /** 週の開始曜日（0: 日曜, 1: 月曜, 6: 土曜） */
+  weekStartsOn: 0 | 1 | 6;
+  /** 週番号を表示するか（calendar grid / mini calendar 共通） */
+  showWeekNumbers: boolean;
+  /** 新規ブロックの既定の長さ（分） */
+  defaultDuration: number;
+  /** ドラッグ&ドロップのスナップ間隔（分） */
+  snapInterval: 5 | 10 | 15 | 30;
+}
+
+interface UserPreferenceStore extends UserPreference {
+  updatePreferences: (preferences: Partial<UserPreference>) => void;
+  resetPreferences: () => void;
+}
+
+const defaultPreferences: UserPreference = {
+  timezone:
+    typeof window !== 'undefined' ? Intl.DateTimeFormat().resolvedOptions().timeZone : 'UTC',
+  timeFormat: '24h',
+  dateFormat: 'yyyy-MM-dd',
+  weekStartsOn: 1,
+  showWeekNumbers: false,
+  defaultDuration: 60,
+  snapInterval: 15,
+};
+
+/**
+ * ユーザー嗜好を管理する Zustand ストア
+ *
+ * persist せず、`UserSettingsInitializer` (Providers 直下) が server (user_settings)
+ * から取得した値を hydrate する。multi-tab 間の staleness を避けるため、localStorage
+ * に独自コピーを保持しない。
+ */
+export const useUserPreferenceStore = create<UserPreferenceStore>()(
+  devtools(
+    (set) => ({
+      ...defaultPreferences,
+
+      updatePreferences: (newPreferences) =>
+        set((state) => ({
+          ...state,
+          ...newPreferences,
+        })),
+
+      resetPreferences: () => set({ ...defaultPreferences }),
+    }),
+    {
+      name: 'user-preference-store',
+      enabled: process.env.NODE_ENV !== 'production',
+    },
+  ),
+);

--- a/apps/product/src/lib/stores/userSettings.ts
+++ b/apps/product/src/lib/stores/userSettings.ts
@@ -1,0 +1,73 @@
+/**
+ * UserSettings — `UserPreference` + `CalendarSettings` を統合した型と dispatcher
+ *
+ * 2 ストアに跨る設定変更（例: `display-settings.tsx` の `saveSettings({ timezone, defaultView })`）
+ * を扱うためのユーティリティ。callsite はこの型 / dispatch を経由することで、
+ * 各 store の責務境界を保ったまま 1 度の呼び出しで両方の state を更新できる。
+ */
+
+import type { CalendarSettings } from './useCalendarSettingsStore';
+import { useCalendarSettingsStore } from './useCalendarSettingsStore';
+import type { UserPreference } from './useUserPreferenceStore';
+import { useUserPreferenceStore } from './useUserPreferenceStore';
+
+/** 2 ストアを統合した設定オブジェクトの型 */
+export type UserSettings = UserPreference & CalendarSettings;
+
+const USER_PREFERENCE_KEYS = [
+  'timezone',
+  'timeFormat',
+  'dateFormat',
+  'weekStartsOn',
+  'showWeekNumbers',
+  'defaultDuration',
+  'snapInterval',
+] as const satisfies ReadonlyArray<keyof UserPreference>;
+
+const CALENDAR_SETTINGS_KEYS = [
+  'defaultView',
+  'showWeekends',
+  'hourHeightDensity',
+  'chronotype',
+  'chronotypeGradient',
+  'sleepSchedule',
+] as const satisfies ReadonlyArray<keyof CalendarSettings>;
+
+/** 統合 partial を 2 ストアに振り分ける純粋ユーティリティ（テスト/外部用途向け） */
+export function splitUserSettings(partial: Partial<UserSettings>): {
+  preference: Partial<UserPreference>;
+  calendar: Partial<CalendarSettings>;
+} {
+  const preference: Partial<UserPreference> = {};
+  const calendar: Partial<CalendarSettings> = {};
+
+  for (const key of USER_PREFERENCE_KEYS) {
+    if (key in partial) {
+      (preference as Record<string, unknown>)[key] = partial[key];
+    }
+  }
+  for (const key of CALENDAR_SETTINGS_KEYS) {
+    if (key in partial) {
+      (calendar as Record<string, unknown>)[key] = partial[key];
+    }
+  }
+
+  return { preference, calendar };
+}
+
+/**
+ * 統合 partial を 2 ストアに dispatch する。
+ *
+ * 既存の `useCalendarSettingsStore.updateSettings({...})` 1 本だった更新を、
+ * UserPreference / CalendarSettings のどちらに属するかで振り分ける。
+ */
+export function dispatchUserSettings(partial: Partial<UserSettings>): void {
+  const { preference, calendar } = splitUserSettings(partial);
+
+  if (Object.keys(preference).length > 0) {
+    useUserPreferenceStore.getState().updatePreferences(preference);
+  }
+  if (Object.keys(calendar).length > 0) {
+    useCalendarSettingsStore.getState().updateSettings(calendar);
+  }
+}

--- a/apps/storybook/.storybook/mocks/stores.tsx
+++ b/apps/storybook/.storybook/mocks/stores.tsx
@@ -24,6 +24,7 @@ import { useCalendarFilterStore } from '@/lib/stores/useCalendarFilterStore';
 import { useCalendarNavigationStore } from '@/lib/stores/useCalendarNavigationStore';
 import { useCalendarSettingsStore } from '@/lib/stores/useCalendarSettingsStore';
 import { useShellStore } from '@/lib/stores/useShellStore';
+import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 
 // ─────────────────────────────────────────────────────────
 // Registry
@@ -42,6 +43,7 @@ const STORE_REGISTRY: Record<string, StoreApi<Record<string, unknown>>> = {
   useCalendarSettingsStore: useCalendarSettingsStore as unknown as StoreApi<
     Record<string, unknown>
   >,
+  useUserPreferenceStore: useUserPreferenceStore as unknown as StoreApi<Record<string, unknown>>,
   useShellStore: useShellStore as unknown as StoreApi<Record<string, unknown>>,
 };
 


### PR DESCRIPTION
## Summary

`useCalendarSettingsStore` に混在していた app-wide な user preference を新規 `useUserPreferenceStore` に切り出し、責務境界を明確化する。今回のPRでは store の物理移動は行わず、両ストアとも `apps/app/src/lib/stores/` 配下に置く。

目的は `lib/hooks/useDateFormat.ts` / `lib/components/ui/mini-calendar.tsx` が calendar-specific store に依存しない状態を作ること。これが解消されることで、後続 PR で `useCalendarSettingsStore` を `features/calendar/stores/` へ移動できる。

### Before / After

```
Before:
lib/hooks/useDateFormat  ─→  useCalendarSettingsStore  ─→  user pref + calendar UI 混在
lib/components/mini-calendar  ─↗

After:
lib/hooks/useDateFormat       ─→  useUserPreferenceStore  （app-wide）
lib/components/mini-calendar  ─↗
                                  useCalendarSettingsStore  （Calendar UI 専用）
```

### 主要変更

- 新規 `lib/stores/useUserPreferenceStore.ts`
  - フィールド: `timezone` / `timeFormat` / `dateFormat` / `weekStartsOn` / `showWeekNumbers` / `defaultDuration` / `snapInterval`
  - `DateFormatType` 型もこちら
  - actions: `updatePreferences` / `resetPreferences`
- 新規 `lib/stores/userSettings.ts`
  - `UserSettings = UserPreference & CalendarSettings` 統合型
  - `splitUserSettings` / `dispatchUserSettings` ヘルパー
- `useCalendarSettingsStore` を Calendar 専用 6 フィールドに縮小（`defaultView` / `showWeekends` / `hourHeightDensity` / `chronotype` / `chronotypeGradient` / `sleepSchedule`）
- `useUserSettings.ts`: hydrate / save 経路を 2 ストアへ振り分け、戻り値 `settings` は merge で既存 consumer API を維持
- consumer 36 ファイルの selector を該当ストアへ振り替え
- `onSettingsChange` callback 型: `Partial<CalendarSettings>` → `Partial<UserSettings>`
- テスト分割: `useCalendarSettingsStore.test.ts` を縮小、`useUserPreferenceStore.test.ts` 新規
- `useDateFormat.test.ts` の mock を新ストアに切り替え
- Storybook mock registry に `useUserPreferenceStore` 登録

### Migration

**persist middleware は使っていないため localStorage migration は不要**。`name: 'calendar-settings-store'` は devtools 識別名のみ。server (user_settings) が単一の source of truth で、`UserSettingsInitializer` / `useUserSettings` 経由で hydrate される。

## Test plan

- [x] `pnpm --filter @dayopt/app typecheck`
- [x] `pnpm --filter @dayopt/app lint`
- [x] `pnpm lint:boundaries`（feature 境界違反 0）
- [x] `pnpm --filter @dayopt/app test:run`（1685 tests pass）
- [x] `pnpm --filter @dayopt/app build`
- [x] `pnpm --filter @dayopt/storybook build`
- [x] `pnpm typecheck`（turbo, 全 8 package）
- [x] `pnpm lint`（turbo, 全 package）
- [ ] PR レビュー後、Storybook で Calendar 系 / Review 系 / mini-calendar の Story が regression なく描画されることを目視確認

## Follow-up

このPRの後に予定している段階的整理:

- `useCalendarSettingsStore` を `features/calendar/stores/` へ物理移動
- `chronotype` / `chronotypeGradient` を `features/chronotype/stores/` に切り出し
- dead state `sleepSchedule` の削除（consumer ゼロ）
- `useCalendarNavigationStore` の移動検討（外部参照は実質ゼロ）
- `lib/calendar-constants.ts` を `features/calendar/lib/constants.ts` に移動（当初の PR2 ゴール）

🤖 Generated with [Claude Code](https://claude.com/claude-code)