### PR TITLE
refactor(entry): getStatsOverview の RPC response unpacking を server helper へ切り出し

### DIFF
--- a/apps/product/src/features/entry/server/__tests__/statistics-overview-transform.test.ts
+++ b/apps/product/src/features/entry/server/__tests__/statistics-overview-transform.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type StatsKpiSummaryRpcResult,
+  transformStatsOverviewResponse,
+} from '../statistics-overview-transform';
+
+function makeFullResult(
+  overrides: Partial<StatsKpiSummaryRpcResult> = {},
+): StatsKpiSummaryRpcResult {
+  return {
+    cumulativeTime: { totalMinutes: 600 },
+    avgFulfillment: { avgFulfillment: 0.85, entryCount: 20 },
+    planRate: { totalEntries: 30, plannedEntries: 25, planRate: 0.83 },
+    contextSwitches: { totalSwitches: 12, avgPerDay: 1.5 },
+    blankRate: {
+      availableMinutes: 480,
+      scheduledMinutes: 360,
+      blankMinutes: 120,
+      blankRate: 0.25,
+    },
+    ...overrides,
+  };
+}
+
+describe('transformStatsOverviewResponse', () => {
+  it('null 入力 → 全 field が default', () => {
+    expect(transformStatsOverviewResponse(null)).toEqual({
+      cumulativeTime: { totalMinutes: 0 },
+      avgFulfillment: { avgFulfillment: undefined, entryCount: 0 },
+      entryRate: { totalEntries: 0, plannedEntries: 0, entryRate: 0 },
+      contextSwitches: { totalSwitches: 0, avgPerDay: 0 },
+      blankRate: {
+        availableMinutes: 0,
+        scheduledMinutes: 0,
+        blankMinutes: 0,
+        blankRate: 0,
+      },
+    });
+  });
+
+  it('undefined 入力 → 全 field が default', () => {
+    const result = transformStatsOverviewResponse(undefined);
+    expect(result.cumulativeTime.totalMinutes).toBe(0);
+    expect(result.avgFulfillment.avgFulfillment).toBeUndefined();
+    expect(result.entryRate.totalEntries).toBe(0);
+  });
+
+  it('完全な response → そのまま受け渡し + planRate → entryRate rename', () => {
+    const result = transformStatsOverviewResponse(makeFullResult());
+    expect(result).toEqual({
+      cumulativeTime: { totalMinutes: 600 },
+      avgFulfillment: { avgFulfillment: 0.85, entryCount: 20 },
+      entryRate: { totalEntries: 30, plannedEntries: 25, entryRate: 0.83 },
+      contextSwitches: { totalSwitches: 12, avgPerDay: 1.5 },
+      blankRate: {
+        availableMinutes: 480,
+        scheduledMinutes: 360,
+        blankMinutes: 120,
+        blankRate: 0.25,
+      },
+    });
+  });
+
+  it('outer key rename: response に entryRate は存在せず entryRate のみ持つ', () => {
+    const result = transformStatsOverviewResponse(makeFullResult());
+    expect('planRate' in result).toBe(false);
+    expect('entryRate' in result).toBe(true);
+  });
+
+  it('avgFulfillment.avgFulfillment が null → undefined に変換', () => {
+    const result = transformStatsOverviewResponse({
+      avgFulfillment: { avgFulfillment: null, entryCount: 5 },
+    });
+    expect(result.avgFulfillment.avgFulfillment).toBeUndefined();
+    expect(result.avgFulfillment.entryCount).toBe(5);
+  });
+
+  it('部分的 response: cumulativeTime のみ missing → そこだけ 0、他は値保持', () => {
+    const partial = makeFullResult();
+    // @ts-expect-error: 部分的に削除した状態を模倣
+    delete partial.cumulativeTime;
+    const result = transformStatsOverviewResponse(partial);
+    expect(result.cumulativeTime.totalMinutes).toBe(0);
+    expect(result.avgFulfillment.entryCount).toBe(20);
+    expect(result.entryRate.totalEntries).toBe(30);
+  });
+
+  it('planRate.planRate が実値 0 → そのまま 0 (default と区別される)', () => {
+    const result = transformStatsOverviewResponse({
+      planRate: { totalEntries: 0, plannedEntries: 0, planRate: 0 },
+    });
+    expect(result.entryRate.entryRate).toBe(0);
+    expect(result.entryRate.totalEntries).toBe(0);
+  });
+
+  it('全 nested が undefined → 全 field default', () => {
+    const result = transformStatsOverviewResponse({});
+    expect(result.cumulativeTime.totalMinutes).toBe(0);
+    expect(result.avgFulfillment.avgFulfillment).toBeUndefined();
+    expect(result.avgFulfillment.entryCount).toBe(0);
+    expect(result.entryRate.totalEntries).toBe(0);
+    expect(result.contextSwitches.totalSwitches).toBe(0);
+    expect(result.blankRate.blankRate).toBe(0);
+  });
+
+  it('blankRate のみ完全 → 他は default', () => {
+    const result = transformStatsOverviewResponse({
+      blankRate: {
+        availableMinutes: 480,
+        scheduledMinutes: 360,
+        blankMinutes: 120,
+        blankRate: 0.25,
+      },
+    });
+    expect(result.blankRate).toEqual({
+      availableMinutes: 480,
+      scheduledMinutes: 360,
+      blankMinutes: 120,
+      blankRate: 0.25,
+    });
+    expect(result.cumulativeTime.totalMinutes).toBe(0);
+  });
+});

--- a/apps/product/src/features/entry/server/statistics-overview-transform.ts
+++ b/apps/product/src/features/entry/server/statistics-overview-transform.ts
@@ -1,0 +1,81 @@
+/**
+ * `getStatsOverview` procedure の RPC response unpacking。
+ *
+ * RPC `get_stats_kpi_summary` の nested response shape を tRPC stable
+ * response shape に変換する server-side adapter。
+ *
+ * 注: domain ではなく server に置く理由:
+ * - RPC response shape (camelCase で `planRate` を含む特定構造) に密結合
+ * - `planRate` → `entryRate` の outer key rename を含む RPC↔tRPC adapter 役割
+ */
+
+/** RPC `get_stats_kpi_summary` が返す nested response shape */
+export interface StatsKpiSummaryRpcResult {
+  cumulativeTime: { totalMinutes: number };
+  avgFulfillment: { avgFulfillment: number | null; entryCount: number };
+  planRate: { totalEntries: number; plannedEntries: number; planRate: number };
+  contextSwitches: { totalSwitches: number; avgPerDay: number };
+  blankRate: {
+    availableMinutes: number;
+    scheduledMinutes: number;
+    blankMinutes: number;
+    blankRate: number;
+  };
+}
+
+/**
+ * tRPC response shape。
+ *
+ * RPC の `planRate` は `entryRate` にリネームされる。
+ * `avgFulfillment.avgFulfillment` は null → undefined に変換される。
+ * その他の missing field は 0 にフォールバックされる。
+ */
+export interface StatsOverviewResult {
+  cumulativeTime: { totalMinutes: number };
+  avgFulfillment: { avgFulfillment: number | undefined; entryCount: number };
+  entryRate: { totalEntries: number; plannedEntries: number; entryRate: number };
+  contextSwitches: { totalSwitches: number; avgPerDay: number };
+  blankRate: {
+    availableMinutes: number;
+    scheduledMinutes: number;
+    blankMinutes: number;
+    blankRate: number;
+  };
+}
+
+/**
+ * RPC `get_stats_kpi_summary` の戻り値を tRPC response shape に変換する。
+ *
+ * - `null` / `undefined` 入力でも全 field を default で埋めた応答を返す
+ * - `planRate` → `entryRate` の outer key rename
+ * - `avgFulfillment.avgFulfillment` の `null` は `undefined` に変換
+ * - その他の missing field は `?? 0`
+ */
+export function transformStatsOverviewResponse(data: unknown): StatsOverviewResult {
+  const result = data as StatsKpiSummaryRpcResult | null | undefined;
+
+  return {
+    cumulativeTime: {
+      totalMinutes: result?.cumulativeTime?.totalMinutes ?? 0,
+    },
+    avgFulfillment: {
+      avgFulfillment: result?.avgFulfillment?.avgFulfillment ?? undefined,
+      entryCount: result?.avgFulfillment?.entryCount ?? 0,
+    },
+    entryRate: {
+      totalEntries: result?.planRate?.totalEntries ?? 0,
+      plannedEntries: result?.planRate?.plannedEntries ?? 0,
+      entryRate: result?.planRate?.planRate ?? 0,
+    },
+    contextSwitches: {
+      totalSwitches: result?.contextSwitches?.totalSwitches ?? 0,
+      avgPerDay: result?.contextSwitches?.avgPerDay ?? 0,
+    },
+    blankRate: {
+      availableMinutes: result?.blankRate?.availableMinutes ?? 0,
+      scheduledMinutes: result?.blankRate?.scheduledMinutes ?? 0,
+      blankMinutes: result?.blankRate?.blankMinutes ?? 0,
+      blankRate: result?.blankRate?.blankRate ?? 0,
+    },
+  };
+}

--- a/apps/product/src/features/entry/server/statistics.ts
+++ b/apps/product/src/features/entry/server/statistics.ts
@@ -26,6 +26,8 @@ import {
   transformEstimationAccuracy,
 } from '../domain';
 
+import { transformStatsOverviewResponse } from './statistics-overview-transform';
+
 /**
  * ユーザーのタイムゾーンで「今日」の日付文字列（YYYY-MM-DD）を返す
  */
@@ -672,43 +674,7 @@ export const entriesStatisticsRouter = createTRPCRouter({
           });
         }
 
-        const result = data as {
-          cumulativeTime: { totalMinutes: number };
-          avgFulfillment: { avgFulfillment: number | null; entryCount: number };
-          planRate: { totalEntries: number; plannedEntries: number; planRate: number };
-          contextSwitches: { totalSwitches: number; avgPerDay: number };
-          blankRate: {
-            availableMinutes: number;
-            scheduledMinutes: number;
-            blankMinutes: number;
-            blankRate: number;
-          };
-        } | null;
-
-        return {
-          cumulativeTime: {
-            totalMinutes: result?.cumulativeTime?.totalMinutes ?? 0,
-          },
-          avgFulfillment: {
-            avgFulfillment: result?.avgFulfillment?.avgFulfillment ?? undefined,
-            entryCount: result?.avgFulfillment?.entryCount ?? 0,
-          },
-          entryRate: {
-            totalEntries: result?.planRate?.totalEntries ?? 0,
-            plannedEntries: result?.planRate?.plannedEntries ?? 0,
-            entryRate: result?.planRate?.planRate ?? 0,
-          },
-          contextSwitches: {
-            totalSwitches: result?.contextSwitches?.totalSwitches ?? 0,
-            avgPerDay: result?.contextSwitches?.avgPerDay ?? 0,
-          },
-          blankRate: {
-            availableMinutes: result?.blankRate?.availableMinutes ?? 0,
-            scheduledMinutes: result?.blankRate?.scheduledMinutes ?? 0,
-            blankMinutes: result?.blankRate?.blankMinutes ?? 0,
-            blankRate: result?.blankRate?.blankRate ?? 0,
-          },
-        };
+        return transformStatsOverviewResponse(data);
       } catch (error) {
         handleStatsError('getStatsOverview', error);
       }


### PR DESCRIPTION
## Summary

`features/entry/server/statistics.ts` の `getStatsOverview` procedure から、RPC nested response の unpacking / response transform を `features/entry/server/statistics-overview-transform.ts` に切り出した。

## 切り出した関数

**`transformStatsOverviewResponse(data: unknown): StatsOverviewResult`**
- RPC `get_stats_kpi_summary` の nested response → tRPC stable response
- `planRate` → `entryRate` の outer key rename
- `avgFulfillment.avgFulfillment` の `null` → `undefined` 変換
- 他 field の missing は `?? 0` で default
- `StatsKpiSummaryRpcResult` / `StatsOverviewResult` 型を同 file で export

## domain ではなく server に置いた理由

RPC `get_stats_kpi_summary` の response shape (camelCase で `planRate` など特定構造) に密結合した adapter のため、`features/entry/domain` には不適切。

`features/entry/server/` 配下の helper として配置することで「RPC contract と tRPC contract の対応」が 1 ファイルに集約される。

## テスト追加 (9 cases)

- `null` / `undefined` 入力 → 全 field default
- 完全な response → そのまま受け渡し + rename 確認
- outer key rename: `planRate` は存在せず `entryRate` のみ持つ
- `avgFulfillment.avgFulfillment` が `null` → `undefined` に変換
- 部分的 response (`cumulativeTime` のみ missing)
- `planRate.planRate` が実値 `0` → default と区別される
- 全 nested が undefined
- `blankRate` のみ完全な partial response

## 効果

- `getStatsOverview` procedure から 25 行の unpacking が分離
- entry feature 全体で 440 tests pass (前 PR の 431 + 新規 9)
- DB / RPC / 応答 shape / 仕様 変更なし
- `features/entry/server` は Layer 1 維持、domain 非依存、boundary 違反なし

## 残課題

`statistics.ts` の残り pure logic 候補:
- `getTimeByTag` transformer (snake→camel mapping)
- 各種 trivial mapper (1-5 LOC) は ROI 低いため別 PR / 据え置き

## Test plan

- [x] `pnpm --filter @dayopt/product typecheck`
- [x] `pnpm --filter @dayopt/product lint`
- [x] `pnpm lint:boundaries`（Cross-feature imports: 0）
- [x] `pnpm --filter @dayopt/product test:run src/features/entry` → 440 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
