### PR TITLE
refactor(entry): getTimeByTag transformer を server helper へ切り出し（シリーズ完結）

### DIFF
--- a/apps/product/src/features/entry/server/__tests__/statistics-time-by-tag-transform.test.ts
+++ b/apps/product/src/features/entry/server/__tests__/statistics-time-by-tag-transform.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { transformTimeByTagResponse } from '../statistics-time-by-tag-transform';
+
+describe('transformTimeByTagResponse', () => {
+  it('null 入力 → 空配列', () => {
+    expect(transformTimeByTagResponse(null)).toEqual([]);
+  });
+
+  it('undefined 入力 → 空配列', () => {
+    expect(transformTimeByTagResponse(undefined)).toEqual([]);
+  });
+
+  it('空配列 → 空配列', () => {
+    expect(transformTimeByTagResponse([])).toEqual([]);
+  });
+
+  it('単一 row: 4 field の rename (tag_name → name, tag_color → color)', () => {
+    const result = transformTimeByTagResponse([
+      { tag_id: 'tag-1', tag_name: 'Deep Work', tag_color: 'blue', hours: 12.5 },
+    ]);
+    expect(result).toEqual([{ tagId: 'tag-1', name: 'Deep Work', color: 'blue', hours: 12.5 }]);
+  });
+
+  it('複数 row: 順序保持', () => {
+    const result = transformTimeByTagResponse([
+      { tag_id: 'tag-a', tag_name: 'A', tag_color: 'red', hours: 1 },
+      { tag_id: 'tag-b', tag_name: 'B', tag_color: 'green', hours: 2 },
+      { tag_id: 'tag-c', tag_name: 'C', tag_color: 'blue', hours: 3 },
+    ]);
+    expect(result.map((r) => r.tagId)).toEqual(['tag-a', 'tag-b', 'tag-c']);
+  });
+
+  it('hours = 0 → そのまま 0', () => {
+    const result = transformTimeByTagResponse([
+      { tag_id: 'tag-1', tag_name: 'X', tag_color: 'gray', hours: 0 },
+    ]);
+    expect(result[0]?.hours).toBe(0);
+  });
+
+  it('hours decimal: 精度保持', () => {
+    const result = transformTimeByTagResponse([
+      { tag_id: 'tag-1', tag_name: 'X', tag_color: 'gray', hours: 1.234567 },
+    ]);
+    expect(result[0]?.hours).toBe(1.234567);
+  });
+
+  it('空文字 tag_color → そのまま空文字 (fallback なし、estimation-accuracy と異なる)', () => {
+    const result = transformTimeByTagResponse([
+      { tag_id: 'tag-1', tag_name: 'X', tag_color: '', hours: 5 },
+    ]);
+    expect(result[0]?.color).toBe('');
+  });
+
+  it('output shape に snake_case key は含まれない', () => {
+    const result = transformTimeByTagResponse([
+      { tag_id: 'tag-1', tag_name: 'X', tag_color: 'blue', hours: 1 },
+    ]);
+    const item = result[0]!;
+    expect('tag_id' in item).toBe(false);
+    expect('tag_name' in item).toBe(false);
+    expect('tag_color' in item).toBe(false);
+  });
+});

--- a/apps/product/src/features/entry/server/statistics-time-by-tag-transform.ts
+++ b/apps/product/src/features/entry/server/statistics-time-by-tag-transform.ts
@@ -1,0 +1,45 @@
+/**
+ * `getTimeByTag` procedure の RPC response transform。
+ *
+ * RPC `get_time_by_tag` の snake_case 行配列を tRPC response の
+ * 短縮 camelCase shape に変換する server-side adapter。
+ *
+ * 注: domain ではなく server に置く理由:
+ * - RPC response shape (snake_case の `tag_*` field 群) に密結合
+ * - `tag_name` → `name` / `tag_color` → `color` の接頭辞除去は RPC↔tRPC adapter 役割
+ */
+
+/** RPC `get_time_by_tag` が返す snake_case 行 */
+export interface TimeByTagRpcRow {
+  tag_id: string;
+  tag_name: string;
+  tag_color: string;
+  hours: number;
+}
+
+/** tRPC response item (tag_ 接頭辞除去 + camelCase) */
+export interface TimeByTagItem {
+  tagId: string;
+  name: string;
+  color: string;
+  hours: number;
+}
+
+/**
+ * RPC `get_time_by_tag` の戻り値を tRPC response shape に変換する。
+ *
+ * - `null` / `undefined` 入力は空配列にフォールバック
+ * - `tag_id` → `tagId` (camelCase)
+ * - `tag_name` → `name` (接頭辞除去)
+ * - `tag_color` → `color` (接頭辞除去)
+ * - `hours` はそのまま
+ */
+export function transformTimeByTagResponse(data: unknown): TimeByTagItem[] {
+  const rows = (data ?? []) as ReadonlyArray<TimeByTagRpcRow>;
+  return rows.map((row) => ({
+    tagId: row.tag_id,
+    name: row.tag_name,
+    color: row.tag_color,
+    hours: row.hours,
+  }));
+}

--- a/apps/product/src/features/entry/server/statistics.ts
+++ b/apps/product/src/features/entry/server/statistics.ts
@@ -27,6 +27,7 @@ import {
 } from '../domain';
 
 import { transformStatsOverviewResponse } from './statistics-overview-transform';
+import { transformTimeByTagResponse } from './statistics-time-by-tag-transform';
 
 /**
  * ユーザーのタイムゾーンで「今日」の日付文字列（YYYY-MM-DD）を返す
@@ -152,19 +153,7 @@ export const entriesStatisticsRouter = createTRPCRouter({
           });
         }
 
-        const rows = (data ?? []) as Array<{
-          tag_id: string;
-          tag_name: string;
-          tag_color: string;
-          hours: number;
-        }>;
-
-        return rows.map((row) => ({
-          tagId: row.tag_id,
-          name: row.tag_name,
-          color: row.tag_color,
-          hours: row.hours,
-        }));
+        return transformTimeByTagResponse(data);
       } catch (error) {
         handleStatsError('getTimeByTag', error);
       }


### PR DESCRIPTION
## Summary

`features/entry/server/statistics.ts` の `getTimeByTag` procedure から、RPC snake_case 行 → tRPC camelCase item の transform を `features/entry/server/statistics-time-by-tag-transform.ts` に切り出した。

これで `statistics.ts` 内の RPC response 直接 map は **ゼロ** になり、本シリーズ (#1222〜) の cross-layer types owner cleanup が完了する。

## 切り出した関数

**`transformTimeByTagResponse(data: unknown): TimeByTagItem[]`**
- `tag_id` → `tagId` / `tag_name` → `name` / `tag_color` → `color` の rename
- `null` / `undefined` 入力は空配列にフォールバック
- `TimeByTagRpcRow` / `TimeByTagItem` 型を同 file で export

## 判断

12 LOC と trivial 寄りだが、過去 PR とのパターン一貫性を優先して切り出し。これで `statistics.ts` 内の RPC response 直接 map はゼロになる。

## domain ではなく server に置いた理由

RPC response shape (snake_case の `tag_*` field 群) に密結合した adapter のため、`features/entry/domain` には不適切。

`features/entry/server/` 配下の helper として配置することで「RPC contract と tRPC contract の対応」が 1 ファイルに集約される (#1227 と同じパターン)。

## テスト追加 (9 cases)

- `null` / `undefined` / 空配列入力 → 空配列
- 単一 row の 4 field rename 確認
- 複数 row の順序保持
- `hours = 0` / decimal の精度保持
- 空文字 `tag_color` → そのまま (fallback なし、estimation-accuracy と異なる)
- output shape に snake_case key を含まないことの確認

## 効果

- `getTimeByTag` procedure から 12 LOC の inline transform が分離
- entry feature 全体で 449 tests pass (前 PR の 440 + 新規 9)
- DB / RPC / 応答 shape / 仕様 変更なし
- `features/entry/server` は Layer 1 維持、domain 非依存、boundary 違反なし

## シリーズ完了

本シリーズで `statistics.ts` / `tag-service.ts` の cross-layer types owner cleanup は完了:

| PR | 切り出し先 | 内容 |
|----|-----------|------|
| #1222 | `tags/domain` | tag merge / ungroup pure logic |
| #1223 | `entry/domain` | hourly / dow / streak |
| #1224 | `entry/domain` | monthly-trend |
| #1225 | `entry/domain` | estimation-accuracy |
| #1226 | `entry/domain` | tag-stats |
| #1227 | `entry/server` | stats-overview-transform |
| #1228 (本 PR) | `entry/server` | time-by-tag-transform |

`statistics.ts` は依然 ~900 LOC だが残る inline は orchestration / error handling のみ。

## Test plan

- [x] `pnpm --filter @dayopt/product typecheck`
- [x] `pnpm --filter @dayopt/product lint`
- [x] `pnpm lint:boundaries`（Cross-feature imports: 0）
- [x] `pnpm --filter @dayopt/product test:run src/features/entry` → 449 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
