### PR TITLE
refactor(product): clarify auth boundaries

### DIFF
--- a/apps/product/src/features/auth/domain/index.ts
+++ b/apps/product/src/features/auth/domain/index.ts
@@ -1,0 +1,1 @@
+export * from '@/lib/auth/domain';

--- a/apps/product/src/lib/auth/domain/access-policy.ts
+++ b/apps/product/src/lib/auth/domain/access-policy.ts
@@ -1,0 +1,62 @@
+import { isProSubscriptionStatus } from '@dayopt/billing';
+
+import { isAdminRole, type ProductRole } from './roles';
+
+export const protectedProductPaths = [
+  '/tasks',
+  '/settings',
+  '/calendar',
+  '/review',
+  '/box',
+  '/table',
+  '/board',
+  '/add',
+  '/tags',
+  '/oauth/authorize',
+  '/oauth/consent',
+] as const;
+
+export const authProductPaths = ['/login', '/signup', '/auth'] as const;
+
+export const publicProductPaths = [
+  '/',
+  '/about',
+  '/privacy',
+  '/terms',
+  '/contact',
+  '/pricing',
+] as const;
+
+export const publicRewritePaths = ['/mcp', '/oauth/token'] as const;
+
+export function canAccessProFeatures(status: string | null | undefined): boolean {
+  return isProSubscriptionStatus(status);
+}
+
+export function canAccessAdminFeatures(role: ProductRole | null | undefined): boolean {
+  return isAdminRole(role);
+}
+
+export function isProtectedProductPath(pathname: string): boolean {
+  return matchesPathPrefix(pathname, protectedProductPaths);
+}
+
+export function isAuthProductPath(pathname: string): boolean {
+  return matchesPathPrefix(pathname, authProductPaths);
+}
+
+export function isPublicProductPath(pathname: string): boolean {
+  return matchesExactPath(pathname, publicProductPaths);
+}
+
+export function isPublicRewritePath(pathname: string): boolean {
+  return matchesExactPath(pathname, publicRewritePaths);
+}
+
+function matchesPathPrefix(pathname: string, prefixes: readonly string[]): boolean {
+  return prefixes.some((path) => pathname.startsWith(path));
+}
+
+function matchesExactPath(pathname: string, paths: readonly string[]): boolean {
+  return paths.some((path) => pathname === path);
+}

--- a/apps/product/src/lib/auth/domain/identity.ts
+++ b/apps/product/src/lib/auth/domain/identity.ts
@@ -1,0 +1,7 @@
+import type { ProductRole } from './roles';
+
+export type ProductIdentity = {
+  userId: string;
+  role?: ProductRole | null;
+  subscriptionStatus?: string | null;
+};

--- a/apps/product/src/lib/auth/domain/index.ts
+++ b/apps/product/src/lib/auth/domain/index.ts
@@ -1,0 +1,4 @@
+export * from './access-policy';
+export * from './identity';
+export * from './permissions';
+export * from './roles';

--- a/apps/product/src/lib/auth/domain/permissions.ts
+++ b/apps/product/src/lib/auth/domain/permissions.ts
@@ -1,0 +1,34 @@
+import { canAccessAdminFeatures, canAccessProFeatures } from './access-policy';
+import type { ProductIdentity } from './identity';
+
+export const productAccessLevels = ['public', 'protected', 'pro', 'admin'] as const;
+
+export type ProductAccessLevel = (typeof productAccessLevels)[number];
+
+export const productPermissions = ['access:protected', 'access:pro', 'access:admin'] as const;
+
+export type ProductPermission = (typeof productPermissions)[number];
+
+export function isProductAccessLevel(
+  value: string | null | undefined,
+): value is ProductAccessLevel {
+  return productAccessLevels.includes(value as ProductAccessLevel);
+}
+
+export function hasProductPermission(
+  identity: ProductIdentity | null | undefined,
+  permission: ProductPermission,
+): boolean {
+  if (!identity?.userId) {
+    return false;
+  }
+
+  switch (permission) {
+    case 'access:protected':
+      return true;
+    case 'access:pro':
+      return canAccessProFeatures(identity.subscriptionStatus);
+    case 'access:admin':
+      return canAccessAdminFeatures(identity.role);
+  }
+}

--- a/apps/product/src/lib/auth/domain/roles.ts
+++ b/apps/product/src/lib/auth/domain/roles.ts
@@ -1,0 +1,11 @@
+export const productRoles = ['user', 'admin'] as const;
+
+export type ProductRole = (typeof productRoles)[number];
+
+export function isProductRole(value: string | null | undefined): value is ProductRole {
+  return productRoles.includes(value as ProductRole);
+}
+
+export function isAdminRole(role: ProductRole | null | undefined): role is 'admin' {
+  return role === 'admin';
+}

--- a/apps/product/src/lib/trpc/procedures.ts
+++ b/apps/product/src/lib/trpc/procedures.ts
@@ -15,6 +15,11 @@ import superjson from 'superjson';
 import { z } from 'zod';
 
 import { env } from '@/env';
+import {
+  canAccessAdminFeatures,
+  canAccessProFeatures,
+  type ProductAccessLevel,
+} from '@/lib/auth/domain';
 import { logger } from '@/lib/logger';
 // 循環依存防止: barrel `@/lib/mcp` は trpc-bridge を再 export し、それが appRouter →
 // feature router → procedures.ts と辿るため、ここでは auth.ts を直 import する。
@@ -24,7 +29,6 @@ import { trpcUserRateLimit } from '@/lib/rate-limit/upstash';
 import { AuthMode, createServiceRoleClient, detectAuthMode } from '@/lib/supabase/oauth';
 import { ServiceError } from '@/lib/trpc/errors';
 
-import { isProSubscriptionStatus } from '@dayopt/billing';
 import type { Database } from '@dayopt/database';
 
 /**
@@ -34,7 +38,7 @@ export interface ProcedureMeta {
   /** OpenAPI description */
   description?: string;
   /** 認証レベル */
-  auth?: 'public' | 'protected' | 'pro' | 'admin';
+  auth?: ProductAccessLevel;
   /** エンドポイント固有のレート制限（グローバル100 req/minを上書き） */
   rateLimit?: { requests: number; window: string };
   /** 非推奨フラグ */
@@ -380,7 +384,7 @@ export const proProcedure = protectedProcedure.meta({ auth: 'pro' }).use(async (
   // Sentryにプラン情報をタグ付け（エラー分析時のフィルタ用）
   Sentry.setTag('user.plan', status ?? 'free');
 
-  const isProActive = isProSubscriptionStatus(status);
+  const isProActive = canAccessProFeatures(status);
 
   if (!isProActive) {
     throw new TRPCError({
@@ -436,7 +440,7 @@ async function checkAdminPermission(_userId: string): Promise<boolean> {
   // TODO: 管理機能が必要になった時点で実装する
   // 候補: ADMIN_USER_IDS 環境変数によるホワイトリスト or profiles.is_admin カラム
   // 現在 adminProcedure を使用するルーターは存在しない（deny-by-default で安全）
-  return false;
+  return canAccessAdminFeatures(null);
 }
 
 /**

--- a/apps/product/src/proxy.ts
+++ b/apps/product/src/proxy.ts
@@ -3,6 +3,12 @@ import { NextResponse, type NextRequest } from 'next/server';
 
 import { dayoptDomains } from '@dayopt/config';
 
+import {
+  isAuthProductPath,
+  isProtectedProductPath,
+  isPublicProductPath,
+  isPublicRewritePath,
+} from '@/lib/auth/domain';
 import { routing } from '@/lib/i18n/routing';
 import { logger } from '@/lib/logger';
 import { updateSession } from '@/lib/supabase/middleware';
@@ -10,30 +16,6 @@ import { updateSession } from '@/lib/supabase/middleware';
 // next-intlのミドルウェアを作成
 const intlMiddleware = createMiddleware(routing);
 
-// 認証が必要なパス
-const protectedPaths = [
-  '/tasks',
-  '/settings',
-  '/calendar',
-  '/review',
-
-  '/box',
-  '/table',
-  '/board',
-  '/add',
-  '/tags',
-  '/oauth/authorize',
-  '/oauth/consent',
-];
-
-// 認証ページのパス
-const authPaths = ['/login', '/signup', '/auth'];
-
-// 公開パス（認証チェック不要）- getUser() 呼び出しをスキップしてパフォーマンス向上
-const publicPaths = ['/', '/about', '/privacy', '/terms', '/contact', '/pricing'];
-
-// Vercel rewritesでAPI routeへ到達させる公開パス
-const publicRewritePaths = ['/mcp', '/oauth/token'];
 const MCP_HOST = dayoptDomains.mcp;
 
 // 言語プレフィックスを除いたパスを取得
@@ -92,7 +74,7 @@ export async function proxy(request: NextRequest) {
     pathname.startsWith('/api') ||
     pathname.includes('.') ||
     (hostname === MCP_HOST && pathname === '/') ||
-    publicRewritePaths.includes(pathname)
+    isPublicRewritePath(pathname)
   ) {
     return NextResponse.next();
   }
@@ -133,9 +115,9 @@ export async function proxy(request: NextRequest) {
   const currentLocale = getCurrentLocale(pathname);
   const pathWithoutLocale = getPathWithoutLocale(pathname);
 
-  const isProtectedPath = protectedPaths.some((path) => pathWithoutLocale.startsWith(path));
-  const isAuthPath = authPaths.some((path) => pathWithoutLocale.startsWith(path));
-  const isPublicPath = publicPaths.some((path) => pathWithoutLocale === path);
+  const isProtectedPath = isProtectedProductPath(pathWithoutLocale);
+  const isAuthPath = isAuthProductPath(pathWithoutLocale);
+  const isPublicPath = isPublicProductPath(pathWithoutLocale);
 
   // パフォーマンス最適化: 公開ページでは getUser() をスキップ
   // getUser() は Supabase API への往復が発生するため、認証が必要なパスのみ実行

--- a/apps/storybook/docs/dev/architecture/PackagesOverview.mdx
+++ b/apps/storybook/docs/dev/architecture/PackagesOverview.mdx
@@ -204,8 +204,16 @@ Storybook は `packages/design` と `packages/ui` の公開面を確認する場
 
 ## Before Auth Package
 
-`packages/auth` へ進む前の follow-up:
+`packages/auth` はまだ作らない。auth / permission は現時点では product-only で、admin app や同じ permission model を使う second runtime がまだないため、まず `apps/product` 内で境界を整える。
+
+Current placement:
+
+- Pure product auth model / access policy: `apps/product/src/lib/auth/domain`
+- Product auth runtime: `apps/product/src/lib/supabase`, `apps/product/src/proxy.ts`, auth routes, server actions
+
+Future extraction:
 
 - `packages/database.databaseTables` を DB access call site に少しずつ適用できるか確認する。
 - billing / legal / pricing 文言は i18n の表示責務と `packages/billing` の public constants の境界を分けて扱う。
-- `packages/auth` はまず pure model のみとし、Supabase client, cookie, middleware, session refresh, route handler は product 側に残す。
+- admin app または別 runtime が同じ permission model を必要とした時点で、product auth domain を `packages/auth` の pure model として昇格する。
+- 昇格後も Supabase client, cookie, middleware, session refresh, route handler は product 側に残す。


### PR DESCRIPTION
## Summary

- Clarify product-local auth / permission boundaries without creating `@dayopt/auth`.
- Add a pure `apps/product/src/lib/auth/domain` layer for roles, access levels, permissions, identities, and route access policy.
- Keep Supabase Auth runtime, middleware behavior, login/signup/MFA flows, OAuth scopes, server actions, and env/secret handling in their existing product runtime boundaries.
- Update Storybook package architecture docs to record why `packages/auth` is intentionally deferred.

## Notes

- `apps/product/src/features/auth/domain` is a thin re-export for feature-facing imports.
- The pure implementation lives under `apps/product/src/lib/auth/domain` so shared `src/lib` code does not depend back on `features/*`.
- Admin access remains deny-by-default because there is no current admin role source of truth.
- Pro access continues to use the existing `@dayopt/billing` subscription semantics.

## Validation

Ran after rebasing onto latest `origin/main`:

- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:boundaries`
- `pnpm build`
- `pnpm build:web`
- `pnpm check:workspace`

Existing warnings observed during builds: Next/Sentry deprecation warning, local Upstash fallback warning, web Turbopack NFT trace warning, and Storybook docgen/chunk-size warnings. All commands completed successfully.
