### PR TITLE
feat(billing): add shared billing model package

### DIFF
--- a/apps/product/package.json
+++ b/apps/product/package.json
@@ -73,6 +73,7 @@
     "eagle:test": "tsx ../../scripts/eagle-api.ts"
   },
   "dependencies": {
+    "@dayopt/billing": "workspace:*",
     "@dayopt/config": "workspace:*",
     "@dayopt/database": "workspace:*",
     "@dnd-kit/core": "^6.3.1",

--- a/apps/product/src/app/api/webhooks/stripe/route.ts
+++ b/apps/product/src/app/api/webhooks/stripe/route.ts
@@ -27,13 +27,13 @@ import { PaymentRecoveredEmail } from '@/emails/PaymentRecoveredEmail';
 import { ProStartEmail } from '@/emails/ProStartEmail';
 import { TrialStartEmail } from '@/emails/TrialStartEmail';
 import { env } from '@/env';
-import type { SubscriptionStatus } from '@/features/settings/server/billing-service';
 import { syncSubscriptionStatus } from '@/features/settings/server/billing-service';
 import { getAppUrl } from '@/lib/app-url';
 import { logger } from '@/lib/logger';
 import { captureBusinessEvent } from '@/lib/sentry';
 import { requireStripe } from '@/lib/stripe/client';
 import { createServiceRoleClient } from '@/lib/supabase/oauth';
+import type { SubscriptionStatus } from '@dayopt/billing';
 
 // ─── Slack 通知 ──────────────────────────────────────
 

--- a/apps/product/src/features/settings/components/billing-settings.tsx
+++ b/apps/product/src/features/settings/components/billing-settings.tsx
@@ -3,6 +3,12 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { toast } from '@/lib/toast';
+import {
+  dayoptPlanIds,
+  getMonthlyUsd,
+  getPlanIdForSubscriptionStatus,
+  type DayoptPlanId,
+} from '@dayopt/billing';
 import { AlertTriangle, Check, CreditCard, Crown } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useRouter, useSearchParams } from 'next/navigation';
@@ -28,18 +34,16 @@ import { api } from '@/lib/trpc';
 import { cn } from '@/lib/utils';
 
 interface Plan {
-  id: string;
+  id: DayoptPlanId;
   nameKey: string;
-  price: number;
   featureKeys: string[];
   recommended?: boolean;
 }
 
 const PLANS: Plan[] = [
   {
-    id: 'free',
+    id: dayoptPlanIds.free,
     nameKey: 'settings.subscription.plans.free.name',
-    price: 0,
     featureKeys: [
       'settings.subscription.plans.free.features.timeboxing',
       'settings.subscription.plans.free.features.basicAnalytics',
@@ -48,9 +52,8 @@ const PLANS: Plan[] = [
     ],
   },
   {
-    id: 'pro',
+    id: dayoptPlanIds.pro,
     nameKey: 'settings.subscription.plans.pro.name',
-    price: 5,
     featureKeys: [
       'settings.subscription.plans.pro.features.fullAnalytics',
       'settings.subscription.plans.pro.features.unlimitedTags',
@@ -97,12 +100,7 @@ export function BillingSettings() {
   });
 
   const subscriptionStatus = overview.data?.billingInfo.subscriptionStatus;
-  const currentPlan =
-    subscriptionStatus === 'active' ||
-    subscriptionStatus === 'trialing' ||
-    subscriptionStatus === 'past_due'
-      ? 'pro'
-      : 'free';
+  const currentPlan = getPlanIdForSubscriptionStatus(subscriptionStatus);
 
   // Checkout Session 作成
   const createCheckout = api.billing.createCheckoutSession.useMutation({
@@ -315,7 +313,7 @@ export function BillingSettings() {
                       {new Intl.NumberFormat(undefined, {
                         style: 'currency',
                         currency: 'usd',
-                      }).format(plan.price)}
+                      }).format(getMonthlyUsd(plan.id))}
                     </span>
                     <span className="text-muted-foreground text-base md:text-sm">
                       {t('settings.subscription.perMonth')}
@@ -332,7 +330,7 @@ export function BillingSettings() {
                   ))}
                 </ul>
 
-                {plan.id === 'pro' ? (
+                {plan.id === dayoptPlanIds.pro ? (
                   <Button
                     className="w-full"
                     variant="primary"

--- a/apps/product/src/features/settings/server/billing-service.ts
+++ b/apps/product/src/features/settings/server/billing-service.ts
@@ -14,12 +14,10 @@ import { getAppUrl } from '@/lib/app-url';
 import { logger } from '@/lib/logger';
 import { requireStripe } from '@/lib/stripe/client';
 import { ServiceError } from '@/lib/trpc/errors';
+import type { SubscriptionStatus } from '@dayopt/billing';
 import type { Database } from '@dayopt/database';
 
 // ===== Types =====
-
-/** Stripeサブスクリプションの状態値 */
-export type SubscriptionStatus = 'free' | 'active' | 'past_due' | 'canceled' | 'trialing';
 
 /** ユーザーの課金情報（サブスクリプション状態・Stripe ID） */
 export interface BillingInfo {

--- a/apps/product/src/lib/trpc/procedures.ts
+++ b/apps/product/src/lib/trpc/procedures.ts
@@ -24,6 +24,7 @@ import { trpcUserRateLimit } from '@/lib/rate-limit/upstash';
 import { AuthMode, createServiceRoleClient, detectAuthMode } from '@/lib/supabase/oauth';
 import { ServiceError } from '@/lib/trpc/errors';
 
+import { isProSubscriptionStatus } from '@dayopt/billing';
 import type { Database } from '@dayopt/database';
 
 /**
@@ -379,7 +380,7 @@ export const proProcedure = protectedProcedure.meta({ auth: 'pro' }).use(async (
   // Sentryにプラン情報をタグ付け（エラー分析時のフィルタ用）
   Sentry.setTag('user.plan', status ?? 'free');
 
-  const isProActive = status === 'active' || status === 'trialing' || status === 'past_due';
+  const isProActive = isProSubscriptionStatus(status);
 
   if (!isProActive) {
     throw new TRPCError({

--- a/apps/storybook/docs/dev/architecture/PackagesOverview.mdx
+++ b/apps/storybook/docs/dev/architecture/PackagesOverview.mdx
@@ -14,7 +14,7 @@ Dayopt の monorepo は、アプリを増やすためだけではなく、責務
 - `packages/config`: public constants / metadata / URL definitions。secrets, request-scoped values, server-only clients は入れない。
 - `packages/domain`: Dayopt domain model / pure types / helpers。DB row shape, React, Next, Supabase, Zustand は入れない。
 - `packages/database`: Supabase/Postgres boundary。generated types / table names / row helper types / converters を扱い、UI components, DB access clients, service role secrets は入れない。
-- `packages/billing`: public plan / entitlement definitions の予定地。Stripe secret key, webhook handlers は入れない。
+- `packages/billing`: Free / Pro plans, subscription status, entitlement, public-safe pricing constants。Stripe secret key, SDK, webhook handlers, checkout / portal 実装は入れない。
 - `packages/utils`: generic pure utilities。Dayopt 固有 domain policy, framework helper は入れない。
 
 ## Dependency Direction
@@ -43,6 +43,7 @@ apps/product, apps/web, apps/admin
 `packages/domain` は Dayopt の意味を表す pure TypeScript package で、現時点では `TimeRange`, `EntryOrigin`, `Tag`, `ReviewPeriod`, `UserPreference`, `Chronotype` などの軽い型・定数・helper だけを持つ。
 
 `packages/database` は Supabase generated types と DB row helper の境界として動き始めている。converter は受け皿だけを先に作り、DB access を含む service は product 側に残す。
+`packages/billing` は Free / Pro の公開 plan model, subscription status, `pro_access` entitlement, pricing 表示用定数の境界として動き始めている。Stripe SDK / secret / webhook / checkout / portal は product 側の server-only 境界に残す。
 `packages/types`, `packages/server`, `packages/utils` はまだ第一段階の placeholder に近い。
 
 ## Package Boundaries
@@ -139,7 +140,22 @@ Supabase/Postgres 上の形を扱う境界。generated types, table names, row h
 
 ### `packages/billing`
 
-公開してよい plan / subscription / entitlement 定義を置く予定の境界。Stripe secret key を使う処理や webhook handler は server-only 境界に置き、client import できる定義と混ぜない。
+公開してよい plan / subscription / entitlement 定義を置く境界。client import できる public-safe な billing model だけを扱う。
+
+例:
+
+- Free / Pro plan id と plan name
+- Free `$0`, Pro `$5/month` の公開価格表示用定数
+- `free | active | past_due | canceled | trialing` の subscription status
+- `pro_access` entitlement と pure helper
+
+入れないもの:
+
+- Stripe secret key / webhook secret
+- Stripe SDK client
+- webhook handler
+- checkout / customer portal 実装
+- env validation / server action / route handler
 
 ## Extraction Rules
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -49,6 +49,7 @@
     "generate:search-index": "tsx scripts/generate-search-index.ts"
   },
   "dependencies": {
+    "@dayopt/billing": "workspace:*",
     "@dayopt/config": "workspace:*",
     "@hookform/resolvers": "^5.1.1",
     "@marsidev/react-turnstile": "^1.5.0",

--- a/apps/web/src/features/marketing/components/PricingSection.tsx
+++ b/apps/web/src/features/marketing/components/PricingSection.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/card';
 import { Container } from '@/components/ui/container';
 import { Link } from '@/platform/i18n/navigation';
+import { dayoptPricing } from '@dayopt/billing';
 import { Check } from 'lucide-react';
 import { getTranslations } from 'next-intl/server';
 
@@ -68,7 +69,7 @@ export async function PricingSection({ locale }: PricingSectionProps) {
             <CardContent className="flex-1">
               <div className="mb-8 text-center">
                 <span className="text-foreground text-4xl font-medium">
-                  {t('pricing.plans.free.price')}
+                  {dayoptPricing.free.displayPrice}
                 </span>
               </div>
               <ul className="space-y-4">
@@ -101,7 +102,7 @@ export async function PricingSection({ locale }: PricingSectionProps) {
             <CardContent className="flex-1">
               <div className="mb-2 text-center">
                 <span className="text-foreground text-4xl font-medium">
-                  {t('pricing.plans.pro.price')}
+                  {dayoptPricing.pro.displayPrice}
                 </span>
                 <span className="text-muted-foreground">{t('pricing.plans.pro.period')}</span>
               </div>

--- a/packages/billing/package.json
+++ b/packages/billing/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@dayopt/billing",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "types": "./src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit"
+  }
+}

--- a/packages/billing/src/entitlement.ts
+++ b/packages/billing/src/entitlement.ts
@@ -1,0 +1,16 @@
+import type { DayoptPlanId } from './plans';
+
+export const entitlementKeys = {
+  proAccess: 'pro_access',
+} as const;
+
+export type EntitlementKey = (typeof entitlementKeys)[keyof typeof entitlementKeys];
+
+export const planEntitlements = {
+  free: [],
+  pro: [entitlementKeys.proAccess],
+} as const satisfies Record<DayoptPlanId, readonly EntitlementKey[]>;
+
+export function canUseEntitlement(planId: DayoptPlanId, entitlement: EntitlementKey): boolean {
+  return (planEntitlements[planId] as readonly EntitlementKey[]).includes(entitlement);
+}

--- a/packages/billing/src/index.ts
+++ b/packages/billing/src/index.ts
@@ -1,0 +1,4 @@
+export * from './entitlement';
+export * from './plans';
+export * from './pricing';
+export * from './subscription';

--- a/packages/billing/src/plans.ts
+++ b/packages/billing/src/plans.ts
@@ -1,0 +1,26 @@
+export const dayoptPlanIds = {
+  free: 'free',
+  pro: 'pro',
+} as const;
+
+export type DayoptPlanId = (typeof dayoptPlanIds)[keyof typeof dayoptPlanIds];
+
+export type DayoptPlan = Readonly<{
+  id: DayoptPlanId;
+  name: string;
+}>;
+
+export const dayoptPlans = {
+  free: {
+    id: dayoptPlanIds.free,
+    name: 'Free',
+  },
+  pro: {
+    id: dayoptPlanIds.pro,
+    name: 'Pro',
+  },
+} as const satisfies Record<DayoptPlanId, DayoptPlan>;
+
+export function isPaidPlan(planId: DayoptPlanId): boolean {
+  return planId === dayoptPlanIds.pro;
+}

--- a/packages/billing/src/pricing.ts
+++ b/packages/billing/src/pricing.ts
@@ -1,0 +1,33 @@
+import { dayoptPlanIds, type DayoptPlanId } from './plans';
+
+export const dayoptProTrialDays = 7;
+
+export type DayoptPlanPricing = Readonly<{
+  monthlyUsdCents: number;
+  displayPrice: string;
+  displayPeriod: string;
+}>;
+
+export const dayoptPricing = {
+  free: {
+    monthlyUsdCents: 0,
+    displayPrice: '$0',
+    displayPeriod: '',
+  },
+  pro: {
+    monthlyUsdCents: 500,
+    displayPrice: '$5',
+    displayPeriod: '/month',
+  },
+} as const satisfies Record<DayoptPlanId, DayoptPlanPricing>;
+
+export function getMonthlyUsdCents(planId: DayoptPlanId): number {
+  return dayoptPricing[planId].monthlyUsdCents;
+}
+
+export function getMonthlyUsd(planId: DayoptPlanId): number {
+  return getMonthlyUsdCents(planId) / 100;
+}
+
+export const freeMonthlyUsd = getMonthlyUsd(dayoptPlanIds.free);
+export const proMonthlyUsd = getMonthlyUsd(dayoptPlanIds.pro);

--- a/packages/billing/src/subscription.ts
+++ b/packages/billing/src/subscription.ts
@@ -1,0 +1,25 @@
+import { dayoptPlanIds, type DayoptPlanId } from './plans';
+
+export const subscriptionStatuses = ['free', 'active', 'past_due', 'canceled', 'trialing'] as const;
+
+export type SubscriptionStatus = (typeof subscriptionStatuses)[number];
+
+export const proSubscriptionStatuses = ['active', 'trialing', 'past_due'] as const;
+
+export type ProSubscriptionStatus = (typeof proSubscriptionStatuses)[number];
+
+export function isSubscriptionStatus(
+  value: string | null | undefined,
+): value is SubscriptionStatus {
+  return subscriptionStatuses.includes(value as SubscriptionStatus);
+}
+
+export function isProSubscriptionStatus(
+  value: string | null | undefined,
+): value is ProSubscriptionStatus {
+  return proSubscriptionStatuses.includes(value as ProSubscriptionStatus);
+}
+
+export function getPlanIdForSubscriptionStatus(status: string | null | undefined): DayoptPlanId {
+  return isProSubscriptionStatus(status) ? dayoptPlanIds.pro : dayoptPlanIds.free;
+}

--- a/packages/billing/tsconfig.json
+++ b/packages/billing/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,9 @@ importers:
 
   apps/product:
     dependencies:
+      '@dayopt/billing':
+        specifier: workspace:*
+        version: link:../../packages/billing
       '@dayopt/config':
         specifier: workspace:*
         version: link:../../packages/config
@@ -670,6 +673,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@dayopt/billing':
+        specifier: workspace:*
+        version: link:../../packages/billing
       '@dayopt/config':
         specifier: workspace:*
         version: link:../../packages/config
@@ -882,6 +888,8 @@ importers:
       lightningcss-linux-x64-gnu:
         specifier: ^1.32.0
         version: 1.32.0
+
+  packages/billing: {}
 
   packages/config:
     devDependencies:


### PR DESCRIPTION
## Summary
- add @dayopt/billing as a pure shared billing model package
- define Free/Pro plans, public pricing constants, subscription status helpers, and the minimal pro_access entitlement
- replace low-risk product/web plan and status usage while leaving Stripe SDK/webhook/checkout/portal implementation in product

## Validation
- pnpm install --frozen-lockfile
- pnpm --filter @dayopt/billing build
- pnpm build:packages
- pnpm typecheck:packages
- pnpm typecheck
- pnpm lint:boundaries
- pnpm lint
- pnpm build
- pnpm build:web
- pnpm build-storybook
- pnpm check:workspace
- pnpm -r list --depth -1 | rg '@dayopt/billing'
- rg '@dayopt/billing' apps/product apps/web packages/billing apps/storybook
- rg 'stripe|STRIPE|process.env|react|next/|zustand|@supabase|@/|features/' packages/billing/src (no matches)
