### PR TITLE
refactor(chronotype): onChronotypeChange callback 注入を廃止し直接 store を呼ぶ

### DIFF
--- a/apps/product/src/features/chronotype/components/chronotype-settings.tsx
+++ b/apps/product/src/features/chronotype/components/chronotype-settings.tsx
@@ -19,6 +19,8 @@ import { LabeledRow } from '@/lib/components/common/LabeledRow';
 import { SectionCard } from '@/lib/components/common/SectionCard';
 import { useAutoSaveSettings } from '@/lib/hooks/useAutoSaveSettings';
 
+import { useChronotypeSettingsStore } from '../stores/useChronotypeSettingsStore';
+
 import { ChronotypeQuiz } from './chronotype-quiz';
 
 import type {
@@ -135,22 +137,11 @@ function TypeCard({
   );
 }
 
-interface ChronotypeSettingsProps {
-  /**
-   * Chronotype 変更時の楽観更新コールバック。
-   *
-   * chronotype state は `useChronotypeSettingsStore` (Layer 0 / 本 feature) に
-   * 集約されているが、各 callsite （`features/settings` の profile-settings 等）が
-   * 直接 store を触る形を保つため、本コンポーネントは callback 注入で楽観更新を
-   * 委譲する。本コンポーネント側では autoSave 経由で DB 保存のみ行う。
-   */
-  onChronotypeChange?: ((chronotype: ChronotypeSettingsState | null) => void) | undefined;
-}
-
 /** クロノタイプ設定パネル */
-export function ChronotypeSettings({ onChronotypeChange }: ChronotypeSettingsProps = {}) {
+export function ChronotypeSettings() {
   const t = useTranslations();
   const utils = api.useUtils();
+  const updateChronotype = useChronotypeSettingsStore((state) => state.updateSettings);
 
   const { data: dbSettings, isPending } = api.userSettings.get.useQuery(undefined, {
     staleTime: CACHE_5_MINUTES,
@@ -190,20 +181,20 @@ export function ChronotypeSettings({ onChronotypeChange }: ChronotypeSettingsPro
   const handleToggle = useCallback(
     (checked: boolean) => {
       const nextChronotype = checked ? { type: selectedType } : null;
-      onChronotypeChange?.(nextChronotype);
+      updateChronotype({ chronotype: nextChronotype });
       autoSave.updateValue('chronotype', nextChronotype);
     },
-    [autoSave, onChronotypeChange, selectedType],
+    [autoSave, updateChronotype, selectedType],
   );
 
   const handleSelectType = useCallback(
     (type: PresetChronotypeType) => {
       const nextChronotype = { type: type as ChronotypeType };
-      onChronotypeChange?.(nextChronotype);
+      updateChronotype({ chronotype: nextChronotype });
       autoSave.updateValue('chronotype', nextChronotype);
       setView('idle');
     },
-    [autoSave, onChronotypeChange],
+    [autoSave, updateChronotype],
   );
 
   const handleQuizComplete = useCallback(

--- a/apps/product/src/features/settings/components/profile-settings.tsx
+++ b/apps/product/src/features/settings/components/profile-settings.tsx
@@ -1,19 +1,15 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 
 import { Camera } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
 import { useAuthStore } from '@/features/auth';
-import {
-  ChronotypeSettingsPanel as ChronotypeSettings,
-  useChronotypeSettingsStore,
-} from '@/features/chronotype';
+import { ChronotypeSettingsPanel as ChronotypeSettings } from '@/features/chronotype';
 import { LabeledRow } from '@/lib/components/common/LabeledRow';
 import { SectionCard } from '@/lib/components/common/SectionCard';
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar';
-import type { ChronotypeSettings as ChronotypeSettingsState } from '@/lib/types/chronotype';
 import { getAvatarUrl, getDisplayName, getInitials } from '@/lib/user';
 
 import { AvatarChangeDialog } from './avatar-change-dialog';
@@ -27,20 +23,12 @@ import { DisplayNameDialog } from './display-name-dialog';
 export function ProfileSettings() {
   const t = useTranslations();
   const user = useAuthStore((state) => state.user);
-  const updateChronotypeSettings = useChronotypeSettingsStore((state) => state.updateSettings);
 
   const [showAvatarDialog, setShowAvatarDialog] = useState(false);
   const [showDisplayNameDialog, setShowDisplayNameDialog] = useState(false);
 
   const avatarUrl = getAvatarUrl(user);
   const displayName = getDisplayName(user);
-
-  const handleChronotypeChange = useCallback(
-    (chronotype: ChronotypeSettingsState | null) => {
-      updateChronotypeSettings({ chronotype });
-    },
-    [updateChronotypeSettings],
-  );
 
   return (
     <div className="space-y-6 sm:space-y-8">
@@ -73,7 +61,7 @@ export function ProfileSettings() {
       </SectionCard>
 
       {/* クロノタイプ */}
-      <ChronotypeSettings onChronotypeChange={handleChronotypeChange} />
+      <ChronotypeSettings />
 
       {/* Dialogs */}
       <AvatarChangeDialog open={showAvatarDialog} onOpenChange={setShowAvatarDialog} />


### PR DESCRIPTION
## Summary

PR #1190 で `useChronotypeSettingsStore` を `features/chronotype/stores/` 配下（Layer 0）に集約済み。当時は呼び出し元 API 互換維持のため `ChronotypeSettings` コンポーネントは `onChronotypeChange` callback を受け取り、profile-settings.tsx (settings feature) 側で store を更新する形を維持していた。

store が L0 に来た今、L0 内で完結する直接 store 呼び出しに切替可能。callback 注入を廃止して API 表面を縮小する。

UI / DB 保存（autoSave 経由）/ persist / store 定義は変更なし。

## 実装した変更

2 ファイル編集（+11 / -32）

### [chronotype-settings.tsx](apps/product/src/features/chronotype/components/chronotype-settings.tsx)

- `onChronotypeChange` prop と `ChronotypeSettingsProps` interface を削除
- `useChronotypeSettingsStore` を相対 import で取り込み（同一 L0 feature 内）
- `handleToggle` / `handleSelectType` 内で `updateChronotype({ chronotype: next })` を直接呼ぶ
- 関数シグネチャを `ChronotypeSettings()` に簡素化

### [profile-settings.tsx](apps/product/src/features/settings/components/profile-settings.tsx)

- `handleChronotypeChange` callback を削除
- `useChronotypeSettingsStore` / `useCallback` / `ChronotypeSettingsState` 型の import を削除
- `<ChronotypeSettings onChronotypeChange={...} />` → `<ChronotypeSettings />`

## 削除したもの

- `onChronotypeChange` prop
- `ChronotypeSettingsProps` interface
- `handleChronotypeChange` callback
- 関連 import / selector（profile-settings 側）

## 追加したもの

- `useChronotypeSettingsStore` の直接呼び出し（chronotype-settings 内部）

## 触らなかったもの

- `useChronotypeSettingsStore` の定義
- autoSave / DB 保存経路（`updateMutation.mutateAsync`）
- Storybook stories（pure demo components のため影響なし）
- barrel export 範囲
- UI / DB / persist 設定

## 検証結果

- ✅ `pnpm --filter @dayopt/product typecheck`
- ✅ `pnpm --filter @dayopt/product lint`
- ✅ `pnpm lint:boundaries`（Cross-feature imports: 0）
- ✅ `pnpm --filter @dayopt/product test:run`（1731 件 pass、件数キープ）
- ✅ `pnpm --filter @dayopt/product build`
- ✅ `pnpm --filter @dayopt/storybook build`

`grep "onChronotypeChange" apps/product/src apps/storybook/.storybook` の結果が空であることを確認。

## 残課題（PR #1190 の他 follow-up）

1. [apps/storybook/.storybook/mocks/presets.ts](apps/storybook/.storybook/mocks/presets.ts) の chronotype mock スキーマと実型 `{ type: ChronotypeType }` の整合修正
2. [useChronotypeGradient.ts](apps/product/src/features/calendar/components/views/shared/hooks/useChronotypeGradient.ts) の所属再検討（Calendar view 専用 hook なら現状維持で OK）

## Test plan

- [ ] CI（typecheck / lint / boundaries / test / build / web build / E2E / Quality Gate）が全て pass
- [ ] Vercel preview deployment が ready
- [ ] Settings > Profile で chronotype 選択 → store が即時反映され、autoSave で DB に保存される

🤖 Generated with [Claude Code](https://claude.com/claude-code)