### PR TITLE
feat(design): add token package

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -13,6 +13,7 @@ const config: StorybookConfig = {
   stories: [
     '../../product/src/**/*.mdx',
     '../../product/src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
+    '../../../packages/design/src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
     '../docs/**/*.mdx',
     '../docs/**/*.stories.@(js|jsx|mjs|ts|tsx)',
     './stories/**/*.stories.@(js|jsx|mjs|ts|tsx)',

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -1,6 +1,7 @@
 import type { Preview } from '@storybook/nextjs-vite';
 import { MINIMAL_VIEWPORTS } from 'storybook/viewport';
 
+import '@dayopt/design/theme.css';
 import '../../product/src/lib/styles/globals.css';
 import { providerDecorator, storeMockDecorator } from './decorators';
 import { dayoptDarkTheme, dayoptLightTheme } from './theme/dayopt';
@@ -47,6 +48,7 @@ const preview: Preview = {
           'Strategy',
           'Components',
           'Features',
+          'Design',
           'Foundations',
           'Patterns',
         ],

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@dayopt/design": "workspace:*",
     "@dayopt/product": "workspace:*",
     "@tanstack/react-query": "^5.100.11",
     "@trpc/client": "^11.17.0",

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -11,6 +11,8 @@
     "noEmit": true,
     "paths": {
       "@/*": ["../product/src/*"],
+      "@dayopt/design": ["../../packages/design/src/index.ts"],
+      "@dayopt/design/*": ["../../packages/design/src/*"],
       "@dayopt/storybook/*": [".storybook/*"]
     },
     "resolveJsonModule": true,
@@ -23,6 +25,8 @@
     ".storybook/**/*.ts",
     ".storybook/**/*.tsx",
     "../product/src/**/*.stories.tsx",
-    "../product/src/**/*.mdx"
+    "../product/src/**/*.mdx",
+    "../../packages/design/src/**/*.ts",
+    "../../packages/design/src/**/*.tsx"
   ]
 }

--- a/packages/design/package.json
+++ b/packages/design/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@dayopt/design",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./theme.css": "./src/theme.css"
+  },
+  "types": "./src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/packages/design/src/colors.stories.tsx
+++ b/packages/design/src/colors.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { colors } from './colors';
+
+const meta = {
+  title: 'Design/Colors',
+  parameters: {
+    layout: 'padded',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Tokens: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 16 }}>
+      {Object.entries(colors).map(([name, token]) => (
+        <div
+          key={name}
+          style={{
+            alignItems: 'center',
+            border: '1px solid var(--dayopt-color-border)',
+            borderRadius: 'var(--dayopt-radius-md)',
+            display: 'grid',
+            gap: 16,
+            gridTemplateColumns: 'minmax(120px, 1fr) minmax(180px, 2fr) minmax(220px, 3fr)',
+            padding: 16,
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            <div
+              aria-hidden="true"
+              style={{
+                background: `var(${token.cssVariable})`,
+                border: '1px solid var(--dayopt-color-border-subtle)',
+                borderRadius: 'var(--dayopt-radius-sm)',
+                boxShadow: 'var(--dayopt-shadow-xs)',
+                height: 40,
+                width: 56,
+              }}
+            />
+            <strong style={{ color: 'var(--dayopt-color-foreground)' }}>{name}</strong>
+          </div>
+          <code style={{ color: 'var(--dayopt-color-muted-foreground)' }}>{token.cssVariable}</code>
+          <div style={{ color: 'var(--dayopt-color-muted-foreground)', display: 'grid', gap: 4 }}>
+            <span>{token.value}</span>
+            {token.darkValue ? <span>dark: {token.darkValue}</span> : null}
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/packages/design/src/colors.ts
+++ b/packages/design/src/colors.ts
@@ -1,0 +1,129 @@
+export type ColorToken = {
+  readonly value: string;
+  readonly darkValue?: string;
+  readonly cssVariable: `--dayopt-color-${string}`;
+  readonly description: string;
+};
+
+export const colors = {
+  background: {
+    value: 'oklch(0.98 0 0)',
+    darkValue: 'oklch(0.18 0.008 60)',
+    cssVariable: '--dayopt-color-background',
+    description: 'Default page background.',
+  },
+  foreground: {
+    value: 'oklch(0.13 0 0)',
+    darkValue: 'oklch(0.9 0.005 70)',
+    cssVariable: '--dayopt-color-foreground',
+    description: 'Default high-emphasis text.',
+  },
+  container: {
+    value: 'oklch(0.96 0 0)',
+    darkValue: 'oklch(0.15 0.008 60)',
+    cssVariable: '--dayopt-color-container',
+    description: 'Recessed surface for sidebars and sections.',
+  },
+  card: {
+    value: 'oklch(1 0 0)',
+    darkValue: 'oklch(0.22 0.008 60)',
+    cssVariable: '--dayopt-color-card',
+    description: 'Raised surface for cards, dialogs, and popovers.',
+  },
+  muted: {
+    value: 'oklch(0.95 0 0)',
+    darkValue: 'oklch(0.25 0.008 60)',
+    cssVariable: '--dayopt-color-muted',
+    description: 'Subtle well/input surface.',
+  },
+  mutedForeground: {
+    value: 'oklch(0.4 0 0)',
+    darkValue: 'oklch(0.68 0.005 60)',
+    cssVariable: '--dayopt-color-muted-foreground',
+    description: 'Lower-emphasis text.',
+  },
+  primary: {
+    value: 'oklch(0.45 0.14 259.8145)',
+    darkValue: 'oklch(0.5 0.188 259.8145)',
+    cssVariable: '--dayopt-color-primary',
+    description: 'Brand action color.',
+  },
+  primaryForeground: {
+    value: 'oklch(1 0 0)',
+    darkValue: 'oklch(1 0 0)',
+    cssVariable: '--dayopt-color-primary-foreground',
+    description: 'Text on primary fills.',
+  },
+  destructive: {
+    value: 'oklch(0.54 0.18 25)',
+    darkValue: 'oklch(0.65 0.14 25)',
+    cssVariable: '--dayopt-color-destructive',
+    description: 'Error and destructive accents.',
+  },
+  destructiveTint: {
+    value: 'oklch(0.96 0.015 25)',
+    darkValue: 'oklch(0.22 0.03 25)',
+    cssVariable: '--dayopt-color-destructive-tint',
+    description: 'Subtle destructive background.',
+  },
+  warning: {
+    value: 'oklch(0.55 0.16 70)',
+    darkValue: 'oklch(0.72 0.14 70)',
+    cssVariable: '--dayopt-color-warning',
+    description: 'Warning accents.',
+  },
+  warningTint: {
+    value: 'oklch(0.97 0.015 70)',
+    darkValue: 'oklch(0.22 0.03 70)',
+    cssVariable: '--dayopt-color-warning-tint',
+    description: 'Subtle warning background.',
+  },
+  success: {
+    value: 'oklch(0.5 0.15 150)',
+    darkValue: 'oklch(0.65 0.12 150)',
+    cssVariable: '--dayopt-color-success',
+    description: 'Success accents.',
+  },
+  successTint: {
+    value: 'oklch(0.95 0.02 150)',
+    darkValue: 'oklch(0.22 0.03 150)',
+    cssVariable: '--dayopt-color-success-tint',
+    description: 'Subtle success background.',
+  },
+  info: {
+    value: 'oklch(0.55 0.02 260)',
+    darkValue: 'oklch(0.65 0.02 260)',
+    cssVariable: '--dayopt-color-info',
+    description: 'Informational accents.',
+  },
+  infoTint: {
+    value: 'oklch(0.96 0.005 260)',
+    darkValue: 'oklch(0.22 0.01 260)',
+    cssVariable: '--dayopt-color-info-tint',
+    description: 'Subtle informational background.',
+  },
+  border: {
+    value: 'oklch(0 0 0 / 0.12)',
+    darkValue: 'oklch(1 0 0 / 0.12)',
+    cssVariable: '--dayopt-color-border',
+    description: 'Default border.',
+  },
+  borderSubtle: {
+    value: 'oklch(0 0 0 / 0.06)',
+    darkValue: 'oklch(1 0 0 / 0.07)',
+    cssVariable: '--dayopt-color-border-subtle',
+    description: 'Low-emphasis divider.',
+  },
+  input: {
+    value: 'oklch(0 0 0 / 0.06)',
+    darkValue: 'oklch(1 0 0 / 0.08)',
+    cssVariable: '--dayopt-color-input',
+    description: 'Input background.',
+  },
+  ring: {
+    value: 'oklch(0.45 0.14 259.8145)',
+    darkValue: 'oklch(0.5 0.188 259.8145)',
+    cssVariable: '--dayopt-color-ring',
+    description: 'Focus ring.',
+  },
+} as const satisfies Record<string, ColorToken>;

--- a/packages/design/src/index.ts
+++ b/packages/design/src/index.ts
@@ -1,0 +1,6 @@
+export { colors } from './colors';
+export { radius } from './radius';
+export { shadow } from './shadow';
+export { spacing } from './spacing';
+export { tokens } from './tokens';
+export { typography } from './typography';

--- a/packages/design/src/radius.stories.tsx
+++ b/packages/design/src/radius.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { radius } from './radius';
+
+const meta = {
+  title: 'Design/Radius',
+  parameters: {
+    layout: 'padded',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Tokens: Story = {
+  render: () => (
+    <div
+      style={{
+        color: 'var(--dayopt-color-foreground)',
+        display: 'grid',
+        gap: 16,
+        gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
+      }}
+    >
+      {Object.entries(radius).map(([name, token]) => (
+        <div key={name} style={{ display: 'grid', gap: 10 }}>
+          <div
+            aria-hidden="true"
+            style={{
+              background: 'var(--dayopt-color-card)',
+              border: '1px solid var(--dayopt-color-border)',
+              borderRadius: `var(${token.cssVariable})`,
+              boxShadow: 'var(--dayopt-shadow-sm)',
+              height: 96,
+            }}
+          />
+          <strong>{name}</strong>
+          <code style={{ color: 'var(--dayopt-color-muted-foreground)' }}>{token.cssVariable}</code>
+          <span style={{ color: 'var(--dayopt-color-muted-foreground)' }}>{token.value}</span>
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/packages/design/src/radius.ts
+++ b/packages/design/src/radius.ts
@@ -1,0 +1,8 @@
+export const radius = {
+  none: { value: '0', px: 0, cssVariable: '--dayopt-radius-none' },
+  sm: { value: '0.25rem', px: 4, cssVariable: '--dayopt-radius-sm' },
+  md: { value: '0.5rem', px: 8, cssVariable: '--dayopt-radius-md' },
+  lg: { value: '1rem', px: 16, cssVariable: '--dayopt-radius-lg' },
+  xl: { value: '1.5rem', px: 24, cssVariable: '--dayopt-radius-xl' },
+  full: { value: '9999px', px: null, cssVariable: '--dayopt-radius-full' },
+} as const;

--- a/packages/design/src/shadow.stories.tsx
+++ b/packages/design/src/shadow.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { shadow } from './shadow';
+
+const meta = {
+  title: 'Design/Shadows',
+  parameters: {
+    layout: 'padded',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Tokens: Story = {
+  render: () => (
+    <div
+      style={{
+        color: 'var(--dayopt-color-foreground)',
+        display: 'grid',
+        gap: 20,
+        gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+      }}
+    >
+      {Object.entries(shadow).map(([name, token]) => (
+        <div
+          key={name}
+          style={{
+            background: 'var(--dayopt-color-card)',
+            borderRadius: 'var(--dayopt-radius-md)',
+            boxShadow: `var(${token.cssVariable})`,
+            display: 'grid',
+            gap: 12,
+            minHeight: 156,
+            padding: 20,
+          }}
+        >
+          <strong>{name}</strong>
+          <code style={{ color: 'var(--dayopt-color-muted-foreground)' }}>{token.cssVariable}</code>
+          <span style={{ color: 'var(--dayopt-color-muted-foreground)' }}>{token.value}</span>
+          {'darkValue' in token && token.darkValue ? (
+            <span style={{ color: 'var(--dayopt-color-muted-foreground)' }}>
+              dark: {token.darkValue}
+            </span>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/packages/design/src/shadow.ts
+++ b/packages/design/src/shadow.ts
@@ -1,0 +1,29 @@
+export const shadow = {
+  xs: {
+    value: '0 1px 2px oklch(0 0 0 / 0.04)',
+    darkValue: '0 1px 2px oklch(0 0 0 / 0.14)',
+    cssVariable: '--dayopt-shadow-xs',
+  },
+  sm: {
+    value: '0 0 0 1px oklch(0 0 0 / 0.03), 0 1px 3px oklch(0 0 0 / 0.03)',
+    darkValue: '0 0 0 1px oklch(1 0 0 / 0.03), 0 1px 4px oklch(0 0 0 / 0.18)',
+    cssVariable: '--dayopt-shadow-sm',
+  },
+  card: {
+    value:
+      '0 0 0 1px oklch(0 0 0 / 0.03), 0 1px 2px oklch(0 0 0 / 0.04), 0 4px 16px oklch(0 0 0 / 0.05)',
+    darkValue: '0 0 0 1px oklch(1 0 0 / 0.04), 0 2px 8px oklch(0 0 0 / 0.25)',
+    cssVariable: '--dayopt-shadow-card',
+  },
+  elevationSunken: {
+    value: 'inset 0 2px 4px 0 oklch(0 0 0 / 0.08), inset 0 1px 2px 0 oklch(0 0 0 / 0.06)',
+    cssVariable: '--dayopt-shadow-elevation-sunken',
+  },
+  elevationRaised: {
+    value:
+      'inset 0 1px 0 0 oklch(1 0 0 / 0.07), 0 1px 3px 0 oklch(0 0 0 / 0.1), 0 4px 8px -2px oklch(0 0 0 / 0.1)',
+    darkValue:
+      'inset 0 1px 0 0 oklch(1 0 0 / 0.05), 0 1px 3px 0 oklch(0 0 0 / 0.2), 0 4px 8px -2px oklch(0 0 0 / 0.25)',
+    cssVariable: '--dayopt-shadow-elevation-raised',
+  },
+} as const;

--- a/packages/design/src/spacing.stories.tsx
+++ b/packages/design/src/spacing.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { spacing } from './spacing';
+
+const meta = {
+  title: 'Design/Spacing',
+  parameters: {
+    layout: 'padded',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Tokens: Story = {
+  render: () => (
+    <div style={{ color: 'var(--dayopt-color-foreground)', display: 'grid', gap: 16 }}>
+      {Object.entries(spacing).map(([name, token]) => (
+        <div
+          key={name}
+          style={{
+            alignItems: 'center',
+            display: 'grid',
+            gap: 16,
+            gridTemplateColumns: '64px 180px 1fr 72px',
+          }}
+        >
+          <strong>{name}</strong>
+          <code style={{ color: 'var(--dayopt-color-muted-foreground)' }}>{token.cssVariable}</code>
+          <div
+            aria-hidden="true"
+            style={{
+              background: 'var(--dayopt-color-primary)',
+              borderRadius: 'var(--dayopt-radius-sm)',
+              height: 24,
+              width: `var(${token.cssVariable})`,
+            }}
+          />
+          <span style={{ color: 'var(--dayopt-color-muted-foreground)' }}>{token.px}px</span>
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/packages/design/src/spacing.ts
+++ b/packages/design/src/spacing.ts
@@ -1,0 +1,8 @@
+export const spacing = {
+  xs: { value: '0.5rem', px: 8, cssVariable: '--dayopt-space-xs' },
+  sm: { value: '1rem', px: 16, cssVariable: '--dayopt-space-sm' },
+  md: { value: '1.5rem', px: 24, cssVariable: '--dayopt-space-md' },
+  lg: { value: '2rem', px: 32, cssVariable: '--dayopt-space-lg' },
+  xl: { value: '3rem', px: 48, cssVariable: '--dayopt-space-xl' },
+  '2xl': { value: '4rem', px: 64, cssVariable: '--dayopt-space-2xl' },
+} as const;

--- a/packages/design/src/theme.css
+++ b/packages/design/src/theme.css
@@ -1,0 +1,91 @@
+:root {
+  --dayopt-color-background: oklch(0.98 0 0);
+  --dayopt-color-foreground: oklch(0.13 0 0);
+  --dayopt-color-container: oklch(0.96 0 0);
+  --dayopt-color-card: oklch(1 0 0);
+  --dayopt-color-muted: oklch(0.95 0 0);
+  --dayopt-color-muted-foreground: oklch(0.4 0 0);
+  --dayopt-color-primary: oklch(0.45 0.14 259.8145);
+  --dayopt-color-primary-foreground: oklch(1 0 0);
+  --dayopt-color-destructive: oklch(0.54 0.18 25);
+  --dayopt-color-destructive-tint: oklch(0.96 0.015 25);
+  --dayopt-color-warning: oklch(0.55 0.16 70);
+  --dayopt-color-warning-tint: oklch(0.97 0.015 70);
+  --dayopt-color-success: oklch(0.5 0.15 150);
+  --dayopt-color-success-tint: oklch(0.95 0.02 150);
+  --dayopt-color-info: oklch(0.55 0.02 260);
+  --dayopt-color-info-tint: oklch(0.96 0.005 260);
+  --dayopt-color-border: oklch(0 0 0 / 0.12);
+  --dayopt-color-border-subtle: oklch(0 0 0 / 0.06);
+  --dayopt-color-input: oklch(0 0 0 / 0.06);
+  --dayopt-color-ring: var(--dayopt-color-primary);
+
+  --dayopt-font-sans: Inter, 'Noto Sans JP', system-ui, sans-serif;
+  --dayopt-font-inter: Inter, system-ui, sans-serif;
+  --dayopt-font-noto-jp: 'Noto Sans JP', system-ui, sans-serif;
+  --dayopt-font-size-xs: 0.75rem;
+  --dayopt-font-size-sm: 0.875rem;
+  --dayopt-font-size-base: 1rem;
+  --dayopt-font-size-lg: 1.125rem;
+  --dayopt-font-size-xl: 1.25rem;
+  --dayopt-font-size-2xl: 1.5rem;
+  --dayopt-font-size-3xl: 1.875rem;
+  --dayopt-font-size-4xl: 2.25rem;
+  --dayopt-font-weight-normal: 400;
+  --dayopt-font-weight-medium: 500;
+  --dayopt-line-height-tight: 1.2;
+  --dayopt-line-height-normal: 1.5;
+  --dayopt-line-height-relaxed: 1.75;
+
+  --dayopt-space-xs: 0.5rem;
+  --dayopt-space-sm: 1rem;
+  --dayopt-space-md: 1.5rem;
+  --dayopt-space-lg: 2rem;
+  --dayopt-space-xl: 3rem;
+  --dayopt-space-2xl: 4rem;
+
+  --dayopt-radius-none: 0;
+  --dayopt-radius-sm: 0.25rem;
+  --dayopt-radius-md: 0.5rem;
+  --dayopt-radius-lg: 1rem;
+  --dayopt-radius-xl: 1.5rem;
+  --dayopt-radius-full: 9999px;
+
+  --dayopt-shadow-xs: 0 1px 2px oklch(0 0 0 / 0.04);
+  --dayopt-shadow-sm: 0 0 0 1px oklch(0 0 0 / 0.03), 0 1px 3px oklch(0 0 0 / 0.03);
+  --dayopt-shadow-card:
+    0 0 0 1px oklch(0 0 0 / 0.03), 0 1px 2px oklch(0 0 0 / 0.04), 0 4px 16px oklch(0 0 0 / 0.05);
+  --dayopt-shadow-elevation-sunken:
+    inset 0 2px 4px 0 oklch(0 0 0 / 0.08), inset 0 1px 2px 0 oklch(0 0 0 / 0.06);
+  --dayopt-shadow-elevation-raised:
+    inset 0 1px 0 0 oklch(1 0 0 / 0.07), 0 1px 3px 0 oklch(0 0 0 / 0.1),
+    0 4px 8px -2px oklch(0 0 0 / 0.1);
+}
+
+.dark {
+  --dayopt-color-background: oklch(0.18 0.008 60);
+  --dayopt-color-foreground: oklch(0.9 0.005 70);
+  --dayopt-color-container: oklch(0.15 0.008 60);
+  --dayopt-color-card: oklch(0.22 0.008 60);
+  --dayopt-color-muted: oklch(0.25 0.008 60);
+  --dayopt-color-muted-foreground: oklch(0.68 0.005 60);
+  --dayopt-color-primary: oklch(0.5 0.188 259.8145);
+  --dayopt-color-primary-foreground: oklch(1 0 0);
+  --dayopt-color-destructive: oklch(0.65 0.14 25);
+  --dayopt-color-destructive-tint: oklch(0.22 0.03 25);
+  --dayopt-color-warning: oklch(0.72 0.14 70);
+  --dayopt-color-warning-tint: oklch(0.22 0.03 70);
+  --dayopt-color-success: oklch(0.65 0.12 150);
+  --dayopt-color-success-tint: oklch(0.22 0.03 150);
+  --dayopt-color-info: oklch(0.65 0.02 260);
+  --dayopt-color-info-tint: oklch(0.22 0.01 260);
+  --dayopt-color-border: oklch(1 0 0 / 0.12);
+  --dayopt-color-border-subtle: oklch(1 0 0 / 0.07);
+  --dayopt-color-input: oklch(1 0 0 / 0.08);
+  --dayopt-shadow-xs: 0 1px 2px oklch(0 0 0 / 0.14);
+  --dayopt-shadow-sm: 0 0 0 1px oklch(1 0 0 / 0.03), 0 1px 4px oklch(0 0 0 / 0.18);
+  --dayopt-shadow-card: 0 0 0 1px oklch(1 0 0 / 0.04), 0 2px 8px oklch(0 0 0 / 0.25);
+  --dayopt-shadow-elevation-raised:
+    inset 0 1px 0 0 oklch(1 0 0 / 0.05), 0 1px 3px 0 oklch(0 0 0 / 0.2),
+    0 4px 8px -2px oklch(0 0 0 / 0.25);
+}

--- a/packages/design/src/tokens.ts
+++ b/packages/design/src/tokens.ts
@@ -1,0 +1,13 @@
+import { colors } from './colors';
+import { radius } from './radius';
+import { shadow } from './shadow';
+import { spacing } from './spacing';
+import { typography } from './typography';
+
+export const tokens = {
+  colors,
+  typography,
+  spacing,
+  radius,
+  shadow,
+} as const;

--- a/packages/design/src/typography.stories.tsx
+++ b/packages/design/src/typography.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { typography } from './typography';
+
+const meta = {
+  title: 'Design/Typography',
+  parameters: {
+    layout: 'padded',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Tokens: Story = {
+  render: () => (
+    <div style={{ color: 'var(--dayopt-color-foreground)', display: 'grid', gap: 32 }}>
+      <section style={{ display: 'grid', gap: 12 }}>
+        {Object.entries(typography.fontFamily).map(([name, token]) => (
+          <div key={name} style={{ display: 'grid', gap: 4 }}>
+            <code style={{ color: 'var(--dayopt-color-muted-foreground)' }}>
+              {token.cssVariable}
+            </code>
+            <div
+              style={{
+                fontFamily: `var(${token.cssVariable})`,
+                fontSize: 'var(--dayopt-font-size-2xl)',
+              }}
+            >
+              {name}: Dayopt design tokens
+            </div>
+          </div>
+        ))}
+      </section>
+      <section style={{ display: 'grid', gap: 16 }}>
+        {Object.entries(typography.fontSize).map(([name, token]) => (
+          <div
+            key={name}
+            style={{
+              alignItems: 'baseline',
+              borderBottom: '1px solid var(--dayopt-color-border-subtle)',
+              display: 'grid',
+              gap: 16,
+              gridTemplateColumns: '96px 180px 1fr',
+              paddingBottom: 12,
+            }}
+          >
+            <strong>{name}</strong>
+            <code style={{ color: 'var(--dayopt-color-muted-foreground)' }}>
+              {token.cssVariable}
+            </code>
+            <span
+              style={{
+                fontSize: `var(${token.cssVariable})`,
+                lineHeight: 'var(--dayopt-line-height-normal)',
+              }}
+            >
+              {token.value} / {token.px}px
+            </span>
+          </div>
+        ))}
+      </section>
+      <section style={{ display: 'flex', flexWrap: 'wrap', gap: 24 }}>
+        {Object.entries(typography.fontWeight).map(([name, token]) => (
+          <div key={name} style={{ display: 'grid', gap: 4 }}>
+            <code style={{ color: 'var(--dayopt-color-muted-foreground)' }}>
+              {token.cssVariable}
+            </code>
+            <span
+              style={{
+                fontSize: 'var(--dayopt-font-size-xl)',
+                fontWeight: `var(${token.cssVariable})`,
+              }}
+            >
+              {name} {token.value}
+            </span>
+          </div>
+        ))}
+        {Object.entries(typography.lineHeight).map(([name, token]) => (
+          <div key={name} style={{ maxWidth: 220, display: 'grid', gap: 4 }}>
+            <code style={{ color: 'var(--dayopt-color-muted-foreground)' }}>
+              {token.cssVariable}
+            </code>
+            <span style={{ lineHeight: `var(${token.cssVariable})` }}>
+              {name}: Line height sample across two lines.
+            </span>
+          </div>
+        ))}
+      </section>
+    </div>
+  ),
+};

--- a/packages/design/src/typography.ts
+++ b/packages/design/src/typography.ts
@@ -1,0 +1,35 @@
+export const typography = {
+  fontFamily: {
+    sans: {
+      value: 'Inter, Noto Sans JP, system-ui, sans-serif',
+      cssVariable: '--dayopt-font-sans',
+    },
+    inter: {
+      value: 'Inter, system-ui, sans-serif',
+      cssVariable: '--dayopt-font-inter',
+    },
+    notoJp: {
+      value: 'Noto Sans JP, system-ui, sans-serif',
+      cssVariable: '--dayopt-font-noto-jp',
+    },
+  },
+  fontSize: {
+    xs: { value: '0.75rem', px: 12, cssVariable: '--dayopt-font-size-xs' },
+    sm: { value: '0.875rem', px: 14, cssVariable: '--dayopt-font-size-sm' },
+    base: { value: '1rem', px: 16, cssVariable: '--dayopt-font-size-base' },
+    lg: { value: '1.125rem', px: 18, cssVariable: '--dayopt-font-size-lg' },
+    xl: { value: '1.25rem', px: 20, cssVariable: '--dayopt-font-size-xl' },
+    '2xl': { value: '1.5rem', px: 24, cssVariable: '--dayopt-font-size-2xl' },
+    '3xl': { value: '1.875rem', px: 30, cssVariable: '--dayopt-font-size-3xl' },
+    '4xl': { value: '2.25rem', px: 36, cssVariable: '--dayopt-font-size-4xl' },
+  },
+  fontWeight: {
+    normal: { value: 400, cssVariable: '--dayopt-font-weight-normal' },
+    medium: { value: 500, cssVariable: '--dayopt-font-weight-medium' },
+  },
+  lineHeight: {
+    tight: { value: 1.2, cssVariable: '--dayopt-line-height-tight' },
+    normal: { value: 1.5, cssVariable: '--dayopt-line-height-normal' },
+    relaxed: { value: 1.75, cssVariable: '--dayopt-line-height-relaxed' },
+  },
+} as const;

--- a/packages/design/tsconfig.json
+++ b/packages/design/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "jsx": "react-jsx",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.stories.tsx"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -585,6 +585,9 @@ importers:
 
   apps/storybook:
     dependencies:
+      '@dayopt/design':
+        specifier: workspace:*
+        version: link:../../packages/design
       '@dayopt/product':
         specifier: workspace:*
         version: link:../product
@@ -869,6 +872,12 @@ importers:
         version: 1.32.0
 
   packages/config:
+    devDependencies:
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+
+  packages/design:
     devDependencies:
       typescript:
         specifier: ^5


### PR DESCRIPTION
## Summary

- Add `@dayopt/design` as a workspace package for shared design tokens.
- Define minimal colors, typography, spacing, radius, and shadow tokens from the current product/web CSS values.
- Add `Design/*` Storybook stories and load `@dayopt/design/theme.css` only in Storybook.

## Impact

- Product/web runtime CSS and imports are unchanged.
- `theme.css` only defines prefixed `--dayopt-*` variables, so it does not override existing `--background`, `--primary`, `--radius-*`, or `--shadow-*` variables.
- `packages/ui` is untouched.

## Validation

- `pnpm install`
- `pnpm --filter @dayopt/design build`
- `pnpm --filter @dayopt/storybook build`
- `pnpm build-storybook`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm -r list --depth -1 | rg '@dayopt/design'`
- `rg -- '--dayopt-' packages/design apps/storybook`
- `rg '@dayopt/design' apps/product apps/web` produced no product/web matches
