### PR TITLE
refactor(entry): statistics.ts から estimation-accuracy transformer を domain へ切り出し

### DIFF
--- a/apps/product/src/features/entry/domain/__tests__/estimation-accuracy.test.ts
+++ b/apps/product/src/features/entry/domain/__tests__/estimation-accuracy.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { type EstimationAccuracyDbRow, transformEstimationAccuracy } from '../estimation-accuracy';
+
+function makeRow(overrides: Partial<EstimationAccuracyDbRow> = {}): EstimationAccuracyDbRow {
+  return {
+    tag_id: 'tag-1',
+    tag_name: 'Deep Work',
+    tag_color: 'blue',
+    avg_planned_minutes: 60,
+    avg_actual_minutes: 75,
+    avg_deviation_minutes: 15,
+    entry_count: 10,
+    ...overrides,
+  };
+}
+
+describe('transformEstimationAccuracy', () => {
+  it('空配列 → 空配列', () => {
+    expect(transformEstimationAccuracy([])).toEqual([]);
+  });
+
+  it('全フィールドを snake → camel に変換する', () => {
+    const result = transformEstimationAccuracy([makeRow()]);
+    expect(result[0]).toEqual({
+      tagId: 'tag-1',
+      tagName: 'Deep Work',
+      tagColor: 'blue',
+      avgPlannedMinutes: 60,
+      avgActualMinutes: 75,
+      avgDeviationMinutes: 15,
+      entryCount: 10,
+    });
+  });
+
+  it('tag_color が空文字 → indigo にフォールバック', () => {
+    const result = transformEstimationAccuracy([makeRow({ tag_color: '' })]);
+    expect(result[0]?.tagColor).toBe('indigo');
+  });
+
+  it('tag_color が値あり → そのまま保持', () => {
+    const result = transformEstimationAccuracy([makeRow({ tag_color: 'crimson' })]);
+    expect(result[0]?.tagColor).toBe('crimson');
+  });
+
+  it('複数 row → 各 row が独立に変換される', () => {
+    const result = transformEstimationAccuracy([
+      makeRow({ tag_id: 'a', tag_color: 'red' }),
+      makeRow({ tag_id: 'b', tag_color: '' }),
+      makeRow({ tag_id: 'c', tag_color: 'green' }),
+    ]);
+    expect(result.map((r) => r.tagId)).toEqual(['a', 'b', 'c']);
+    expect(result.map((r) => r.tagColor)).toEqual(['red', 'indigo', 'green']);
+  });
+
+  it('0 / 負数の minutes / count を保持する', () => {
+    const result = transformEstimationAccuracy([
+      makeRow({
+        avg_planned_minutes: 0,
+        avg_actual_minutes: 0,
+        avg_deviation_minutes: -30,
+        entry_count: 0,
+      }),
+    ]);
+    expect(result[0]).toMatchObject({
+      avgPlannedMinutes: 0,
+      avgActualMinutes: 0,
+      avgDeviationMinutes: -30,
+      entryCount: 0,
+    });
+  });
+});

--- a/apps/product/src/features/entry/domain/estimation-accuracy.ts
+++ b/apps/product/src/features/entry/domain/estimation-accuracy.ts
@@ -1,0 +1,51 @@
+/**
+ * 見積もり精度（estimation accuracy）の pure transformation。
+ *
+ * Server 層 (`features/entry/server/statistics.ts`) の `getEstimationAccuracy`
+ * から DB 行 → tRPC response shape の snake→camel 変換だけを切り出している。
+ *
+ * Review UI が消費する型 (`features/review/types/metrics.types.ts` の
+ * `EstimationAccuracyData`) と構造的に互換だが、boundary rule により
+ * review/domain への配置は不可。
+ */
+
+export interface EstimationAccuracyDbRow {
+  tag_id: string;
+  tag_name: string;
+  tag_color: string;
+  avg_planned_minutes: number;
+  avg_actual_minutes: number;
+  avg_deviation_minutes: number;
+  entry_count: number;
+}
+
+export interface EstimationAccuracyItem {
+  tagId: string;
+  tagName: string;
+  /** 空文字の場合は 'indigo' にフォールバック */
+  tagColor: string;
+  avgPlannedMinutes: number;
+  avgActualMinutes: number;
+  avgDeviationMinutes: number;
+  entryCount: number;
+}
+
+/**
+ * DB RPC 行配列を tRPC response 用に変換する。
+ *
+ * - snake_case → camelCase
+ * - `tag_color` が空文字なら `'indigo'` にフォールバック
+ */
+export function transformEstimationAccuracy(
+  rows: ReadonlyArray<EstimationAccuracyDbRow>,
+): EstimationAccuracyItem[] {
+  return rows.map((row) => ({
+    tagId: row.tag_id,
+    tagName: row.tag_name,
+    tagColor: row.tag_color || 'indigo',
+    avgPlannedMinutes: row.avg_planned_minutes,
+    avgActualMinutes: row.avg_actual_minutes,
+    avgDeviationMinutes: row.avg_deviation_minutes,
+    entryCount: row.entry_count,
+  }));
+}

--- a/apps/product/src/features/entry/domain/index.ts
+++ b/apps/product/src/features/entry/domain/index.ts
@@ -33,3 +33,6 @@ export type { StreakInput } from './streak-calculator';
 
 export { aggregateMonthlyTrend, getMonthlyStartDate } from './monthly-trend';
 export type { MonthTrendSlot, MonthlyTrendRow } from './monthly-trend';
+
+export { transformEstimationAccuracy } from './estimation-accuracy';
+export type { EstimationAccuracyDbRow, EstimationAccuracyItem } from './estimation-accuracy';

--- a/apps/product/src/features/entry/server/statistics.ts
+++ b/apps/product/src/features/entry/server/statistics.ts
@@ -20,7 +20,9 @@ import {
   aggregateHourlyDistribution,
   aggregateMonthlyTrend,
   calculateStreak,
+  type EstimationAccuracyDbRow,
   getMonthlyStartDate,
+  transformEstimationAccuracy,
 } from '../domain';
 
 /**
@@ -384,25 +386,7 @@ export const entriesStatisticsRouter = createTRPCRouter({
           });
         }
 
-        const rows = (data ?? []) as Array<{
-          tag_id: string;
-          tag_name: string;
-          tag_color: string;
-          avg_planned_minutes: number;
-          avg_actual_minutes: number;
-          avg_deviation_minutes: number;
-          entry_count: number;
-        }>;
-
-        return rows.map((row) => ({
-          tagId: row.tag_id,
-          tagName: row.tag_name,
-          tagColor: row.tag_color || 'indigo',
-          avgPlannedMinutes: row.avg_planned_minutes,
-          avgActualMinutes: row.avg_actual_minutes,
-          avgDeviationMinutes: row.avg_deviation_minutes,
-          entryCount: row.entry_count,
-        }));
+        return transformEstimationAccuracy((data ?? []) as ReadonlyArray<EstimationAccuracyDbRow>);
       } catch (error) {
         handleStatsError('getEstimationAccuracy', error);
       }


### PR DESCRIPTION
## Summary

`features/entry/server/statistics.ts` の `getEstimationAccuracy` procedure から、DB 行 → tRPC response の snake→camel 変換を `features/entry/domain/estimation-accuracy.ts` に切り出した。

## review/domain への移動を見送った理由

調査の結果、ESLint boundary rule で **Layer 1 (entry) → Layer 2 (review) の import が禁止**されていることが判明した。`features/review/domain` への配置は DAG 違反になるため不可。

代替策として、前 PR 群 (#1223 hourly/dow/streak, #1224 monthly-trend) と同じ `features/entry/domain` への切り出しを採用。

## 切り出した関数

**`transformEstimationAccuracy(rows): EstimationAccuracyItem[]`**
- snake→camel mapping
- `tag_color` 空文字 → `'indigo'` フォールバック保全
- `EstimationAccuracyDbRow` / `EstimationAccuracyItem` 型を同 file で export

## テスト追加 (6 cases)

- 空配列 → 空配列
- 全フィールドの snake→camel 変換
- `tag_color` 空文字 → `'indigo'` フォールバック
- `tag_color` あり → そのまま保持
- 複数 row の独立変換
- 0 / 負数の minutes / count 保持

## 効果

- `getEstimationAccuracy` procedure から pure transform が分離
- entry feature 全体で 423 tests pass (前 PR の 417 + 新規 6)
- DB / RPC / 応答 shape / 仕様 変更なし
- `features/entry/domain` は Layer 1 維持、boundary 違反なし

## 残課題

`statistics.ts` の残り pure logic 候補:
- `getTagStats` aggregation → `tag-dashboard.ts` との設計判断必要
- `getStatsOverview` の unpacking → RPC response 構造に密結合

別 PR で検討する。

## Test plan

- [x] `pnpm --filter @dayopt/product typecheck`
- [x] `pnpm --filter @dayopt/product lint`
- [x] `pnpm lint:boundaries`（Cross-feature imports: 0）
- [x] `pnpm --filter @dayopt/product test:run src/features/entry` → 423 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
