### PR TITLE
refactor(calendar): useCalendarFilterStore を features/calendar/stores へ移動

### DIFF
--- a/apps/product/src/features/calendar/components/controller/hooks/useCalendarData.ts
+++ b/apps/product/src/features/calendar/components/controller/hooks/useCalendarData.ts
@@ -12,7 +12,7 @@ import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 import { api } from '@/lib/trpc';
 import { expandEntriesToCalendarEvents } from '../../../lib/entry-adapter';
 
-import { useCalendarFilterStore } from '@/lib/stores/useCalendarFilterStore';
+import { useCalendarFilterStore } from '@/features/calendar/stores/useCalendarFilterStore';
 
 import { calculateViewDateRange } from '../../../domain/view-range';
 
@@ -107,16 +107,17 @@ export function useCalendarData({
     refetch: refetchEntries,
   } = useEntries(dateFilter);
 
-  // タグマスタ取得（EntryCard等で使用するためキャッシュをwarm up + フィルタ初期化）
+  // タグマスタ取得（EntryCard等で使用するためキャッシュをwarm up + フィルタ同期）
   const { data: tagsData } = useTags();
-  const initializeWithTags = useCalendarFilterStore((state) => state.initializeWithTags);
+  const syncWithTags = useCalendarFilterStore((state) => state.syncWithTags);
 
-  // タグフィルタを初期化（モバイルではサイドバーがマウントされないため、ここで保証する）
+  // タグフィルタを tagsData と同期（新規 tag は visible として追加、削除済み tag は orphan として除去）
+  // モバイルではサイドバーがマウントされないため、ここで保証する
   useEffect(() => {
     if (tagsData && tagsData.length > 0) {
-      initializeWithTags(tagsData.map((tag) => tag.id));
+      syncWithTags(tagsData.map((tag) => tag.id));
     }
-  }, [tagsData, initializeWithTags]);
+  }, [tagsData, syncWithTags]);
 
   // tRPC utils（プリフェッチ用）
   const utils = api.useUtils();

--- a/apps/product/src/features/calendar/components/tag-filter/CalendarFilterList.tsx
+++ b/apps/product/src/features/calendar/components/tag-filter/CalendarFilterList.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Plus } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
-import { useCalendarFilterStore } from '@/lib/stores/useCalendarFilterStore';
+import { useCalendarFilterStore } from '@/features/calendar/stores/useCalendarFilterStore';
 import { useShellStore } from '@/lib/stores/useShellStore';
 
 import { useIsFetching } from '@tanstack/react-query';
@@ -54,7 +54,7 @@ export function CalendarFilterList() {
   // セレクタで必要な状態のみ購読
   const visibleTagIds = useCalendarFilterStore((s) => s.visibleTagIds);
   const toggleTag = useCalendarFilterStore((s) => s.toggleTag);
-  const initializeWithTags = useCalendarFilterStore((s) => s.initializeWithTags);
+  const syncWithTags = useCalendarFilterStore((s) => s.syncWithTags);
   const showOnlyTag = useCalendarFilterStore((s) => s.showOnlyTag);
   const toggleGroupTags = useCalendarFilterStore((s) => s.toggleGroupTags);
   const showOnlyGroupTags = useCalendarFilterStore((s) => s.showOnlyGroupTags);
@@ -63,14 +63,15 @@ export function CalendarFilterList() {
   // hierarchy フェッチ中はフィルター初期化をスキップ（Race Condition防止）
   const isTagsFetching = useIsFetching({ queryKey: tagKeys.hierarchy() }) > 0;
 
-  // タグ一覧取得後に初期化（フェッチ中は競合防止のためスキップ）
+  // タグ一覧と filter state を同期（新規は visible 追加、削除済みは orphan として除去）
+  // フェッチ中は競合防止のためスキップ
   useEffect(() => {
     if (isTagsFetching) return;
 
     if (tags && tags.length > 0) {
-      initializeWithTags(tags.map((tag) => tag.id));
+      syncWithTags(tags.map((tag) => tag.id));
     }
-  }, [tags, initializeWithTags, isTagsFetching]);
+  }, [tags, syncWithTags, isTagsFetching]);
 
   const isLoading = tagsLoading;
 

--- a/apps/product/src/features/calendar/components/tag-filter/components/FilterItem/FilterItem.tsx
+++ b/apps/product/src/features/calendar/components/tag-filter/components/FilterItem/FilterItem.tsx
@@ -8,8 +8,8 @@ import { useTranslations } from 'next-intl';
 import { getTagColorClasses } from '@/lib/tag-colors';
 import { cn } from '@/lib/utils';
 
+import { useCalendarFilterStore } from '@/features/calendar/stores/useCalendarFilterStore';
 import { useTags } from '@/features/tags';
-import { useCalendarFilterStore } from '@/lib/stores/useCalendarFilterStore';
 import { useTagModalNavigation } from '../../../../hooks/useTagModalNavigation';
 
 import { Checkbox } from '@/lib/components/ui/checkbox';

--- a/apps/product/src/features/calendar/stores/__tests__/useCalendarFilterStore.test.ts
+++ b/apps/product/src/features/calendar/stores/__tests__/useCalendarFilterStore.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { useCalendarFilterStore } from './useCalendarFilterStore';
+import { useCalendarFilterStore } from '../useCalendarFilterStore';
 
 describe('useCalendarFilterStore', () => {
   beforeEach(() => {
@@ -79,21 +79,44 @@ describe('useCalendarFilterStore', () => {
     });
   });
 
-  describe('initializeWithTags', () => {
+  describe('syncWithTags', () => {
     it('初回は全タグを表示＆initializedをtrue', () => {
-      useCalendarFilterStore.getState().initializeWithTags(['tag-1', 'tag-2']);
+      useCalendarFilterStore.getState().syncWithTags(['tag-1', 'tag-2']);
       const state = useCalendarFilterStore.getState();
       expect(state.initialized).toBe(true);
       expect(state.visibleTagIds.size).toBe(2);
     });
 
-    it('2回目は既存タグは変更せず新しいタグを追加', () => {
-      useCalendarFilterStore.getState().initializeWithTags(['tag-1', 'tag-2']);
-      useCalendarFilterStore.getState().initializeWithTags(['tag-1', 'tag-2', 'tag-3']);
+    it('2回目は既存 visible タグを保持しつつ新規タグを visible として追加', () => {
+      useCalendarFilterStore.getState().syncWithTags(['tag-1', 'tag-2']);
+      useCalendarFilterStore.getState().syncWithTags(['tag-1', 'tag-2', 'tag-3']);
       const ids = useCalendarFilterStore.getState().visibleTagIds;
       expect(ids.has('tag-1')).toBe(true);
       expect(ids.has('tag-2')).toBe(true);
       expect(ids.has('tag-3')).toBe(true);
+    });
+
+    it('削除済みタグ（orphan ID）は除去される', () => {
+      useCalendarFilterStore.getState().syncWithTags(['tag-1', 'tag-2', 'tag-3']);
+      // tag-3 が削除された想定で再 sync
+      useCalendarFilterStore.getState().syncWithTags(['tag-1', 'tag-2']);
+      const ids = useCalendarFilterStore.getState().visibleTagIds;
+      expect(ids.has('tag-1')).toBe(true);
+      expect(ids.has('tag-2')).toBe(true);
+      expect(ids.has('tag-3')).toBe(false);
+    });
+
+    it('一時 ID → 実 ID の置き換えで orphan が cleanup される', () => {
+      useCalendarFilterStore.getState().syncWithTags(['tag-1']);
+      // 楽観更新で temp-2 を追加
+      useCalendarFilterStore.getState().syncWithTags(['tag-1', 'temp-2']);
+      expect(useCalendarFilterStore.getState().visibleTagIds.has('temp-2')).toBe(true);
+      // mutation 成功で temp-2 → real-2 に置き換わる
+      useCalendarFilterStore.getState().syncWithTags(['tag-1', 'real-2']);
+      const ids = useCalendarFilterStore.getState().visibleTagIds;
+      expect(ids.has('tag-1')).toBe(true);
+      expect(ids.has('real-2')).toBe(true);
+      expect(ids.has('temp-2')).toBe(false);
     });
   });
 

--- a/apps/product/src/features/calendar/stores/useCalendarFilterStore.ts
+++ b/apps/product/src/features/calendar/stores/useCalendarFilterStore.ts
@@ -39,8 +39,14 @@ export interface CalendarFilterActions {
   /** グループ内のタグを一括切替（全ON→全OFF、それ以外→全ON） */
   toggleGroupTags: (tagIds: string[]) => void;
 
-  /** タグ一覧で初期化（まだ設定がないタグを追加） */
-  initializeWithTags: (tagIds: string[]) => void;
+  /**
+   * タグ一覧と filter state を同期する。
+   *
+   * - 初回: 全タグを表示 + `initialized=true`
+   * - 2 回目以降: 既存の visible / hidden toggle を保持しつつ、
+   *   新規タグは visible として追加、削除済みタグ（orphan ID）は除去
+   */
+  syncWithTags: (tagIds: string[]) => void;
 
   /** 特定のタグを削除（マージ後などに使用） */
   removeTag: (tagId: string) => void;
@@ -142,25 +148,28 @@ export const useCalendarFilterStore = create<CalendarFilterStore>()(
           return { visibleTagIds: newSet };
         }),
 
-      initializeWithTags: (tagIds) =>
+      syncWithTags: (tagIds) =>
         set((state) => {
-          if (state.initialized) {
-            // すでに初期化済みの場合は、新しいタグのみ追加
-            const newSet = new Set(state.visibleTagIds);
-            tagIds.forEach((id) => {
-              // 存在しないタグは追加（デフォルト表示）
-              if (!state.visibleTagIds.has(id)) {
-                newSet.add(id);
-              }
-            });
-            return { visibleTagIds: newSet };
+          if (!state.initialized) {
+            // 初回は全タグを表示
+            return {
+              visibleTagIds: new Set(tagIds),
+              initialized: true,
+            };
           }
 
-          // 初回は全タグを表示
-          return {
-            visibleTagIds: new Set(tagIds),
-            initialized: true,
-          };
+          // 2 回目以降: 既存の visible / hidden toggle を保持しつつ
+          //   - 新規タグは visible として追加
+          //   - 削除済みタグ（orphan ID）は除去
+          const tagIdSet = new Set(tagIds);
+          const newSet = new Set<string>();
+          for (const id of state.visibleTagIds) {
+            if (tagIdSet.has(id)) newSet.add(id);
+          }
+          for (const id of tagIds) {
+            if (!state.visibleTagIds.has(id)) newSet.add(id);
+          }
+          return { visibleTagIds: newSet };
         }),
 
       removeTag: (tagId) =>

--- a/apps/product/src/features/tags/hooks/useTagCrudMutations.ts
+++ b/apps/product/src/features/tags/hooks/useTagCrudMutations.ts
@@ -3,7 +3,6 @@
 import { toast } from '@/lib/toast';
 import { useTranslations } from 'next-intl';
 
-import { useCalendarFilterStore } from '@/lib/stores/useCalendarFilterStore';
 import type { TagColorName } from '@/lib/tag-colors';
 import { DEFAULT_TAG_COLOR } from '@/lib/tag-colors';
 import {
@@ -60,7 +59,9 @@ export function useCreateTag({ showToast = true }: { showToast?: boolean } = {})
         return { ...old, data: [tempTag, ...old.data], count: old.count + 1 };
       });
 
-      useCalendarFilterStore.getState().initializeWithTags([tempId]);
+      // Calendar filter store の sync は useCalendarData / CalendarFilterList の effect が
+      // utils.tags.list 変更を検知して syncWithTags 経由で行う（Layer 0 境界を保つため、
+      // tags hook からは calendar store を直接触らない）。
       return { listSnapshot, tempId, tagName: input.name };
     },
     onSuccess: (result, _input, context) => {
@@ -71,15 +72,10 @@ export function useCreateTag({ showToast = true }: { showToast?: boolean } = {})
       );
       utils.tags.getById.setData({ id: result.id }, result);
 
-      const filterStore = useCalendarFilterStore.getState();
-      filterStore.removeTag(context.tempId);
-      filterStore.initializeWithTags([result.id]);
-
       if (showToast) toast.success(t('toast.created', { name: result.name }));
     },
     onError: (_err, _input, context) => {
       context?.listSnapshot?.restore();
-      if (context?.tempId) useCalendarFilterStore.getState().removeTag(context.tempId);
       if (showToast) toast.error(t('toast.createFailed'));
     },
     onSettled: () => {

--- a/apps/storybook/.storybook/mocks/stores.tsx
+++ b/apps/storybook/.storybook/mocks/stores.tsx
@@ -20,10 +20,10 @@ import { useEffect } from 'react';
 import type { StoreApi } from 'zustand';
 
 import { useAuthStore } from '@/features/auth';
+import { useCalendarFilterStore } from '@/features/calendar/stores/useCalendarFilterStore';
 import { useCalendarNavigationStore } from '@/features/calendar/stores/useCalendarNavigationStore';
 import { useCalendarSettingsStore } from '@/features/calendar/stores/useCalendarSettingsStore';
 import { useChronotypeSettingsStore } from '@/features/chronotype';
-import { useCalendarFilterStore } from '@/lib/stores/useCalendarFilterStore';
 import { useShellStore } from '@/lib/stores/useShellStore';
 import { useUserPreferenceStore } from '@/lib/stores/useUserPreferenceStore';
 


### PR DESCRIPTION
## Summary

`features/tags` (Layer 0) → `useCalendarFilterStore` への直接依存を解消し、store を **`features/calendar/stores/`** 配下へ移動。これにより Layer 0 境界が完全に clean になり、Calendar feature が filter state を自律的に管理する構造になる。

仕様 / UI / DB / persist (`name='calendar-filter-storage'`, `version=5`) 変更なし。localStorage 互換性維持。

## 調査結果

- `useTagCrudMutations.useCreateTag` が onMutate / onSuccess / onError で filter store を 4 箇所直接触っており、Layer 0 違反の原因
- Calendar 側に **既存の effect-based sync** が 2 箇所ある（[useCalendarData.ts:115-119](apps/product/src/features/calendar/components/controller/hooks/useCalendarData.ts:115), [CalendarFilterList.tsx:67-73](apps/product/src/features/calendar/components/tag-filter/CalendarFilterList.tsx:67)）
- これらは `utils.tags.list.setData()` で即座にトリガーされるため、tempTag の可視化は effect 経由で代替可能
- ただし旧 `initializeWithTags` は orphan 除去をしないため、onSuccess/onError の cleanup を effect 側に取り込むには semantics 拡張が必要

## Tags → Calendar filter 依存の解消方針

**effect-based sync を採用**:

1. `initializeWithTags` を `syncWithTags` にリネーム + orphan cleanup ロジックを追加（追加 + 削除を 1 アクションに統合）
2. 既存 effect 2 箇所を `syncWithTags` に切替
3. `useCreateTag` から filter store 直接呼び出し 4 箇所を削除

filter sync は Calendar 側の effect が `utils.tags.list` 変更を検知して自動で行うため、tags hook は純粋な tRPC mutation + 楽観更新（query cache のみ）の責務に専念できる。

### 楽観更新 trace（仕様維持の担保）

| Phase | DB Cache | Filter Store（effect 経由） |
| --- | --- | --- |
| onMutate | `setData([tempTag, ...existing])` | `syncWithTags([existing, tempId])` → `{existing, tempId}` |
| onSuccess | `setData(replace temp→real)` | `syncWithTags([existing, realId])` → `{existing, realId}`（tempId は orphan 除去） |
| onError | `listSnapshot.restore()` | `syncWithTags([existing])` → `{existing}`（tempId は orphan 除去） |

**結果セットは既存挙動と完全に等価**。

## 実装した変更

7 files changed（+74 / -44）

### 移動（`git mv`）

| 旧 | 新 |
| --- | --- |
| `apps/product/src/lib/stores/useCalendarFilterStore.ts` | `apps/product/src/features/calendar/stores/useCalendarFilterStore.ts` |
| `apps/product/src/lib/stores/useCalendarFilterStore.test.ts` | `apps/product/src/features/calendar/stores/__tests__/useCalendarFilterStore.test.ts` |

### 編集

- [features/calendar/stores/useCalendarFilterStore.ts](apps/product/src/features/calendar/stores/useCalendarFilterStore.ts) — `initializeWithTags` → `syncWithTags` rename + orphan cleanup
- [features/calendar/stores/__tests__/useCalendarFilterStore.test.ts](apps/product/src/features/calendar/stores/__tests__/useCalendarFilterStore.test.ts) — test rename + orphan cleanup / temp→real 置き換えの新規 case 追加（+2 件）
- [features/calendar/components/controller/hooks/useCalendarData.ts](apps/product/src/features/calendar/components/controller/hooks/useCalendarData.ts) — import path + selector を `syncWithTags` に
- [features/calendar/components/tag-filter/CalendarFilterList.tsx](apps/product/src/features/calendar/components/tag-filter/CalendarFilterList.tsx) — 同上
- [features/calendar/components/tag-filter/components/FilterItem/FilterItem.tsx](apps/product/src/features/calendar/components/tag-filter/components/FilterItem/FilterItem.tsx) — import path のみ
- [features/tags/hooks/useTagCrudMutations.ts](apps/product/src/features/tags/hooks/useTagCrudMutations.ts) — filter store import + 4 箇所の直接呼び出し削除、コメントで effect 経由 sync の方針を記載
- [apps/storybook/.storybook/mocks/stores.tsx](apps/storybook/.storybook/mocks/stores.tsx) — import path のみ

## `useCalendarFilterStore` を移動したか / しなかったか

**Yes、移動した**。`lib/stores/` → `features/calendar/stores/` へ。

Tags hook の直接依存が消えたため、Layer 0 boundary 違反が起きずに移動可能になった。これで Calendar 専用 state は全て `features/calendar/stores/` に集約（settings / navigation / filter）。

## 触らなかったもの

- `useCalendarFilterStore` の persist `name` / `version` / `migrate` ロジック（localStorage 互換性維持）
- ESLint boundary rule
- Tags UI / Calendar filter UI のデザイン
- Review tag 集計 / Calendar interaction / Entry / Tags domain の追加整理
- `features/calendar/index.ts` の barrel 公開範囲（既存方針「barrel 公開せず deep import」を維持）
- DB schema / migration / tRPC route
- `Tags.docs.mdx` の連携記述（effect 経由で連携は継続のため）

## 検証結果

- ✅ `pnpm --filter @dayopt/product typecheck`
- ✅ `pnpm --filter @dayopt/product lint`
- ✅ `pnpm lint:boundaries`（Cross-feature imports: 0）
- ✅ `pnpm --filter @dayopt/product test:run`（1731 件 pass、前回 1729 から +2 件 = orphan cleanup + temp→real test）
- ✅ `pnpm --filter @dayopt/product build`
- ✅ `pnpm --filter @dayopt/storybook build`

`grep "@/lib/stores/useCalendarFilterStore"` 結果: 0 件。`grep "useCalendarFilterStore" features/tags`: 残り 1 件は docs/mdx のみ（説明テキスト）。

## 残課題（follow-up）

1. `lib/stores/` 配下に残る store（`useShellStore` / `useUserPreferenceStore`）の所在地再評価
2. `useTagCrudMutations.ts` の他 mutation（`useDeleteTag` / `useDeleteGroup` / `useUngroupTags` / `useMergeTag` 等）の filter sync が effect 経由で完全担保されているか追加 trace
3. `features/tags/components/Tags.docs.mdx` の旧 store API 言及（`isTypeVisible` / `isPlanVisible` は既に削除済み）の更新
4. 「toggled-off タグが tags refetch で visible に戻る」既存挙動への対処（要件次第で `knownTagIds` を分離する設計判断）

## Test plan

- [ ] CI（typecheck / lint / boundaries / test / build / web build / E2E / Quality Gate）が全て pass
- [ ] Vercel preview deployment が ready
- [ ] 開発環境で tag 作成 → サイドバーに即時可視化 → エラー時 rollback が今と同じ挙動

🤖 Generated with [Claude Code](https://claude.com/claude-code)