### PR TITLE
feat(domain): add Dayopt domain model package

### DIFF
--- a/apps/storybook/docs/dev/architecture/PackagesOverview.mdx
+++ b/apps/storybook/docs/dev/architecture/PackagesOverview.mdx
@@ -4,25 +4,24 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 # Packages Overview
 
-Dayopt の monorepo は、アプリケーションを増やすための置き場ではなく、責務を小さく保つための境界として `packages/*` を使う。
-
-このページは「どのコードをどの package に出すか」を決めるための基準であり、今すぐ大規模な実装移動をするための計画ではない。Phase 1 では `apps/product` の中にある実装を壊さず、抽出候補だけを明確にしておく。
+Dayopt の monorepo は、アプリを増やすためだけではなく、責務を小さく保つために `packages/*` を使う。
+このページは「どのコードをどの package に出すか」を決めるための境界メモであり、大規模な移動計画ではない。
 
 ## Package Map
 
-| Package             | 責務                                                  | 入れてよいもの                                               | 入れないもの                                         |
-| ------------------- | ----------------------------------------------------- | ------------------------------------------------------------ | ---------------------------------------------------- |
-| `packages/design`   | design tokens / theme css / CSS variables             | colors, typography, spacing, radius, shadow, motion, z-index | React components, domain logic, DB 型                |
-| `packages/ui`       | React UI primitives / reusable components             | Button, Badge, Card, Input, Logo, layout primitives          | Supabase, Stripe, feature-specific business rules    |
-| `packages/config`   | public constants / metadata / URL definitions         | Dayopt URLs, app metadata, public feature flags              | secrets, request-scoped values, server-only clients  |
-| `packages/domain`   | Dayopt の純粋な domain model                          | entry, tag, plan, entitlement などの型と pure definitions    | DB row shape, React, Supabase client                 |
-| `packages/database` | Supabase generated types と database/domain 変換      | generated `Database` types, row aliases, converters          | UI components, Stripe secret handling                |
-| `packages/billing`  | plan / subscription / entitlement の公開 billing 定義 | plan ids, price metadata, entitlement matrix                 | Stripe secret key を使う処理、webhook handlers       |
-| `packages/utils`    | generic pure utilities                                | date/string/array/object helpers, type guards                | Dayopt 固有 domain policy, framework-specific helper |
+| Package             | 責務                                          | 入れてよいもの                                      | 入れないもの                                        |
+| ------------------- | --------------------------------------------- | --------------------------------------------------- | --------------------------------------------------- |
+| `packages/design`   | design tokens / theme css / CSS variables     | colors, typography, spacing, radius, shadow         | React components, domain logic, DB 型               |
+| `packages/ui`       | React UI primitives / reusable components     | Button, Badge, Card, Logo, layout primitives        | Supabase, Stripe, feature-specific business rules   |
+| `packages/config`   | public constants / metadata / URL definitions | Dayopt URLs, contact, brand constants, URL helpers  | secrets, request-scoped values, server-only clients |
+| `packages/domain`   | Dayopt domain model / pure types / helpers    | Entry, Tag, Review, Chronotype, TimeRange concepts  | DB row shape, React, Next, Supabase, Zustand        |
+| `packages/database` | Supabase generated types と converters         | generated `Database` types, row aliases, converters | UI components, Stripe secret handling               |
+| `packages/billing`  | public plan / entitlement definitions          | plan ids, public price metadata, entitlement matrix | Stripe secret key, webhook handlers                 |
+| `packages/utils`    | generic pure utilities                        | date/string/array/object helpers, type guards       | Dayopt 固有 domain policy, framework helper         |
 
 ## Dependency Direction
 
-`packages/*` は下の方向にだけ依存する。上位の app や feature へ戻る import を作らない。
+`packages/*` は app / feature へ戻る import を作らない。共有 package 同士も、下位の意味を上位に漏らさない。
 
 ```txt
 apps/product, apps/web, apps/admin, apps/storybook
@@ -37,88 +36,43 @@ apps/product, apps/web, apps/admin
   -> packages/utils
 ```
 
-実際には `packages/ui` は `packages/design` の token / CSS variables を使えるが、`packages/design` は `packages/ui` を知らない。`packages/domain` は `packages/database` を知らない。DB の都合を domain model に漏らす場合は `packages/database` 側の converter で吸収する。
+実際には `packages/ui` は `packages/design` の token / CSS variables を使えるが、`packages/design` は `packages/ui` を知らない。
+`packages/domain` は `packages/database` を知らない。DB の都合を domain model に漏らす場合は `packages/database` 側の converter で吸収する。
 
 ## Current Phase
 
-現在の実装はまだ `apps/product` 中心だが、`packages/design`, `packages/ui`, `packages/config` は最小の公開面を持つ package として動き始めている。`packages/types`, `packages/server`, `packages/utils` は第一段階の placeholder に近い。
+`packages/design`, `packages/ui`, `packages/config`, `packages/domain` は最小の公開面を持つ package として動き始めている。
+`packages/domain` は Dayopt の意味を表す pure TypeScript package で、現時点では `TimeRange`, `EntryOrigin`, `Tag`, `ReviewPeriod`, `UserPreference`, `Chronotype` などの軽い型・定数・helper だけを持つ。
 
-次の段階では `packages/types` をそのまま拡張し続けるより、責務を `packages/domain` と `packages/database` に分ける。`packages/server` は Supabase / Stripe / admin helper のような server-only 境界に残すか、用途が明確になったものから `packages/database` / `packages/billing` へ分離する。
+`packages/types`, `packages/server`, `packages/utils` はまだ第一段階の placeholder に近い。次に DB row / Supabase generated types / domain converter を扱うなら `packages/database` を別 package として作る。
 
-## `packages/design`
+## Package Boundaries
 
-`packages/design` は Dayopt の見た目の source of truth にする。React component は持たず、tokens と theme だけを扱う。
+### `packages/design`
 
-### Scope
+Dayopt の見た目の source of truth。React component は持たず、tokens と theme だけを扱う。
+CSS variables は `--dayopt-*` prefix で公開し、既存 app の `--background`, `--primary`, `--radius-*` などは上書きしない。
 
-| 領域       | Source                                           | Storybook 表示      |
-| ---------- | ------------------------------------------------ | ------------------- |
-| Colors     | `packages/design/src/colors.ts`, `theme.css`     | `Design/Colors`     |
-| Typography | `packages/design/src/typography.ts`, `theme.css` | `Design/Typography` |
-| Spacing    | `packages/design/src/spacing.ts`, `theme.css`    | `Design/Spacing`    |
-| Radius     | `packages/design/src/radius.ts`, `theme.css`     | `Design/Radius`     |
-| Shadow     | `packages/design/src/shadow.ts`, `theme.css`     | `Design/Shadows`    |
-| Motion     | 未定義。必要になった時に追加                     | 未定                |
-| Z-Index    | 未定義。必要になった時に追加                     | 未定                |
+Storybook 表示:
 
-Storybook は token の可視化面であり、token の所有者は `packages/design` にする。`apps/product/src/lib/styles/tokens/` は既存 product UI のための layer として残し、段階的に `packages/design` の contract へ寄せる。
+- `Design/Colors`
+- `Design/Typography`
+- `Design/Spacing`
+- `Design/Radius`
+- `Design/Shadows`
 
-### Export Shape
+### `packages/ui`
 
-`packages/design` は CSS を主たる public API にする。
+Domain logic を持たない React UI primitive の置き場。Button, Badge, Card, Logo のように複数 app で使える部品だけを入れる。
 
-```txt
-packages/design/
-  src/
-    colors.ts
-    typography.ts
-    spacing.ts
-    radius.ts
-    shadow.ts
-    tokens.ts
-    theme.css
-    index.ts
-```
-
-推奨 import:
-
-```ts
-import '@dayopt/design/theme.css';
-```
-
-CSS variables は `--dayopt-*` prefix で公開し、既存 app の `--background`, `--primary`, `--radius-*` などは上書きしない。React component 内で raw OKLCH 値や hex 値を直書きしない。
-
-## `packages/config`
-
-`packages/config` は product/web が共有する public constants の置き場にする。副作用を持たず、Next.js / React / Zod / env / server-only に依存しない。
-
-置いてよいもの:
-
-- Dayopt の domain と canonical URL
-- support / security / contact email
-- brand name / public social URL
-- URL join helper
-
-置かないもの:
-
-- env validation
-- secrets
-- request-scoped value
-- Next.js metadata generator 本体
-- server-only client
-
-## `packages/ui`
-
-`packages/ui` は domain logic を持たない React UI の置き場にする。Button, Badge, Card, Input, Logo のような primitive と、複数 app で再利用する小さな composition を入れる。
-
-`packages/ui` が知ってよいもの:
+知ってよいもの:
 
 - React
 - accessibility primitives
 - `packages/design`
 - generic utility
 
-`packages/ui` が知ってはいけないもの:
+知ってはいけないもの:
 
 - `apps/product/src/features/*`
 - Supabase / database row
@@ -126,23 +80,48 @@ CSS variables は `--dayopt-*` prefix で公開し、既存 app の `--backgroun
 - user session / auth policy
 - entry/tag/calendar 固有の business rule
 
-## Domain, Database, Billing
+### `packages/config`
+
+Product/web が共有する public constants の置き場。副作用を持たず、Next.js / React / Zod / env / server-only に依存しない。
+
+入れてよいもの:
+
+- Dayopt の domain と canonical URL
+- support / security / contact email
+- brand name / public social URL
+- URL join helper
+
+入れないもの:
+
+- env validation
+- secrets
+- request-scoped value
+- Next.js metadata generator 本体
+- server-only client
 
 ### `packages/domain`
 
-Dayopt の言葉を型と pure definition にする。DB に保存する形ではなく、アプリが考える概念を置く。
+Dayopt の「意味」を pure TypeScript の型・定数・helper にする。DB に保存する形ではなく、アプリが考える概念を置く。
 
-例:
+入れてよいもの:
 
-- `Entry`
-- `TimeRange`
-- `Tag`
-- `Plan`
-- `Entitlement`
+- pure TypeScript types
+- enum 相当の union type / const arrays
+- Date と primitive だけを使う pure helper
+- DB/UI に依存しない business concept
+
+入れないもの:
+
+- Supabase generated types
+- DB row shape
+- React component / props
+- Zustand store state
+- Next.js route / server-only helper
+- CSS / UI token
 
 ### `packages/database`
 
-Supabase generated types と DB row の alias を置く。domain model との変換もここで扱う。
+Supabase generated types と DB row alias を置く予定の境界。domain model との変換もここで扱う。
 
 例:
 
@@ -154,7 +133,7 @@ Supabase generated types と DB row の alias を置く。domain model との変
 
 ### `packages/billing`
 
-公開してよい plan / subscription / entitlement 定義を置く。Stripe secret key を使う処理や webhook handler は server-only 境界に置き、client import できる定義と混ぜない。
+公開してよい plan / subscription / entitlement 定義を置く予定の境界。Stripe secret key を使う処理や webhook handler は server-only 境界に置き、client import できる定義と混ぜない。
 
 ## Extraction Rules
 
@@ -180,11 +159,7 @@ Storybook は `packages/design` と `packages/ui` の公開面を確認する場
 - `packages/domain`, `packages/database`, `packages/billing`: UI カタログではなく docs と decision table で境界を説明する。
 - `apps/product` 固有の feature component は `Features/*` に残し、汎用化できたものだけ `packages/ui` に移す。
 
-移動後も Storybook の階層名は利用者の認知に合わせて調整する。現在の shared package は `Design/*` と `UI/*` を公開面にする。
-
 ## Ownership And Operations
-
-UI ownership は Storybook の表示階層で判断する。
 
 | Storybook 階層   | Owner                               | Source of truth                          |
 | ---------------- | ----------------------------------- | ---------------------------------------- |
@@ -192,9 +167,6 @@ UI ownership は Storybook の表示階層で判断する。
 | `UI/*`           | reusable UI primitives              | `packages/ui`                            |
 | `Foundations/*`  | legacy / product-facing foundations | `apps/product` 由来の既存 Storybook 表示 |
 | `Primitives/*`   | legacy reusable UI primitives       | `apps/product/src/lib/components/ui/`    |
-| `Recipes/*`      | reusable UI compositions            | `packages/ui` または app 共通 component  |
 | `Features/*`     | product feature UI                  | `apps/product/src/features/*`            |
 | `Operations/*`   | deployment / release ops            | `apps/storybook/docs/operations/*`       |
 | `Architecture/*` | engineering decisions               | `apps/storybook/docs/dev/architecture/*` |
-
-Deployment と release の手順は code package ではなく `Operations/*` docs の責務にする。package 境界のページには運用手順を重複させず、参照先だけを固定する。

--- a/apps/storybook/docs/dev/architecture/PackagesOverview.mdx
+++ b/apps/storybook/docs/dev/architecture/PackagesOverview.mdx
@@ -9,15 +9,13 @@ Dayopt の monorepo は、アプリを増やすためだけではなく、責務
 
 ## Package Map
 
-| Package             | 責務                                          | 入れてよいもの                                      | 入れないもの                                        |
-| ------------------- | --------------------------------------------- | --------------------------------------------------- | --------------------------------------------------- |
-| `packages/design`   | design tokens / theme css / CSS variables     | colors, typography, spacing, radius, shadow         | React components, domain logic, DB 型               |
-| `packages/ui`       | React UI primitives / reusable components     | Button, Badge, Card, Logo, layout primitives        | Supabase, Stripe, feature-specific business rules   |
-| `packages/config`   | public constants / metadata / URL definitions | Dayopt URLs, contact, brand constants, URL helpers  | secrets, request-scoped values, server-only clients |
-| `packages/domain`   | Dayopt domain model / pure types / helpers    | Entry, Tag, Review, Chronotype, TimeRange concepts  | DB row shape, React, Next, Supabase, Zustand        |
-| `packages/database` | Supabase generated types と converters         | generated `Database` types, row aliases, converters | UI components, Stripe secret handling               |
-| `packages/billing`  | public plan / entitlement definitions          | plan ids, public price metadata, entitlement matrix | Stripe secret key, webhook handlers                 |
-| `packages/utils`    | generic pure utilities                        | date/string/array/object helpers, type guards       | Dayopt 固有 domain policy, framework helper         |
+- `packages/design`: design tokens / theme css / CSS variables。React components, domain logic, DB 型は入れない。
+- `packages/ui`: React UI primitives / reusable components。Supabase, Stripe, feature-specific business rules は入れない。
+- `packages/config`: public constants / metadata / URL definitions。secrets, request-scoped values, server-only clients は入れない。
+- `packages/domain`: Dayopt domain model / pure types / helpers。DB row shape, React, Next, Supabase, Zustand は入れない。
+- `packages/database`: Supabase generated types と converters の予定地。UI components, Stripe secret handling は入れない。
+- `packages/billing`: public plan / entitlement definitions の予定地。Stripe secret key, webhook handlers は入れない。
+- `packages/utils`: generic pure utilities。Dayopt 固有 domain policy, framework helper は入れない。
 
 ## Dependency Direction
 
@@ -36,7 +34,7 @@ apps/product, apps/web, apps/admin
   -> packages/utils
 ```
 
-実際には `packages/ui` は `packages/design` の token / CSS variables を使えるが、`packages/design` は `packages/ui` を知らない。
+`packages/ui` は `packages/design` の token / CSS variables を使えるが、`packages/design` は `packages/ui` を知らない。
 `packages/domain` は `packages/database` を知らない。DB の都合を domain model に漏らす場合は `packages/database` 側の converter で吸収する。
 
 ## Current Phase
@@ -139,16 +137,14 @@ Supabase generated types と DB row alias を置く予定の境界。domain mode
 
 抽出は「共通化したいから」ではなく、責務境界が明確になった時だけ行う。
 
-| 条件                                                | 移動先              |
-| --------------------------------------------------- | ------------------- |
-| UI だけで成立し、domain を知らない                  | `packages/ui`       |
-| 見た目の token / CSS variable / theme               | `packages/design`   |
-| URL / metadata / public constants                   | `packages/config`   |
-| DB なしで説明できる Dayopt の business definition   | `packages/domain`   |
-| Supabase row / generated type / domain converter    | `packages/database` |
-| plan / subscription / entitlement の公開定義        | `packages/billing`  |
-| Dayopt に依存しない pure helper                     | `packages/utils`    |
-| secret, admin, webhook, service-role を使う共通処理 | server-only package |
+- UI だけで成立し、domain を知らない: `packages/ui`
+- 見た目の token / CSS variable / theme: `packages/design`
+- URL / metadata / public constants: `packages/config`
+- DB なしで説明できる Dayopt の business definition: `packages/domain`
+- Supabase row / generated type / domain converter: `packages/database`
+- plan / subscription / entitlement の公開定義: `packages/billing`
+- Dayopt に依存しない pure helper: `packages/utils`
+- secret, admin, webhook, service-role を使う共通処理: server-only package
 
 ## Storybook Policy
 
@@ -161,12 +157,10 @@ Storybook は `packages/design` と `packages/ui` の公開面を確認する場
 
 ## Ownership And Operations
 
-| Storybook 階層   | Owner                               | Source of truth                          |
-| ---------------- | ----------------------------------- | ---------------------------------------- |
-| `Design/*`       | design tokens                       | `packages/design`                        |
-| `UI/*`           | reusable UI primitives              | `packages/ui`                            |
-| `Foundations/*`  | legacy / product-facing foundations | `apps/product` 由来の既存 Storybook 表示 |
-| `Primitives/*`   | legacy reusable UI primitives       | `apps/product/src/lib/components/ui/`    |
-| `Features/*`     | product feature UI                  | `apps/product/src/features/*`            |
-| `Operations/*`   | deployment / release ops            | `apps/storybook/docs/operations/*`       |
-| `Architecture/*` | engineering decisions               | `apps/storybook/docs/dev/architecture/*` |
+- `Design/*`: design tokens。Source of truth は `packages/design`。
+- `UI/*`: reusable UI primitives。Source of truth は `packages/ui`。
+- `Foundations/*`: legacy / product-facing foundations。Source of truth は `apps/product` 由来の既存 Storybook 表示。
+- `Primitives/*`: legacy reusable UI primitives。Source of truth は `apps/product/src/lib/components/ui/`。
+- `Features/*`: product feature UI。Source of truth は `apps/product/src/features/*`。
+- `Operations/*`: deployment / release ops。Source of truth は `apps/storybook/docs/operations/*`。
+- `Architecture/*`: engineering decisions。Source of truth は `apps/storybook/docs/dev/architecture/*`。

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@dayopt/domain",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "types": "./src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit"
+  }
+}

--- a/packages/domain/src/chronotype.ts
+++ b/packages/domain/src/chronotype.ts
@@ -1,0 +1,34 @@
+export const chronotypeTypes = ['lion', 'bear', 'wolf', 'dolphin'] as const;
+export const productivityLevels = ['warmup', 'deep', 'ease', 'recovery', 'winddown'] as const;
+
+export type ChronotypeType = (typeof chronotypeTypes)[number];
+
+export type PresetChronotypeType = ChronotypeType;
+
+export type ProductivityLevel = (typeof productivityLevels)[number];
+
+export type ProductivityZone = Readonly<{
+  startHour: number;
+  endHour: number;
+  level: ProductivityLevel;
+  label: string;
+}>;
+
+export type ChronotypeProfile = Readonly<{
+  type: ChronotypeType;
+  name: string;
+  description: string;
+  productivityZones: readonly ProductivityZone[];
+}>;
+
+export type ChronotypeSettings = Readonly<{
+  type: ChronotypeType;
+}>;
+
+export function isChronotypeType(value: string): value is ChronotypeType {
+  return chronotypeTypes.includes(value as ChronotypeType);
+}
+
+export function isProductivityLevel(value: string): value is ProductivityLevel {
+  return productivityLevels.includes(value as ProductivityLevel);
+}

--- a/packages/domain/src/entry.ts
+++ b/packages/domain/src/entry.ts
@@ -1,0 +1,29 @@
+import type { TimeRange } from './time-range';
+
+export const entryOrigins = ['planned', 'unplanned'] as const;
+
+export type EntryOrigin = (typeof entryOrigins)[number];
+
+export type EntryState = 'upcoming' | 'active' | 'past';
+
+export type FulfillmentScore = 1 | 2 | 3;
+
+export type EntryTimeRangeKind = 'planned' | 'actual';
+
+export type EntryTimeRanges = Readonly<{
+  planned?: TimeRange | null;
+  actual?: TimeRange | null;
+}>;
+
+export type EntryTimeRangePatch = Readonly<{
+  kind: EntryTimeRangeKind;
+  range: TimeRange;
+}>;
+
+export function isEntryOrigin(value: string): value is EntryOrigin {
+  return entryOrigins.includes(value as EntryOrigin);
+}
+
+export function determineEntryOrigin(end: Date, now: Date = new Date()): EntryOrigin {
+  return end.getTime() <= now.getTime() ? 'unplanned' : 'planned';
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,0 +1,6 @@
+export * from './chronotype';
+export * from './entry';
+export * from './review';
+export * from './tag';
+export * from './time-range';
+export * from './user-preference';

--- a/packages/domain/src/review.ts
+++ b/packages/domain/src/review.ts
@@ -1,6 +1,6 @@
 import type { TimeRange } from './time-range';
 
-export const reviewPeriods = ['day', 'week', 'month'] as const;
+export const reviewPeriods = ['day', 'week', 'month', 'year'] as const;
 
 export type ReviewPeriod = (typeof reviewPeriods)[number];
 

--- a/packages/domain/src/review.ts
+++ b/packages/domain/src/review.ts
@@ -1,0 +1,14 @@
+import type { TimeRange } from './time-range';
+
+export const reviewPeriods = ['day', 'week', 'month'] as const;
+
+export type ReviewPeriod = (typeof reviewPeriods)[number];
+
+export type ReviewRange = TimeRange &
+  Readonly<{
+    period: ReviewPeriod;
+  }>;
+
+export function isReviewPeriod(value: string): value is ReviewPeriod {
+  return reviewPeriods.includes(value as ReviewPeriod);
+}

--- a/packages/domain/src/tag.ts
+++ b/packages/domain/src/tag.ts
@@ -1,0 +1,26 @@
+export type TagId = string;
+export type TagColor = string;
+
+export type Tag = Readonly<{
+  id: TagId;
+  name: string;
+  color?: TagColor | null;
+  icon?: string | null;
+  parentId?: TagId | null;
+}>;
+
+export type TagTreeNode = Readonly<{
+  tag: Tag;
+  children: readonly TagTreeNode[];
+}>;
+
+export function isRootTag(tag: Pick<Tag, 'parentId'>): boolean {
+  return tag.parentId == null;
+}
+
+export function createTagPath(parentName: string | null | undefined, name: string): string {
+  const normalizedName = name.trim();
+  const normalizedParentName = parentName?.trim();
+
+  return normalizedParentName ? `${normalizedParentName}:${normalizedName}` : normalizedName;
+}

--- a/packages/domain/src/time-range.ts
+++ b/packages/domain/src/time-range.ts
@@ -1,0 +1,27 @@
+export type TimeRange = Readonly<{
+  start: Date;
+  end: Date;
+}>;
+
+function cloneDate(value: Date): Date {
+  return new Date(value.getTime());
+}
+
+export function createTimeRange(start: Date, end: Date): TimeRange {
+  return {
+    start: cloneDate(start),
+    end: cloneDate(end),
+  };
+}
+
+export function getTimeRangeDurationMs(range: TimeRange): number {
+  return range.end.getTime() - range.start.getTime();
+}
+
+export function isValidTimeRange(range: TimeRange): boolean {
+  return (
+    Number.isFinite(range.start.getTime()) &&
+    Number.isFinite(range.end.getTime()) &&
+    getTimeRangeDurationMs(range) > 0
+  );
+}

--- a/packages/domain/src/user-preference.ts
+++ b/packages/domain/src/user-preference.ts
@@ -1,0 +1,26 @@
+export const timeFormats = ['12h', '24h'] as const;
+export const dateFormats = ['yyyy-MM-dd', 'MM/dd/yyyy', 'dd/MM/yyyy'] as const;
+export const weekStartsOnValues = [0, 1, 6] as const;
+
+export type TimeFormat = (typeof timeFormats)[number];
+export type DateFormat = (typeof dateFormats)[number];
+export type WeekStartsOn = (typeof weekStartsOnValues)[number];
+
+export type UserPreference = Readonly<{
+  timezone: string;
+  timeFormat: TimeFormat;
+  dateFormat: DateFormat;
+  weekStartsOn: WeekStartsOn;
+}>;
+
+export function isTimeFormat(value: string): value is TimeFormat {
+  return timeFormats.includes(value as TimeFormat);
+}
+
+export function isDateFormat(value: string): value is DateFormat {
+  return dateFormats.includes(value as DateFormat);
+}
+
+export function isWeekStartsOn(value: number): value is WeekStartsOn {
+  return weekStartsOnValues.includes(value as WeekStartsOn);
+}

--- a/packages/domain/src/user-preference.ts
+++ b/packages/domain/src/user-preference.ts
@@ -1,5 +1,5 @@
 export const timeFormats = ['12h', '24h'] as const;
-export const dateFormats = ['yyyy-MM-dd', 'MM/dd/yyyy', 'dd/MM/yyyy'] as const;
+export const dateFormats = ['yyyy-MM-dd', 'yyyy/MM/dd', 'MM/dd/yyyy', 'dd/MM/yyyy'] as const;
 export const weekStartsOnValues = [0, 1, 6] as const;
 
 export type TimeFormat = (typeof timeFormats)[number];

--- a/packages/domain/tsconfig.json
+++ b/packages/domain/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -892,6 +892,8 @@ importers:
         specifier: ^5
         version: 5.9.3
 
+  packages/domain: {}
+
   packages/server:
     dependencies:
       server-only:


### PR DESCRIPTION
## Summary

- Add `@dayopt/domain` as a pure TypeScript workspace package for Dayopt domain concepts.
- Define minimal Entry, Tag, Review, Chronotype, UserPreference, and TimeRange types/constants/helpers.
- Update Storybook package boundary docs to describe `packages/domain` as the pure domain model boundary.

## Scope Notes

- No product/web runtime imports were changed in this PR.
- `packages/domain` does not depend on React, Next.js, Supabase, Zustand, app aliases, or feature code.
- DB row shapes and converters are intentionally left for a future `@dayopt/database` package.

## Validation

Pending CI:

- `pnpm install`
- `pnpm --filter @dayopt/domain build`
- `pnpm build:packages`
- `pnpm typecheck:packages`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:boundaries`
- `pnpm build`
- `pnpm build:web`
- `pnpm build-storybook`
- `pnpm check:workspace`
