### PR TITLE
refactor(review): variance 計算を features/review/domain へ切り出す

### DIFF
--- a/apps/product/src/features/review/components/time-pl/data/timePL.derivers.ts
+++ b/apps/product/src/features/review/components/time-pl/data/timePL.derivers.ts
@@ -5,6 +5,8 @@
  * 全てのパーセンテージ・ステータス・集計値はここで算出する。
  */
 
+import { computeVariance } from '@/features/review/domain/variance';
+
 import type {
   AccuracyStatus,
   BalanceSheetData,
@@ -128,17 +130,19 @@ export function deriveStatement(input: TimePLInput): StatementViewData {
   const allTagIds = new Set(input.tags.map((t) => t.tagId));
   for (const tagId of allTagIds) {
     const tag = input.tags.find((t) => t.tagId === tagId)!;
-    const variance = tag.budgetMinutes - tag.actualMinutes;
     if (tag.budgetMinutes === 0 && tag.actualMinutes === 0) continue;
+    const { varianceMinutes, variancePercent } = computeVariance(
+      tag.budgetMinutes,
+      tag.actualMinutes,
+      tag.isPlanned,
+    );
     varianceRows.push({
       tagId: tag.tagId,
       tagName: tag.tagName,
       tagColor: tag.tagColor,
       tagIcon: tag.tagIcon,
-      varianceMinutes: variance,
-      variancePercent: tag.isPlanned
-        ? Math.round((variance / Math.max(tag.budgetMinutes, 1)) * 100)
-        : null,
+      varianceMinutes,
+      variancePercent,
     });
   }
 
@@ -199,7 +203,11 @@ export function deriveBarComparison(input: TimePLInput): BarComparisonRow[] {
   return input.tags
     .filter((t) => t.budgetMinutes > 0 || t.actualMinutes > 0)
     .map((t) => {
-      const variance = t.budgetMinutes - t.actualMinutes;
+      const { varianceMinutes, variancePercent } = computeVariance(
+        t.budgetMinutes,
+        t.actualMinutes,
+        t.isPlanned,
+      );
       return {
         tagId: t.tagId,
         tagName: t.tagName,
@@ -207,10 +215,8 @@ export function deriveBarComparison(input: TimePLInput): BarComparisonRow[] {
         tagIcon: t.tagIcon,
         budgetMinutes: t.budgetMinutes,
         actualMinutes: t.actualMinutes,
-        varianceMinutes: variance,
-        variancePercent: t.isPlanned
-          ? Math.round((variance / Math.max(t.budgetMinutes, 1)) * 100)
-          : null,
+        varianceMinutes,
+        variancePercent,
       };
     })
     .sort(

--- a/apps/product/src/features/review/domain/__tests__/variance.test.ts
+++ b/apps/product/src/features/review/domain/__tests__/variance.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeVariance } from '../variance';
+
+describe('computeVariance', () => {
+  it('budget > actual → positive varianceMinutes と切り上げ済み percent', () => {
+    const result = computeVariance(120, 90, true);
+    expect(result.varianceMinutes).toBe(30);
+    expect(result.variancePercent).toBe(25);
+  });
+
+  it('budget < actual → negative varianceMinutes と negative percent', () => {
+    const result = computeVariance(60, 90, true);
+    expect(result.varianceMinutes).toBe(-30);
+    expect(result.variancePercent).toBe(-50);
+  });
+
+  it('budget === actual → ±0 / 0%', () => {
+    const result = computeVariance(60, 60, true);
+    expect(result.varianceMinutes).toBe(0);
+    expect(result.variancePercent).toBe(0);
+  });
+
+  it('isPlanned === false → variancePercent は null', () => {
+    const result = computeVariance(0, 45, false);
+    expect(result.varianceMinutes).toBe(-45);
+    expect(result.variancePercent).toBeNull();
+  });
+
+  it('isPlanned === true かつ budgetMinutes === 0 → Math.max ガードで落ちずに計算される', () => {
+    const result = computeVariance(0, 30, true);
+    expect(result.varianceMinutes).toBe(-30);
+    // -30 / Math.max(0, 1) = -30 → -30 * 100 = -3000
+    expect(result.variancePercent).toBe(-3000);
+  });
+
+  it('端数 budget=100 actual=33 → variance=67, percent=67（rounding）', () => {
+    const result = computeVariance(100, 33, true);
+    expect(result.varianceMinutes).toBe(67);
+    expect(result.variancePercent).toBe(67);
+  });
+});

--- a/apps/product/src/features/review/domain/variance.ts
+++ b/apps/product/src/features/review/domain/variance.ts
@@ -1,0 +1,29 @@
+/**
+ * Time P/L variance 計算 — 純粋関数
+ *
+ * 符号規約: budgetMinutes - actualMinutes
+ *   - positive → under-budget（予定より実績が少なかった = 節約）
+ *   - negative → over-budget（予定より実績が多かった = 超過）
+ *   - zero     → ±0
+ *
+ * variancePercent は `isPlanned === false`（計画外のみのタグ）の場合 null。
+ * budgetMinutes === 0 の時は除算ゼロ回避のため Math.max(budget, 1) で分母化する。
+ */
+
+export interface VarianceResult {
+  varianceMinutes: number;
+  /** 計画外のみのタグ (`isPlanned === false`) では null */
+  variancePercent: number | null;
+}
+
+export function computeVariance(
+  budgetMinutes: number,
+  actualMinutes: number,
+  isPlanned: boolean,
+): VarianceResult {
+  const varianceMinutes = budgetMinutes - actualMinutes;
+  const variancePercent = isPlanned
+    ? Math.round((varianceMinutes / Math.max(budgetMinutes, 1)) * 100)
+    : null;
+  return { varianceMinutes, variancePercent };
+}


### PR DESCRIPTION
## Summary

Time P/L の `deriveStatement` / `deriveBarComparison` で重複していた `variance = budget - actual` + `isPlanned` による percent 計算を **`features/review/domain/variance.ts`** の純粋関数 `computeVariance` に集約。`features/review/domain/` ディレクトリを初めて新設し、以後の review 系 domain helper 追加の土台にする。

仕様 / UI / DB 変更なし。出力 shape（`TimePLVarianceRow` / `BarComparisonRow`）は維持。

## 調査結果

- `features/entry/server/statistics.ts` / `tag-statistics.ts` は **ほぼ DB RPC pass-through**。純粋計算は薄く、本 PR の Scope では切り出し対象なし
- 純粋集計を担っているのは `features/review/components/time-pl/data/timePL.derivers.ts` と `features/review/lib/metrics.ts`。後者は UI フォーマット helper が大半で「集計」より「表示変換」
- timePL.derivers.ts 内の **重複が明確な箇所は variance 計算（2 箇所）のみ**
- `tag-dashboard.ts:26-31` の `diffMinutes(ISO start, ISO end)` は Entry domain の `getDiffMinutes(entry)` とシグネチャが違う（ISO string vs Entry オブジェクト）。統合には Entry domain 拡張が必要で Non-scope
- `features/review` は ESLint layer 未登録 → boundary 違反リスクなし（barrel / deep どちらも許可）

## 実装した変更

新規 2 + 編集 1（+87 / -10）

### 新規

- [apps/product/src/features/review/domain/variance.ts](apps/product/src/features/review/domain/variance.ts) — `computeVariance(budgetMinutes, actualMinutes, isPlanned)`
- [apps/product/src/features/review/domain/__tests__/variance.test.ts](apps/product/src/features/review/domain/__tests__/variance.test.ts) — edge case 6 件

### 編集

- [features/review/components/time-pl/data/timePL.derivers.ts](apps/product/src/features/review/components/time-pl/data/timePL.derivers.ts) — `deriveStatement` / `deriveBarComparison` の variance 計算を helper 呼び出しに置換

## 切り出した domain helper

\`\`\`ts
export interface VarianceResult {
  varianceMinutes: number;
  variancePercent: number | null; // isPlanned === false では null
}

export function computeVariance(
  budgetMinutes: number,
  actualMinutes: number,
  isPlanned: boolean,
): VarianceResult
\`\`\`

**符号規約**: `budgetMinutes - actualMinutes`（positive = under-budget / 節約、negative = over-budget / 超過）。`budgetMinutes === 0` での除算ゼロは `Math.max(budget, 1)` でガード。

## 追加したテスト

variance.test.ts 6 件:

1. `budget > actual` → positive variance, rounded percent
2. `budget < actual` → negative variance, negative percent
3. `budget === actual` → 0 / 0%
4. `isPlanned === false` → variancePercent === null
5. `budget === 0 && isPlanned === true` → Math.max ガードで落ちず計算
6. 端数 budget=100, actual=33 → variance=67, percent=67（rounding 確認）

## 触らなかったもの

- `features/entry/server/tag-dashboard.ts` の ISO range `diffMinutes`（Entry domain 拡張が必要、Non-scope）
- `features/review/lib/metrics.ts`（UI フォーマット helper が大半、Scope 外）
- `deriveAccuracy` / `deriveBreakEven`（重複なし、即時利得なし）
- `features/entry/server/statistics.ts` / `tag-statistics.ts`（DB RPC pass-through）
- ESLint boundary rule（review は未登録のまま）
- DB schema / migration / tRPC route

## blocker

無し。最小単位として安全に切り出せた。

## 検証結果

- ✅ `pnpm --filter @dayopt/product typecheck`
- ✅ `pnpm --filter @dayopt/product lint`
- ✅ `pnpm lint:boundaries`（Cross-feature imports: 0）
- ✅ `pnpm --filter @dayopt/product test:run`（1729 pass、前回 1723 から +6 件 = variance.test.ts ぴったり）
- ✅ `pnpm --filter @dayopt/product build`
- ✅ `pnpm --filter @dayopt/storybook build`

`grep "budgetMinutes - .*actualMinutes" apps/product/src/features/review` の結果が `variance.ts` のみになり、`timePL.derivers.ts` から重複が消えたことを確認済み。

## 残課題（follow-up）

1. `tag-dashboard.ts` の `diffMinutes(ISO, ISO)` を Entry domain の ISO range helper に統合
2. `metrics.ts` の UI 表示 helper と純粋集計の境界整理（`calculateDeepUtilization` のみ集計、他は表示変換）
3. `deriveBreakEven` のアルゴリズム部分を `features/review/domain/break-even.ts` に切り出し
4. `features/review` を ESLint layer に登録（boundary check を機能させる）

## Test plan

- [ ] CI（typecheck / lint / boundaries / test / build / web build / E2E / Quality Gate）が全て pass
- [ ] Vercel preview deployment が ready
- [ ] Review > Time P/L の Statement / BarComparison view で variance 数値・%表示・色分けに変化がない（既存 timePL.derivers.test.ts の regression test が担保）

🤖 Generated with [Claude Code](https://claude.com/claude-code)