### PR TITLE
chore(stores): useCalendarSettingsStore から dead state sleepSchedule を削除

### DIFF
--- a/apps/product/src/features/settings/stores/useCalendarSettingsStore.test.ts
+++ b/apps/product/src/features/settings/stores/useCalendarSettingsStore.test.ts
@@ -19,13 +19,6 @@ describe('useCalendarSettingsStore', () => {
       const state = useCalendarSettingsStore.getState();
       expect(state.chronotype).toBeNull();
     });
-
-    it('睡眠スケジュールのデフォルト', () => {
-      const state = useCalendarSettingsStore.getState();
-      expect(state.sleepSchedule.enabled).toBe(true);
-      expect(state.sleepSchedule.bedtime).toBe(23);
-      expect(state.sleepSchedule.wakeTime).toBe(7);
-    });
   });
 
   describe('updateSettings', () => {

--- a/apps/product/src/lib/stores/useCalendarSettingsStore.ts
+++ b/apps/product/src/lib/stores/useCalendarSettingsStore.ts
@@ -21,13 +21,6 @@ export interface CalendarSettings {
   // クロノタイプ設定
   chronotype: ChronotypeSettingsState | null;
   chronotypeGradient: { light: string | null; dark: string | null };
-
-  // 睡眠スケジュール設定
-  sleepSchedule: {
-    enabled: boolean; // 睡眠時間帯の表示オン/オフ
-    bedtime: number; // 就寝時刻（0-23）
-    wakeTime: number; // 起床時刻（0-23）
-  };
 }
 
 interface CalendarSettingsStore extends CalendarSettings {
@@ -41,11 +34,6 @@ const defaultSettings: CalendarSettings = {
   hourHeightDensity: 'default',
   chronotype: DEFAULT_CHRONOTYPE_SETTINGS,
   chronotypeGradient: { light: null, dark: null },
-  sleepSchedule: {
-    enabled: true,
-    bedtime: 23,
-    wakeTime: 7,
-  },
 };
 
 /**

--- a/apps/product/src/lib/stores/userSettings.ts
+++ b/apps/product/src/lib/stores/userSettings.ts
@@ -30,7 +30,6 @@ const CALENDAR_SETTINGS_KEYS = [
   'hourHeightDensity',
   'chronotype',
   'chronotypeGradient',
-  'sleepSchedule',
 ] as const satisfies ReadonlyArray<keyof CalendarSettings>;
 
 /** 統合 partial を 2 ストアに振り分ける純粋ユーティリティ（テスト/外部用途向け） */


### PR DESCRIPTION
## Summary

`useCalendarSettingsStore` に残っていた dead state `sleepSchedule` を削除する。次の段階で `useCalendarSettingsStore` を `features/calendar/stores/` へ物理移動する前の軽量化。

PR #1180（user preference store split）の事前調査で「どこからも読まれていない」と判明していた state。

## 調査

`sleepSchedule` / `SleepSchedule` / `sleep_schedule` を全文 grep し、参照は以下の 3 ファイル / 7 ヶ所のみ:

- `apps/product/src/lib/stores/useCalendarSettingsStore.ts` — interface 定義 + defaults
- `apps/product/src/lib/stores/userSettings.ts` — `CALENDAR_SETTINGS_KEYS` 配列の要素
- `apps/product/src/features/settings/stores/useCalendarSettingsStore.test.ts` — defaults assertion

確認できなかった = 存在しないもの:

- selector 使用（`useCalendarSettingsStore((s) => s.sleepSchedule)`）
- mutation（`updateSettings({ sleepSchedule: ... })`）
- 専用 setter / action
- DB schema の `sleep_schedule` カラム / server router の mapping
- `useUserSettings.ts` の dbSettings 読み出し
- Storybook mock entry
- UI form

**server には一度も persist されたことがない**ため、削除によるデータ損失リスクなし。

## 削除内容

| File | 内容 |
| --- | --- |
| `lib/stores/useCalendarSettingsStore.ts` | `CalendarSettings` interface の field + `defaultSettings` の値 |
| `lib/stores/userSettings.ts` | `CALENDAR_SETTINGS_KEYS` から `'sleepSchedule'` |
| `features/settings/stores/useCalendarSettingsStore.test.ts` | 「睡眠スケジュールのデフォルト」test block |

3 files, 20 deletions / 0 additions

## Test plan

- [x] `pnpm --filter @dayopt/product typecheck`
- [x] `pnpm --filter @dayopt/product lint`
- [x] `pnpm lint:boundaries`（0 violations）
- [x] `pnpm --filter @dayopt/product test:run`（1684 tests pass、削除した 1 件分マイナス）

## Follow-up

PR #1180 で立てた次段階タスクは継続:

- `useCalendarSettingsStore` を `features/calendar/stores/` へ物理移動
- `chronotype` / `chronotypeGradient` を `features/chronotype/stores/` に切り出し
- `useCalendarNavigationStore` の移動検討
- `lib/calendar-constants.ts` を `features/calendar/lib/` に移動

🤖 Generated with [Claude Code](https://claude.com/claude-code)