### PR TITLE
docs(types): lib/types/settings.ts の残存理由を明記

### DIFF
--- a/apps/product/src/lib/types/settings.ts
+++ b/apps/product/src/lib/types/settings.ts
@@ -1,6 +1,8 @@
 /**
  * 設定カテゴリの識別子（5カテゴリ）
  *
- * 複数featureから参照されるため @/types に配置
+ * lib/stores/useShellStore および lib/components/shell から参照されるため lib/types に配置。
+ * lib/ → features/* の import は DAG 違反になるため features/settings への移動は不可。
+ * features/settings からは features/settings/types/index.ts 経由で re-export している。
  */
 export type SettingsCategory = 'profile' | 'display' | 'data' | 'billing' | 'account';


### PR DESCRIPTION
## Summary

- cross-layer types の owner 確定タスクの一環として、`lib/types/settings.ts` に残存理由のコメントを補強
- `lib/types/entry.ts` は既に [#138953c9](../commit/138953c9) で `features/entry/types/` に移動済み

## Owner 判断

`SettingsCategory` は以下から参照されている:

- `lib/stores/useShellStore.ts` — SheetType union の一部（lib 層）
- `lib/components/shell/sidebar/UserMenu.tsx` — 引数型（lib 層）
- `features/settings/types/index.ts` — re-export
- `features/settings/{constants,SettingsContent,SettingsSidebar}.tsx` — feature 内利用

ESLint boundary rule により `lib/ → features/*` の import は禁止のため、`features/settings` への移動は DAG 違反になる。現在の配置（`lib/types` 定義 → `features/settings/types/index.ts` で re-export）が正しい構造。

## 残課題

- `src/lib/types` は `settings.ts` のみとなり、曖昧な型置き場ではなくなった
- 仕様変更・UI変更・DB変更なし

## Test plan

- [x] コメント更新のみ（runtime 変更なし）
- [x] prettier / eslint via lint-staged

🤖 Generated with [Claude Code](https://claude.com/claude-code)