### PR TITLE
refactor(storybook): chronotype mock schema を実型に整合させる

### DIFF
--- a/apps/storybook/.storybook/mocks/presets.ts
+++ b/apps/storybook/.storybook/mocks/presets.ts
@@ -15,7 +15,10 @@
  * } satisfies Meta;
  */
 
+import { generateChronotypeGradient, getChronotypeProfile } from '@/features/chronotype';
 import { createMockTag } from '@/lib/test/factories';
+
+const BEAR_ZONES = getChronotypeProfile('bear').productivityZones;
 
 // ─────────────────────────────────────────────────────────
 // Tags
@@ -54,11 +57,9 @@ export const PRESET_USER_SETTINGS = {
     hourHeightDensity: 'default',
     planRecordMode: 'both',
     chronotype: {
-      enabled: true,
-      type: 'moderate_morning' as const,
-      displayMode: 'background' as const,
-      opacity: 0.15,
-      customZones: null,
+      type: 'bear' as const,
+      gradientLight: generateChronotypeGradient(BEAR_ZONES, 'light'),
+      gradientDark: generateChronotypeGradient(BEAR_ZONES, 'dark'),
     },
   },
 } as const;


### PR DESCRIPTION
## Summary

PR #1190 以降取り残されていた古い chronotype mock shape を、server `userSettings.get` の実 return 型に整合させる。仕様 / UI / store / DB / persist 変更なし。

## 調査結果

[presets.ts:56-62](apps/storybook/.storybook/mocks/presets.ts:56) に残っていた chronotype mock は 2026-04-14 の schema 簡素化（`enabled` / `customZones` 等削除）以降取り残されていた古い shape:

```ts
chronotype: {
  enabled: true,                       // ❌ 実型に存在しない
  type: 'moderate_morning' as const,   // ❌ 不正な ChronotypeType
  displayMode: 'background' as const,  // ❌ 実型に存在しない
  opacity: 0.15,                       // ❌ 実型に存在しない
  customZones: null,                   // ❌ 実型に存在しない
}
```

`'moderate_morning'` は `ChronotypeType = 'lion' | 'bear' | 'wolf' | 'dolphin'` に含まれず、これを `getChronotypeProfile()` に渡すと undefined アクセスでクラッシュする可能性があった。

## 実型の chronotype schema

[router.ts:101-111](apps/product/src/features/settings/server/router.ts:101) の `userSettings.get` 実装より:

```ts
chronotype: { type: ChronotypeType; gradientLight: string; gradientDark: string } | null
```

server は `generateChronotypeGradient(zones, mode)` で light/dark の gradient CSS を pre-compute して返す。

## Storybook mock 側でズレていた内容

| Mock field | 実型 |
| --- | --- |
| `enabled: true` | 存在しない |
| `type: 'moderate_morning'` | `'lion' \| 'bear' \| 'wolf' \| 'dolphin'` のみ |
| `displayMode: 'background'` | 存在しない |
| `opacity: 0.15` | 存在しない |
| `customZones: null` | 存在しない |
| ❌ なし | `gradientLight: string` |
| ❌ なし | `gradientDark: string` |

## 実装した変更

1 ファイル編集（+6 / -5）

### [apps/storybook/.storybook/mocks/presets.ts](apps/storybook/.storybook/mocks/presets.ts)

- `generateChronotypeGradient` / `getChronotypeProfile` を `@/features/chronotype` barrel から import（既に [stores.tsx:26](apps/storybook/.storybook/mocks/stores.tsx:26) で同じ経路を使用中の実績あり）
- module-level に `BEAR_ZONES = getChronotypeProfile('bear').productivityZones` を計算
- chronotype mock を実型 shape に置換:

```ts
chronotype: {
  type: 'bear' as const,
  gradientLight: generateChronotypeGradient(BEAR_ZONES, 'light'),
  gradientDark: generateChronotypeGradient(BEAR_ZONES, 'dark'),
}
```

これで `PRESET_USER_SETTINGS.default` を `'userSettings.get'` tRPC mock として渡す stories（[DisplaySettings.stories.tsx](apps/product/src/features/settings/components/DisplaySettings.stories.tsx), [SettingsDialog.stories.tsx](apps/product/src/features/settings/components/SettingsDialog.stories.tsx), [ProfileSettings.stories.tsx](apps/product/src/features/settings/components/ProfileSettings.stories.tsx)）が chronotype 有効状態を server 実装と同じ shape でデモできる。

## 触らなかったもの

- `PRESET_USER_SETTINGS.default` の他フィールド（`showUtcOffset` / `planRecordMode` 等の整合確認は Non-scope）
- `ProfileSettings.stories.tsx:47` の `'chronotype.get'` dead mock 行（存在しない tRPC procedure への mock、独立 follow-up）
- store 定義 / autoSave / DB 保存経路
- chronotype UI / tRPC route / DB schema
- ESLint boundary rule

## 検証結果

- ✅ `pnpm --filter @dayopt/product typecheck`
- ✅ `pnpm --filter @dayopt/product lint`
- ✅ `pnpm lint:boundaries`（Cross-feature imports: 0）
- ✅ `pnpm --filter @dayopt/product test:run`（1731 件 pass、件数キープ）
- ✅ `pnpm --filter @dayopt/product build`
- ✅ `pnpm --filter @dayopt/storybook build`

`grep "moderate_morning\|displayMode\|customZones" apps/storybook/.storybook` の結果が空であることを確認（古い shape 残骸なし）。

## 残課題

1. `ProfileSettings.stories.tsx:47` の `'chronotype.get'` dead mock 行削除（実 procedure が存在しない）
2. `PRESET_USER_SETTINGS.default` の他フィールド（`showUtcOffset` / `planRecordMode` 等）が server 実 return 型と整合しているか別途確認

## Test plan

- [ ] CI が全て pass
- [ ] Vercel preview deployment が ready
- [ ] Storybook の `Features/Settings/ProfileSettings` story で chronotype 'bear' 選択状態が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)