### PR TITLE
refactor(config): centralize public constants

### DIFF
--- a/apps/product/package.json
+++ b/apps/product/package.json
@@ -73,6 +73,7 @@
     "eagle:test": "tsx ../../scripts/eagle-api.ts"
   },
   "dependencies": {
+    "@dayopt/config": "workspace:*",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/apps/product/package.json
+++ b/apps/product/package.json
@@ -27,7 +27,7 @@
     "docs:check": "tsx ../../scripts/validate-doc-references.ts",
     "api:spec": "NEXT_PUBLIC_SUPABASE_URL=https://dummy.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy tsx ../../scripts/generate-api-spec.ts",
     "api:spec:check": "NEXT_PUBLIC_SUPABASE_URL=https://dummy.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy tsx ../../scripts/generate-api-spec.ts --check",
-    "license:check": "license-checker --production --excludePackages \"@dayopt/product@$(node -p 'require(\"./package.json\").version')\" --onlyAllow \"$(cat .licensrc.json | jq -r .onlyAllow)\"",
+    "license:check": "license-checker --production --excludePrivatePackages --onlyAllow \"$(cat .licensrc.json | jq -r .onlyAllow)\"",
     "license:check-risks": "tsx ../../scripts/check-license-risks.ts",
     "license:audit": "license-checker --production --summary",
     "generate-licenses": "tsx ../../scripts/generate-licenses.ts",

--- a/apps/product/src/app/[locale]/(app)/settings/page.tsx
+++ b/apps/product/src/app/[locale]/(app)/settings/page.tsx
@@ -3,6 +3,7 @@
 import { Link, useRouter } from '@/lib/i18n/navigation';
 import { useEffect, useState } from 'react';
 
+import { createDayoptUrl, dayoptUrls } from '@dayopt/config';
 import {
   Book,
   ChevronDown,
@@ -86,7 +87,7 @@ export default function SettingsPage() {
     },
     {
       labelKey: 'settings.accountPage.documentation',
-      href: 'https://docs.dayopt.app',
+      href: dayoptUrls.docs,
       icon: Book,
       external: true,
     },
@@ -104,19 +105,19 @@ export default function SettingsPage() {
   }> = [
     {
       labelKey: 'settings.accountPage.termsOfService',
-      href: `https://dayopt.app/${locale}/legal/terms`,
+      href: createDayoptUrl(dayoptUrls.marketing, `/${locale}/legal/terms`),
     },
     {
       labelKey: 'settings.accountPage.privacyPolicy',
-      href: `https://dayopt.app/${locale}/legal/privacy`,
+      href: createDayoptUrl(dayoptUrls.marketing, `/${locale}/legal/privacy`),
     },
     {
       labelKey: 'settings.accountPage.tokushoho',
-      href: `https://dayopt.app/${locale}/legal/tokushoho`,
+      href: createDayoptUrl(dayoptUrls.marketing, `/${locale}/legal/tokushoho`),
     },
     {
       labelKey: 'settings.accountPage.security',
-      href: `https://dayopt.app/${locale}/legal/security`,
+      href: createDayoptUrl(dayoptUrls.marketing, `/${locale}/legal/security`),
     },
   ];
 

--- a/apps/product/src/app/api/mcp/route.ts
+++ b/apps/product/src/app/api/mcp/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from 'next/server';
 
+import { createDayoptUrl, dayoptUrls } from '@dayopt/config';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 
 import { logger } from '@/lib/logger';
@@ -14,13 +15,16 @@ import { createMcpServer } from './_server';
  * Bearer token を `oauth_tokens` で検証 → per-request stateless transport を立て、
  * MCP server に dispatch する。
  *
- * Vercel rewrite で `mcp.dayopt.app/` から到達する (production)。
+ * Vercel rewrite で MCP host の `/` から到達する (production)。
  * `/mcp` も既存 client 向けの互換 alias として同じ handler に到達する。
  * 401 のときは `WWW-Authenticate` の `resource_metadata` で client が
  * `/.well-known/oauth-protected-resource` を辿れるようにする (MCP spec 2025-03)。
  */
 
-const RESOURCE_METADATA_URL = 'https://mcp.dayopt.app/.well-known/oauth-protected-resource';
+const RESOURCE_METADATA_URL = createDayoptUrl(
+  dayoptUrls.mcp,
+  '/.well-known/oauth-protected-resource',
+);
 
 export const dynamic = 'force-dynamic';
 

--- a/apps/product/src/app/api/oauth/token/route.ts
+++ b/apps/product/src/app/api/oauth/token/route.ts
@@ -18,7 +18,7 @@ import {
  *   - refresh_token (rotation あり、旧 refresh は revoke)
  *
  * 認証は不要 (public client only — token endpoint auth method = "none")。
- * Vercel rewrite で `app.dayopt.app/oauth/token` から到達する。
+ * Vercel rewrite で product host の `/oauth/token` から到達する。
  */
 export const dynamic = 'force-dynamic';
 

--- a/apps/product/src/app/api/webhooks/resend/route.ts
+++ b/apps/product/src/app/api/webhooks/resend/route.ts
@@ -2,7 +2,7 @@
  * Resend Webhook エンドポイント
  *
  * Resend Dashboard → Webhooks でこのURLを登録:
- *   https://dayopt.app/api/webhooks/resend
+ *   dayoptUrls.marketing + /api/webhooks/resend
  *
  * 監視イベント:
  * - email.bounced: バウンス検知（無効アドレス）

--- a/apps/product/src/app/api/webhooks/stripe/route.ts
+++ b/apps/product/src/app/api/webhooks/stripe/route.ts
@@ -2,7 +2,7 @@
  * Stripe Webhook エンドポイント
  *
  * Stripe Dashboard → Webhooks でこのURLを登録:
- *   https://dayopt.app/api/webhooks/stripe
+ *   dayoptUrls.marketing + /api/webhooks/stripe
  *
  * 監視イベント:
  * - checkout.session.completed: チェックアウト完了

--- a/apps/product/src/app/api/well-known/oauth-authorization-server/route.ts
+++ b/apps/product/src/app/api/well-known/oauth-authorization-server/route.ts
@@ -5,7 +5,7 @@ import { buildAuthorizationServerMetadata } from '@/lib/oauth-server/metadata';
 /**
  * RFC 8414 - OAuth 2.0 Authorization Server Metadata
  *
- * Public metadata. Production hostname `app.dayopt.app` の `/.well-known/oauth-authorization-server`
+ * Public metadata. Production product host の `/.well-known/oauth-authorization-server`
  * からの vercel rewrite で到達する。
  *
  * MCP / OAuth client (Claude.ai connectors 等) が discovery 用に取得する。

--- a/apps/product/src/app/api/well-known/oauth-protected-resource/route.ts
+++ b/apps/product/src/app/api/well-known/oauth-protected-resource/route.ts
@@ -5,7 +5,7 @@ import { buildProtectedResourceMetadata } from '@/lib/oauth-server/metadata';
 /**
  * RFC 9728 - OAuth 2.0 Protected Resource Metadata
  *
- * Public metadata. Production hostname `mcp.dayopt.app` の `/.well-known/oauth-protected-resource`
+ * Public metadata. Production MCP host の `/.well-known/oauth-protected-resource`
  * からの vercel rewrite で到達する。
  *
  * MCP client (Claude.ai connectors 等) は MCP server を Bearer token なしで叩いた際の

--- a/apps/product/src/emails/AccountDeletionEmail.tsx
+++ b/apps/product/src/emails/AccountDeletionEmail.tsx
@@ -7,6 +7,8 @@
 
 import { Body, Container, Head, Html, Link, Section, Text } from '@react-email/components';
 
+import { dayoptUrls } from '@dayopt/config';
+
 import { createEmailTranslator, type EmailLocale } from './i18n';
 import * as styles from './styles';
 
@@ -21,11 +23,11 @@ export function AccountDeletionEmail({
   userName,
   deletionDate,
   locale = 'en',
-  appUrl = 'https://app.dayopt.app',
+  appUrl = dayoptUrls.product,
 }: AccountDeletionEmailProps) {
   const t = createEmailTranslator(locale);
   const supportEmail = t('emailCommon.supportEmail');
-  const appLinkText = 'app.dayopt.app';
+  const appLinkText = new URL(dayoptUrls.product).hostname;
 
   const mistakeLine = t('accountDeletion.mistakeLine', { supportEmail });
   const [mistakeBefore, mistakeAfter] = mistakeLine.split(supportEmail);

--- a/apps/product/src/emails/CancellationConfirmEmail.tsx
+++ b/apps/product/src/emails/CancellationConfirmEmail.tsx
@@ -7,6 +7,8 @@
 
 import { Body, Button, Container, Head, Html, Section, Text } from '@react-email/components';
 
+import { dayoptUrls } from '@dayopt/config';
+
 import { createEmailTranslator, type EmailLocale } from './i18n';
 import * as styles from './styles';
 
@@ -22,7 +24,7 @@ export function CancellationConfirmEmail({
   userName,
   periodEndDate,
   locale = 'en',
-  appUrl = 'https://app.dayopt.app',
+  appUrl = dayoptUrls.product,
 }: CancellationConfirmEmailProps) {
   const t = createEmailTranslator(locale);
   return (

--- a/apps/product/src/emails/ConfirmEmail.tsx
+++ b/apps/product/src/emails/ConfirmEmail.tsx
@@ -8,6 +8,8 @@
 
 import { Body, Button, Container, Head, Html, Link, Section, Text } from '@react-email/components';
 
+import { dayoptUrls } from '@dayopt/config';
+
 import { createEmailTranslator, type EmailLocale } from './i18n';
 import * as styles from './styles';
 
@@ -22,7 +24,7 @@ export function ConfirmEmail({
   userName,
   confirmUrl,
   locale = 'en',
-  appUrl = 'https://app.dayopt.app',
+  appUrl = dayoptUrls.product,
 }: ConfirmEmailProps) {
   const t = createEmailTranslator(locale);
   const ignoreLine = t('confirm.ignoreLine');

--- a/apps/product/src/emails/MagicLinkEmail.tsx
+++ b/apps/product/src/emails/MagicLinkEmail.tsx
@@ -8,6 +8,8 @@
 
 import { Body, Button, Container, Head, Html, Link, Section, Text } from '@react-email/components';
 
+import { dayoptDomains, dayoptUrls } from '@dayopt/config';
+
 import { createEmailTranslator, type EmailLocale } from './i18n';
 import * as styles from './styles';
 
@@ -20,7 +22,7 @@ export interface MagicLinkEmailProps {
 export function MagicLinkEmail({
   loginUrl,
   locale = 'en',
-  appUrl = 'https://app.dayopt.app',
+  appUrl = dayoptUrls.product,
 }: MagicLinkEmailProps) {
   const t = createEmailTranslator(locale);
 
@@ -47,7 +49,7 @@ export function MagicLinkEmail({
               <br />
               <br />
               <Link style={styles.link} href={appUrl}>
-                app.dayopt.app
+                {dayoptDomains.product}
               </Link>
               <br />
               <br />

--- a/apps/product/src/emails/PasswordChangedEmail.tsx
+++ b/apps/product/src/emails/PasswordChangedEmail.tsx
@@ -7,6 +7,8 @@
 
 import { Body, Container, Head, Html, Link, Section, Text } from '@react-email/components';
 
+import { dayoptUrls } from '@dayopt/config';
+
 import { createEmailTranslator, type EmailLocale } from './i18n';
 import * as styles from './styles';
 
@@ -19,7 +21,7 @@ export interface PasswordChangedEmailProps {
 export function PasswordChangedEmail({
   userName,
   locale = 'en',
-  appUrl = 'https://app.dayopt.app',
+  appUrl = dayoptUrls.product,
 }: PasswordChangedEmailProps) {
   const t = createEmailTranslator(locale);
   const supportEmail = t('emailCommon.supportEmail');

--- a/apps/product/src/emails/PasswordResetEmail.tsx
+++ b/apps/product/src/emails/PasswordResetEmail.tsx
@@ -8,6 +8,8 @@
 
 import { Body, Button, Container, Head, Html, Link, Section, Text } from '@react-email/components';
 
+import { dayoptUrls } from '@dayopt/config';
+
 import { createEmailTranslator, type EmailLocale } from './i18n';
 import * as styles from './styles';
 
@@ -22,7 +24,7 @@ export function PasswordResetEmail({
   userName,
   resetUrl,
   locale = 'en',
-  appUrl = 'https://app.dayopt.app',
+  appUrl = dayoptUrls.product,
 }: PasswordResetEmailProps) {
   const t = createEmailTranslator(locale);
   const settingsLinkText = t('passwordReset.yourSettings');

--- a/apps/product/src/emails/PaymentFailedEmail.tsx
+++ b/apps/product/src/emails/PaymentFailedEmail.tsx
@@ -7,6 +7,8 @@
 
 import { Body, Button, Container, Head, Html, Link, Section, Text } from '@react-email/components';
 
+import { dayoptUrls } from '@dayopt/config';
+
 import { createEmailTranslator, type EmailLocale } from './i18n';
 import * as styles from './styles';
 
@@ -22,7 +24,7 @@ export function PaymentFailedEmail({
   userName,
   portalUrl,
   locale = 'en',
-  appUrl = 'https://app.dayopt.app',
+  appUrl = dayoptUrls.product,
 }: PaymentFailedEmailProps) {
   const t = createEmailTranslator(locale);
   const ctaUrl = portalUrl || `${appUrl}/settings/billing`;

--- a/apps/product/src/emails/PaymentRecoveredEmail.tsx
+++ b/apps/product/src/emails/PaymentRecoveredEmail.tsx
@@ -7,6 +7,8 @@
 
 import { Body, Button, Container, Head, Html, Section, Text } from '@react-email/components';
 
+import { dayoptUrls } from '@dayopt/config';
+
 import { createEmailTranslator, type EmailLocale } from './i18n';
 import * as styles from './styles';
 
@@ -19,7 +21,7 @@ export interface PaymentRecoveredEmailProps {
 export function PaymentRecoveredEmail({
   userName,
   locale = 'en',
-  appUrl = 'https://app.dayopt.app',
+  appUrl = dayoptUrls.product,
 }: PaymentRecoveredEmailProps) {
   const t = createEmailTranslator(locale);
   return (

--- a/apps/product/src/emails/ProStartEmail.tsx
+++ b/apps/product/src/emails/ProStartEmail.tsx
@@ -8,6 +8,8 @@
 
 import { Body, Button, Container, Head, Html, Section, Text } from '@react-email/components';
 
+import { dayoptUrls } from '@dayopt/config';
+
 import { createEmailTranslator, type EmailLocale } from './i18n';
 import * as styles from './styles';
 
@@ -20,7 +22,7 @@ export interface ProStartEmailProps {
 export function ProStartEmail({
   userName,
   locale = 'en',
-  appUrl = 'https://app.dayopt.app',
+  appUrl = dayoptUrls.product,
 }: ProStartEmailProps) {
   const t = createEmailTranslator(locale);
   return (

--- a/apps/product/src/emails/TrialExpiredEmail.tsx
+++ b/apps/product/src/emails/TrialExpiredEmail.tsx
@@ -7,6 +7,8 @@
 
 import { Body, Button, Container, Head, Html, Section, Text } from '@react-email/components';
 
+import { dayoptUrls } from '@dayopt/config';
+
 import { createEmailTranslator, type EmailLocale } from './i18n';
 import * as styles from './styles';
 
@@ -19,7 +21,7 @@ export interface TrialExpiredEmailProps {
 export function TrialExpiredEmail({
   userName,
   locale = 'en',
-  appUrl = 'https://app.dayopt.app',
+  appUrl = dayoptUrls.product,
 }: TrialExpiredEmailProps) {
   const t = createEmailTranslator(locale);
   return (

--- a/apps/product/src/emails/TrialExpiringEmail.tsx
+++ b/apps/product/src/emails/TrialExpiringEmail.tsx
@@ -7,6 +7,8 @@
 
 import { Body, Button, Container, Head, Html, Section, Text } from '@react-email/components';
 
+import { dayoptUrls } from '@dayopt/config';
+
 import { createEmailTranslator, type EmailLocale } from './i18n';
 import * as styles from './styles';
 
@@ -21,7 +23,7 @@ export function TrialExpiringEmail({
   userName,
   trialEndDate,
   locale = 'en',
-  appUrl = 'https://app.dayopt.app',
+  appUrl = dayoptUrls.product,
 }: TrialExpiringEmailProps) {
   const t = createEmailTranslator(locale);
   return (

--- a/apps/product/src/emails/TrialStartEmail.tsx
+++ b/apps/product/src/emails/TrialStartEmail.tsx
@@ -7,6 +7,8 @@
 
 import { Body, Button, Container, Head, Html, Section, Text } from '@react-email/components';
 
+import { dayoptUrls } from '@dayopt/config';
+
 import { createEmailTranslator, type EmailLocale } from './i18n';
 import * as styles from './styles';
 
@@ -21,7 +23,7 @@ export function TrialStartEmail({
   userName,
   trialEndDate,
   locale = 'en',
-  appUrl = 'https://app.dayopt.app',
+  appUrl = dayoptUrls.product,
 }: TrialStartEmailProps) {
   const t = createEmailTranslator(locale);
   return (

--- a/apps/product/src/emails/WelcomeEmail.tsx
+++ b/apps/product/src/emails/WelcomeEmail.tsx
@@ -5,6 +5,8 @@
 
 import { Body, Button, Container, Head, Html, Link, Section, Text } from '@react-email/components';
 
+import { dayoptUrls } from '@dayopt/config';
+
 import { createEmailTranslator, type EmailLocale } from './i18n';
 import * as styles from './styles';
 
@@ -17,7 +19,7 @@ export interface WelcomeEmailProps {
 export function WelcomeEmail({
   userName,
   locale = 'en',
-  appUrl = 'https://app.dayopt.app',
+  appUrl = dayoptUrls.product,
 }: WelcomeEmailProps) {
   const t = createEmailTranslator(locale);
   const supportEmail = t('emailCommon.supportEmail');

--- a/apps/product/src/features/auth/components/SignupForm.tsx
+++ b/apps/product/src/features/auth/components/SignupForm.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useState } from 'react';
 
+import { createDayoptUrl, dayoptUrls } from '@dayopt/config';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Eye, EyeOff, Mail } from 'lucide-react';
 import { useTranslations } from 'next-intl';
@@ -327,7 +328,7 @@ export function SignupForm({ className, ...props }: React.ComponentProps<'div'>)
                 <p className="text-muted-foreground text-center text-xs leading-relaxed">
                   {t('auth.signupForm.byContinuing')}{' '}
                   <a
-                    href="https://dayopt.app/legal/terms"
+                    href={createDayoptUrl(dayoptUrls.marketing, '/legal/terms')}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="hover:text-foreground underline underline-offset-4"
@@ -336,7 +337,7 @@ export function SignupForm({ className, ...props }: React.ComponentProps<'div'>)
                   </a>{' '}
                   {t('auth.signupForm.and')}{' '}
                   <a
-                    href="https://dayopt.app/legal/privacy"
+                    href={createDayoptUrl(dayoptUrls.marketing, '/legal/privacy')}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="hover:text-foreground underline underline-offset-4"

--- a/apps/product/src/features/contact/components/ContactDialogContent.tsx
+++ b/apps/product/src/features/contact/components/ContactDialogContent.tsx
@@ -12,6 +12,8 @@
 
 import { useCallback, useState } from 'react';
 
+import { dayoptContact } from '@dayopt/config';
+
 import { Button } from '@/lib/components/ui/button';
 import {
   Dialog,
@@ -179,8 +181,11 @@ export function ContactDialogContent({
             <DrawerTitle>{labels.title}</DrawerTitle>
             <DrawerDescription>
               {labels.description}{' '}
-              <a href="mailto:support@dayopt.app" className="text-primary hover:underline">
-                support@dayopt.app
+              <a
+                href={`mailto:${dayoptContact.supportEmail}`}
+                className="text-primary hover:underline"
+              >
+                {dayoptContact.supportEmail}
               </a>
             </DrawerDescription>
           </DrawerHeader>
@@ -210,8 +215,11 @@ export function ContactDialogContent({
           <DialogTitle>{labels.title}</DialogTitle>
           <DialogDescription>
             {labels.description}{' '}
-            <a href="mailto:support@dayopt.app" className="text-primary hover:underline">
-              support@dayopt.app
+            <a
+              href={`mailto:${dayoptContact.supportEmail}`}
+              className="text-primary hover:underline"
+            >
+              {dayoptContact.supportEmail}
             </a>
           </DialogDescription>
         </DialogHeader>

--- a/apps/product/src/features/settings/components/data-settings.tsx
+++ b/apps/product/src/features/settings/components/data-settings.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useRef, useState } from 'react';
 
 import { toast } from '@/lib/toast';
+import { dayoptUrls } from '@dayopt/config';
 import {
   AlertTriangle,
   Check,
@@ -261,7 +262,7 @@ function McpApiSection() {
 
   // OAuth 接続のため client (Claude.ai etc.) に渡すのはこの URL のみ。
   // API key 入力欄は Phase 1.5 で「接続済み client 一覧」に置換する vestige。
-  const mcpServerUrl = 'https://mcp.dayopt.app';
+  const mcpServerUrl = dayoptUrls.mcp;
 
   const handleCopy = useCallback(
     (text: string, type: 'url' | 'key') => {

--- a/apps/product/src/lib/app-url.ts
+++ b/apps/product/src/lib/app-url.ts
@@ -1,3 +1,5 @@
+import { dayoptUrls } from '@dayopt/config';
+
 import { env } from '@/env';
 
 /**
@@ -12,3 +14,5 @@ export function getAppUrl(): string {
   if (env.VERCEL_URL) return `https://${env.VERCEL_URL}`;
   return 'http://localhost:3000';
 }
+
+export const PRODUCT_APP_URL = dayoptUrls.product;

--- a/apps/product/src/lib/components/shell/CookieConsentBanner.tsx
+++ b/apps/product/src/lib/components/shell/CookieConsentBanner.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 
 import { acceptAllCookies, acceptNecessaryOnly, needsCookieConsent } from '@/lib/cookie-consent';
+import { createDayoptUrl, dayoptUrls } from '@dayopt/config';
 import { useLocale, useTranslations } from 'next-intl';
 import { usePathname } from 'next/navigation';
 
@@ -67,7 +68,7 @@ export function CookieConsentBanner() {
     return null;
   }
 
-  const privacyUrl = `https://dayopt.app/${locale}/legal/privacy`;
+  const privacyUrl = createDayoptUrl(dayoptUrls.marketing, `/${locale}/legal/privacy`);
 
   return (
     <div

--- a/apps/product/src/lib/components/shell/sidebar/UserMenu.tsx
+++ b/apps/product/src/lib/components/shell/sidebar/UserMenu.tsx
@@ -18,6 +18,8 @@ import {
 } from 'lucide-react';
 import Link from 'next/link';
 
+import { createDayoptUrl, dayoptUrls } from '@dayopt/config';
+
 import { MEDIA_QUERIES } from '@/lib/breakpoints';
 import { Avatar, AvatarFallback, AvatarImage } from '@/lib/components/ui/avatar';
 import {
@@ -149,7 +151,7 @@ export function UserMenu({
                 </Link>
               </DropdownMenuItem>
               <DropdownMenuItem asChild>
-                <Link href="https://docs.dayopt.app" target="_blank" rel="noopener noreferrer">
+                <Link href={dayoptUrls.docs} target="_blank" rel="noopener noreferrer">
                   <Book />
                   <span className="flex-1">
                     {t('navigation.navUser.helpSubmenu.documentation')}
@@ -160,7 +162,7 @@ export function UserMenu({
               <DropdownMenuSeparator />
               <DropdownMenuItem asChild>
                 <a
-                  href={`https://dayopt.app/${locale}/legal/terms`}
+                  href={createDayoptUrl(dayoptUrls.marketing, `/${locale}/legal/terms`)}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
@@ -173,7 +175,7 @@ export function UserMenu({
               </DropdownMenuItem>
               <DropdownMenuItem asChild>
                 <a
-                  href={`https://dayopt.app/${locale}/legal/privacy`}
+                  href={createDayoptUrl(dayoptUrls.marketing, `/${locale}/legal/privacy`)}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
@@ -186,7 +188,7 @@ export function UserMenu({
               </DropdownMenuItem>
               <DropdownMenuItem asChild>
                 <a
-                  href={`https://dayopt.app/${locale}/legal/tokushoho`}
+                  href={createDayoptUrl(dayoptUrls.marketing, `/${locale}/legal/tokushoho`)}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
@@ -197,7 +199,7 @@ export function UserMenu({
               </DropdownMenuItem>
               <DropdownMenuItem asChild>
                 <a
-                  href={`https://dayopt.app/${locale}/legal/security`}
+                  href={createDayoptUrl(dayoptUrls.marketing, `/${locale}/legal/security`)}
                   target="_blank"
                   rel="noopener noreferrer"
                 >

--- a/apps/product/src/lib/oauth-server/metadata.ts
+++ b/apps/product/src/lib/oauth-server/metadata.ts
@@ -1,5 +1,7 @@
 import 'server-only';
 
+import { createDayoptUrl, dayoptUrls } from '@dayopt/config';
+
 import { SUPPORTED_SCOPES } from './scopes';
 
 /**
@@ -7,13 +9,13 @@ import { SUPPORTED_SCOPES } from './scopes';
  *
  * RFC 8414 §3 では metadata の issuer はそれが提供されている URL と完全一致する
  * 必要がある。`NEXT_PUBLIC_APP_URL` は marketing apex (`dayopt.app`) を指しており、
- * AS は `app.dayopt.app` の subdomain で稼働する設計 (vercel.json rewrite が
- * `/.well-known/oauth-authorization-server` を `app.dayopt.app` host filter で
+ * AS は `dayoptDomains.product` の subdomain で稼働する設計 (vercel.json rewrite が
+ * `/.well-known/oauth-authorization-server` を product host filter で
  * 拾う) のため、apex を返してしまうと `dayopt.app/oauth/authorize` のような
  * 存在しない URL を client に伝えてしまう。
  */
-const AUTHORIZATION_SERVER_URL = 'https://app.dayopt.app';
-const MCP_RESOURCE_URL = 'https://mcp.dayopt.app';
+const AUTHORIZATION_SERVER_URL = dayoptUrls.product;
+const MCP_RESOURCE_URL = dayoptUrls.mcp;
 
 /**
  * RFC 8414 - OAuth 2.0 Authorization Server Metadata
@@ -22,8 +24,8 @@ const MCP_RESOURCE_URL = 'https://mcp.dayopt.app';
 export function buildAuthorizationServerMetadata() {
   return {
     issuer: AUTHORIZATION_SERVER_URL,
-    authorization_endpoint: `${AUTHORIZATION_SERVER_URL}/oauth/authorize`,
-    token_endpoint: `${AUTHORIZATION_SERVER_URL}/oauth/token`,
+    authorization_endpoint: createDayoptUrl(AUTHORIZATION_SERVER_URL, '/oauth/authorize'),
+    token_endpoint: createDayoptUrl(AUTHORIZATION_SERVER_URL, '/oauth/token'),
     response_types_supported: ['code'],
     grant_types_supported: ['authorization_code', 'refresh_token'],
     code_challenge_methods_supported: ['S256'],

--- a/apps/product/src/proxy.ts
+++ b/apps/product/src/proxy.ts
@@ -1,6 +1,8 @@
 import createMiddleware from 'next-intl/middleware';
 import { NextResponse, type NextRequest } from 'next/server';
 
+import { dayoptDomains } from '@dayopt/config';
+
 import { routing } from '@/lib/i18n/routing';
 import { logger } from '@/lib/logger';
 import { updateSession } from '@/lib/supabase/middleware';
@@ -32,7 +34,7 @@ const publicPaths = ['/', '/about', '/privacy', '/terms', '/contact', '/pricing'
 
 // Vercel rewritesでAPI routeへ到達させる公開パス
 const publicRewritePaths = ['/mcp', '/oauth/token'];
-const MCP_HOST = 'mcp.dayopt.app';
+const MCP_HOST = dayoptDomains.mcp;
 
 // 言語プレフィックスを除いたパスを取得
 // as-needed設定: デフォルト言語(en)はプレフィックスなし

--- a/apps/storybook/docs/dev/architecture/PackagesOverview.mdx
+++ b/apps/storybook/docs/dev/architecture/PackagesOverview.mdx
@@ -41,7 +41,7 @@ apps/product, apps/web, apps/admin
 
 ## Current Phase
 
-現在の実装はまだ `apps/product` 中心で、`packages/ui`, `packages/config`, `packages/types`, `packages/server`, `packages/utils` は第一段階の placeholder に近い。
+現在の実装はまだ `apps/product` 中心だが、`packages/design`, `packages/ui`, `packages/config` は最小の公開面を持つ package として動き始めている。`packages/types`, `packages/server`, `packages/utils` は第一段階の placeholder に近い。
 
 次の段階では `packages/types` をそのまま拡張し続けるより、責務を `packages/domain` と `packages/database` に分ける。`packages/server` は Supabase / Stripe / admin helper のような server-only 境界に残すか、用途が明確になったものから `packages/database` / `packages/billing` へ分離する。
 
@@ -51,17 +51,17 @@ apps/product, apps/web, apps/admin
 
 ### Scope
 
-| 領域       | Source                                   | Storybook 表示                             |
-| ---------- | ---------------------------------------- | ------------------------------------------ |
-| Colors     | `tokens/colors.css`, `tokens/states.css` | `Foundations/Colors`, `Foundations/States` |
-| Typography | typography scale / font variables        | `Foundations/Typography`                   |
-| Spacing    | spacing scale / layout rhythm            | `Foundations/Spacing`                      |
-| Radius     | radius scale / partial radius rules      | `Foundations/Radius`                       |
-| Shadow     | elevation / shadow variables             | `Foundations/Elevation`                    |
-| Motion     | duration / easing rules                  | `Foundations/Motion`                       |
-| Z-Index    | layering scale                           | `Foundations/ZIndex`                       |
+| 領域       | Source                                           | Storybook 表示      |
+| ---------- | ------------------------------------------------ | ------------------- |
+| Colors     | `packages/design/src/colors.ts`, `theme.css`     | `Design/Colors`     |
+| Typography | `packages/design/src/typography.ts`, `theme.css` | `Design/Typography` |
+| Spacing    | `packages/design/src/spacing.ts`, `theme.css`    | `Design/Spacing`    |
+| Radius     | `packages/design/src/radius.ts`, `theme.css`     | `Design/Radius`     |
+| Shadow     | `packages/design/src/shadow.ts`, `theme.css`     | `Design/Shadows`    |
+| Motion     | 未定義。必要になった時に追加                     | 未定                |
+| Z-Index    | 未定義。必要になった時に追加                     | 未定                |
 
-現在はこれらが `apps/product/src/lib/styles/tokens/` にある。移動時は Storybook の表示名を変えず、source path だけを `packages/design` に寄せる。Storybook は token の可視化面であり、token の所有者は `packages/design` にする。
+Storybook は token の可視化面であり、token の所有者は `packages/design` にする。`apps/product/src/lib/styles/tokens/` は既存 product UI のための layer として残し、段階的に `packages/design` の contract へ寄せる。
 
 ### Export Shape
 
@@ -70,13 +70,13 @@ apps/product, apps/web, apps/admin
 ```txt
 packages/design/
   src/
+    colors.ts
+    typography.ts
+    spacing.ts
+    radius.ts
+    shadow.ts
+    tokens.ts
     theme.css
-    tokens/
-      colors.css
-      spacing.css
-      radius.css
-      states.css
-      z-index.css
     index.ts
 ```
 
@@ -86,7 +86,26 @@ packages/design/
 import '@dayopt/design/theme.css';
 ```
 
-CSS variables は `--color-*`, `--shadow-*`, `--radius-*` のような token として公開し、アプリ側では Tailwind semantic class 経由で使う。React component 内で raw OKLCH 値や hex 値を直書きしない。
+CSS variables は `--dayopt-*` prefix で公開し、既存 app の `--background`, `--primary`, `--radius-*` などは上書きしない。React component 内で raw OKLCH 値や hex 値を直書きしない。
+
+## `packages/config`
+
+`packages/config` は product/web が共有する public constants の置き場にする。副作用を持たず、Next.js / React / Zod / env / server-only に依存しない。
+
+置いてよいもの:
+
+- Dayopt の domain と canonical URL
+- support / security / contact email
+- brand name / public social URL
+- URL join helper
+
+置かないもの:
+
+- env validation
+- secrets
+- request-scoped value
+- Next.js metadata generator 本体
+- server-only client
 
 ## `packages/ui`
 
@@ -156,24 +175,26 @@ Supabase generated types と DB row の alias を置く。domain model との変
 
 Storybook は `packages/design` と `packages/ui` の公開面を確認する場所にする。
 
-- `packages/design`: token の一覧、意味、使用禁止例を `Foundations/*` で可視化する。
-- `packages/ui`: props と状態を `Primitives/*` / `Recipes/*` で可視化する。
+- `packages/design`: token の一覧、意味、使用禁止例を `Design/*` で可視化する。
+- `packages/ui`: props と状態を `UI/*` で可視化する。
 - `packages/domain`, `packages/database`, `packages/billing`: UI カタログではなく docs と decision table で境界を説明する。
 - `apps/product` 固有の feature component は `Features/*` に残し、汎用化できたものだけ `packages/ui` に移す。
 
-移動後も Storybook の階層名は利用者の認知に合わせて維持する。内部 path が `packages/design` になっても、閲覧面では `Foundations/Colors` のままでよい。
+移動後も Storybook の階層名は利用者の認知に合わせて調整する。現在の shared package は `Design/*` と `UI/*` を公開面にする。
 
 ## Ownership And Operations
 
 UI ownership は Storybook の表示階層で判断する。
 
-| Storybook 階層   | Owner                    | Source of truth                                                 |
-| ---------------- | ------------------------ | --------------------------------------------------------------- |
-| `Foundations/*`  | design tokens            | `packages/design`、現状は `apps/product/src/lib/styles/tokens/` |
-| `Primitives/*`   | reusable UI primitives   | `packages/ui`、現状は `apps/product/src/lib/components/ui/`     |
-| `Recipes/*`      | reusable UI compositions | `packages/ui` または app 共通 component                         |
-| `Features/*`     | product feature UI       | `apps/product/src/features/*`                                   |
-| `Operations/*`   | deployment / release ops | `apps/storybook/docs/operations/*`                              |
-| `Architecture/*` | engineering decisions    | `apps/storybook/docs/dev/architecture/*`                        |
+| Storybook 階層   | Owner                               | Source of truth                          |
+| ---------------- | ----------------------------------- | ---------------------------------------- |
+| `Design/*`       | design tokens                       | `packages/design`                        |
+| `UI/*`           | reusable UI primitives              | `packages/ui`                            |
+| `Foundations/*`  | legacy / product-facing foundations | `apps/product` 由来の既存 Storybook 表示 |
+| `Primitives/*`   | legacy reusable UI primitives       | `apps/product/src/lib/components/ui/`    |
+| `Recipes/*`      | reusable UI compositions            | `packages/ui` または app 共通 component  |
+| `Features/*`     | product feature UI                  | `apps/product/src/features/*`            |
+| `Operations/*`   | deployment / release ops            | `apps/storybook/docs/operations/*`       |
+| `Architecture/*` | engineering decisions               | `apps/storybook/docs/dev/architecture/*` |
 
 Deployment と release の手順は code package ではなく `Operations/*` docs の責務にする。package 境界のページには運用手順を重複させず、参照先だけを固定する。

--- a/apps/storybook/docs/dev/guides/DeveloperMap.mdx
+++ b/apps/storybook/docs/dev/guides/DeveloperMap.mdx
@@ -57,7 +57,7 @@ apps/product/src/
 ├── hooks/                     # 共有カスタムフック
 ├── types/                     # 共有型定義
 ├── lib/                       # ユーティリティ（日付、セキュリティ、PWA等）
-├── lib/styles/tokens/         # 現在のデザイントークン + Storybook可視化
+├── lib/styles/tokens/         # product 固有 / legacy token layer
 │
 ├── stories/
 │   ├── patterns/              # 実装パターン Story
@@ -66,9 +66,9 @@ apps/product/src/
 └── emails/                    # メールテンプレート
 
 packages/
-├── design/                    # 将来のデザイントークン source of truth
+├── design/                    # design token source of truth
 ├── ui/                        # domain logic を持たない React UI
-├── config/                    # URL / metadata / public constants
+├── config/                    # URL / domain / contact / public constants
 ├── domain/                    # DB に依存しない Dayopt domain model
 ├── database/                  # Supabase generated types / converters
 ├── billing/                   # plans / subscription / entitlement
@@ -81,7 +81,7 @@ packages/
 
 責務境界の詳細は [Packages Overview](?path=/docs/architecture-packages-overview--docs) を参照。
 
-現在は `apps/product/src/lib/styles/tokens/` が token の実体と Storybook 可視化を持つ。今後 `packages/design` を作る時は、Storybook の `Foundations/*` 階層を維持したまま source path だけを移す。
+現在は `packages/design` が token の source of truth で、Storybook の `Design/*` で最小 token を確認できる。`packages/config` は product/web が共有する URL / domain / contact / brand constants の置き場にする。
 
 ## 目的別ガイド
 
@@ -92,7 +92,7 @@ packages/
 | ボタン・入力欄を変更     | `src/components/ui/`      | `button.tsx`, `input.tsx`             |
 | 共通UIを変更             | `src/components/common/`  | `EmptyState.tsx`, `DateNavigator.tsx` |
 | ヘッダー・サイドバー変更 | `src/shell/components/`   | `AppHeader.tsx`, `sidebar/`           |
-| デザイントークン変更     | `src/lib/styles/tokens/`  | `colors.css`, `spacing.css`           |
+| デザイントークン変更     | `packages/design/src/`    | `colors.ts`, `theme.css`              |
 | アイコン確認             | `Foundations/Icons` Story | lucide-react 一覧                     |
 
 ### Feature を変更したい

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -49,6 +49,7 @@
     "generate:search-index": "tsx scripts/generate-search-index.ts"
   },
   "dependencies": {
+    "@dayopt/config": "workspace:*",
     "@hookform/resolvers": "^5.1.1",
     "@marsidev/react-turnstile": "^1.5.0",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/apps/web/src/app/[locale]/(marketing)/legal/security/security-content.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/legal/security/security-content.tsx
@@ -1,3 +1,4 @@
+import { dayoptContact } from '@dayopt/config';
 import { AlertTriangle, ExternalLink, FileText, Lock, Mail, Shield } from 'lucide-react';
 import { getTranslations } from 'next-intl/server';
 import Link from 'next/link';
@@ -96,7 +97,10 @@ export async function SecurityContent() {
             <li className="flex items-center gap-2">
               <Mail className="size-4" />
               <strong>{t('security.vulnerability.contacts.email')}</strong>:{' '}
-              <a href="mailto:security@dayopt.app" className="text-primary hover:underline">
+              <a
+                href={`mailto:${dayoptContact.securityEmail}`}
+                className="text-primary hover:underline"
+              >
                 {t('security.vulnerability.contacts.emailAddress')}
               </a>
             </li>
@@ -291,14 +295,20 @@ export async function SecurityContent() {
           <p className="flex items-center gap-2">
             <Mail className="size-4" />
             <strong>{t('security.contact.securityTeam')}</strong>:{' '}
-            <a href="mailto:security@dayopt.app" className="text-primary hover:underline">
+            <a
+              href={`mailto:${dayoptContact.securityEmail}`}
+              className="text-primary hover:underline"
+            >
               {t('security.contact.securityEmail')}
             </a>
           </p>
           <p className="flex items-center gap-2">
             <Mail className="size-4" />
             <strong>{t('security.contact.general')}</strong>:{' '}
-            <a href="mailto:support@dayopt.app" className="text-primary hover:underline">
+            <a
+              href={`mailto:${dayoptContact.supportEmail}`}
+              className="text-primary hover:underline"
+            >
               {t('security.contact.generalEmail')}
             </a>
           </p>

--- a/apps/web/src/app/[locale]/(marketing)/legal/tokushoho/page.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/legal/tokushoho/page.tsx
@@ -1,4 +1,5 @@
 import type { Locale } from '@/platform/i18n/routing';
+import { dayoptContact } from '@dayopt/config';
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 
@@ -118,7 +119,8 @@ export default async function TokushohoPage({ params }: PageProps) {
               <td className="text-foreground px-6 py-4 text-sm">
                 <div className="space-y-1">
                   <p>
-                    <span className="text-muted-foreground">Email:</span> support@dayopt.app
+                    <span className="text-muted-foreground">Email:</span>{' '}
+                    {dayoptContact.supportEmail}
                   </p>
                   <p>
                     <span className="text-muted-foreground">

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { generateEnhancedMetadata, StructuredData } from '@/components/seo/Enhan
 import { Toaster } from '@/components/ui/sonner';
 import { cn } from '@/lib/utils';
 import { ThemeProvider } from '@/shell/providers/theme-provider';
+import { dayoptBrand, dayoptContact } from '@dayopt/config';
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import type { Metadata } from 'next';
@@ -41,28 +42,28 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <StructuredData
           type="Organization"
           data={{
-            name: 'Dayopt',
-            alternateName: 'Dayopt Platform',
+            name: dayoptBrand.name,
+            alternateName: dayoptBrand.platformName,
             description: 'Modern SaaS platform for businesses',
             foundingDate: '2024-01-01',
             contactPoint: {
               '@type': 'ContactPoint',
               contactType: 'customer service',
-              email: 'contact@dayopt.app',
+              email: dayoptContact.contactEmail,
             },
           }}
         />
         <StructuredData
           type="WebSite"
           data={{
-            name: 'Dayopt Platform',
-            alternateName: 'Dayopt',
+            name: dayoptBrand.platformName,
+            alternateName: dayoptBrand.name,
           }}
         />
         <StructuredData
           type="SoftwareApplication"
           data={{
-            name: 'Dayopt',
+            name: dayoptBrand.name,
             description: 'Plan, execute, and reflect — a simple cycle to optimize your day.',
             applicationCategory: 'ProductivityApplication',
             operatingSystem: 'Web',

--- a/apps/web/src/components/seo/EnhancedSEO.tsx
+++ b/apps/web/src/components/seo/EnhancedSEO.tsx
@@ -1,4 +1,5 @@
 import { env, getAppUrl } from '@/platform/config/env';
+import { createDayoptUrl, dayoptBrand, dayoptUrls } from '@dayopt/config';
 import type { Metadata } from 'next';
 
 interface SEOProps {
@@ -167,19 +168,19 @@ export function StructuredData({ type, data }: StructuredDataProps) {
 
   // 組織の基本情報
   if (type === 'Organization') {
-    baseStructure.name = 'Dayopt';
-    baseStructure.url = 'https://dayopt.app';
-    baseStructure.logo = 'https://dayopt.app/logo.png';
-    baseStructure.sameAs = ['https://x.com/dayoptapp', 'https://github.com/dayoptapp'];
+    baseStructure.name = dayoptBrand.name;
+    baseStructure.url = dayoptUrls.marketing;
+    baseStructure.logo = createDayoptUrl(dayoptUrls.marketing, '/logo.png');
+    baseStructure.sameAs = [dayoptBrand.xUrl, dayoptBrand.githubUrl];
   }
 
   // ウェブサイトの情報
   if (type === 'WebSite') {
-    baseStructure.name = 'Dayopt';
-    baseStructure.url = 'https://dayopt.app';
+    baseStructure.name = dayoptBrand.name;
+    baseStructure.url = dayoptUrls.marketing;
     baseStructure.potentialAction = {
       '@type': 'SearchAction',
-      target: 'https://dayopt.app/search?q={search_term_string}',
+      target: createDayoptUrl(dayoptUrls.marketing, '/search?q={search_term_string}'),
       'query-input': 'required name=search_term_string',
     };
   }
@@ -283,7 +284,7 @@ export function ArticleStructuredData({
       name: 'Dayopt',
       logo: {
         '@type': 'ImageObject',
-        url: 'https://dayopt.app/logo.png',
+        url: createDayoptUrl(dayoptUrls.marketing, '/logo.png'),
       },
     },
     ...(category && { category }),

--- a/apps/web/src/platform/config/env.ts
+++ b/apps/web/src/platform/config/env.ts
@@ -1,3 +1,5 @@
+import { dayoptUrls } from '@dayopt/config';
+
 /**
  * 環境変数の型定義とバリデーション
  *
@@ -48,14 +50,14 @@ export interface EnvConfig {
    * アプリケーションの公開 URL
    *
    * @required Production環境では必須
-   * @example 'https://dayopt.app'
+   * @example dayoptUrls.marketing
    */
   NEXT_PUBLIC_APP_URL?: string;
 
   /**
    * サイトの公開 URL（SEO・OGP用）
    *
-   * @default 'https://dayopt.app'
+   * @default dayoptUrls.marketing
    */
   NEXT_PUBLIC_SITE_URL?: string;
 
@@ -372,7 +374,7 @@ export const isCI = env.CI === true;
  * 優先順位:
  * 1. NEXT_PUBLIC_APP_URL
  * 2. VERCEL_URL (https:// プレフィックス付与)
- * 3. デフォルト値 (開発: localhost:3000, 本番: https://dayopt.app)
+ * 3. デフォルト値 (開発: localhost:3000, 本番: dayoptUrls.marketing)
  */
 export const getAppUrl = (): string => {
   if (env.NEXT_PUBLIC_APP_URL) {
@@ -387,7 +389,7 @@ export const getAppUrl = (): string => {
     return 'http://localhost:3000';
   }
 
-  return 'https://dayopt.app';
+  return dayoptUrls.marketing;
 };
 
 /**

--- a/apps/web/src/platform/security/csrf-protection.ts
+++ b/apps/web/src/platform/security/csrf-protection.ts
@@ -1,4 +1,5 @@
 import { env } from '@/platform/config/env';
+import { dayoptUrls } from '@dayopt/config';
 import { NextRequest } from 'next/server';
 
 /**
@@ -35,7 +36,7 @@ function getAllowedOrigins(): string[] {
   }
 
   // デフォルトの本番ドメイン
-  allowedOrigins.push('https://dayopt.app', 'https://www.dayopt.app');
+  allowedOrigins.push(dayoptUrls.marketing, dayoptUrls.www);
 
   return allowedOrigins;
 }

--- a/apps/web/src/platform/seo/metadata.ts
+++ b/apps/web/src/platform/seo/metadata.ts
@@ -1,4 +1,5 @@
 import { env, getSiteUrl } from '@/platform/config/env';
+import { createDayoptUrl, dayoptBrand, dayoptContact } from '@dayopt/config';
 import type { Metadata } from 'next';
 
 export interface SEOData {
@@ -33,14 +34,14 @@ export interface SiteConfig {
 }
 
 export const siteConfig: SiteConfig = {
-  name: 'Dayopt',
+  name: dayoptBrand.name,
   title: 'Dayopt - スケーラブルなアプリケーションのためのモダンSaaSプラットフォーム',
   description:
     'Dayoptで次世代のSaaSアプリケーションを構築、デプロイ、スケール。認証、ユーザー管理、請求処理など包括的なツールを提供します。',
   url: getSiteUrl(),
   ogImage: '/og-image.png',
-  creator: 'Dayopt Team',
-  twitterHandle: '@dayoptapp',
+  creator: dayoptBrand.teamName,
+  twitterHandle: dayoptBrand.twitterHandle,
   keywords: [
     'SaaS',
     'Software as a Service',
@@ -267,11 +268,11 @@ export function generateStructuredData(type: string, data: StructuredDataInput) 
         url: baseUrl,
         logo: `${baseUrl}/logo.png`,
         description: siteConfig.description,
-        sameAs: ['https://x.com/dayoptapp', 'https://github.com/dayoptapp'],
+        sameAs: [dayoptBrand.xUrl, dayoptBrand.githubUrl],
         contactPoint: {
           '@type': 'ContactPoint',
           contactType: 'Customer Service',
-          email: 'support@dayopt.app',
+          email: dayoptContact.supportEmail,
         },
       };
 
@@ -286,7 +287,7 @@ export function generateStructuredData(type: string, data: StructuredDataInput) 
           '@type': 'SearchAction',
           target: {
             '@type': 'EntryPoint',
-            urlTemplate: `${baseUrl}/search?q={search_term_string}`,
+            urlTemplate: createDayoptUrl(baseUrl, '/search?q={search_term_string}'),
           },
           'query-input': 'required name=search_term_string',
         },

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -8,6 +8,7 @@
   },
   "types": "./src/index.ts",
   "scripts": {
+    "build": "tsc --noEmit",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/config/src/constants.ts
+++ b/packages/config/src/constants.ts
@@ -1,0 +1,39 @@
+export const dayoptDomains = {
+  marketing: 'dayopt.app',
+  product: 'app.dayopt.app',
+  mcp: 'mcp.dayopt.app',
+  docs: 'docs.dayopt.app',
+  www: 'www.dayopt.app',
+} as const;
+
+export const dayoptUrls = {
+  marketing: `https://${dayoptDomains.marketing}`,
+  product: `https://${dayoptDomains.product}`,
+  mcp: `https://${dayoptDomains.mcp}`,
+  docs: `https://${dayoptDomains.docs}`,
+  www: `https://${dayoptDomains.www}`,
+} as const;
+
+export const dayoptContact = {
+  supportEmail: 'support@dayopt.app',
+  securityEmail: 'security@dayopt.app',
+  contactEmail: 'contact@dayopt.app',
+} as const;
+
+export const dayoptBrand = {
+  name: 'Dayopt',
+  teamName: 'Dayopt Team',
+  platformName: 'Dayopt Platform',
+  twitterHandle: '@dayoptapp',
+  xUrl: 'https://x.com/dayoptapp',
+  githubUrl: 'https://github.com/dayoptapp',
+} as const;
+
+export type DayoptUrlBase = string;
+
+export function createDayoptUrl(base: DayoptUrlBase, path = ''): string {
+  if (!path || path === '/') return base;
+
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${base}${normalizedPath}`;
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,1 +1,8 @@
-export {};
+export {
+  createDayoptUrl,
+  dayoptBrand,
+  dayoptContact,
+  dayoptDomains,
+  dayoptUrls,
+  type DayoptUrlBase,
+} from './constants';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,9 @@ importers:
 
   apps/product:
     dependencies:
+      '@dayopt/config':
+        specifier: workspace:*
+        version: link:../../packages/config
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -664,6 +667,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@dayopt/config':
+        specifier: workspace:*
+        version: link:../../packages/config
       '@hookform/resolvers':
         specifier: ^5.1.1
         version: 5.2.2(react-hook-form@7.76.0(react@19.2.6))


### PR DESCRIPTION
## Summary

- add `@dayopt/config` as the shared public constants package
- centralize Dayopt domains, canonical URLs, contact emails, brand constants, and `createDayoptUrl`
- replace low-risk product/web runtime hardcodes for Dayopt URLs and contact emails
- update Storybook architecture docs to reflect `packages/design` and `packages/config` ownership

## Notes

- product/web env validation and Next.js metadata generator bodies stay in their apps
- product/web UI and routing behavior are not intentionally changed
- stories, fixtures, and historical docs were left alone outside the current Storybook ownership docs

## Validation

- `pnpm install`
- `pnpm --filter @dayopt/config build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:boundaries`
- `pnpm build`
- `pnpm build:web`
- `pnpm build-storybook`
- `pnpm -r list --depth -1 | rg @dayopt/config`
- `rg "https://(app\.|mcp\.|docs\.)?dayopt\.app|support@dayopt\.app|security@dayopt\.app|contact@dayopt\.app" apps/product/src apps/web/src -g "!**/*.stories.tsx" -g "!**/__tests__/**"`
- `rg "@dayopt/config" apps/product apps/web packages/config`