### PR TITLE
refactor(entry): statistics.ts から getTagStats aggregation を domain へ切り出し

### DIFF
--- a/apps/product/src/features/entry/domain/__tests__/tag-stats.test.ts
+++ b/apps/product/src/features/entry/domain/__tests__/tag-stats.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import { aggregateTagStats } from '../tag-stats';
+
+describe('aggregateTagStats', () => {
+  it('空配列 → 空 Record 2 つ', () => {
+    expect(aggregateTagStats([])).toEqual({ counts: {}, lastUsed: {} });
+  });
+
+  it('null 入力 → 空 Record 2 つ', () => {
+    expect(aggregateTagStats(null)).toEqual({ counts: {}, lastUsed: {} });
+  });
+
+  it('undefined 入力 → 空 Record 2 つ', () => {
+    expect(aggregateTagStats(undefined)).toEqual({ counts: {}, lastUsed: {} });
+  });
+
+  it('全 row に last_used → 両 Record に全 tag を含む', () => {
+    const result = aggregateTagStats([
+      { tag_id: 'tag-1', entry_count: 5, last_used: '2026-04-20' },
+      { tag_id: 'tag-2', entry_count: 3, last_used: '2026-04-22' },
+    ]);
+    expect(result).toEqual({
+      counts: { 'tag-1': 5, 'tag-2': 3 },
+      lastUsed: { 'tag-1': '2026-04-20', 'tag-2': '2026-04-22' },
+    });
+  });
+
+  it('last_used が null の row → lastUsed から除外、counts には含む', () => {
+    const result = aggregateTagStats([
+      { tag_id: 'tag-1', entry_count: 5, last_used: '2026-04-20' },
+      { tag_id: 'tag-2', entry_count: 2, last_used: null },
+    ]);
+    expect(result).toEqual({
+      counts: { 'tag-1': 5, 'tag-2': 2 },
+      lastUsed: { 'tag-1': '2026-04-20' },
+    });
+  });
+
+  it('全 row の last_used が null → lastUsed は空', () => {
+    const result = aggregateTagStats([
+      { tag_id: 'tag-1', entry_count: 1, last_used: null },
+      { tag_id: 'tag-2', entry_count: 0, last_used: null },
+    ]);
+    expect(result.counts).toEqual({ 'tag-1': 1, 'tag-2': 0 });
+    expect(result.lastUsed).toEqual({});
+  });
+
+  it('同 tag_id が複数現れた場合は後勝ち', () => {
+    const result = aggregateTagStats([
+      { tag_id: 'tag-1', entry_count: 5, last_used: '2026-04-20' },
+      { tag_id: 'tag-1', entry_count: 7, last_used: '2026-04-22' },
+    ]);
+    expect(result).toEqual({
+      counts: { 'tag-1': 7 },
+      lastUsed: { 'tag-1': '2026-04-22' },
+    });
+  });
+
+  it('entry_count=0 でも counts に含まれる', () => {
+    const result = aggregateTagStats([
+      { tag_id: 'tag-1', entry_count: 0, last_used: '2026-04-20' },
+    ]);
+    expect(result.counts).toEqual({ 'tag-1': 0 });
+    expect(result.lastUsed).toEqual({ 'tag-1': '2026-04-20' });
+  });
+});

--- a/apps/product/src/features/entry/domain/index.ts
+++ b/apps/product/src/features/entry/domain/index.ts
@@ -36,3 +36,6 @@ export type { MonthTrendSlot, MonthlyTrendRow } from './monthly-trend';
 
 export { transformEstimationAccuracy } from './estimation-accuracy';
 export type { EstimationAccuracyDbRow, EstimationAccuracyItem } from './estimation-accuracy';
+
+export { aggregateTagStats } from './tag-stats';
+export type { TagStatsResult, TagStatsRow } from './tag-stats';

--- a/apps/product/src/features/entry/domain/tag-stats.ts
+++ b/apps/product/src/features/entry/domain/tag-stats.ts
@@ -1,0 +1,47 @@
+/**
+ * タグ別統計（counts / lastUsed）の pure aggregation。
+ *
+ * Server 層 (`features/entry/server/statistics.ts`) の `getTagStats` から
+ * DB 非依存の純粋な reduce を切り出している。
+ *
+ * 注: `buildTagDashboard` (`./tag-dashboard.ts`) は entry rows から daily 集計を
+ * 組み立てる別概念で、入力 / 出力 / 消費者が異なるため並置している。
+ */
+
+export interface TagStatsRow {
+  tag_id: string;
+  entry_count: number;
+  last_used: string | null;
+}
+
+export interface TagStatsResult {
+  /** tagId → entry_count の Record */
+  counts: Record<string, number>;
+  /** tagId → last_used 日付文字列。null だった row は含まない */
+  lastUsed: Record<string, string>;
+}
+
+/**
+ * RPC `get_tag_stats` の結果を `{ counts, lastUsed }` の 2 Record に reduce する。
+ *
+ * - `last_used` が null / falsy の row は `lastUsed` から除外（`counts` には含む）
+ * - 入力 `null` / `undefined` でも空オブジェクトを返す
+ * - 同 tag_id が複数現れた場合は後勝ち（reduce 仕様）
+ */
+export function aggregateTagStats(
+  rows: ReadonlyArray<TagStatsRow> | null | undefined,
+): TagStatsResult {
+  const counts: Record<string, number> = {};
+  const lastUsed: Record<string, string> = {};
+
+  if (rows) {
+    for (const row of rows) {
+      counts[row.tag_id] = row.entry_count;
+      if (row.last_used) {
+        lastUsed[row.tag_id] = row.last_used;
+      }
+    }
+  }
+
+  return { counts, lastUsed };
+}

--- a/apps/product/src/features/entry/server/statistics.ts
+++ b/apps/product/src/features/entry/server/statistics.ts
@@ -19,6 +19,7 @@ import {
   aggregateDayOfWeekDistribution,
   aggregateHourlyDistribution,
   aggregateMonthlyTrend,
+  aggregateTagStats,
   calculateStreak,
   type EstimationAccuracyDbRow,
   getMonthlyStartDate,
@@ -116,19 +117,7 @@ export const entriesStatisticsRouter = createTRPCRouter({
           });
         }
 
-        const counts: Record<string, number> = {};
-        const lastUsed: Record<string, string> = {};
-
-        if (data) {
-          for (const row of data) {
-            counts[row.tag_id] = row.entry_count;
-            if (row.last_used) {
-              lastUsed[row.tag_id] = row.last_used;
-            }
-          }
-        }
-
-        return { counts, lastUsed };
+        return aggregateTagStats(data);
       } catch (error) {
         handleStatsError('getTagStats', error);
       }


### PR DESCRIPTION
## Summary

`features/entry/server/statistics.ts` の `getTagStats` procedure から、RPC 行 → `{ counts, lastUsed }` への pure reduce を `features/entry/domain/tag-stats.ts` に切り出した。

## 切り出した関数

**`aggregateTagStats(rows): TagStatsResult`**
- `null` / `undefined` 入力許容（既存の `if (data)` ガードを内包）
- `last_used` が null/falsy の row は `lastUsed` から除外（`counts` には含む）
- `TagStatsRow` / `TagStatsResult` 型を同 file で export

## `tag-dashboard.ts` との設計判断

|        | `buildTagDashboard` (既存)     | `aggregateTagStats` (新規)                   |
| ------ | ------------------------------ | -------------------------------------------- |
| Input  | entry rows (start/end/actual…) | RPC stat rows (tag_id/entry_count/last_used) |
| Output | daily 集計 + 合計 + entry 詳細 | `{ counts, lastUsed }` Record 2 つ           |
| 用途   | tag detail page                | tag list / sidebar tag chip                  |

入力 / 出力 / 消費者が完全に異なる別概念のため、統合せず並置。命名で機能を区別する。

## テスト追加 (8 cases)

- 空配列 / `null` / `undefined` 入力 → 空 Record 2 つ
- 全 row に `last_used` → 両 Record に全 tag を含む
- 一部 row の `last_used` が null → `lastUsed` から除外、`counts` には含む
- 全 row の `last_used` が null → `lastUsed` は空
- 同 `tag_id` 複数 → 後勝ち (reduce 仕様)
- `entry_count=0` でも `counts` に含む

## 効果

- `getTagStats` procedure から pure reduce が分離
- entry feature 全体で 431 tests pass (前 PR の 423 + 新規 8)
- DB / RPC / 応答 shape / 仕様 変更なし
- `features/entry/domain` は Layer 1 維持、boundary 違反なし

## 残課題

`statistics.ts` の残り pure logic 候補:
- `getTimeByTag` transformer (snake→camel mapping)
- `getStatsOverview` の unpacking (RPC nested struct 依存)

別 PR で検討する。

## Test plan

- [x] `pnpm --filter @dayopt/product typecheck`
- [x] `pnpm --filter @dayopt/product lint`
- [x] `pnpm lint:boundaries`（Cross-feature imports: 0）
- [x] `pnpm --filter @dayopt/product test:run src/features/entry` → 431 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
