### PR TITLE
refactor(chronotype): useChronotypeZones hook を追加し Calendar から profile 計算を除去

### DIFF
--- a/apps/product/src/features/calendar/components/views/shared/components/ScrollableCalendarLayout.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/ScrollableCalendarLayout.tsx
@@ -9,13 +9,9 @@
 
 'use client';
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback } from 'react';
 
-import {
-  getChronotypeProfile,
-  useChronotypeGradient,
-  useChronotypeSettingsStore,
-} from '@/features/chronotype';
+import { useChronotypeGradient, useChronotypeZones } from '@/features/chronotype';
 import { cn } from '@/lib/utils';
 
 import { formatTimeString } from '@/lib/date';
@@ -151,11 +147,7 @@ export const ScrollableCalendarLayout = ({
   const gradientCss = useChronotypeGradient();
 
   // Chronotype ゾーン配列（TimeColumn ラベル装飾用）
-  const chronotype = useChronotypeSettingsStore((s) => s.chronotype);
-  const chronotypeZones = useMemo(() => {
-    if (!chronotype) return undefined;
-    return getChronotypeProfile(chronotype.type).productivityZones;
-  }, [chronotype]);
+  const chronotypeZones = useChronotypeZones();
 
   // 現在時刻のフォーマット（設定に応じて 24h/12h）
   const timeFormat = useUserPreferenceStore((s) => s.timeFormat);

--- a/apps/product/src/features/chronotype/hooks/useChronotypeZones.ts
+++ b/apps/product/src/features/chronotype/hooks/useChronotypeZones.ts
@@ -1,0 +1,21 @@
+/**
+ * Chronotype の productivityZones を返すフック
+ *
+ * chronotype が無効な場合は undefined を返す。consumer は zones 配列を
+ * そのまま render（例: TimeColumn のラベル装飾用）に使う想定。
+ */
+
+import { useMemo } from 'react';
+
+import type { ProductivityZone } from '@/lib/types/chronotype';
+
+import { getChronotypeProfile } from '../lib/chronotype-profile';
+import { useChronotypeSettingsStore } from '../stores/useChronotypeSettingsStore';
+
+export function useChronotypeZones(): ProductivityZone[] | undefined {
+  const chronotype = useChronotypeSettingsStore((s) => s.chronotype);
+  return useMemo(() => {
+    if (!chronotype) return undefined;
+    return getChronotypeProfile(chronotype.type).productivityZones;
+  }, [chronotype]);
+}

--- a/apps/product/src/features/chronotype/index.ts
+++ b/apps/product/src/features/chronotype/index.ts
@@ -17,6 +17,7 @@ export { CHRONOTYPE_EMOJI, CHRONOTYPE_SELECTABLE_TYPES } from './lib/constants';
 
 // --- Hooks ---
 export { useChronotypeGradient } from './hooks/useChronotypeGradient';
+export { useChronotypeZones } from './hooks/useChronotypeZones';
 
 // --- Lib ---
 export { getChronotypeProfile } from './lib/chronotype-profile';


### PR DESCRIPTION
## Summary

PR #1199 で `useChronotypeGradient` を `features/chronotype/hooks/` に移動した残課題として、`ScrollableCalendarLayout.tsx` 内に同パターン（`useChronotypeSettingsStore` + `getChronotypeProfile` で `productivityZones` を取り出す）が残っていたため hook 化。

仕様 / UI / DB / store / gradient ロジック変更なし。

## 調査結果

該当箇所（[ScrollableCalendarLayout.tsx:153-158](apps/product/src/features/calendar/components/views/shared/components/ScrollableCalendarLayout.tsx:153)）:

```tsx
const chronotype = useChronotypeSettingsStore((s) => s.chronotype);
const chronotypeZones = useMemo(() => {
  if (!chronotype) return undefined;
  return getChronotypeProfile(chronotype.type).productivityZones;
}, [chronotype]);
```

- 利用箇所: `<TimeColumn zones={chronotypeZones} />`
- 戻り値型: `ProductivityZone[] | undefined`（disabled 時は undefined）
- Calendar が Chronotype の store + profile lib を直接組み合わせており、`useChronotypeGradient` と全く同じ責務形

## 実装した変更

新規 1 + 編集 2（+25 / -11）

### 追加した hook

`apps/product/src/features/chronotype/hooks/useChronotypeZones.ts`:

```ts
export function useChronotypeZones(): ProductivityZone[] | undefined {
  const chronotype = useChronotypeSettingsStore((s) => s.chronotype);
  return useMemo(() => {
    if (!chronotype) return undefined;
    return getChronotypeProfile(chronotype.type).productivityZones;
  }, [chronotype]);
}
```

[useChronotypeGradient](apps/product/src/features/chronotype/hooks/useChronotypeGradient.ts) と同じ相対 import パターン。

### barrel

[features/chronotype/index.ts](apps/product/src/features/chronotype/index.ts) の `// --- Hooks ---` セクションに `useChronotypeZones` を export 追加。

### consumer

[ScrollableCalendarLayout.tsx](apps/product/src/features/calendar/components/views/shared/components/ScrollableCalendarLayout.tsx):

- import から `getChronotypeProfile` / `useChronotypeSettingsStore` を削除、`useChronotypeZones` を追加
- zones 算出 6 行 → `const chronotypeZones = useChronotypeZones();` 1 行に置換

## Calendar 側から削除した責務

- `useChronotypeSettingsStore` の selector 直接購読
- `getChronotypeProfile(...).productivityZones` の組合せ計算
- `useMemo` での chronotype 派生計算

Calendar は zones の "出所" を知る必要がなくなり、`useChronotypeZones()` を呼ぶだけで宣言的に使える形になった。

## 触らなかったもの

- `useChronotypeGradient` 内部の `getChronotypeProfile` 呼び出し
- store / lib の実装
- `NowBadge.tsx` 内の同パターン（useMemo 内で `getChronotypeProfile` から zoneLevel まで導出している形なので、本 PR の最小単位を超える）
- Storybook stories / mock / DB / ESLint boundary rule

## 検証結果

- ✅ `pnpm --filter @dayopt/product typecheck`
- ✅ `pnpm --filter @dayopt/product lint`
- ✅ `pnpm lint:boundaries`（Cross-feature imports: 0）
- ✅ `pnpm --filter @dayopt/product test:run`（1731 件 pass、件数キープ）
- ✅ `pnpm --filter @dayopt/product build`
- ✅ `pnpm --filter @dayopt/storybook build`

`grep "getChronotypeProfile\|useChronotypeSettingsStore" ScrollableCalendarLayout.tsx` の結果が空であることを確認。

## 残課題

- `NowBadge.tsx` 内の同パターン（`getChronotypeProfile` → `getActiveZoneLevel` まで useMemo 内で導出）の hook 化検討（例: `useActiveZoneLevel(currentHour)` を chronotype hooks 側に追加）

## Test plan

- [ ] CI が全て pass
- [ ] Vercel preview deployment が ready
- [ ] Storybook で Calendar TimeColumn の chronotype zone ラベルが引き続き正常表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)