### PR TITLE
refactor(tags): tag-service.ts の merge / ungroupTags から pure logic を切り出し

### DIFF
--- a/apps/product/src/features/tags/domain/__tests__/tag-merge.test.ts
+++ b/apps/product/src/features/tags/domain/__tests__/tag-merge.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatRpcErrorDetail } from '../tag-merge';
+
+describe('formatRpcErrorDetail', () => {
+  it('全フィールドを ` | ` 区切りで連結する', () => {
+    expect(
+      formatRpcErrorDetail({
+        message: 'failed',
+        code: 'P0001',
+        details: 'detail text',
+        hint: 'try again',
+      }),
+    ).toBe('failed | code=P0001 | details=detail text | hint=try again');
+  });
+
+  it('null フィールドを除外する', () => {
+    expect(
+      formatRpcErrorDetail({
+        message: 'failed',
+        code: null,
+        details: null,
+        hint: null,
+      }),
+    ).toBe('failed');
+  });
+
+  it('undefined フィールドを除外する', () => {
+    expect(formatRpcErrorDetail({ message: 'failed' })).toBe('failed');
+  });
+
+  it('一部のみ存在 → 存在するフィールドだけ含む', () => {
+    expect(
+      formatRpcErrorDetail({
+        message: 'failed',
+        code: 'P0001',
+        hint: 'check policy',
+      }),
+    ).toBe('failed | code=P0001 | hint=check policy');
+  });
+
+  it('空文字の補助フィールドは除外する', () => {
+    expect(
+      formatRpcErrorDetail({
+        message: 'failed',
+        code: '',
+        details: '',
+        hint: '',
+      }),
+    ).toBe('failed');
+  });
+});

--- a/apps/product/src/features/tags/domain/__tests__/tag-ungroup.test.ts
+++ b/apps/product/src/features/tags/domain/__tests__/tag-ungroup.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractTagSuffixes, partitionByExistingName } from '../tag-ungroup';
+
+describe('extractTagSuffixes', () => {
+  it('コロンあり → suffix を抽出', () => {
+    const result = extractTagSuffixes([{ name: 'Work:api' }, { name: 'Work:web' }]);
+    expect(result.map((r) => r.suffix)).toEqual(['api', 'web']);
+  });
+
+  it('コロンなし → タグ名全体を suffix とする', () => {
+    const result = extractTagSuffixes([{ name: 'Solo' }]);
+    expect(result[0]?.suffix).toBe('Solo');
+  });
+
+  it('コロン複数 → 最初のコロン以降が suffix', () => {
+    const result = extractTagSuffixes([{ name: 'a:b:c' }]);
+    expect(result[0]?.suffix).toBe('b:c');
+  });
+
+  it('元の tag オブジェクトを保持する', () => {
+    const tag = { name: 'Work:api', id: 'tag-1' };
+    const result = extractTagSuffixes([tag]);
+    expect(result[0]?.tag).toBe(tag);
+  });
+
+  it('空配列 → 空配列', () => {
+    expect(extractTagSuffixes([])).toEqual([]);
+  });
+});
+
+describe('partitionByExistingName', () => {
+  it('衝突あり / なしを分類する', () => {
+    const entries = [
+      { tag: { name: 'Work:api' }, suffix: 'api' },
+      { tag: { name: 'Work:web' }, suffix: 'web' },
+      { tag: { name: 'Work:db' }, suffix: 'db' },
+    ];
+    const existing = new Map([
+      ['api', { id: 'existing-api' }],
+      ['db', { id: 'existing-db' }],
+    ]);
+    const { conflicts, nonConflicts } = partitionByExistingName(entries, existing);
+    expect(conflicts.map((c) => c.suffix)).toEqual(['api', 'db']);
+    expect(nonConflicts.map((c) => c.suffix)).toEqual(['web']);
+  });
+
+  it('全て衝突 → nonConflicts 空', () => {
+    const entries = [{ tag: { name: 'Work:api' }, suffix: 'api' }];
+    const existing = new Map([['api', { id: 'x' }]]);
+    const { conflicts, nonConflicts } = partitionByExistingName(entries, existing);
+    expect(conflicts).toHaveLength(1);
+    expect(nonConflicts).toHaveLength(0);
+  });
+
+  it('衝突なし → conflicts 空', () => {
+    const entries = [{ tag: { name: 'Work:api' }, suffix: 'api' }];
+    const existing = new Map<string, unknown>();
+    const { conflicts, nonConflicts } = partitionByExistingName(entries, existing);
+    expect(conflicts).toHaveLength(0);
+    expect(nonConflicts).toHaveLength(1);
+  });
+
+  it('空配列入力 → 双方空', () => {
+    const { conflicts, nonConflicts } = partitionByExistingName([], new Map());
+    expect(conflicts).toEqual([]);
+    expect(nonConflicts).toEqual([]);
+  });
+
+  it('Set でも動作する（has を持つオブジェクトを受け取る）', () => {
+    const entries = [
+      { tag: { name: 'Work:api' }, suffix: 'api' },
+      { tag: { name: 'Work:web' }, suffix: 'web' },
+    ];
+    const existing = new Set(['api']);
+    const { conflicts, nonConflicts } = partitionByExistingName(entries, existing);
+    expect(conflicts.map((c) => c.suffix)).toEqual(['api']);
+    expect(nonConflicts.map((c) => c.suffix)).toEqual(['web']);
+  });
+});

--- a/apps/product/src/features/tags/domain/index.ts
+++ b/apps/product/src/features/tags/domain/index.ts
@@ -9,3 +9,9 @@ export {
   parseColonTag,
 } from './tag-colon';
 export type { GroupedTags, ParsedColonTag } from './tag-colon';
+
+export { extractTagSuffixes, partitionByExistingName } from './tag-ungroup';
+export type { PartitionedSuffixes, TagSuffixEntry } from './tag-ungroup';
+
+export { formatRpcErrorDetail } from './tag-merge';
+export type { RpcErrorLike } from './tag-merge';

--- a/apps/product/src/features/tags/domain/tag-merge.ts
+++ b/apps/product/src/features/tags/domain/tag-merge.ts
@@ -1,0 +1,30 @@
+/**
+ * tag merge 操作で使う pure formatting。
+ *
+ * Service 層 (`features/tags/server/tag-service.ts`) の `merge()` から
+ * DB 非依存の純粋なロジックだけを切り出している。
+ */
+
+export interface RpcErrorLike {
+  message: string;
+  code?: string | null;
+  details?: string | null;
+  hint?: string | null;
+}
+
+/**
+ * Supabase RPC のエラーオブジェクトを debug 用の 1行 string に整形する。
+ *
+ * PostgREST が返す 502 は `message` が generic ("invalid response from upstream") に
+ * なるため、`code` / `details` / `hint` を含めて debug できるようにする。
+ */
+export function formatRpcErrorDetail(rpcError: RpcErrorLike): string {
+  return [
+    rpcError.message,
+    rpcError.code ? `code=${rpcError.code}` : null,
+    rpcError.details ? `details=${rpcError.details}` : null,
+    rpcError.hint ? `hint=${rpcError.hint}` : null,
+  ]
+    .filter(Boolean)
+    .join(' | ');
+}

--- a/apps/product/src/features/tags/domain/tag-ungroup.ts
+++ b/apps/product/src/features/tags/domain/tag-ungroup.ts
@@ -1,0 +1,63 @@
+/**
+ * ungroupTags 操作で使う pure transformation。
+ *
+ * Service 層 (`features/tags/server/tag-service.ts`) の `ungroupTags()` から
+ * DB 非依存の純粋なロジックだけを切り出している。
+ */
+
+import { parseColonTag } from './tag-colon';
+
+export interface TagSuffixEntry<TTag> {
+  /** 元のタグ（DB row） */
+  tag: TTag;
+  /** コロン以降の suffix。コロンが無ければタグ名全体 */
+  suffix: string;
+}
+
+/**
+ * `prefix:xxx` 形式のタグ群から、各タグの suffix を算出する。
+ *
+ * @example
+ *   extractTagSuffixes([{ name: 'Work:api' }, { name: 'Work:web' }])
+ *   → [{ tag, suffix: 'api' }, { tag, suffix: 'web' }]
+ */
+export function extractTagSuffixes<TTag extends { name: string }>(
+  tags: readonly TTag[],
+): Array<TagSuffixEntry<TTag>> {
+  return tags.map((tag) => {
+    const { suffix } = parseColonTag(tag.name);
+    return {
+      tag,
+      suffix: suffix ?? tag.name,
+    };
+  });
+}
+
+export interface PartitionedSuffixes<TTag> {
+  /** 同名の既存タグが存在するため衝突するエントリ */
+  conflicts: Array<TagSuffixEntry<TTag>>;
+  /** 衝突なしでそのままリネームできるエントリ */
+  nonConflicts: Array<TagSuffixEntry<TTag>>;
+}
+
+/**
+ * suffix を持つエントリ群を、既存タグ名との衝突有無で分類する。
+ *
+ * @param entries `extractTagSuffixes` の結果
+ * @param existingNames 既存タグの名前集合（`Map` の場合は `has(suffix)` を利用）
+ */
+export function partitionByExistingName<TTag>(
+  entries: ReadonlyArray<TagSuffixEntry<TTag>>,
+  existingNames: { has(name: string): boolean },
+): PartitionedSuffixes<TTag> {
+  const conflicts: Array<TagSuffixEntry<TTag>> = [];
+  const nonConflicts: Array<TagSuffixEntry<TTag>> = [];
+  for (const entry of entries) {
+    if (existingNames.has(entry.suffix)) {
+      conflicts.push(entry);
+    } else {
+      nonConflicts.push(entry);
+    }
+  }
+  return { conflicts, nonConflicts };
+}

--- a/apps/product/src/features/tags/server/tag-service.ts
+++ b/apps/product/src/features/tags/server/tag-service.ts
@@ -21,7 +21,9 @@ import 'server-only';
 import { ServiceError } from '@/lib/trpc/errors';
 import type { Database } from '@dayopt/database';
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { formatRpcErrorDetail } from '../domain/tag-merge';
 import { buildTagTree, flattenTagTree } from '../domain/tag-tree';
+import { extractTagSuffixes, partitionByExistingName } from '../domain/tag-ungroup';
 import type { Tag, TagDeleteStrategy, TagTreeNode } from '../types';
 
 /** DB タグ行の型 */
@@ -498,13 +500,7 @@ export class TagService {
     }
 
     // 各タグの suffix を算出
-    const tagSuffixes = matchingTags.map((tag) => {
-      const colonIndex = tag.name.indexOf(':');
-      return {
-        tag,
-        suffix: colonIndex !== -1 ? tag.name.slice(colonIndex + 1) : tag.name,
-      };
-    });
+    const tagSuffixes = extractTagSuffixes(matchingTags);
 
     // 全 suffix 名で既存タグを一括検索（衝突チェック）
     const suffixNames = [...new Set(tagSuffixes.map((t) => t.suffix))];
@@ -517,8 +513,7 @@ export class TagService {
     const existingByName = new Map((existingTags ?? []).map((t) => [t.name, t]));
 
     // 衝突と非衝突を分類
-    const conflicts = tagSuffixes.filter((t) => existingByName.has(t.suffix));
-    const nonConflicts = tagSuffixes.filter((t) => !existingByName.has(t.suffix));
+    const { conflicts, nonConflicts } = partitionByExistingName(tagSuffixes, existingByName);
 
     // 衝突があるが mergeConflicts が false → エラー（衝突リストを返す）
     if (conflicts.length > 0 && !mergeConflicts) {
@@ -749,17 +744,10 @@ export class TagService {
     );
 
     if (rpcError) {
-      // PostgREST が返す 502 は message が generic ("invalid response from upstream") に
-      // なるため、code / details / hint を含めて debug できるようにする
-      const detail = [
-        rpcError.message,
-        rpcError.code ? `code=${rpcError.code}` : null,
-        rpcError.details ? `details=${rpcError.details}` : null,
-        rpcError.hint ? `hint=${rpcError.hint}` : null,
-      ]
-        .filter(Boolean)
-        .join(' | ');
-      throw new TagServiceError('MERGE_FAILED', `Failed to merge tags atomically: ${detail}`);
+      throw new TagServiceError(
+        'MERGE_FAILED',
+        `Failed to merge tags atomically: ${formatRpcErrorDetail(rpcError)}`,
+      );
     }
 
     const migrated =


### PR DESCRIPTION
## Summary

\`features/tags/server/tag-service.ts\` (1033 LOC) の \`merge()\` / \`ungroupTags()\` から、DB transaction に依存しない pure transformation を \`features/tags/domain/\` に切り出した。

## 切り出した関数

**\`domain/tag-ungroup.ts\` (新規)**
- \`extractTagSuffixes\`: \`prefix:xxx\` 形式タグから suffix を抽出（既存の \`parseColonTag\` を再利用）
- \`partitionByExistingName\`: 既存タグ名との衝突有無で \`conflicts\` / \`nonConflicts\` に分類

**\`domain/tag-merge.ts\` (新規)**
- \`formatRpcErrorDetail\`: Supabase RPC エラーを \`message | code=X | details=Y | hint=Z\` 形式に整形

## 切り出さなかったもの

- \`validateMergeSelf\` / \`validateMergeHierarchy\` / \`validateUngroupPreconditions\`: \`TagServiceError\` (server-layer) 依存のため service に残す
- \`merge()\` の DB orchestration / RPC 呼び出し: scope 外
- 代表色/icon 選択 (\`matchingTags[0]?.color ?? 'blue'\`): 1-2 行で service context に密接
- \`tag-service.ts\` 全面分割: scope 外

## 効果

- \`tag-service.ts\` の merge() / ungroupTags() で pure transformation が可視化される
- domain 単体テスト 11件追加（\`extractTagSuffixes\` / \`partitionByExistingName\` / \`formatRpcErrorDetail\`）
- DB / transaction / API / UI / 仕様 変更なし
- \`features/tags\` は Layer 0 維持、boundary 違反なし

## Test plan

- [x] \`pnpm --filter @dayopt/product typecheck\`
- [x] \`pnpm --filter @dayopt/product lint\`
- [x] \`pnpm lint:boundaries\`（Cross-feature imports: 0）
- [x] \`pnpm --filter @dayopt/product test:run src/features/tags\` → 95 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)