### PR TITLE
refactor(chronotype): useActiveZoneLevel hook を追加し NowBadge から profile 計算を除去

### DIFF
--- a/apps/product/src/features/calendar/components/views/shared/grid/CurrentTimeLine/NowBadge.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/grid/CurrentTimeLine/NowBadge.tsx
@@ -7,13 +7,9 @@
 
 'use client';
 
-import { memo, useMemo } from 'react';
+import { memo } from 'react';
 
-import {
-  getActiveZoneLevel,
-  getChronotypeProfile,
-  useChronotypeSettingsStore,
-} from '@/features/chronotype';
+import { useActiveZoneLevel } from '@/features/chronotype';
 import { useTranslations } from 'next-intl';
 
 interface NowBadgeProps {
@@ -23,13 +19,7 @@ interface NowBadgeProps {
 
 export const NowBadge = memo<NowBadgeProps>(function NowBadge({ currentHour }) {
   const t = useTranslations('calendar.nowBadge');
-  const chronotype = useChronotypeSettingsStore((s) => s.chronotype);
-
-  const zoneLevel = useMemo(() => {
-    if (!chronotype) return null;
-    const profile = getChronotypeProfile(chronotype.type);
-    return getActiveZoneLevel(profile.productivityZones, currentHour);
-  }, [chronotype, currentHour]);
+  const zoneLevel = useActiveZoneLevel(currentHour);
 
   if (!zoneLevel) return null;
 

--- a/apps/product/src/features/chronotype/hooks/useActiveZoneLevel.ts
+++ b/apps/product/src/features/chronotype/hooks/useActiveZoneLevel.ts
@@ -1,0 +1,21 @@
+/**
+ * 指定時刻が現在の chronotype の deep/ease ゾーン内かどうかを返すフック
+ *
+ * chronotype が無効、もしくは時刻がゾーン外の場合は null を返す。
+ * consumer は null チェックで badge 表示等の有無を判定する。
+ */
+
+import { useMemo } from 'react';
+
+import { getChronotypeProfile } from '../lib/chronotype-profile';
+import { getActiveZoneLevel } from '../lib/gradient';
+import { useChronotypeSettingsStore } from '../stores/useChronotypeSettingsStore';
+
+export function useActiveZoneLevel(hour: number): 'deep' | 'ease' | null {
+  const chronotype = useChronotypeSettingsStore((s) => s.chronotype);
+  return useMemo(() => {
+    if (!chronotype) return null;
+    const profile = getChronotypeProfile(chronotype.type);
+    return getActiveZoneLevel(profile.productivityZones, hour);
+  }, [chronotype, hour]);
+}

--- a/apps/product/src/features/chronotype/index.ts
+++ b/apps/product/src/features/chronotype/index.ts
@@ -16,6 +16,7 @@ export { ChronotypeSettings as ChronotypeSettingsPanel } from './components/chro
 export { CHRONOTYPE_EMOJI, CHRONOTYPE_SELECTABLE_TYPES } from './lib/constants';
 
 // --- Hooks ---
+export { useActiveZoneLevel } from './hooks/useActiveZoneLevel';
 export { useChronotypeGradient } from './hooks/useChronotypeGradient';
 export { useChronotypeZones } from './hooks/useChronotypeZones';
 


### PR DESCRIPTION
## Summary

PR #1199 (`useChronotypeGradient`) / #1204 (`useChronotypeZones`) に続く chronotype hook 整理の最終手。`NowBadge.tsx` 内の `useChronotypeSettingsStore` + `getChronotypeProfile` + `getActiveZoneLevel` の組合せを `useActiveZoneLevel` hook に集約し、Calendar 側から Chronotype の内部計算知識を更に除去する。

仕様 / UI / DB / store / 判定ロジック変更なし。

## 調査結果

該当箇所（[NowBadge.tsx:24-32](apps/product/src/features/calendar/components/views/shared/grid/CurrentTimeLine/NowBadge.tsx:24)）:

```tsx
const chronotype = useChronotypeSettingsStore((s) => s.chronotype);
const zoneLevel = useMemo(() => {
  if (!chronotype) return null;
  const profile = getChronotypeProfile(chronotype.type);
  return getActiveZoneLevel(profile.productivityZones, currentHour);
}, [chronotype, currentHour]);
```

- 戻り値型: `'deep' | 'ease' | null`
- 入力: `currentHour: number`
- 利用: badge 表示の有無 / ラベル / 色 / 矢印の分岐

**TimeColumn.tsx も `getActiveZoneLevel` を使うが用途が異なる**: zones prop を受け取って各 hour 分の zone level を for ループ内で導出している。hook 化すると Rules of Hooks 違反になるため対象外。zones の `getActiveZoneLevel` 直接呼び出しは維持。

## 実装した変更

新規 1 + 編集 2（+25 / -13）

### 追加した hook

`apps/product/src/features/chronotype/hooks/useActiveZoneLevel.ts`:

```ts
export function useActiveZoneLevel(hour: number): 'deep' | 'ease' | null {
  const chronotype = useChronotypeSettingsStore((s) => s.chronotype);
  return useMemo(() => {
    if (!chronotype) return null;
    const profile = getChronotypeProfile(chronotype.type);
    return getActiveZoneLevel(profile.productivityZones, hour);
  }, [chronotype, hour]);
}
```

[useChronotypeGradient](apps/product/src/features/chronotype/hooks/useChronotypeGradient.ts) / [useChronotypeZones](apps/product/src/features/chronotype/hooks/useChronotypeZones.ts) と同じ相対 import パターン。

### barrel

[features/chronotype/index.ts](apps/product/src/features/chronotype/index.ts) の `// --- Hooks ---` セクションに alphabetical 順で追加。

### consumer

[NowBadge.tsx](apps/product/src/features/calendar/components/views/shared/grid/CurrentTimeLine/NowBadge.tsx):

- barrel import から `getChronotypeProfile` / `getActiveZoneLevel` / `useChronotypeSettingsStore` を削除
- `useActiveZoneLevel` を import
- chronotype selector + useMemo ブロック → `const zoneLevel = useActiveZoneLevel(currentHour);` 1 行に置換
- 不要になった `useMemo` を react import から削除

## NowBadge から削除した責務

- `useChronotypeSettingsStore` の selector 直接購読
- `getChronotypeProfile` の組合せ計算
- `getActiveZoneLevel` の直接呼び出し
- `useMemo` でのメモ化

## 触らなかったもの

- `TimeColumn.tsx` の `getActiveZoneLevel` 利用（zones prop の pure loop derivation、hook 化対象外）
- `getActiveZoneLevel` lib helper の barrel export（TimeColumn が継続利用）
- store / lib の実装
- NowBadge UI / クラス / 表示挙動
- Storybook stories / mock / DB / ESLint boundary rule

## 検証結果

- ✅ `pnpm --filter @dayopt/product typecheck`
- ✅ `pnpm --filter @dayopt/product lint`
- ✅ `pnpm lint:boundaries`（Cross-feature imports: 0）
- ✅ `pnpm --filter @dayopt/product test:run`（1731 件 pass、件数キープ）
- ✅ `pnpm --filter @dayopt/product build`
- ✅ `pnpm --filter @dayopt/storybook build`

`grep "getChronotypeProfile\|useChronotypeSettingsStore" NowBadge.tsx` の結果が空であることを確認。

## 残課題

特になし。Chronotype 周辺の hook 化候補は本 PR でひとまず出揃った。将来 `TimeColumn` の zones-prop ベース derivation をさらに hide したくなった場合、`useChronotypeZoneLevels(startHour, endHour)` のような配列返却 hook を別途検討。

## Test plan

- [ ] CI が全て pass
- [ ] Vercel preview deployment が ready
- [ ] Storybook の `Features/Calendar/Views/Grid/NowBadge/InDeep` story で bear chronotype の deep badge が引き続き正常表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)