### PR TITLE
refactor(chronotype): chronotype state を features/chronotype/stores へ切り出す

### DIFF
--- a/apps/product/src/features/calendar/components/views/shared/components/ScrollableCalendarLayout.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/ScrollableCalendarLayout.tsx
@@ -11,10 +11,9 @@
 
 import React, { useCallback, useMemo } from 'react';
 
-import { getChronotypeProfile } from '@/features/chronotype';
+import { getChronotypeProfile, useChronotypeSettingsStore } from '@/features/chronotype';
 import { cn } from '@/lib/utils';
 
-import { useCalendarSettingsStore } from '@/features/calendar/stores/useCalendarSettingsStore';
 import { formatTimeString } from '@/lib/date';
 import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 
@@ -149,7 +148,7 @@ export const ScrollableCalendarLayout = ({
   const gradientCss = useChronotypeGradient();
 
   // Chronotype ゾーン配列（TimeColumn ラベル装飾用）
-  const chronotype = useCalendarSettingsStore((s) => s.chronotype);
+  const chronotype = useChronotypeSettingsStore((s) => s.chronotype);
   const chronotypeZones = useMemo(() => {
     if (!chronotype) return undefined;
     return getChronotypeProfile(chronotype.type).productivityZones;

--- a/apps/product/src/features/calendar/components/views/shared/grid/CurrentTimeLine/NowBadge.stories.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/grid/CurrentTimeLine/NowBadge.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
-import { useCalendarSettingsStore } from '@/features/calendar/stores/useCalendarSettingsStore';
+import { useChronotypeSettingsStore } from '@/features/chronotype';
 
 import { NowBadge } from './NowBadge';
 
@@ -24,13 +24,13 @@ type Story = StoryObj<typeof meta>;
 // ─────────────────────────────────────────────────────────
 
 const enableBearChronotype = () => {
-  useCalendarSettingsStore.setState({
+  useChronotypeSettingsStore.setState({
     chronotype: { type: 'bear' },
   });
 };
 
 const disableChronotype = () => {
-  useCalendarSettingsStore.setState({
+  useChronotypeSettingsStore.setState({
     chronotype: null,
   });
 };

--- a/apps/product/src/features/calendar/components/views/shared/grid/CurrentTimeLine/NowBadge.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/grid/CurrentTimeLine/NowBadge.tsx
@@ -9,8 +9,11 @@
 
 import { memo, useMemo } from 'react';
 
-import { useCalendarSettingsStore } from '@/features/calendar/stores/useCalendarSettingsStore';
-import { getActiveZoneLevel, getChronotypeProfile } from '@/features/chronotype';
+import {
+  getActiveZoneLevel,
+  getChronotypeProfile,
+  useChronotypeSettingsStore,
+} from '@/features/chronotype';
 import { useTranslations } from 'next-intl';
 
 interface NowBadgeProps {
@@ -20,7 +23,7 @@ interface NowBadgeProps {
 
 export const NowBadge = memo<NowBadgeProps>(function NowBadge({ currentHour }) {
   const t = useTranslations('calendar.nowBadge');
-  const chronotype = useCalendarSettingsStore((s) => s.chronotype);
+  const chronotype = useChronotypeSettingsStore((s) => s.chronotype);
 
   const zoneLevel = useMemo(() => {
     if (!chronotype) return null;

--- a/apps/product/src/features/calendar/components/views/shared/hooks/useChronotypeGradient.ts
+++ b/apps/product/src/features/calendar/components/views/shared/hooks/useChronotypeGradient.ts
@@ -7,13 +7,16 @@
 
 import { useMemo } from 'react';
 
-import { useCalendarSettingsStore } from '@/features/calendar/stores/useCalendarSettingsStore';
-import { generateChronotypeGradient, getChronotypeProfile } from '@/features/chronotype';
+import {
+  generateChronotypeGradient,
+  getChronotypeProfile,
+  useChronotypeSettingsStore,
+} from '@/features/chronotype';
 import { useTheme } from '@/lib/hooks/useTheme';
 
 export function useChronotypeGradient(): string | null {
-  const chronotype = useCalendarSettingsStore((s) => s.chronotype);
-  const chronotypeGradient = useCalendarSettingsStore((s) => s.chronotypeGradient);
+  const chronotype = useChronotypeSettingsStore((s) => s.chronotype);
+  const chronotypeGradient = useChronotypeSettingsStore((s) => s.chronotypeGradient);
   const { resolvedTheme } = useTheme();
 
   return useMemo(() => {

--- a/apps/product/src/features/calendar/stores/useCalendarSettingsStore.ts
+++ b/apps/product/src/features/calendar/stores/useCalendarSettingsStore.ts
@@ -1,8 +1,6 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 
-import { DEFAULT_CHRONOTYPE_SETTINGS } from '@/lib/chronotype-defaults';
-import type { ChronotypeSettings as ChronotypeSettingsState } from '@/lib/types/chronotype';
 import type { CalendarViewType, HourHeightDensity } from '../lib/constants';
 
 export type { CalendarViewType } from '../lib/constants';
@@ -17,10 +15,6 @@ export interface CalendarSettings {
 
   // グリッド密度
   hourHeightDensity: HourHeightDensity;
-
-  // クロノタイプ設定
-  chronotype: ChronotypeSettingsState | null;
-  chronotypeGradient: { light: string | null; dark: string | null };
 }
 
 interface CalendarSettingsStore extends CalendarSettings {
@@ -32,8 +26,6 @@ const defaultSettings: CalendarSettings = {
   defaultView: 'week',
   showWeekends: true,
   hourHeightDensity: 'default',
-  chronotype: DEFAULT_CHRONOTYPE_SETTINGS,
-  chronotypeGradient: { light: null, dark: null },
 };
 
 /**
@@ -45,7 +37,8 @@ const defaultSettings: CalendarSettings = {
  * 永続 cache から hydrate される流れでほぼ即時に正しい値になる。
  *
  * app-wide な user preference (timezone / weekStartsOn 等) は `useUserPreferenceStore`
- * に分離されている。
+ * に分離されている。chronotype 設定は `useChronotypeSettingsStore`
+ * (`@/features/chronotype`) に分離されている。
  */
 export const useCalendarSettingsStore = create<CalendarSettingsStore>()(
   devtools(

--- a/apps/product/src/features/calendar/stores/userSettings.ts
+++ b/apps/product/src/features/calendar/stores/userSettings.ts
@@ -1,18 +1,19 @@
 /**
- * UserSettings — `UserPreference` + `CalendarSettings` を統合した型と dispatcher
+ * UserSettings — `UserPreference` + `CalendarSettings` + `ChronotypeSettings` を統合した型と dispatcher
  *
- * 2 ストアに跨る設定変更（例: `display-settings.tsx` の `saveSettings({ timezone, defaultView })`）
+ * 3 ストアに跨る設定変更（例: `useUserSettings.saveSettings({ timezone, defaultView, chronotype })`）
  * を扱うためのユーティリティ。callsite はこの型 / dispatch を経由することで、
- * 各 store の責務境界を保ったまま 1 度の呼び出しで両方の state を更新できる。
+ * 各 store の責務境界を保ったまま 1 度の呼び出しで複数 store の state を更新できる。
  */
 
+import { type ChronotypeSettings, useChronotypeSettingsStore } from '@/features/chronotype';
 import type { UserPreference } from '@/lib/stores/useUserPreferenceStore';
 import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 import type { CalendarSettings } from './useCalendarSettingsStore';
 import { useCalendarSettingsStore } from './useCalendarSettingsStore';
 
-/** 2 ストアを統合した設定オブジェクトの型 */
-export type UserSettings = UserPreference & CalendarSettings;
+/** 3 ストアを統合した設定オブジェクトの型 */
+export type UserSettings = UserPreference & CalendarSettings & ChronotypeSettings;
 
 const USER_PREFERENCE_KEYS = [
   'timezone',
@@ -28,17 +29,22 @@ const CALENDAR_SETTINGS_KEYS = [
   'defaultView',
   'showWeekends',
   'hourHeightDensity',
-  'chronotype',
-  'chronotypeGradient',
 ] as const satisfies ReadonlyArray<keyof CalendarSettings>;
 
-/** 統合 partial を 2 ストアに振り分ける純粋ユーティリティ（テスト/外部用途向け） */
+const CHRONOTYPE_SETTINGS_KEYS = [
+  'chronotype',
+  'chronotypeGradient',
+] as const satisfies ReadonlyArray<keyof ChronotypeSettings>;
+
+/** 統合 partial を 3 ストアに振り分ける純粋ユーティリティ（テスト/外部用途向け） */
 export function splitUserSettings(partial: Partial<UserSettings>): {
   preference: Partial<UserPreference>;
   calendar: Partial<CalendarSettings>;
+  chronotype: Partial<ChronotypeSettings>;
 } {
   const preference: Partial<UserPreference> = {};
   const calendar: Partial<CalendarSettings> = {};
+  const chronotype: Partial<ChronotypeSettings> = {};
 
   for (const key of USER_PREFERENCE_KEYS) {
     if (key in partial) {
@@ -50,23 +56,31 @@ export function splitUserSettings(partial: Partial<UserSettings>): {
       (calendar as Record<string, unknown>)[key] = partial[key];
     }
   }
+  for (const key of CHRONOTYPE_SETTINGS_KEYS) {
+    if (key in partial) {
+      (chronotype as Record<string, unknown>)[key] = partial[key];
+    }
+  }
 
-  return { preference, calendar };
+  return { preference, calendar, chronotype };
 }
 
 /**
- * 統合 partial を 2 ストアに dispatch する。
+ * 統合 partial を 3 ストアに dispatch する。
  *
  * 既存の `useCalendarSettingsStore.updateSettings({...})` 1 本だった更新を、
- * UserPreference / CalendarSettings のどちらに属するかで振り分ける。
+ * UserPreference / CalendarSettings / ChronotypeSettings のどれに属するかで振り分ける。
  */
 export function dispatchUserSettings(partial: Partial<UserSettings>): void {
-  const { preference, calendar } = splitUserSettings(partial);
+  const { preference, calendar, chronotype } = splitUserSettings(partial);
 
   if (Object.keys(preference).length > 0) {
     useUserPreferenceStore.getState().updatePreferences(preference);
   }
   if (Object.keys(calendar).length > 0) {
     useCalendarSettingsStore.getState().updateSettings(calendar);
+  }
+  if (Object.keys(chronotype).length > 0) {
+    useChronotypeSettingsStore.getState().updateSettings(chronotype);
   }
 }

--- a/apps/product/src/features/chronotype/components/chronotype-settings.tsx
+++ b/apps/product/src/features/chronotype/components/chronotype-settings.tsx
@@ -139,10 +139,10 @@ interface ChronotypeSettingsProps {
   /**
    * Chronotype 変更時の楽観更新コールバック。
    *
-   * Why: chronotype state は Calendar UI store (`useCalendarSettingsStore`) 配下に
-   * あるが、本コンポーネントは Layer 0 (chronotype feature) のため Calendar feature
-   * (Layer 2) を直接 import できない。呼び出し元（features/settings 層）から
-   * store 更新関数を注入することで feature DAG を保つ。
+   * chronotype state は `useChronotypeSettingsStore` (Layer 0 / 本 feature) に
+   * 集約されているが、各 callsite （`features/settings` の profile-settings 等）が
+   * 直接 store を触る形を保つため、本コンポーネントは callback 注入で楽観更新を
+   * 委譲する。本コンポーネント側では autoSave 経由で DB 保存のみ行う。
    */
   onChronotypeChange?: ((chronotype: ChronotypeSettingsState | null) => void) | undefined;
 }

--- a/apps/product/src/features/chronotype/index.ts
+++ b/apps/product/src/features/chronotype/index.ts
@@ -20,4 +20,8 @@ export { getChronotypeProfile } from './lib/chronotype-profile';
 export { generateChronotypeGradient, getActiveZoneLevel } from './lib/gradient';
 export { chronotypeTypeSchema } from './lib/schemas';
 
+// --- Stores ---
+export { useChronotypeSettingsStore } from './stores/useChronotypeSettingsStore';
+export type { ChronotypeSettings } from './stores/useChronotypeSettingsStore';
+
 // ここにないものはfeature内部専用

--- a/apps/product/src/features/chronotype/stores/__tests__/useChronotypeSettingsStore.test.ts
+++ b/apps/product/src/features/chronotype/stores/__tests__/useChronotypeSettingsStore.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { DEFAULT_CHRONOTYPE_SETTINGS } from '@/lib/chronotype-defaults';
+
+import { useChronotypeSettingsStore } from '../useChronotypeSettingsStore';
+
+describe('useChronotypeSettingsStore', () => {
+  beforeEach(() => {
+    useChronotypeSettingsStore.getState().resetSettings();
+  });
+
+  describe('初期状態', () => {
+    it('chronotype は DEFAULT_CHRONOTYPE_SETTINGS', () => {
+      const state = useChronotypeSettingsStore.getState();
+      expect(state.chronotype).toEqual(DEFAULT_CHRONOTYPE_SETTINGS);
+    });
+
+    it('chronotypeGradient は light/dark とも null', () => {
+      const state = useChronotypeSettingsStore.getState();
+      expect(state.chronotypeGradient).toEqual({ light: null, dark: null });
+    });
+  });
+
+  describe('updateSettings', () => {
+    it('chronotype を更新できる', () => {
+      useChronotypeSettingsStore.getState().updateSettings({
+        chronotype: { type: 'lion' },
+      });
+      const state = useChronotypeSettingsStore.getState();
+      expect(state.chronotype).toEqual({ type: 'lion' });
+    });
+
+    it('chronotype を null にできる', () => {
+      useChronotypeSettingsStore.getState().updateSettings({ chronotype: null });
+      expect(useChronotypeSettingsStore.getState().chronotype).toBeNull();
+    });
+
+    it('chronotypeGradient を更新できる', () => {
+      const gradient = {
+        light: 'linear-gradient(...)',
+        dark: 'linear-gradient(...)',
+      };
+      useChronotypeSettingsStore.getState().updateSettings({
+        chronotypeGradient: gradient,
+      });
+      expect(useChronotypeSettingsStore.getState().chronotypeGradient).toEqual(gradient);
+    });
+
+    it('部分更新で他フィールドは維持される', () => {
+      useChronotypeSettingsStore.getState().updateSettings({
+        chronotypeGradient: { light: 'g1', dark: null },
+      });
+      useChronotypeSettingsStore.getState().updateSettings({
+        chronotype: { type: 'wolf' },
+      });
+      const state = useChronotypeSettingsStore.getState();
+      expect(state.chronotype).toEqual({ type: 'wolf' });
+      expect(state.chronotypeGradient).toEqual({ light: 'g1', dark: null });
+    });
+  });
+
+  describe('resetSettings', () => {
+    it('全フィールドが default に戻る', () => {
+      useChronotypeSettingsStore.getState().updateSettings({
+        chronotype: { type: 'dolphin' },
+        chronotypeGradient: { light: 'g1', dark: 'g2' },
+      });
+      useChronotypeSettingsStore.getState().resetSettings();
+      const state = useChronotypeSettingsStore.getState();
+      expect(state.chronotype).toEqual(DEFAULT_CHRONOTYPE_SETTINGS);
+      expect(state.chronotypeGradient).toEqual({ light: null, dark: null });
+    });
+  });
+});

--- a/apps/product/src/features/chronotype/stores/useChronotypeSettingsStore.ts
+++ b/apps/product/src/features/chronotype/stores/useChronotypeSettingsStore.ts
@@ -1,0 +1,46 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+
+import { DEFAULT_CHRONOTYPE_SETTINGS } from '@/lib/chronotype-defaults';
+import type { ChronotypeSettings as ChronotypeSettingsState } from '@/lib/types/chronotype';
+
+export interface ChronotypeSettings {
+  chronotype: ChronotypeSettingsState | null;
+  chronotypeGradient: { light: string | null; dark: string | null };
+}
+
+interface ChronotypeSettingsStore extends ChronotypeSettings {
+  updateSettings: (settings: Partial<ChronotypeSettings>) => void;
+  resetSettings: () => void;
+}
+
+const defaultSettings: ChronotypeSettings = {
+  chronotype: DEFAULT_CHRONOTYPE_SETTINGS,
+  chronotypeGradient: { light: null, dark: null },
+};
+
+/**
+ * Chronotype 設定（生体リズム選択 + 派生 gradient）の Zustand ストア。
+ *
+ * persist せず、server (user_settings.chronotype_settings) が SoT。
+ * `UserSettingsInitializer` が起動時に DB から取得した値を hydrate する。
+ */
+export const useChronotypeSettingsStore = create<ChronotypeSettingsStore>()(
+  devtools(
+    (set) => ({
+      ...defaultSettings,
+
+      updateSettings: (newSettings) =>
+        set((state) => ({
+          ...state,
+          ...newSettings,
+        })),
+
+      resetSettings: () => set({ ...defaultSettings }),
+    }),
+    {
+      name: 'chronotype-settings-store',
+      enabled: process.env.NODE_ENV !== 'production',
+    },
+  ),
+);

--- a/apps/product/src/features/settings/components/profile-settings.tsx
+++ b/apps/product/src/features/settings/components/profile-settings.tsx
@@ -6,8 +6,10 @@ import { Camera } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
 import { useAuthStore } from '@/features/auth';
-import { useCalendarSettingsStore } from '@/features/calendar/stores/useCalendarSettingsStore';
-import { ChronotypeSettingsPanel as ChronotypeSettings } from '@/features/chronotype';
+import {
+  ChronotypeSettingsPanel as ChronotypeSettings,
+  useChronotypeSettingsStore,
+} from '@/features/chronotype';
 import { LabeledRow } from '@/lib/components/common/LabeledRow';
 import { SectionCard } from '@/lib/components/common/SectionCard';
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar';
@@ -25,7 +27,7 @@ import { DisplayNameDialog } from './display-name-dialog';
 export function ProfileSettings() {
   const t = useTranslations();
   const user = useAuthStore((state) => state.user);
-  const updateCalendarSettings = useCalendarSettingsStore((state) => state.updateSettings);
+  const updateChronotypeSettings = useChronotypeSettingsStore((state) => state.updateSettings);
 
   const [showAvatarDialog, setShowAvatarDialog] = useState(false);
   const [showDisplayNameDialog, setShowDisplayNameDialog] = useState(false);
@@ -35,9 +37,9 @@ export function ProfileSettings() {
 
   const handleChronotypeChange = useCallback(
     (chronotype: ChronotypeSettingsState | null) => {
-      updateCalendarSettings({ chronotype });
+      updateChronotypeSettings({ chronotype });
     },
-    [updateCalendarSettings],
+    [updateChronotypeSettings],
   );
 
   return (

--- a/apps/product/src/features/settings/hooks/useUserSettings.ts
+++ b/apps/product/src/features/settings/hooks/useUserSettings.ts
@@ -14,6 +14,7 @@ import { api } from '@/lib/trpc';
 import { useCalendarSettingsStore } from '@/features/calendar/stores/useCalendarSettingsStore';
 import type { UserSettings } from '@/features/calendar/stores/userSettings';
 import { dispatchUserSettings } from '@/features/calendar/stores/userSettings';
+import { useChronotypeSettingsStore } from '@/features/chronotype';
 import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 
 /**
@@ -129,12 +130,13 @@ export function useUserSettings() {
     [updateMutation],
   );
 
-  // UI表示用に2ストアを merge した shape を返す（既存 consumer との互換性維持）
+  // UI表示用に3ストアを merge した shape を返す（既存 consumer との互換性維持）
   const preferences = useUserPreferenceStore();
   const calendarSettings = useCalendarSettingsStore();
+  const chronotypeSettings = useChronotypeSettingsStore();
   const settings = useMemo<UserSettings>(
-    () => ({ ...preferences, ...calendarSettings }),
-    [preferences, calendarSettings],
+    () => ({ ...preferences, ...calendarSettings, ...chronotypeSettings }),
+    [preferences, calendarSettings, chronotypeSettings],
   );
 
   return {

--- a/apps/product/src/features/settings/stores/useCalendarSettingsStore.test.ts
+++ b/apps/product/src/features/settings/stores/useCalendarSettingsStore.test.ts
@@ -14,11 +14,6 @@ describe('useCalendarSettingsStore', () => {
       expect(state.showWeekends).toBe(true);
       expect(state.hourHeightDensity).toBe('default');
     });
-
-    it('クロノタイプはデフォルト無効（null）', () => {
-      const state = useCalendarSettingsStore.getState();
-      expect(state.chronotype).toBeNull();
-    });
   });
 
   describe('updateSettings', () => {
@@ -32,14 +27,6 @@ describe('useCalendarSettingsStore', () => {
       expect(state.hourHeightDensity).toBe('compact');
       // 他は維持
       expect(state.showWeekends).toBe(true);
-    });
-
-    it('クロノタイプを有効化できる', () => {
-      useCalendarSettingsStore.getState().updateSettings({
-        chronotype: { type: 'lion' },
-      });
-      const state = useCalendarSettingsStore.getState();
-      expect(state.chronotype).toEqual({ type: 'lion' });
     });
 
     it('showWeekends を切り替えられる', () => {

--- a/apps/storybook/.storybook/mocks/stores.tsx
+++ b/apps/storybook/.storybook/mocks/stores.tsx
@@ -22,6 +22,7 @@ import type { StoreApi } from 'zustand';
 import { useAuthStore } from '@/features/auth';
 import { useCalendarNavigationStore } from '@/features/calendar/stores/useCalendarNavigationStore';
 import { useCalendarSettingsStore } from '@/features/calendar/stores/useCalendarSettingsStore';
+import { useChronotypeSettingsStore } from '@/features/chronotype';
 import { useCalendarFilterStore } from '@/lib/stores/useCalendarFilterStore';
 import { useShellStore } from '@/lib/stores/useShellStore';
 import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
@@ -41,6 +42,9 @@ const STORE_REGISTRY: Record<string, StoreApi<Record<string, unknown>>> = {
     Record<string, unknown>
   >,
   useCalendarSettingsStore: useCalendarSettingsStore as unknown as StoreApi<
+    Record<string, unknown>
+  >,
+  useChronotypeSettingsStore: useChronotypeSettingsStore as unknown as StoreApi<
     Record<string, unknown>
   >,
   useUserPreferenceStore: useUserPreferenceStore as unknown as StoreApi<Record<string, unknown>>,


### PR DESCRIPTION
## Summary

- `useCalendarSettingsStore` に同居していた `chronotype` / `chronotypeGradient` を **`features/chronotype/stores/useChronotypeSettingsStore.ts`** に分離
- `useCalendarSettingsStore` は Calendar UI 専用の `defaultView` / `showWeekends` / `hourHeightDensity` のみを保持する状態に
- `dispatchUserSettings` / `splitUserSettings` を 3-way（preference / calendar / chronotype）に拡張
- L2 (calendar / settings) → L0 (chronotype) は barrel import のみで完結。ESLint boundary rule 変更なし

仕様変更 / UI 変更 / DB 変更なし。localStorage persist 未使用のため key migration / version bump も不要。

## 調査結果

`chronotype` / `chronotypeGradient` の参照は全 8 箇所:

| Path | 分類 |
| --- | --- |
| `features/calendar/components/views/shared/hooks/useChronotypeGradient.ts` | calendar (selector × 2) |
| `features/calendar/components/views/shared/components/ScrollableCalendarLayout.tsx` | calendar (selector) |
| `features/calendar/components/views/shared/grid/CurrentTimeLine/NowBadge.tsx` | calendar (selector) |
| `features/calendar/components/views/shared/grid/CurrentTimeLine/NowBadge.stories.tsx` | calendar (story setState) |
| `features/settings/components/profile-settings.tsx` | settings (selector + setter) |
| `features/settings/hooks/useUserSettings.ts` | settings (hydration / saveSettings / merge) |
| `features/settings/stores/useCalendarSettingsStore.test.ts` | test (assertion) |
| `apps/storybook/.storybook/mocks/stores.tsx` | storybook (mock registry) |

`features/calendar/stores/userSettings.ts` の `splitUserSettings` / `dispatchUserSettings` も chronotype を扱っていたため、ここを 3-way 化した。

## chronotype state の責務判断

**Calendar UI 専用ではなく、`features/chronotype` 配下に所属させるのが自然。**

- chronotype state は本質的に「ユーザーの生体リズム選択」と「派生 gradient」であり、Calendar の表示密度や週末表示と質が違う
- `features/chronotype/` 配下に lib (gradient / profile / schemas) / components / tests が既に揃っており、store だけが Calendar 側にあるのは責務的に非整合
- `chronotype-settings.tsx:142-145` の旧コメント「Calendar UI store にあるため caller から store 更新関数を注入する」が、store の所属が誤った場所にあることへの workaround だったと読める

## 変更内容

### 新規

- `apps/product/src/features/chronotype/stores/useChronotypeSettingsStore.ts`（state + `updateSettings(Partial)` + `resetSettings` + devtools `chronotype-settings-store`、persist なし）
- `apps/product/src/features/chronotype/stores/__tests__/useChronotypeSettingsStore.test.ts`（初期状態 / updateSettings / resetSettings の 6 件）

### 編集

- `features/chronotype/index.ts` — barrel に `useChronotypeSettingsStore` と `ChronotypeSettings` 型を追加
- `features/calendar/stores/useCalendarSettingsStore.ts` — chronotype 系 2 field と関連 import を削除、doc コメント更新
- `features/calendar/stores/userSettings.ts` — `UserSettings = UserPreference & CalendarSettings & ChronotypeSettings` に拡張、`CHRONOTYPE_SETTINGS_KEYS` を追加して 3-way split/dispatch に
- `features/calendar/components/views/shared/hooks/useChronotypeGradient.ts` — selector を新 store に切替（barrel 経由）
- `features/calendar/components/views/shared/components/ScrollableCalendarLayout.tsx` — 同上
- `features/calendar/components/views/shared/grid/CurrentTimeLine/NowBadge.tsx` — 同上
- `features/calendar/components/views/shared/grid/CurrentTimeLine/NowBadge.stories.tsx` — `setState` 呼び出しを新 store に切替
- `features/settings/components/profile-settings.tsx` — selector / setter を新 store に切替
- `features/settings/hooks/useUserSettings.ts` — return shape の merge に `chronotypeSettings` を追加
- `features/settings/stores/useCalendarSettingsStore.test.ts` — chronotype 関連 assertion を削除
- `features/chronotype/components/chronotype-settings.tsx` — `onChronotypeChange` callback 注入コメントを実態（store が L0 にある）に合わせて更新
- `apps/storybook/.storybook/mocks/stores.tsx` — `STORE_REGISTRY` に新 store を登録

合計: 新規 2 + 編集 12 ファイル（+189 / -58）

## 触らなかったもの

- `useCalendarFilterStore`（前 PR で別途確認済み、tags hook との cross-feature 依存のため移動不可）
- `chronotype-settings.tsx` の `onChronotypeChange` callback 仕様（store は L0 に揃ったが、callback 注入パターン自体は維持。コメント文言のみ更新）
- `apps/storybook/.storybook/mocks/presets.ts` の chronotype mock スキーマ不整合（独立 bug、Non-scope）
- `useChronotypeGradient` の所属（Calendar view 専用 hook のため Calendar 配下のまま）
- `DEFAULT_CHRONOTYPE_SETTINGS` / `ChronotypeType` の場所（`@/lib/` のまま）
- tRPC router / DB schema / ESLint boundary rule

## 検証結果

- ✅ `pnpm --filter @dayopt/product typecheck`
- ✅ `pnpm --filter @dayopt/product lint`
- ✅ `pnpm lint:boundaries`（Cross-feature imports: 0）
- ✅ `pnpm --filter @dayopt/product test:run`（1723 pass、前回 1718 から +5 件）
- ✅ `pnpm --filter @dayopt/product build`
- ✅ `pnpm --filter @dayopt/storybook build`

## 残課題（follow-up）

1. `chronotype-settings.tsx` の `onChronotypeChange` callback 注入パターン廃止（store が L0 に来たので内部から直接呼べる構造に変更可能）
2. `presets.ts` の chronotype mock スキーマと実型 `{ type: ChronotypeType }` の整合修正
3. `useChronotypeGradient` の所属再検討（Calendar view 専用なら今のままで OK）

## Test plan

- [ ] CI（typecheck / lint / boundaries / test / build / web build / E2E / Quality Gate）が全て pass
- [ ] Vercel preview deployment が ready
- [ ] Storybook の `Features/Calendar/Views/Grid/NowBadge/InDeep` で bear chronotype の deep badge が表示される
- [ ] Settings > Profile で chronotype 選択が optimistic に反映され、autoSave 経由で DB に永続化される

🤖 Generated with [Claude Code](https://claude.com/claude-code)