### PR TITLE
chore(monorepo): audit shared package integration

### DIFF
--- a/apps/product/package.json
+++ b/apps/product/package.json
@@ -76,6 +76,7 @@
     "@dayopt/billing": "workspace:*",
     "@dayopt/config": "workspace:*",
     "@dayopt/database": "workspace:*",
+    "@dayopt/domain": "workspace:*",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/apps/product/src/features/entry/domain/entry-time-model.ts
+++ b/apps/product/src/features/entry/domain/entry-time-model.ts
@@ -1,4 +1,7 @@
-import type { EntryOrigin } from '../types/entry';
+import type { EntryOrigin, TimeRange } from '@dayopt/domain';
+import { determineEntryOrigin as determineDomainEntryOrigin } from '@dayopt/domain';
+
+export type { TimeRange } from '@dayopt/domain';
 
 export type EntryLike = {
   origin?: string | null;
@@ -9,11 +12,9 @@ export type EntryLike = {
   duration_minutes?: number | null;
 };
 
-export type TimeRange = { start: Date; end: Date };
-
 /** end <= now なら 'unplanned'、それ以外は 'planned'。now を注入できるのでテストが決定論的になる。 */
 export function determineEntryOrigin(end: Date | string, now: Date = new Date()): EntryOrigin {
-  return new Date(end).getTime() <= now.getTime() ? 'unplanned' : 'planned';
+  return determineDomainEntryOrigin(new Date(end), now);
 }
 
 export function isPlannedEntry(entry: EntryLike): boolean {

--- a/apps/product/src/features/entry/types/entry.ts
+++ b/apps/product/src/features/entry/types/entry.ts
@@ -1,28 +1,13 @@
 // Entry型定義（Canonical source）
 // plans + records を統合した entries テーブルに対応
 
-/**
- * エントリの時間位置ベースの状態
- * - upcoming: 未来の予定
- * - active: 現在進行中
- * - past: 過去の記録
- */
-export type EntryState = 'upcoming' | 'active' | 'past';
+import type { EntryOrigin, EntryState, FulfillmentScore } from '@dayopt/domain';
 
 /**
- * エントリの起源
- * - planned: 計画済み（予定あり）
- * - unplanned: 計画外（記録のみ）
+ * Entry の共通 domain type は @dayopt/domain を source of truth にする。
+ * この feature API は既存 import を壊さないための re-export。
  */
-export type EntryOrigin = 'planned' | 'unplanned';
-
-/**
- * 充実度スコア（3段階）
- * 1: 微妙
- * 2: 普通
- * 3: 良い
- */
-export type FulfillmentScore = 1 | 2 | 3;
+export type { EntryOrigin, EntryState, FulfillmentScore };
 
 /**
  * エントリ基本型（entries テーブルに対応）

--- a/apps/storybook/docs/dev/architecture/PackagesOverview.mdx
+++ b/apps/storybook/docs/dev/architecture/PackagesOverview.mdx
@@ -46,6 +46,19 @@ apps/product, apps/web, apps/admin
 `packages/billing` は Free / Pro の公開 plan model, subscription status, `pro_access` entitlement, pricing 表示用定数の境界として動き始めている。Stripe SDK / secret / webhook / checkout / portal は product 側の server-only 境界に残す。
 `packages/types`, `packages/server`, `packages/utils` はまだ第一段階の placeholder に近い。
 
+## Integration Audit
+
+現時点の shared package 統合では、`packages/*` から `apps/*` / product feature / app alias へ戻る依存は作らない。`packages/ui` の React / Radix 依存は UI primitive の責務として許容し、`packages/database` の Stripe 文字列は generated DB type と table name 由来の DB boundary として扱う。
+
+Source of truth:
+
+- URL / domain / contact / public brand constants: `packages/config`
+- Entry origin / fulfillment score / date-time preference / pure Dayopt concept: `packages/domain`
+- Supabase generated type / table name / row helper type: `packages/database`
+- Free / Pro plan / subscription status / `pro_access` entitlement / public pricing: `packages/billing`
+
+Apps 側に残る legal / i18n / docs / test fixture の URL, email, price 文字列は、ユーザー向け文言・履歴・例示が混ざるため機械的には置換しない。DB access の `.from('entries')` / `.from('tags')` / `.from('user_settings')` も Supabase 型推論と呼び出し箇所が多いため、`databaseTables` 適用は段階的な follow-up にする。
+
 ## Package Boundaries
 
 ### `packages/design`
@@ -188,3 +201,11 @@ Storybook は `packages/design` と `packages/ui` の公開面を確認する場
 - `Features/*`: product feature UI。Source of truth は `apps/product/src/features/*`。
 - `Operations/*`: deployment / release ops。Source of truth は `apps/storybook/docs/operations/*`。
 - `Architecture/*`: engineering decisions。Source of truth は `apps/storybook/docs/dev/architecture/*`。
+
+## Before Auth Package
+
+`packages/auth` へ進む前の follow-up:
+
+- `packages/database.databaseTables` を DB access call site に少しずつ適用できるか確認する。
+- billing / legal / pricing 文言は i18n の表示責務と `packages/billing` の public constants の境界を分けて扱う。
+- `packages/auth` はまず pure model のみとし、Supabase client, cookie, middleware, session refresh, route handler は product 側に残す。

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,6 +209,9 @@ importers:
       '@dayopt/database':
         specifier: workspace:*
         version: link:../../packages/database
+      '@dayopt/domain':
+        specifier: workspace:*
+        version: link:../../packages/domain
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)


### PR DESCRIPTION
## Summary
- audit shared package integration boundaries after design/ui/config/domain/database/billing package additions
- add @dayopt/domain to product and keep product Entry API stable while delegating shared entry types/origin helper to the domain package
- document current source-of-truth boundaries and follow-ups before introducing @dayopt/auth

## Audit Notes
- packages/* has no apps/features/app-alias imports
- @dayopt/ui React/Radix dependency is expected for UI primitives
- @dayopt/database Stripe string hits are generated DB type/table-name boundary only
- DB table constants and legal/i18n URL/price strings are intentionally left for follow-up

## Validation
- pnpm install --frozen-lockfile
- pnpm build:packages
- pnpm typecheck:packages
- pnpm typecheck
- pnpm lint
- pnpm lint:boundaries
- pnpm build
- pnpm build:web
- pnpm build-storybook
- pnpm check:workspace
- pnpm -r list --depth -1 | rg '@dayopt/(design|ui|config|domain|database|billing)'
- rg '@/|apps/|features/|next/|zustand|@supabase|stripe|process.env' packages
- rg '@dayopt/(design|ui|config|domain|database|billing)/' apps packages
- rg 'dayopt.app|app.dayopt.app|support@dayopt.app|Dayopt/dayopt' apps packages
- rg '"free"|"pro"|SubscriptionStatus|Entitlement|planId|price' apps packages
- rg '"planned"|"unplanned"|EntryOrigin|TimeRange' apps/product/src packages
- rg '"entries"|"tags"|"user_settings"|"product_events"' apps/product/src packages
