### PR TITLE
refactor(entry): statistics.ts 残存 inline RPC unpacking の完全クリーンアップ

### DIFF
--- a/apps/product/src/features/entry/server/__tests__/statistics-energy-map-transform.test.ts
+++ b/apps/product/src/features/entry/server/__tests__/statistics-energy-map-transform.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { transformEnergyMapResponse } from '../statistics-energy-map-transform';
+
+describe('transformEnergyMapResponse', () => {
+  it('null 入力 → 空配列', () => {
+    expect(transformEnergyMapResponse(null)).toEqual([]);
+  });
+
+  it('undefined 入力 → 空配列', () => {
+    expect(transformEnergyMapResponse(undefined)).toEqual([]);
+  });
+
+  it('空配列 → 空配列', () => {
+    expect(transformEnergyMapResponse([])).toEqual([]);
+  });
+
+  it('単一 row: 5 field の rename を確認', () => {
+    const result = transformEnergyMapResponse([
+      {
+        hour: 9,
+        dow: 1,
+        avg_fulfillment: 4.2,
+        total_minutes: 120,
+        entry_count: 3,
+      },
+    ]);
+    expect(result).toEqual([
+      { hour: 9, dow: 1, avgFulfillment: 4.2, totalMinutes: 120, entryCount: 3 },
+    ]);
+  });
+
+  it('avg_fulfillment: null はそのまま null で保持', () => {
+    const result = transformEnergyMapResponse([
+      { hour: 9, dow: 1, avg_fulfillment: null, total_minutes: 120, entry_count: 3 },
+    ]);
+    expect(result[0]?.avgFulfillment).toBeNull();
+  });
+
+  it('複数 row: 順序保持', () => {
+    const result = transformEnergyMapResponse([
+      { hour: 9, dow: 1, avg_fulfillment: 4, total_minutes: 60, entry_count: 1 },
+      { hour: 10, dow: 1, avg_fulfillment: 3, total_minutes: 90, entry_count: 2 },
+      { hour: 11, dow: 1, avg_fulfillment: 5, total_minutes: 30, entry_count: 1 },
+    ]);
+    expect(result.map((r) => r.hour)).toEqual([9, 10, 11]);
+  });
+
+  it('output shape に snake_case key は含まれない', () => {
+    const result = transformEnergyMapResponse([
+      { hour: 9, dow: 1, avg_fulfillment: 4, total_minutes: 60, entry_count: 1 },
+    ]);
+    const item = result[0]!;
+    expect('avg_fulfillment' in item).toBe(false);
+    expect('total_minutes' in item).toBe(false);
+    expect('entry_count' in item).toBe(false);
+  });
+});

--- a/apps/product/src/features/entry/server/__tests__/statistics-kpi-unpackers.test.ts
+++ b/apps/product/src/features/entry/server/__tests__/statistics-kpi-unpackers.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  unpackAvgFulfillment,
+  unpackBlankRate,
+  unpackContextSwitches,
+  unpackCumulativeTime,
+  unpackEntryRate,
+} from '../statistics-kpi-unpackers';
+
+describe('unpackCumulativeTime', () => {
+  it('null → totalMinutes: 0', () => {
+    expect(unpackCumulativeTime(null)).toEqual({ totalMinutes: 0 });
+  });
+
+  it('undefined → totalMinutes: 0', () => {
+    expect(unpackCumulativeTime(undefined)).toEqual({ totalMinutes: 0 });
+  });
+
+  it('値あり → そのまま受け渡し', () => {
+    expect(unpackCumulativeTime({ totalMinutes: 600 })).toEqual({ totalMinutes: 600 });
+  });
+
+  it('実値 0 → default と区別される (そのまま 0)', () => {
+    expect(unpackCumulativeTime({ totalMinutes: 0 })).toEqual({ totalMinutes: 0 });
+  });
+});
+
+describe('unpackAvgFulfillment', () => {
+  it('null → 全 default (avgFulfillment: undefined, entryCount: 0)', () => {
+    expect(unpackAvgFulfillment(null)).toEqual({
+      avgFulfillment: undefined,
+      entryCount: 0,
+    });
+  });
+
+  it('avgFulfillment が null → undefined に変換', () => {
+    expect(unpackAvgFulfillment({ avgFulfillment: null, entryCount: 5 })).toEqual({
+      avgFulfillment: undefined,
+      entryCount: 5,
+    });
+  });
+
+  it('値あり → そのまま受け渡し', () => {
+    expect(unpackAvgFulfillment({ avgFulfillment: 0.85, entryCount: 20 })).toEqual({
+      avgFulfillment: 0.85,
+      entryCount: 20,
+    });
+  });
+
+  it('部分: entryCount のみ → avgFulfillment は undefined', () => {
+    expect(unpackAvgFulfillment({ entryCount: 5 })).toEqual({
+      avgFulfillment: undefined,
+      entryCount: 5,
+    });
+  });
+});
+
+describe('unpackEntryRate', () => {
+  it('null → 全 default (0)', () => {
+    expect(unpackEntryRate(null)).toEqual({
+      totalEntries: 0,
+      plannedEntries: 0,
+      entryRate: 0,
+    });
+  });
+
+  it('planRate → entryRate に rename される', () => {
+    expect(unpackEntryRate({ totalEntries: 30, plannedEntries: 25, planRate: 0.83 })).toEqual({
+      totalEntries: 30,
+      plannedEntries: 25,
+      entryRate: 0.83,
+    });
+  });
+
+  it('output に planRate field は含まれない', () => {
+    const result = unpackEntryRate({ totalEntries: 30, plannedEntries: 25, planRate: 0.83 });
+    expect('planRate' in result).toBe(false);
+    expect('entryRate' in result).toBe(true);
+  });
+
+  it('実値 0 → default と区別される', () => {
+    expect(unpackEntryRate({ totalEntries: 0, plannedEntries: 0, planRate: 0 })).toEqual({
+      totalEntries: 0,
+      plannedEntries: 0,
+      entryRate: 0,
+    });
+  });
+});
+
+describe('unpackContextSwitches', () => {
+  it('null → 全 0', () => {
+    expect(unpackContextSwitches(null)).toEqual({ totalSwitches: 0, avgPerDay: 0 });
+  });
+
+  it('値あり → そのまま受け渡し', () => {
+    expect(unpackContextSwitches({ totalSwitches: 12, avgPerDay: 1.5 })).toEqual({
+      totalSwitches: 12,
+      avgPerDay: 1.5,
+    });
+  });
+
+  it('部分: totalSwitches のみ → avgPerDay は 0', () => {
+    expect(unpackContextSwitches({ totalSwitches: 5 })).toEqual({
+      totalSwitches: 5,
+      avgPerDay: 0,
+    });
+  });
+});
+
+describe('unpackBlankRate', () => {
+  it('null → 全 0', () => {
+    expect(unpackBlankRate(null)).toEqual({
+      availableMinutes: 0,
+      scheduledMinutes: 0,
+      blankMinutes: 0,
+      blankRate: 0,
+    });
+  });
+
+  it('値あり → そのまま受け渡し', () => {
+    expect(
+      unpackBlankRate({
+        availableMinutes: 480,
+        scheduledMinutes: 360,
+        blankMinutes: 120,
+        blankRate: 0.25,
+      }),
+    ).toEqual({
+      availableMinutes: 480,
+      scheduledMinutes: 360,
+      blankMinutes: 120,
+      blankRate: 0.25,
+    });
+  });
+
+  it('部分: blankRate のみ → 他は 0', () => {
+    expect(unpackBlankRate({ blankRate: 0.5 })).toEqual({
+      availableMinutes: 0,
+      scheduledMinutes: 0,
+      blankMinutes: 0,
+      blankRate: 0.5,
+    });
+  });
+
+  it('undefined → 全 0', () => {
+    expect(unpackBlankRate(undefined)).toEqual({
+      availableMinutes: 0,
+      scheduledMinutes: 0,
+      blankMinutes: 0,
+      blankRate: 0,
+    });
+  });
+});

--- a/apps/product/src/features/entry/server/statistics-energy-map-transform.ts
+++ b/apps/product/src/features/entry/server/statistics-energy-map-transform.ts
@@ -1,0 +1,46 @@
+/**
+ * `getEnergyMap` procedure の RPC response transform。
+ *
+ * RPC `get_energy_map` の snake_case 行配列を tRPC response の camelCase に
+ * 変換する server-side adapter。
+ *
+ * 注: domain ではなく server に置く理由:
+ * - RPC response shape (snake_case の `avg_fulfillment` / `total_minutes` /
+ *   `entry_count` を含む特定構造) に密結合
+ * - 過去 PR `statistics-time-by-tag-transform.ts` (#1229) と同じ配置パターン
+ */
+
+export interface EnergyMapRpcRow {
+  hour: number;
+  dow: number;
+  avg_fulfillment: number | null;
+  total_minutes: number;
+  entry_count: number;
+}
+
+export interface EnergyMapItem {
+  hour: number;
+  dow: number;
+  avgFulfillment: number | null;
+  totalMinutes: number;
+  entryCount: number;
+}
+
+/**
+ * RPC `get_energy_map` の戻り値を tRPC response shape に変換する。
+ *
+ * - `null` / `undefined` 入力は空配列にフォールバック
+ * - `avg_fulfillment: null` はそのまま `null` で保持（既存契約）
+ * - snake → camel: `avg_fulfillment → avgFulfillment` / `total_minutes → totalMinutes` /
+ *   `entry_count → entryCount`
+ */
+export function transformEnergyMapResponse(data: unknown): EnergyMapItem[] {
+  const rows = (data ?? []) as ReadonlyArray<EnergyMapRpcRow>;
+  return rows.map((row) => ({
+    hour: row.hour,
+    dow: row.dow,
+    avgFulfillment: row.avg_fulfillment,
+    totalMinutes: row.total_minutes,
+    entryCount: row.entry_count,
+  }));
+}

--- a/apps/product/src/features/entry/server/statistics-kpi-unpackers.ts
+++ b/apps/product/src/features/entry/server/statistics-kpi-unpackers.ts
@@ -1,0 +1,113 @@
+/**
+ * 単一 KPI の RPC response unpacker。
+ *
+ * 各 unpacker は `unknown` を受け取り、その KPI の sub-shape を `?.` + `?? default`
+ * で安全に unpack する。以下 2 種類の呼び出し元から共通利用される:
+ *
+ * 1. 個別 KPI procedure: `get_cumulative_time` / `get_avg_fulfillment` /
+ *    `get_plan_rate` / `get_context_switches` / `get_blank_rate` の各 RPC が
+ *    返す flat な inner shape をそのまま unpack
+ * 2. `transformStatsOverviewResponse`: `get_stats_kpi_summary` RPC が返す
+ *    nested wrapper から `wrapper?.<kpi>` を取り出して同じ unpacker に渡す
+ *
+ * このように両者で同じ default 値・rename ロジックを共有することで、
+ * `getStatsOverview` と個別 KPI endpoint で挙動が乖離しないことを保証する。
+ */
+
+/** `unpackCumulativeTime` の入力 inner shape */
+export interface CumulativeTimeRpcInner {
+  totalMinutes: number;
+}
+
+/** `unpackAvgFulfillment` の入力 inner shape */
+export interface AvgFulfillmentRpcInner {
+  avgFulfillment: number | null;
+  entryCount: number;
+}
+
+/** `unpackEntryRate` の入力 inner shape (RPC は `planRate` field を含む) */
+export interface PlanRateRpcInner {
+  totalEntries: number;
+  plannedEntries: number;
+  planRate: number;
+}
+
+/** `unpackContextSwitches` の入力 inner shape */
+export interface ContextSwitchesRpcInner {
+  totalSwitches: number;
+  avgPerDay: number;
+}
+
+/** `unpackBlankRate` の入力 inner shape */
+export interface BlankRateRpcInner {
+  availableMinutes: number;
+  scheduledMinutes: number;
+  blankMinutes: number;
+  blankRate: number;
+}
+
+/** 累計時間 KPI を default 埋めして unpack */
+export function unpackCumulativeTime(data: unknown): { totalMinutes: number } {
+  const result = data as Partial<CumulativeTimeRpcInner> | null | undefined;
+  return { totalMinutes: result?.totalMinutes ?? 0 };
+}
+
+/**
+ * 平均充実度 KPI を default 埋めして unpack。
+ * `avgFulfillment` は RPC の `null` を `undefined` に変換する（既存契約）。
+ */
+export function unpackAvgFulfillment(data: unknown): {
+  avgFulfillment: number | undefined;
+  entryCount: number;
+} {
+  const result = data as Partial<AvgFulfillmentRpcInner> | null | undefined;
+  return {
+    avgFulfillment: result?.avgFulfillment ?? undefined,
+    entryCount: result?.entryCount ?? 0,
+  };
+}
+
+/**
+ * エントリ率 KPI を default 埋めして unpack。
+ * RPC の `planRate` field は `entryRate` field として出力する（既存契約の rename）。
+ */
+export function unpackEntryRate(data: unknown): {
+  totalEntries: number;
+  plannedEntries: number;
+  entryRate: number;
+} {
+  const result = data as Partial<PlanRateRpcInner> | null | undefined;
+  return {
+    totalEntries: result?.totalEntries ?? 0,
+    plannedEntries: result?.plannedEntries ?? 0,
+    entryRate: result?.planRate ?? 0,
+  };
+}
+
+/** コンテキストスイッチ KPI を default 埋めして unpack */
+export function unpackContextSwitches(data: unknown): {
+  totalSwitches: number;
+  avgPerDay: number;
+} {
+  const result = data as Partial<ContextSwitchesRpcInner> | null | undefined;
+  return {
+    totalSwitches: result?.totalSwitches ?? 0,
+    avgPerDay: result?.avgPerDay ?? 0,
+  };
+}
+
+/** 空白率 KPI を default 埋めして unpack */
+export function unpackBlankRate(data: unknown): {
+  availableMinutes: number;
+  scheduledMinutes: number;
+  blankMinutes: number;
+  blankRate: number;
+} {
+  const result = data as Partial<BlankRateRpcInner> | null | undefined;
+  return {
+    availableMinutes: result?.availableMinutes ?? 0,
+    scheduledMinutes: result?.scheduledMinutes ?? 0,
+    blankMinutes: result?.blankMinutes ?? 0,
+    blankRate: result?.blankRate ?? 0,
+  };
+}

--- a/apps/product/src/features/entry/server/statistics-overview-transform.ts
+++ b/apps/product/src/features/entry/server/statistics-overview-transform.ts
@@ -1,26 +1,33 @@
 /**
  * `getStatsOverview` procedure の RPC response unpacking。
  *
- * RPC `get_stats_kpi_summary` の nested response shape を tRPC stable
+ * RPC `get_stats_kpi_summary` の nested response wrapper を tRPC stable
  * response shape に変換する server-side adapter。
  *
- * 注: domain ではなく server に置く理由:
- * - RPC response shape (camelCase で `planRate` を含む特定構造) に密結合
- * - `planRate` → `entryRate` の outer key rename を含む RPC↔tRPC adapter 役割
+ * 各 KPI の inner unpack は `./statistics-kpi-unpackers` に集約しており、
+ * 個別 KPI procedure (`get_cumulative_time` 等) と共通の default / rename ロジックを共有する。
  */
+
+import {
+  type AvgFulfillmentRpcInner,
+  type BlankRateRpcInner,
+  type ContextSwitchesRpcInner,
+  type CumulativeTimeRpcInner,
+  type PlanRateRpcInner,
+  unpackAvgFulfillment,
+  unpackBlankRate,
+  unpackContextSwitches,
+  unpackCumulativeTime,
+  unpackEntryRate,
+} from './statistics-kpi-unpackers';
 
 /** RPC `get_stats_kpi_summary` が返す nested response shape */
 export interface StatsKpiSummaryRpcResult {
-  cumulativeTime: { totalMinutes: number };
-  avgFulfillment: { avgFulfillment: number | null; entryCount: number };
-  planRate: { totalEntries: number; plannedEntries: number; planRate: number };
-  contextSwitches: { totalSwitches: number; avgPerDay: number };
-  blankRate: {
-    availableMinutes: number;
-    scheduledMinutes: number;
-    blankMinutes: number;
-    blankRate: number;
-  };
+  cumulativeTime: CumulativeTimeRpcInner;
+  avgFulfillment: AvgFulfillmentRpcInner;
+  planRate: PlanRateRpcInner;
+  contextSwitches: ContextSwitchesRpcInner;
+  blankRate: BlankRateRpcInner;
 }
 
 /**
@@ -47,35 +54,17 @@ export interface StatsOverviewResult {
  * RPC `get_stats_kpi_summary` の戻り値を tRPC response shape に変換する。
  *
  * - `null` / `undefined` 入力でも全 field を default で埋めた応答を返す
- * - `planRate` → `entryRate` の outer key rename
+ * - `planRate` → `entryRate` の outer key rename (`unpackEntryRate` 内で実施)
  * - `avgFulfillment.avgFulfillment` の `null` は `undefined` に変換
  * - その他の missing field は `?? 0`
  */
 export function transformStatsOverviewResponse(data: unknown): StatsOverviewResult {
-  const result = data as StatsKpiSummaryRpcResult | null | undefined;
-
+  const result = data as Partial<StatsKpiSummaryRpcResult> | null | undefined;
   return {
-    cumulativeTime: {
-      totalMinutes: result?.cumulativeTime?.totalMinutes ?? 0,
-    },
-    avgFulfillment: {
-      avgFulfillment: result?.avgFulfillment?.avgFulfillment ?? undefined,
-      entryCount: result?.avgFulfillment?.entryCount ?? 0,
-    },
-    entryRate: {
-      totalEntries: result?.planRate?.totalEntries ?? 0,
-      plannedEntries: result?.planRate?.plannedEntries ?? 0,
-      entryRate: result?.planRate?.planRate ?? 0,
-    },
-    contextSwitches: {
-      totalSwitches: result?.contextSwitches?.totalSwitches ?? 0,
-      avgPerDay: result?.contextSwitches?.avgPerDay ?? 0,
-    },
-    blankRate: {
-      availableMinutes: result?.blankRate?.availableMinutes ?? 0,
-      scheduledMinutes: result?.blankRate?.scheduledMinutes ?? 0,
-      blankMinutes: result?.blankRate?.blankMinutes ?? 0,
-      blankRate: result?.blankRate?.blankRate ?? 0,
-    },
+    cumulativeTime: unpackCumulativeTime(result?.cumulativeTime),
+    avgFulfillment: unpackAvgFulfillment(result?.avgFulfillment),
+    entryRate: unpackEntryRate(result?.planRate),
+    contextSwitches: unpackContextSwitches(result?.contextSwitches),
+    blankRate: unpackBlankRate(result?.blankRate),
   };
 }

--- a/apps/product/src/features/entry/server/statistics.ts
+++ b/apps/product/src/features/entry/server/statistics.ts
@@ -26,6 +26,14 @@ import {
   transformEstimationAccuracy,
 } from '../domain';
 
+import { transformEnergyMapResponse } from './statistics-energy-map-transform';
+import {
+  unpackAvgFulfillment,
+  unpackBlankRate,
+  unpackContextSwitches,
+  unpackCumulativeTime,
+  unpackEntryRate,
+} from './statistics-kpi-unpackers';
 import { transformStatsOverviewResponse } from './statistics-overview-transform';
 import { transformTimeByTagResponse } from './statistics-time-by-tag-transform';
 
@@ -323,17 +331,7 @@ export const entriesStatisticsRouter = createTRPCRouter({
           });
         }
 
-        const result = data as {
-          totalEntries: number;
-          plannedEntries: number;
-          planRate: number;
-        } | null;
-
-        return {
-          totalEntries: result?.totalEntries ?? 0,
-          plannedEntries: result?.plannedEntries ?? 0,
-          entryRate: result?.planRate ?? 0,
-        };
+        return unpackEntryRate(data);
       } catch (error) {
         handleStatsError('getEntryRate', error);
       }
@@ -396,21 +394,7 @@ export const entriesStatisticsRouter = createTRPCRouter({
           });
         }
 
-        const rows = (data ?? []) as Array<{
-          hour: number;
-          dow: number;
-          avg_fulfillment: number | null;
-          total_minutes: number;
-          entry_count: number;
-        }>;
-
-        return rows.map((row) => ({
-          hour: row.hour,
-          dow: row.dow,
-          avgFulfillment: row.avg_fulfillment,
-          totalMinutes: row.total_minutes,
-          entryCount: row.entry_count,
-        }));
+        return transformEnergyMapResponse(data);
       } catch (error) {
         handleStatsError('getEnergyMap', error);
       }
@@ -443,15 +427,7 @@ export const entriesStatisticsRouter = createTRPCRouter({
           });
         }
 
-        const result = data as {
-          totalSwitches: number;
-          avgPerDay: number;
-        } | null;
-
-        return {
-          totalSwitches: result?.totalSwitches ?? 0,
-          avgPerDay: result?.avgPerDay ?? 0,
-        };
+        return unpackContextSwitches(data);
       } catch (error) {
         handleStatsError('getContextSwitches', error);
       }
@@ -491,19 +467,7 @@ export const entriesStatisticsRouter = createTRPCRouter({
           });
         }
 
-        const result = data as {
-          availableMinutes: number;
-          scheduledMinutes: number;
-          blankMinutes: number;
-          blankRate: number;
-        } | null;
-
-        return {
-          availableMinutes: result?.availableMinutes ?? 0,
-          scheduledMinutes: result?.scheduledMinutes ?? 0,
-          blankMinutes: result?.blankMinutes ?? 0,
-          blankRate: result?.blankRate ?? 0,
-        };
+        return unpackBlankRate(data);
       } catch (error) {
         handleStatsError('getBlankRate', error);
       }
@@ -536,8 +500,7 @@ export const entriesStatisticsRouter = createTRPCRouter({
           });
         }
 
-        const result = data as { totalMinutes: number } | null;
-        return { totalMinutes: result?.totalMinutes ?? 0 };
+        return unpackCumulativeTime(data);
       } catch (error) {
         handleStatsError('getCumulativeTime', error);
       }
@@ -570,11 +533,7 @@ export const entriesStatisticsRouter = createTRPCRouter({
           });
         }
 
-        const result = data as { avgFulfillment: number | null; entryCount: number } | null;
-        return {
-          avgFulfillment: result?.avgFulfillment ?? undefined,
-          entryCount: result?.entryCount ?? 0,
-        };
+        return unpackAvgFulfillment(data);
       } catch (error) {
         handleStatsError('getAvgFulfillment', error);
       }


### PR DESCRIPTION
## Summary

`features/entry/server/statistics.ts` に残っていた inline RPC unpacking を完全にクリーンアップ。

5 つの KPI procedure と #1227 `transformStatsOverviewResponse` が **完全に同じ単一 KPI unpack ロジックを重複定義** していたのを発見したため、共通 unpacker に集約。加えて `getEnergyMap` の独立 transform も切り出し。

**これで `statistics.ts` 内の RPC response 直接 unpacking / map は完全にゼロになります。**

## 切り出した helper

### `statistics-kpi-unpackers.ts` (新規)

5 つの単一 KPI unpacker。個別 KPI procedure と `transformStatsOverviewResponse` の双方から共通利用:

- `unpackCumulativeTime` — `{ totalMinutes }`
- `unpackAvgFulfillment` — `{ avgFulfillment: number | undefined, entryCount }` (null → undefined 変換)
- `unpackEntryRate` — `{ totalEntries, plannedEntries, entryRate }` (RPC の `planRate` → `entryRate` rename)
- `unpackContextSwitches` — `{ totalSwitches, avgPerDay }`
- `unpackBlankRate` — `{ availableMinutes, scheduledMinutes, blankMinutes, blankRate }`

### `statistics-energy-map-transform.ts` (新規)

`transformEnergyMapResponse(data)`: RPC 5 field 行 → tRPC camelCase item。`avg_fulfillment: null` は null のまま保持。

### `statistics-overview-transform.ts` の DRY 化

旧: 5 KPI を inline で `?.+??` 展開 (~30 LOC)
新: 5 つの unpacker を compose する 7 行。型は kpi-unpackers から re-export。

## `statistics.ts` の 6 procedure 置換

- `getCumulativeTime` / `getAvgFulfillment` / `getEntryRate` / `getContextSwitches` / `getBlankRate` の 5 KPI procedure (~50 LOC 削減)
- `getEnergyMap` procedure (~15 LOC 削減)

## DRY 効果

5 KPI の unpack ロジックが従来 **2 箇所** で重複していた:

```
get_plan_rate (flat)              ──┐
                                    ├─→ どちらも同じ default + rename
get_stats_kpi_summary.planRate    ──┘
```

unpacker に集約後、片方だけ default 挙動が乖離するリスクが排除される。

## テスト追加 (26 cases)

**`statistics-kpi-unpackers.test.ts`** (20 cases):
- 各 unpacker の null / undefined / 完全 input / 部分 input / 0 保持
- `unpackEntryRate` の `planRate → entryRate` rename 確認
- `unpackAvgFulfillment` の `null → undefined` 変換確認

**`statistics-energy-map-transform.test.ts`** (6 cases):
- null / undefined / 空配列入力
- 単一 row mapping
- `avg_fulfillment: null` 保持
- 複数 row の順序保持
- output に snake_case key を含まない

## 既存テストの保全

- `statistics-overview-transform.test.ts` (9 cases): compose 化後も全 pass
- `statistics-router.test.ts`: 関連 6 procedure テストが挙動変更なしで pass
- entry feature 全体: **475 tests pass** (前 PR の 449 + 新規 26)

## 効果

- `statistics.ts` 内 RPC response 直接 unpack: **完全ゼロ**
- DRY: 5 KPI unpack ロジックを 1 箇所に集約
- DB / RPC / 応答 shape / 仕様 変更なし
- `features/entry/server` は Layer 1 維持、domain 非依存、boundary 違反なし

## シリーズ完結

| PR | 切り出し先 | 内容 |
|----|-----------|------|
| #1222 | `tags/domain` | tag merge / ungroup pure logic |
| #1223 | `entry/domain` | hourly / dow / streak |
| #1224 | `entry/domain` | monthly-trend |
| #1225 | `entry/domain` | estimation-accuracy |
| #1226 | `entry/domain` | tag-stats |
| #1227 | `entry/server` | stats-overview-transform |
| #1229 | `entry/server` | time-by-tag-transform |
| **本 PR** | `entry/server` | **kpi-unpackers + energy-map-transform** ← inline RPC unpack ゼロ達成 |

## 残課題

orchestration helper (`handleStatsError` / `stripUndefined` / `getTodayInTimezone`) の整理は別 PR で検討。

## Test plan

- [x] `pnpm --filter @dayopt/product typecheck`
- [x] `pnpm --filter @dayopt/product lint`
- [x] `pnpm lint:boundaries`（Cross-feature imports: 0）
- [x] `pnpm --filter @dayopt/product test:run src/features/entry` → 475 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
