### PR TITLE
refactor(storybook): dead chronotype.get mock を ProfileSettings story から削除

### DIFF
--- a/apps/product/src/features/settings/components/ProfileSettings.stories.tsx
+++ b/apps/product/src/features/settings/components/ProfileSettings.stories.tsx
@@ -44,7 +44,6 @@ export const Default: Story = {
   parameters: {
     trpcMocks: {
       'userSettings.get': PRESET_USER_SETTINGS.default,
-      'chronotype.get': PRESET_USER_SETTINGS.default.chronotype,
     },
   },
 };


### PR DESCRIPTION
## Summary

`ProfileSettings.stories.tsx:47` に残っていた `'chronotype.get'` の dead mock を削除。`appRouter` に `chronotype` router は存在せず（`billing` / `contact` / `email` / `entries` / `tags` / `user` / `userSettings` のみ）、`chronotype.get` procedure は未定義のため完全な dead code だった。

仕様 / UI / DB 変更なし。

## 調査結果

- `grep -R "chronotype.get" apps/product/src apps/storybook` の結果は **1 件のみ**: `ProfileSettings.stories.tsx:47`
- [root.ts](apps/product/src/lib/trpc/root.ts) の `appRouter` sub-router 一覧に `chronotype` なし
- `features/chronotype/` 配下に `server/` ディレクトリ自体が存在しない
- 該当 mock value は `PRESET_USER_SETTINGS.default.chronotype` を再エクスポートしているだけで、実質的な consumer は `userSettings.get` の mock 内に既に含まれている

## 削除した dead mock

```diff
   trpcMocks: {
     'userSettings.get': PRESET_USER_SETTINGS.default,
-    'chronotype.get': PRESET_USER_SETTINGS.default.chronotype,
   },
```

1 行削除のみ（+0 / -1）。

## 触らなかったもの

- [presets.ts](apps/storybook/.storybook/mocks/presets.ts) の `PRESET_USER_SETTINGS.default.chronotype` 自体
- 他 stories の `trpcMocks` 構成
- tRPC router / Chronotype UI / DB / store

## 検証結果

- ✅ `pnpm --filter @dayopt/product typecheck`
- ✅ `pnpm --filter @dayopt/product lint`
- ✅ `pnpm lint:boundaries`（Cross-feature imports: 0）
- ✅ `pnpm --filter @dayopt/product test:run`（1731 件 pass、件数キープ）
- ✅ `pnpm --filter @dayopt/product build`
- ✅ `pnpm --filter @dayopt/storybook build`

`grep "chronotype.get"` の結果が空であることを確認。

## 残課題

- `PRESET_USER_SETTINGS.default` の他フィールド（`showUtcOffset` / `planRecordMode` 等）が server 実 return 型と整合しているか別途確認

## Test plan

- [ ] CI が全て pass
- [ ] Vercel preview deployment が ready
- [ ] Storybook の `Features/Settings/ProfileSettings/Default` story が引き続き正常に render される

🤖 Generated with [Claude Code](https://claude.com/claude-code)