### PR TITLE
refactor(chronotype): useChronotypeGradient を features/chronotype/hooks へ移動

### DIFF
--- a/apps/product/src/features/calendar/components/views/shared/components/ScrollableCalendarLayout.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/ScrollableCalendarLayout.tsx
@@ -11,7 +11,11 @@
 
 import React, { useCallback, useMemo } from 'react';
 
-import { getChronotypeProfile, useChronotypeSettingsStore } from '@/features/chronotype';
+import {
+  getChronotypeProfile,
+  useChronotypeGradient,
+  useChronotypeSettingsStore,
+} from '@/features/chronotype';
 import { cn } from '@/lib/utils';
 
 import { formatTimeString } from '@/lib/date';
@@ -21,7 +25,6 @@ import { TIME_COLUMN_WIDTH, Z_INDEX } from '../constants/grid.constants';
 import { CurrentTimeLine } from '../grid/CurrentTimeLine';
 import { NowBadge } from '../grid/CurrentTimeLine/NowBadge';
 import { TimeColumn } from '../grid/TimeColumn/TimeColumn';
-import { useChronotypeGradient } from '../hooks/useChronotypeGradient';
 import { useCurrentTimeLine } from '../hooks/useCurrentTimeLine';
 import { useHourHeightSync, useResponsiveHourHeight } from '../hooks/useResponsiveHourHeight';
 import { useScrollableCalendar } from '../hooks/useScrollableCalendar';

--- a/apps/product/src/features/chronotype/hooks/useChronotypeGradient.ts
+++ b/apps/product/src/features/chronotype/hooks/useChronotypeGradient.ts
@@ -7,12 +7,11 @@
 
 import { useMemo } from 'react';
 
-import {
-  generateChronotypeGradient,
-  getChronotypeProfile,
-  useChronotypeSettingsStore,
-} from '@/features/chronotype';
 import { useTheme } from '@/lib/hooks/useTheme';
+
+import { getChronotypeProfile } from '../lib/chronotype-profile';
+import { generateChronotypeGradient } from '../lib/gradient';
+import { useChronotypeSettingsStore } from '../stores/useChronotypeSettingsStore';
 
 export function useChronotypeGradient(): string | null {
   const chronotype = useChronotypeSettingsStore((s) => s.chronotype);

--- a/apps/product/src/features/chronotype/index.ts
+++ b/apps/product/src/features/chronotype/index.ts
@@ -15,6 +15,9 @@ export { ChronotypeSettings as ChronotypeSettingsPanel } from './components/chro
 // --- Constants ---
 export { CHRONOTYPE_EMOJI, CHRONOTYPE_SELECTABLE_TYPES } from './lib/constants';
 
+// --- Hooks ---
+export { useChronotypeGradient } from './hooks/useChronotypeGradient';
+
 // --- Lib ---
 export { getChronotypeProfile } from './lib/chronotype-profile';
 export { generateChronotypeGradient, getActiveZoneLevel } from './lib/gradient';


### PR DESCRIPTION
## Summary

`useChronotypeGradient` を `features/calendar/components/views/shared/hooks/` から **`features/chronotype/hooks/`** へ移動。実装は `chronotype + theme → CSS 文字列` のみで Calendar-specific な要素がゼロのため、責務的には Chronotype feature の public hook が自然。

仕様 / UI / DB / store / gradient 生成ロジック変更なし。

## 調査結果

| 観点 | 結果 |
| --- | --- |
| 現在地 | `features/calendar/components/views/shared/hooks/useChronotypeGradient.ts` |
| 実装内容 | `useChronotypeSettingsStore` から chronotype を読み、theme を判定し、DB-stored gradient または `generateChronotypeGradient` でフォールバック生成して CSS を返す |
| Calendar-specific 依存 | **ゼロ**（layout / viewport / date range / grid 等の参照なし） |
| consumer | 唯一 [ScrollableCalendarLayout.tsx:148](apps/product/src/features/calendar/components/views/shared/components/ScrollableCalendarLayout.tsx:148) のみ |
| Tests / Storybook stories | 無し |

## `useChronotypeGradient.ts` の所属判断

**Chronotype 汎用 hook** と判断。理由:

1. 責務が `chronotype + theme → CSS` のみで Calendar 構造には触れていない
2. 名前そのものが Chronotype 概念（`useCalendarBackground` ではない）
3. 既に sibling `features/chronotype/lib/gradient.ts` の `generateChronotypeGradient` を React で wrap したものに過ぎず、wrapper はラップ対象と同じ feature に置くべき
4. Calendar → Chronotype の依存方向が「barrel only」に揃い、boundary 構造が clean になる

前回のセッション内 chat-only 判断（「consumer が Calendar に 1 つだから現状維持」）を、再調査により更新した。

## 実装した変更

3 files changed（+12 / -7）

### 移動（`git mv`）

```
features/calendar/components/views/shared/hooks/useChronotypeGradient.ts
  → features/chronotype/hooks/useChronotypeGradient.ts
```

### 編集

- 移動した hook の内部 import を相対 path に切替（`@/features/chronotype` 自己 import を回避）:
  ```ts
  import { getChronotypeProfile } from '../lib/chronotype-profile';
  import { generateChronotypeGradient } from '../lib/gradient';
  import { useChronotypeSettingsStore } from '../stores/useChronotypeSettingsStore';
  ```
- [features/chronotype/index.ts](apps/product/src/features/chronotype/index.ts) barrel に `// --- Hooks ---` セクションを新設して `useChronotypeGradient` を export
- [ScrollableCalendarLayout.tsx](apps/product/src/features/calendar/components/views/shared/components/ScrollableCalendarLayout.tsx) の deep import を削除し、既存の `@/features/chronotype` import に `useChronotypeGradient` を統合

## 触らなかったもの

- hook 内部のロジック（`useMemo` 内の判定・生成・theme 解決）
- `generateChronotypeGradient` / `getChronotypeProfile` / `useChronotypeSettingsStore` の実装
- ScrollableCalendarLayout の `gradientCss` 利用箇所
- gradient CSS の出力結果
- store / persist / autoSave / tRPC / DB / Calendar UI
- ESLint boundary rule

## 検証結果

- ✅ `pnpm --filter @dayopt/product typecheck`
- ✅ `pnpm --filter @dayopt/product lint`
- ✅ `pnpm lint:boundaries`（Cross-feature imports: 0）
- ✅ `pnpm --filter @dayopt/product test:run`（1731 件 pass、件数キープ）
- ✅ `pnpm --filter @dayopt/product build`
- ✅ `pnpm --filter @dayopt/storybook build`

## 残課題

- `chronotypeZones` 計算（ScrollableCalendarLayout 内で `useChronotypeSettingsStore` + `getChronotypeProfile` を組合せて zones を取得している箇所）を `useChronotypeZones` フック化する余地

## Test plan

- [ ] CI が全て pass
- [ ] Vercel preview deployment が ready
- [ ] Storybook で Calendar grid 上の chronotype gradient 背景が引き続き正常表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)