### PR TITLE
refactor(entry): entry 時間更新ルールを features/entry/domain へ寄せる

### DIFF
--- a/apps/product/src/features/calendar/hooks/operations/__tests__/useEntryOperations.test.tsx
+++ b/apps/product/src/features/calendar/hooks/operations/__tests__/useEntryOperations.test.tsx
@@ -9,12 +9,19 @@ const getByIdGetData = vi.fn();
 const toastSuccess = vi.fn();
 const loggerError = vi.fn();
 
-vi.mock('@/features/entry', () => ({
-  useEntryMutations: () => ({
-    updateEntry: { mutate: updateMutate },
-    deleteEntry: { mutate: deleteMutate },
-  }),
-}));
+// domain helper (buildTimeUpdateData 等) は実体を保持し、hook のみ mock する。
+// useEntryOperations は entry barrel から buildTimeUpdateData / buildUndoTimeUpdateData を
+// import するので、これらが undefined だと time patch の構築が壊れる。
+vi.mock('@/features/entry', async () => {
+  const actual = await vi.importActual<typeof import('@/features/entry')>('@/features/entry');
+  return {
+    ...actual,
+    useEntryMutations: () => ({
+      updateEntry: { mutate: updateMutate },
+      deleteEntry: { mutate: deleteMutate },
+    }),
+  };
+});
 
 vi.mock('@/lib/trpc', () => ({
   api: {

--- a/apps/product/src/features/calendar/hooks/operations/useEntryOperations.ts
+++ b/apps/product/src/features/calendar/hooks/operations/useEntryOperations.ts
@@ -1,6 +1,11 @@
 import { useCallback } from 'react';
 
-import { useEntryMutations } from '@/features/entry';
+import {
+  buildTimeUpdateData,
+  buildUndoTimeUpdateData,
+  useEntryMutations,
+  type EntryLike,
+} from '@/features/entry';
 import { logger } from '@/lib/logger';
 import { toast } from '@/lib/toast';
 import { api } from '@/lib/trpc';
@@ -8,143 +13,14 @@ import { useTranslations } from 'next-intl';
 
 import type { CalendarEvent } from '../../types/calendar.types';
 
-type TimeUpdateEntry = {
-  origin?: string | null | undefined;
-  start_time?: string | null;
-  end_time?: string | null;
-  actual_start_time?: string | null;
-  actual_end_time?: string | null;
-};
-
-function rangesMatch(
-  firstStart: string | null | undefined,
-  firstEnd: string | null | undefined,
-  secondStart: string | null | undefined,
-  secondEnd: string | null | undefined,
-): boolean {
-  return firstStart === secondStart && firstEnd === secondEnd;
-}
-
-function hasActualDiff(entry: TimeUpdateEntry | null | undefined): boolean {
-  if (entry?.origin !== 'planned') return false;
-  return !rangesMatch(
-    entry.start_time,
-    entry.end_time,
-    entry.actual_start_time,
-    entry.actual_end_time,
-  );
-}
-
-function buildTimeUpdateData(
-  entry: TimeUpdateEntry | null | undefined,
-  startTime: Date,
-  endTime: Date,
-  resetActualTime = false,
-): {
-  start_time?: string | null;
-  end_time?: string | null;
-  actual_start_time?: string | null;
-  actual_end_time?: string | null;
-} {
-  const startISO = startTime.toISOString();
-  const endISO = endTime.toISOString();
-
-  if (entry?.origin === 'planned' && resetActualTime) {
-    return {
-      start_time: startISO,
-      end_time: endISO,
-      actual_start_time: startISO,
-      actual_end_time: endISO,
-    };
-  }
-
-  if (entry?.origin === 'unplanned') {
-    return {
-      actual_start_time: startISO,
-      actual_end_time: endISO,
-    };
-  }
-
-  if (entry?.origin === 'planned' && hasActualDiff(entry) && !resetActualTime) {
-    return {
-      start_time: startISO,
-      end_time: endISO,
-    };
-  }
-
-  if (entry?.origin === 'planned' || !entry) {
-    return {
-      start_time: startISO,
-      end_time: endISO,
-      actual_start_time: startISO,
-      actual_end_time: endISO,
-    };
-  }
-
-  return {
-    actual_start_time: startISO,
-    actual_end_time: endISO,
-  };
-}
-
-function buildUndoTimeUpdateData(
-  entry: TimeUpdateEntry | null | undefined,
-  resetActualTime = false,
-): ReturnType<typeof buildTimeUpdateData> | null {
-  if (!entry) return null;
-
-  if (entry.origin === 'unplanned') {
-    if (!entry.actual_start_time || !entry.actual_end_time) return null;
-    return {
-      actual_start_time: entry.actual_start_time,
-      actual_end_time: entry.actual_end_time,
-    };
-  }
-
-  if (resetActualTime) {
-    if (
-      !entry.start_time ||
-      !entry.end_time ||
-      !entry.actual_start_time ||
-      !entry.actual_end_time
-    ) {
-      return null;
-    }
-    return {
-      start_time: entry.start_time,
-      end_time: entry.end_time,
-      actual_start_time: entry.actual_start_time,
-      actual_end_time: entry.actual_end_time,
-    };
-  }
-
-  if (entry.origin === 'planned' && hasActualDiff(entry)) {
-    if (!entry.start_time || !entry.end_time) return null;
-    return {
-      start_time: entry.start_time,
-      end_time: entry.end_time,
-    };
-  }
-
-  if (!entry.start_time || !entry.end_time || !entry.actual_start_time || !entry.actual_end_time) {
-    return null;
-  }
-  return {
-    start_time: entry.start_time,
-    end_time: entry.end_time,
-    actual_start_time: entry.actual_start_time,
-    actual_end_time: entry.actual_end_time,
-  };
-}
-
-function entryFromCalendarEvent(event: CalendarEvent): TimeUpdateEntry {
+function entryFromCalendarEvent(event: CalendarEvent): EntryLike {
   const plannedStartDate =
     event.plannedStartDate ?? (event.origin === 'planned' ? event.startDate : null);
   const plannedEndDate =
     event.plannedEndDate ?? (event.origin === 'planned' ? event.endDate : null);
 
   return {
-    origin: event.origin,
+    origin: event.origin ?? null,
     start_time: plannedStartDate?.toISOString() ?? null,
     end_time: plannedEndDate?.toISOString() ?? null,
     actual_start_time: (event.actualStartDate ?? event.startDate)?.toISOString() ?? null,
@@ -166,11 +42,7 @@ export const useEntryOperations = () => {
    * ドラッグ/リサイズで時間が変わった場合にのみ呼び出す
    */
   const showTimeChangeUndoToast = useCallback(
-    (
-      entryId: string,
-      previousEntry: TimeUpdateEntry | null | undefined,
-      resetActualTime = false,
-    ) => {
+    (entryId: string, previousEntry: EntryLike | null | undefined, resetActualTime = false) => {
       const undoData = buildUndoTimeUpdateData(previousEntry, resetActualTime);
       if (!undoData) return;
 

--- a/apps/product/src/features/entry/domain/__tests__/entry-time-update.test.ts
+++ b/apps/product/src/features/entry/domain/__tests__/entry-time-update.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it } from 'vitest';
+
+import type { EntryLike } from '../entry-time-model';
+import {
+  buildTimeUpdateData,
+  buildUndoTimeUpdateData,
+  hasActualRangeDiff,
+  rangesMatch,
+} from '../entry-time-update';
+
+const PLANNED_START = '2026-03-12T09:00:00.000Z';
+const PLANNED_END = '2026-03-12T10:00:00.000Z';
+const ACTUAL_START = '2026-03-12T09:05:00.000Z';
+const ACTUAL_END = '2026-03-12T10:10:00.000Z';
+
+const NEW_START = new Date('2026-03-12T14:00:00.000Z');
+const NEW_END = new Date('2026-03-12T15:00:00.000Z');
+const NEW_START_ISO = NEW_START.toISOString();
+const NEW_END_ISO = NEW_END.toISOString();
+
+describe('rangesMatch', () => {
+  it('両 range の時刻が完全一致すれば true', () => {
+    expect(rangesMatch(PLANNED_START, PLANNED_END, PLANNED_START, PLANNED_END)).toBe(true);
+  });
+
+  it('start だけ違えば false', () => {
+    expect(rangesMatch(PLANNED_START, PLANNED_END, ACTUAL_START, PLANNED_END)).toBe(false);
+  });
+
+  it('end だけ違えば false', () => {
+    expect(rangesMatch(PLANNED_START, PLANNED_END, PLANNED_START, ACTUAL_END)).toBe(false);
+  });
+
+  it('両 range とも null なら true（同一とみなす）', () => {
+    expect(rangesMatch(null, null, null, null)).toBe(true);
+  });
+
+  it('片方が undefined / もう片方が null だと false', () => {
+    expect(rangesMatch(undefined, undefined, null, null)).toBe(false);
+  });
+});
+
+describe('hasActualRangeDiff', () => {
+  it('entry が null/undefined なら false', () => {
+    expect(hasActualRangeDiff(null)).toBe(false);
+    expect(hasActualRangeDiff(undefined)).toBe(false);
+  });
+
+  it('origin が unplanned なら false（unplanned は planned を持たない）', () => {
+    expect(
+      hasActualRangeDiff({
+        origin: 'unplanned',
+        actual_start_time: ACTUAL_START,
+        actual_end_time: ACTUAL_END,
+      }),
+    ).toBe(false);
+  });
+
+  it('planned origin で planned == actual なら false', () => {
+    expect(
+      hasActualRangeDiff({
+        origin: 'planned',
+        start_time: PLANNED_START,
+        end_time: PLANNED_END,
+        actual_start_time: PLANNED_START,
+        actual_end_time: PLANNED_END,
+      }),
+    ).toBe(false);
+  });
+
+  it('planned origin で actual_start がズレていれば true', () => {
+    expect(
+      hasActualRangeDiff({
+        origin: 'planned',
+        start_time: PLANNED_START,
+        end_time: PLANNED_END,
+        actual_start_time: ACTUAL_START,
+        actual_end_time: PLANNED_END,
+      }),
+    ).toBe(true);
+  });
+
+  it('planned origin で actual_end がズレていれば true', () => {
+    expect(
+      hasActualRangeDiff({
+        origin: 'planned',
+        start_time: PLANNED_START,
+        end_time: PLANNED_END,
+        actual_start_time: PLANNED_START,
+        actual_end_time: ACTUAL_END,
+      }),
+    ).toBe(true);
+  });
+
+  it('同じ duration で時刻全体がシフトしているケースでも true（hasPlannedActualDiff と違う点）', () => {
+    expect(
+      hasActualRangeDiff({
+        origin: 'planned',
+        start_time: '2026-03-12T09:00:00.000Z',
+        end_time: '2026-03-12T10:00:00.000Z',
+        actual_start_time: '2026-03-12T09:30:00.000Z',
+        actual_end_time: '2026-03-12T10:30:00.000Z',
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('buildTimeUpdateData', () => {
+  it('entry が null（新規作成）なら planned/actual 両方を新時刻に揃える', () => {
+    const result = buildTimeUpdateData(null, NEW_START, NEW_END);
+    expect(result).toEqual({
+      start_time: NEW_START_ISO,
+      end_time: NEW_END_ISO,
+      actual_start_time: NEW_START_ISO,
+      actual_end_time: NEW_END_ISO,
+    });
+  });
+
+  it('planned origin で resetActualTime=true なら planned/actual 両方を新時刻に揃える', () => {
+    const entry: EntryLike = {
+      origin: 'planned',
+      start_time: PLANNED_START,
+      end_time: PLANNED_END,
+      actual_start_time: ACTUAL_START,
+      actual_end_time: ACTUAL_END,
+    };
+    const result = buildTimeUpdateData(entry, NEW_START, NEW_END, true);
+    expect(result).toEqual({
+      start_time: NEW_START_ISO,
+      end_time: NEW_END_ISO,
+      actual_start_time: NEW_START_ISO,
+      actual_end_time: NEW_END_ISO,
+    });
+  });
+
+  it('unplanned origin なら actual だけ更新（planned は触らない）', () => {
+    const entry: EntryLike = {
+      origin: 'unplanned',
+      actual_start_time: ACTUAL_START,
+      actual_end_time: ACTUAL_END,
+    };
+    const result = buildTimeUpdateData(entry, NEW_START, NEW_END);
+    expect(result).toEqual({
+      actual_start_time: NEW_START_ISO,
+      actual_end_time: NEW_END_ISO,
+    });
+  });
+
+  it('planned origin で actual に差分があり resetActualTime=false なら planned のみ更新', () => {
+    const entry: EntryLike = {
+      origin: 'planned',
+      start_time: PLANNED_START,
+      end_time: PLANNED_END,
+      actual_start_time: ACTUAL_START,
+      actual_end_time: ACTUAL_END,
+    };
+    const result = buildTimeUpdateData(entry, NEW_START, NEW_END, false);
+    expect(result).toEqual({
+      start_time: NEW_START_ISO,
+      end_time: NEW_END_ISO,
+    });
+  });
+
+  it('planned origin で actual と一致しているなら planned/actual 両方を新時刻に揃える', () => {
+    const entry: EntryLike = {
+      origin: 'planned',
+      start_time: PLANNED_START,
+      end_time: PLANNED_END,
+      actual_start_time: PLANNED_START,
+      actual_end_time: PLANNED_END,
+    };
+    const result = buildTimeUpdateData(entry, NEW_START, NEW_END);
+    expect(result).toEqual({
+      start_time: NEW_START_ISO,
+      end_time: NEW_END_ISO,
+      actual_start_time: NEW_START_ISO,
+      actual_end_time: NEW_END_ISO,
+    });
+  });
+
+  it('origin 不明なら actual のみ更新（フォールバック）', () => {
+    const entry: EntryLike = { origin: null };
+    const result = buildTimeUpdateData(entry, NEW_START, NEW_END);
+    expect(result).toEqual({
+      actual_start_time: NEW_START_ISO,
+      actual_end_time: NEW_END_ISO,
+    });
+  });
+});
+
+describe('buildUndoTimeUpdateData', () => {
+  it('entry が null なら null', () => {
+    expect(buildUndoTimeUpdateData(null)).toBeNull();
+    expect(buildUndoTimeUpdateData(undefined)).toBeNull();
+  });
+
+  it('unplanned origin: actual を書き戻す', () => {
+    const entry: EntryLike = {
+      origin: 'unplanned',
+      actual_start_time: ACTUAL_START,
+      actual_end_time: ACTUAL_END,
+    };
+    expect(buildUndoTimeUpdateData(entry)).toEqual({
+      actual_start_time: ACTUAL_START,
+      actual_end_time: ACTUAL_END,
+    });
+  });
+
+  it('unplanned origin で actual が欠けていれば null', () => {
+    const entry: EntryLike = { origin: 'unplanned', actual_start_time: ACTUAL_START };
+    expect(buildUndoTimeUpdateData(entry)).toBeNull();
+  });
+
+  it('resetActualTime=true: 4 フィールドすべて書き戻す', () => {
+    const entry: EntryLike = {
+      origin: 'planned',
+      start_time: PLANNED_START,
+      end_time: PLANNED_END,
+      actual_start_time: ACTUAL_START,
+      actual_end_time: ACTUAL_END,
+    };
+    expect(buildUndoTimeUpdateData(entry, true)).toEqual({
+      start_time: PLANNED_START,
+      end_time: PLANNED_END,
+      actual_start_time: ACTUAL_START,
+      actual_end_time: ACTUAL_END,
+    });
+  });
+
+  it('resetActualTime=true で 1 フィールドでも欠けていれば null', () => {
+    const entry: EntryLike = {
+      origin: 'planned',
+      start_time: PLANNED_START,
+      end_time: PLANNED_END,
+      actual_start_time: ACTUAL_START,
+      // actual_end_time 欠落
+    };
+    expect(buildUndoTimeUpdateData(entry, true)).toBeNull();
+  });
+
+  it('planned origin で actual に差分があれば planned のみ書き戻す', () => {
+    const entry: EntryLike = {
+      origin: 'planned',
+      start_time: PLANNED_START,
+      end_time: PLANNED_END,
+      actual_start_time: ACTUAL_START,
+      actual_end_time: ACTUAL_END,
+    };
+    expect(buildUndoTimeUpdateData(entry, false)).toEqual({
+      start_time: PLANNED_START,
+      end_time: PLANNED_END,
+    });
+  });
+
+  it('planned origin で actual に差分があり planned が欠けていれば null', () => {
+    const entry: EntryLike = {
+      origin: 'planned',
+      actual_start_time: ACTUAL_START,
+      actual_end_time: ACTUAL_END,
+    };
+    // hasActualRangeDiff は planned/actual の不一致を見るが planned が空なら判定上 true 扱い
+    expect(buildUndoTimeUpdateData(entry, false)).toBeNull();
+  });
+
+  it('planned origin で actual と一致 → 4 フィールドすべて書き戻す', () => {
+    const entry: EntryLike = {
+      origin: 'planned',
+      start_time: PLANNED_START,
+      end_time: PLANNED_END,
+      actual_start_time: PLANNED_START,
+      actual_end_time: PLANNED_END,
+    };
+    expect(buildUndoTimeUpdateData(entry, false)).toEqual({
+      start_time: PLANNED_START,
+      end_time: PLANNED_END,
+      actual_start_time: PLANNED_START,
+      actual_end_time: PLANNED_END,
+    });
+  });
+});

--- a/apps/product/src/features/entry/domain/entry-time-update.ts
+++ b/apps/product/src/features/entry/domain/entry-time-update.ts
@@ -1,0 +1,167 @@
+/**
+ * Entry 時間更新ルール — drag / resize / undo 時にどのフィールドを書き換えるかの policy
+ *
+ * `entry-time-model.ts` は read 系（origin 判定、range 取得、duration 計算）に閉じる。
+ * このファイルは write 系（mutation 用 patch 構築）を担う。
+ *
+ * 全関数は React / tRPC / Zustand / DOM 非依存の純粋関数。Calendar / Inspector など
+ * caller を問わず一貫したルールで `entries.update` の payload を組み立てるために使う。
+ */
+
+import type { EntryLike } from './entry-time-model';
+
+/** `entries.update` mutation に渡せる時間関連フィールドの部分集合。 */
+export type EntryTimeUpdateData = {
+  start_time?: string | null;
+  end_time?: string | null;
+  actual_start_time?: string | null;
+  actual_end_time?: string | null;
+};
+
+/** 2 つの時刻 range（ISO 文字列の組）が完全一致するか。null/undefined もそのまま比較する。 */
+export function rangesMatch(
+  firstStart: string | null | undefined,
+  firstEnd: string | null | undefined,
+  secondStart: string | null | undefined,
+  secondEnd: string | null | undefined,
+): boolean {
+  return firstStart === secondStart && firstEnd === secondEnd;
+}
+
+/**
+ * planned origin の entry で、planned range (start_time/end_time) と actual range
+ * (actual_start_time/actual_end_time) の時刻 ISO が**完全一致していない**かどうか。
+ *
+ * 注意: `hasPlannedActualDiff` (entry-time-model) は duration の差分を見ているのに対し、
+ * こちらは ISO 文字列の完全一致を見る。同じ duration で時刻だけシフトしているケースは
+ * `hasPlannedActualDiff` では false / こちらでは true になる。drag / resize 時に
+ * 「planned を温存して actual だけ動かす」判断にはこちらの定義が必要。
+ */
+export function hasActualRangeDiff(entry: EntryLike | null | undefined): boolean {
+  if (entry?.origin !== 'planned') return false;
+  return !rangesMatch(
+    entry.start_time,
+    entry.end_time,
+    entry.actual_start_time,
+    entry.actual_end_time,
+  );
+}
+
+/**
+ * Drag / resize / 新規作成時の時刻 patch を構築する。entry.origin と
+ * actual range の状態に応じて、planned / actual の片方だけ更新するか両方更新するかを決める。
+ *
+ * ルール:
+ * - `entry.origin === 'planned' && resetActualTime`: planned / actual 両方を新時刻に揃える
+ * - `entry.origin === 'unplanned'`: actual だけ更新（planned は触らない）
+ * - `entry.origin === 'planned' && hasActualRangeDiff && !resetActualTime`: planned のみ更新（actual は保持）
+ * - `entry.origin === 'planned'` で actual と一致している、または `entry` が null（新規）: planned / actual 両方を新時刻に揃える
+ * - その他（origin が不明など）: actual のみ更新
+ */
+export function buildTimeUpdateData(
+  entry: EntryLike | null | undefined,
+  startTime: Date,
+  endTime: Date,
+  resetActualTime = false,
+): EntryTimeUpdateData {
+  const startISO = startTime.toISOString();
+  const endISO = endTime.toISOString();
+
+  if (entry?.origin === 'planned' && resetActualTime) {
+    return {
+      start_time: startISO,
+      end_time: endISO,
+      actual_start_time: startISO,
+      actual_end_time: endISO,
+    };
+  }
+
+  if (entry?.origin === 'unplanned') {
+    return {
+      actual_start_time: startISO,
+      actual_end_time: endISO,
+    };
+  }
+
+  if (entry?.origin === 'planned' && hasActualRangeDiff(entry) && !resetActualTime) {
+    return {
+      start_time: startISO,
+      end_time: endISO,
+    };
+  }
+
+  if (entry?.origin === 'planned' || !entry) {
+    return {
+      start_time: startISO,
+      end_time: endISO,
+      actual_start_time: startISO,
+      actual_end_time: endISO,
+    };
+  }
+
+  return {
+    actual_start_time: startISO,
+    actual_end_time: endISO,
+  };
+}
+
+/**
+ * `buildTimeUpdateData` の逆操作。直前の entry スナップショットから、Undo で書き戻すべき
+ * 時刻 patch を構築する。元の時刻が一部欠けていて復元不可能な場合は null を返す。
+ *
+ * ルール:
+ * - `entry === null`: null（復元不可）
+ * - `entry.origin === 'unplanned'`: 元の actual_start/end を書き戻す。欠落していれば null
+ * - `resetActualTime === true`: planned / actual の 4 フィールドすべて書き戻す。欠落していれば null
+ * - `entry.origin === 'planned' && hasActualRangeDiff`: planned だけ書き戻す（actual は触らない）
+ * - その他: planned / actual の 4 フィールドすべて書き戻す
+ */
+export function buildUndoTimeUpdateData(
+  entry: EntryLike | null | undefined,
+  resetActualTime = false,
+): EntryTimeUpdateData | null {
+  if (!entry) return null;
+
+  if (entry.origin === 'unplanned') {
+    if (!entry.actual_start_time || !entry.actual_end_time) return null;
+    return {
+      actual_start_time: entry.actual_start_time,
+      actual_end_time: entry.actual_end_time,
+    };
+  }
+
+  if (resetActualTime) {
+    if (
+      !entry.start_time ||
+      !entry.end_time ||
+      !entry.actual_start_time ||
+      !entry.actual_end_time
+    ) {
+      return null;
+    }
+    return {
+      start_time: entry.start_time,
+      end_time: entry.end_time,
+      actual_start_time: entry.actual_start_time,
+      actual_end_time: entry.actual_end_time,
+    };
+  }
+
+  if (entry.origin === 'planned' && hasActualRangeDiff(entry)) {
+    if (!entry.start_time || !entry.end_time) return null;
+    return {
+      start_time: entry.start_time,
+      end_time: entry.end_time,
+    };
+  }
+
+  if (!entry.start_time || !entry.end_time || !entry.actual_start_time || !entry.actual_end_time) {
+    return null;
+  }
+  return {
+    start_time: entry.start_time,
+    end_time: entry.end_time,
+    actual_start_time: entry.actual_start_time,
+    actual_end_time: entry.actual_end_time,
+  };
+}

--- a/apps/product/src/features/entry/domain/index.ts
+++ b/apps/product/src/features/entry/domain/index.ts
@@ -10,3 +10,11 @@ export {
   isUnplannedEntry,
 } from './entry-time-model';
 export type { EntryLike, TimeRange } from './entry-time-model';
+
+export {
+  buildTimeUpdateData,
+  buildUndoTimeUpdateData,
+  hasActualRangeDiff,
+  rangesMatch,
+} from './entry-time-update';
+export type { EntryTimeUpdateData } from './entry-time-update';

--- a/apps/product/src/features/entry/index.ts
+++ b/apps/product/src/features/entry/index.ts
@@ -29,17 +29,21 @@ export { computeActualTimeDiffOverlay } from './lib/actual-time-overlay';
 // Domain (Entry 時間モデル — 純粋関数、DB/tRPC/React 非依存)
 // =============================================================================
 export {
+  buildTimeUpdateData,
+  buildUndoTimeUpdateData,
   determineEntryOrigin,
   getActualMinutes,
   getActualRange,
   getDiffMinutes,
   getPlannedMinutes,
   getPlannedRange,
+  hasActualRangeDiff,
   hasPlannedActualDiff,
   isPlannedEntry,
   isUnplannedEntry,
+  rangesMatch,
 } from './domain';
-export type { EntryLike, TimeRange } from './domain';
+export type { EntryLike, EntryTimeUpdateData, TimeRange } from './domain';
 
 // =============================================================================
 // Lib (entry-status utilities)


### PR DESCRIPTION
## Summary

Calendar hook (`useEntryOperations.ts`) に閉じていた **純粋関数 4 つ**を `features/entry/domain` に切り出し、Calendar 側を React/mutation orchestration に集中させる。

事前調査（前回の plan）で「Calendar 側に origin ベースの planned/actual 更新ルールが残っている」ことが判明したため、その最優先 1 ステップを実装。

仕様変更・UI 変更なし。DB / devtools への影響なし。

## 調査結果（実装前確認）

| 対象 | 純粋性 | React/DOM 依存 | mutation/Zustand 依存 |
| --- | --- | --- | --- |
| `rangesMatch` | ✓ | なし | なし |
| `hasActualDiff` → `hasActualRangeDiff` に改名 | ✓ | なし | なし |
| `buildTimeUpdateData` | ✓ | なし | なし（`Date.toISOString` のみ） |
| `buildUndoTimeUpdateData` | ✓ | なし | なし |

`entryFromCalendarEvent` は CalendarEvent → EntryLike 変換 adapter のため Calendar 側に残置（domain ではない）。

### `hasPlannedActualDiff` との意味差

| 関数 | 比較対象 | 例: 同 duration の時刻シフト（09→09:30, 10→10:30） |
| --- | --- | --- |
| `hasPlannedActualDiff` (既存) | duration（分） | **false**（diff = 0 分） |
| `hasActualRangeDiff` (新規) | ISO 文字列の完全一致 | **true**（range が違う） |

drag/resize 時の「planned 温存 or actual だけ動かす」判断にはこちらの定義が必要なため別関数として残す。改名で意味差を表現。

## 変更内容

### 新規ファイル
- `features/entry/domain/entry-time-update.ts` — 4 helper + `EntryTimeUpdateData` 型
- `features/entry/domain/__tests__/entry-time-update.test.ts` — 25 unit tests

### 編集
- `features/entry/domain/index.ts` — re-export 追加
- `features/entry/index.ts` — barrel 公開
- `features/calendar/hooks/operations/useEntryOperations.ts` — helper 4 つを削除して barrel import に置換（146 行削減）。`TimeUpdateEntry` ローカル型を `EntryLike` に統合
- `features/calendar/hooks/operations/__tests__/useEntryOperations.test.tsx` — mock を `vi.importActual` で実体保持しつつ `useEntryMutations` のみ override に変更（移動した domain helper を実体のまま使うため）

合計: 6 files, **+482 / -144**

## 触らなかったもの

- `features/calendar/domain/` の新設（次 PR）
- `entry-adapter.ts` の責務再設計
- `range.ts` / `precision.ts` の移動
- `DraftEntryBlock.tsx` の `isEntryPast` 置換
- Calendar lib / hooks の他の部分
- Review / Tags / chronotype
- UI / DB / ESLint boundary rule

## Test plan

- [x] `pnpm --filter @dayopt/product typecheck`
- [x] `pnpm --filter @dayopt/product lint`
- [x] `pnpm lint:boundaries`（0 violations）
- [x] `pnpm --filter @dayopt/product test:run`（**1709 pass**, +25 件は新規 entry-time-update test）
- [x] `pnpm --filter @dayopt/product build`
- [x] `pnpm --filter @dayopt/storybook build`

## 残課題（follow-up）

- `features/calendar/domain/` の新設（`range.ts` / `precision.ts` の移動候補あり）
- `DraftEntryBlock.tsx` の `isPast` 独自実装を `isEntryPast` 利用に置換
- `entry-adapter.ts` の責務整理
- `useCalendarFilterStore` の所在地検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)