### PR TITLE
refactor(entry): statistics.ts から monthly-trend aggregation を domain へ切り出し

### DIFF
--- a/apps/product/src/features/entry/domain/__tests__/monthly-trend.test.ts
+++ b/apps/product/src/features/entry/domain/__tests__/monthly-trend.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+
+import { aggregateMonthlyTrend, getMonthlyStartDate } from '../monthly-trend';
+
+describe('getMonthlyStartDate', () => {
+  it('通常: 2026年5月から3ヶ月前 → 2026-03-01 UTC', () => {
+    expect(getMonthlyStartDate(2026, 5, 3).toISOString()).toBe('2026-03-01T00:00:00.000Z');
+  });
+
+  it('年跨ぎ: 2026年2月から4ヶ月前 → 2025-11-01 UTC', () => {
+    expect(getMonthlyStartDate(2026, 2, 4).toISOString()).toBe('2025-11-01T00:00:00.000Z');
+  });
+
+  it('1年分: 2026年1月から12ヶ月前 → 2025-02-01 UTC', () => {
+    expect(getMonthlyStartDate(2026, 1, 12).toISOString()).toBe('2025-02-01T00:00:00.000Z');
+  });
+
+  it('単月: monthCount=1 → 当月の1日', () => {
+    expect(getMonthlyStartDate(2026, 5, 1).toISOString()).toBe('2026-05-01T00:00:00.000Z');
+  });
+
+  it('24ヶ月（leap year 2024 を跨ぐ）: 2026年5月から → 2024-06-01 UTC', () => {
+    expect(getMonthlyStartDate(2026, 5, 24).toISOString()).toBe('2024-06-01T00:00:00.000Z');
+  });
+
+  it('12月終わり: 2026年12月から2ヶ月前 → 2026-11-01 UTC', () => {
+    expect(getMonthlyStartDate(2026, 12, 2).toISOString()).toBe('2026-11-01T00:00:00.000Z');
+  });
+
+  it('1月始め: 2026年1月から2ヶ月前 → 2025-12-01 UTC', () => {
+    expect(getMonthlyStartDate(2026, 1, 2).toISOString()).toBe('2025-12-01T00:00:00.000Z');
+  });
+});
+
+describe('aggregateMonthlyTrend', () => {
+  it('通常: rows 空 → 3 slot 全て hours=0、月キーは降順 2026-03/04/05', () => {
+    const result = aggregateMonthlyTrend([], 2026, 5, 3);
+    expect(result).toEqual([
+      { month: '2026-03', label: '3', hours: 0 },
+      { month: '2026-04', label: '4', hours: 0 },
+      { month: '2026-05', label: '5', hours: 0 },
+    ]);
+  });
+
+  it('年跨ぎ: 2026年2月から4ヶ月 → 2025-11/12 + 2026-01/02', () => {
+    const result = aggregateMonthlyTrend([], 2026, 2, 4);
+    expect(result.map((s) => s.month)).toEqual(['2025-11', '2025-12', '2026-01', '2026-02']);
+  });
+
+  it('2月を含む期間: 2026年3月から2ヶ月 → 2026-02/03', () => {
+    const result = aggregateMonthlyTrend([], 2026, 3, 2);
+    expect(result.map((s) => s.month)).toEqual(['2026-02', '2026-03']);
+  });
+
+  it('leap year + 年跨ぎ: 2024年3月から14ヶ月 → 2023-02 + 2024-02 を含む', () => {
+    const result = aggregateMonthlyTrend([], 2024, 3, 14);
+    const months = result.map((s) => s.month);
+    expect(months[0]).toBe('2023-02');
+    expect(months.at(-1)).toBe('2024-03');
+    expect(months).toContain('2024-02');
+    expect(result).toHaveLength(14);
+  });
+
+  it('partial month: 一部の row のみ → 既知月だけ上書き、未知月は 0', () => {
+    const result = aggregateMonthlyTrend(
+      [
+        { month: '2026-04', hours: 12.5 },
+        { month: '2026-05', hours: 30 },
+      ],
+      2026,
+      5,
+      3,
+    );
+    expect(result).toEqual([
+      { month: '2026-03', label: '3', hours: 0 },
+      { month: '2026-04', label: '4', hours: 12.5 },
+      { month: '2026-05', label: '5', hours: 30 },
+    ]);
+  });
+
+  it('未知 month の row は無視: 範囲外でも結果には現れない', () => {
+    const result = aggregateMonthlyTrend(
+      [
+        { month: '2020-01', hours: 999 },
+        { month: '2026-05', hours: 5 },
+      ],
+      2026,
+      5,
+      3,
+    );
+    expect(result.find((s) => s.month === '2020-01')).toBeUndefined();
+    expect(result.find((s) => s.month === '2026-05')?.hours).toBe(5);
+  });
+
+  it('同月複数 row: 後勝ち (overlay)', () => {
+    const result = aggregateMonthlyTrend(
+      [
+        { month: '2026-05', hours: 10 },
+        { month: '2026-05', hours: 20 },
+      ],
+      2026,
+      5,
+      1,
+    );
+    expect(result[0]?.hours).toBe(20);
+  });
+
+  it('label format: leading zero なし', () => {
+    const result = aggregateMonthlyTrend([], 2026, 12, 12);
+    expect(result.map((s) => s.label)).toEqual([
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+      '7',
+      '8',
+      '9',
+      '10',
+      '11',
+      '12',
+    ]);
+  });
+
+  it('sort: shuffle した rows でも結果は月昇順', () => {
+    const result = aggregateMonthlyTrend(
+      [
+        { month: '2026-05', hours: 5 },
+        { month: '2026-03', hours: 3 },
+        { month: '2026-04', hours: 4 },
+      ],
+      2026,
+      5,
+      3,
+    );
+    expect(result.map((s) => s.month)).toEqual(['2026-03', '2026-04', '2026-05']);
+    expect(result.map((s) => s.hours)).toEqual([3, 4, 5]);
+  });
+
+  it('monthCount=1 → 単一 slot', () => {
+    const result = aggregateMonthlyTrend([{ month: '2026-05', hours: 7 }], 2026, 5, 1);
+    expect(result).toEqual([{ month: '2026-05', label: '5', hours: 7 }]);
+  });
+});

--- a/apps/product/src/features/entry/domain/index.ts
+++ b/apps/product/src/features/entry/domain/index.ts
@@ -30,3 +30,6 @@ export type { DayOfWeekRow, DayOfWeekSlot } from './day-of-week-distribution';
 
 export { calculateStreak } from './streak-calculator';
 export type { StreakInput } from './streak-calculator';
+
+export { aggregateMonthlyTrend, getMonthlyStartDate } from './monthly-trend';
+export type { MonthTrendSlot, MonthlyTrendRow } from './monthly-trend';

--- a/apps/product/src/features/entry/domain/monthly-trend.ts
+++ b/apps/product/src/features/entry/domain/monthly-trend.ts
@@ -1,0 +1,69 @@
+/**
+ * 月別トレンド集計の pure logic。
+ *
+ * Server 層 (`features/entry/server/statistics.ts`) の `getMonthlyTrend` から
+ * DB 非依存の純粋な date math と aggregation だけを切り出している。
+ *
+ * TZ 形式化は procedure 側で行い、ここには `nowYear` / `nowMonth` 既に確定値を
+ * 受け取る前提（domain 層は TZ 非依存）。
+ */
+
+export interface MonthlyTrendRow {
+  /** "YYYY-MM" 形式の月キー */
+  month: string;
+  hours: number;
+}
+
+export interface MonthTrendSlot {
+  /** "YYYY-MM" 形式の月キー */
+  month: string;
+  /** 月の数値部分（leading zero なし）。"2026-05" → "5" / "2026-12" → "12" */
+  label: string;
+  hours: number;
+}
+
+/**
+ * `nowYear`/`nowMonth` を「現在月」とし、そこから `monthCount - 1` 月前の 1 日 (UTC) を返す。
+ *
+ * JavaScript の `Date.UTC` は month が負数のとき自動で year を roll-back するため、
+ * `Date.UTC(2026, -7, 1)` は `2025-06-01T00:00:00Z` になる。
+ *
+ * RPC `get_monthly_hours` の `p_start_date` 引数として使われる。
+ */
+export function getMonthlyStartDate(nowYear: number, nowMonth: number, monthCount: number): Date {
+  return new Date(Date.UTC(nowYear, nowMonth - 1 - (monthCount - 1), 1));
+}
+
+/**
+ * `monthCount` 個の "YYYY-MM" キーを生成し、`rows` の hours を overlay して
+ * 月昇順の slot 配列を返す。未知 month の row は無視される。
+ *
+ * 負数 modulo の補正で年跨ぎ・leap year 期間も正しく処理する。
+ */
+export function aggregateMonthlyTrend(
+  rows: ReadonlyArray<MonthlyTrendRow>,
+  nowYear: number,
+  nowMonth: number,
+  monthCount: number,
+): MonthTrendSlot[] {
+  const monthlyHours: Record<string, number> = {};
+  for (let i = 0; i < monthCount; i++) {
+    const offset = nowMonth - 1 - (monthCount - 1) + i;
+    const year = nowYear + Math.floor(offset / 12);
+    const month = (((offset % 12) + 12) % 12) + 1;
+    const key = `${year}-${month.toString().padStart(2, '0')}`;
+    monthlyHours[key] = 0;
+  }
+  for (const row of rows) {
+    if (monthlyHours[row.month] !== undefined) {
+      monthlyHours[row.month] = row.hours;
+    }
+  }
+
+  return Object.entries(monthlyHours)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([month, hours]) => {
+      const monthPart = month.split('-')[1];
+      return { month, label: `${monthPart ? parseInt(monthPart) : 0}`, hours };
+    });
+}

--- a/apps/product/src/features/entry/server/statistics.ts
+++ b/apps/product/src/features/entry/server/statistics.ts
@@ -18,7 +18,9 @@ import type { Database } from '@dayopt/database';
 import {
   aggregateDayOfWeekDistribution,
   aggregateHourlyDistribution,
+  aggregateMonthlyTrend,
   calculateStreak,
+  getMonthlyStartDate,
 } from '../domain';
 
 /**
@@ -285,8 +287,7 @@ export const entriesStatisticsRouter = createTRPCRouter({
         const nowStr = formatInTimeZone(new Date(), timezone, 'yyyy-MM');
         const [nowYear, nowMonth] = nowStr.split('-').map(Number) as [number, number];
 
-        // monthCount ヶ月前の1日（UTC ISO形式）
-        const startDate = new Date(Date.UTC(nowYear, nowMonth - 1 - (monthCount - 1), 1));
+        const startDate = getMonthlyStartDate(nowYear, nowMonth, monthCount);
 
         const { data, error } = await traceDbQuery('stats.get_monthly_hours', async () =>
           supabase.rpc('get_monthly_hours', {
@@ -303,24 +304,7 @@ export const entriesStatisticsRouter = createTRPCRouter({
           });
         }
 
-        const rows = data ?? [];
-        const monthlyHours: Record<string, number> = {};
-        for (let i = 0; i < monthCount; i++) {
-          const year = nowYear + Math.floor((nowMonth - 1 - (monthCount - 1) + i) / 12);
-          const month = ((((nowMonth - 1 - (monthCount - 1) + i) % 12) + 12) % 12) + 1;
-          const key = `${year}-${month.toString().padStart(2, '0')}`;
-          monthlyHours[key] = 0;
-        }
-        for (const row of rows) {
-          if (monthlyHours[row.month] !== undefined) monthlyHours[row.month] = row.hours;
-        }
-
-        return Object.entries(monthlyHours)
-          .sort(([a], [b]) => a.localeCompare(b))
-          .map(([month, hours]) => {
-            const monthPart = month.split('-')[1];
-            return { month, label: `${monthPart ? parseInt(monthPart) : 0}`, hours };
-          });
+        return aggregateMonthlyTrend(data ?? [], nowYear, nowMonth, monthCount);
       } catch (error) {
         handleStatsError('getMonthlyTrend', error);
       }


### PR DESCRIPTION
## Summary

\`features/entry/server/statistics.ts\` の \`getMonthlyTrend\` procedure から、月跨ぎ・年跨ぎ・leap year math を含む pure aggregation を \`features/entry/domain/monthly-trend.ts\` に切り出した。前 PR (#1223) の続編。

## 切り出した 2 関数

**\`getMonthlyStartDate(nowYear, nowMonth, monthCount): Date\`**
- \`Date.UTC\` の負数 month roll-back を利用
- RPC \`get_monthly_hours\` の \`p_start_date\` 引数用

**\`aggregateMonthlyTrend(rows, nowYear, nowMonth, monthCount): MonthTrendSlot[]\`**
- \"YYYY-MM\" キー生成（負数 modulo 補正）+ overlay + 昇順 sort + label map

## 既存挙動の保全

- 負数 modulo: \`((offset % 12) + 12) % 12 + 1\`
- year 補正: \`Math.floor(offset / 12)\`
- label format: leading zero なし (\"05\" → \"5\")
- sort: \`localeCompare\` で \"YYYY-MM\" 時系列順

## 設計判断

TZ 形式化（\`formatInTimeZone(new Date(), tz, 'yyyy-MM')\` → \`nowYear\`/\`nowMonth\`）は procedure 側に残し、domain は \`nowYear\`/\`nowMonth\` を引数で受ける形にした。これにより:
- domain helper は TZ 非依存（test stable）
- \`Date.now()\` に依存しない pure 関数として扱える

## テスト追加（17 cases）

**\`getMonthlyStartDate\`** (7 cases):
- 通常 / 年跨ぎ / 1年分 / 単月 / 24ヶ月（leap year 2024 跨ぎ）/ 12月終わり / 1月始め

**\`aggregateMonthlyTrend\`** (10 cases):
- 通常（rows 空）/ 年跨ぎ / 2月含む / leap year + 年跨ぎ / partial month / 未知 month 無視 / 同月複数 row（後勝ち）/ label format / sort（shuffle 入力）/ monthCount=1

## 効果

- \`getMonthlyTrend\` procedure から date math と aggregation が分離
- entry feature 全体で 417 tests pass（前 PR の 400 + 新規 17）
- DB / RPC / 応答 shape / 仕様 変更なし
- \`features/entry/domain\` は Layer 0 維持、cross-feature dep なし

## 残課題

\`statistics.ts\` の残り pure logic 候補:
- \`transformEstimationAccuracy\` → \`review/domain\` 移動（cross-feature 境界判断必要）
- \`getTagStats\` aggregation → \`tag-dashboard.ts\` との設計判断

別 PR で検討する。

## Test plan

- [x] \`pnpm --filter @dayopt/product typecheck\`
- [x] \`pnpm --filter @dayopt/product lint\`
- [x] \`pnpm lint:boundaries\`（Cross-feature imports: 0）
- [x] \`pnpm --filter @dayopt/product test:run src/features/entry\` → 417 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)