### PR TITLE
feat(product): expand shared ui primitive adoption

### DIFF
--- a/apps/product/src/app/[locale]/(app)/_providers/ServiceWorkerProvider.tsx
+++ b/apps/product/src/app/[locale]/(app)/_providers/ServiceWorkerProvider.tsx
@@ -5,6 +5,8 @@ import { useState } from 'react';
 import { RefreshCw } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
+import { Button, Card } from '@dayopt/ui';
+
 import { InstallBanner } from '@/lib/components/shell/InstallBanner';
 import { IOSInstallGuide } from '@/lib/components/shell/IOSInstallGuide';
 import { useInstallPrompt } from '@/lib/hooks/useInstallPrompt';
@@ -44,7 +46,7 @@ export function ServiceWorkerProvider({ children }: { children: React.ReactNode 
       {/* 更新バナー（インストールバナーより優先） */}
       {showUpdateBanner && (
         <div className="animate-in slide-in-from-bottom-4 fixed right-4 bottom-20 z-50 md:bottom-4">
-          <div className="bg-card border-border-subtle shadow-card flex items-center gap-4 rounded-2xl border p-4">
+          <Card className="bg-card border-border-subtle shadow-card flex-row items-center gap-4 rounded-2xl p-4 py-4">
             <RefreshCw className="text-primary h-5 w-5" />
             <div className="flex-1">
               <p className="text-foreground text-base font-normal md:text-sm">
@@ -60,15 +62,11 @@ export function ServiceWorkerProvider({ children }: { children: React.ReactNode 
               >
                 {t('later')}
               </button>
-              <button
-                type="button"
-                onClick={applyUpdate}
-                className="bg-primary text-primary-foreground hover:bg-primary-hover rounded-lg px-4 py-2 text-base font-normal transition-colors md:text-sm"
-              >
+              <Button onClick={applyUpdate} className="rounded-lg px-4 py-2 text-base md:text-sm">
                 {t('update')}
-              </button>
+              </Button>
             </div>
-          </div>
+          </Card>
         </div>
       )}
 

--- a/apps/product/src/app/[locale]/(app)/error.tsx
+++ b/apps/product/src/app/[locale]/(app)/error.tsx
@@ -14,8 +14,8 @@ import { AlertCircle } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useEffect } from 'react';
 
-import { Button } from '@/lib/components/ui/button';
 import { logger } from '@/lib/logger';
+import { Button, Card } from '@dayopt/ui';
 
 interface ErrorProps {
   error: Error & { digest?: string };
@@ -32,7 +32,7 @@ export default function AppError({ error, reset }: ErrorProps) {
   return (
     // eslint-disable-next-line tailwindcss/no-arbitrary-value -- viewport unit
     <div className="grid min-h-[60vh] w-full place-items-center p-8">
-      <div className="flex max-w-md flex-col items-center gap-6 text-center">
+      <Card className="w-full max-w-md items-center gap-6 border-0 bg-transparent py-0 text-center shadow-none">
         <div className="border-destructive flex size-16 items-center justify-center rounded-full border-2">
           <AlertCircle className="text-destructive size-8" />
         </div>
@@ -56,7 +56,7 @@ export default function AppError({ error, reset }: ErrorProps) {
         </div>
 
         <p className="text-muted-foreground text-xs">{t('sentryReport')}</p>
-      </div>
+      </Card>
     </div>
   );
 }

--- a/apps/product/src/app/[locale]/(app)/not-found.tsx
+++ b/apps/product/src/app/[locale]/(app)/not-found.tsx
@@ -14,7 +14,7 @@ import { FileQuestion } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 
-import { Button } from '@dayopt/ui';
+import { Button, Card } from '@dayopt/ui';
 
 export default function AppNotFound() {
   const t = useTranslations('error.notFound');
@@ -22,7 +22,7 @@ export default function AppNotFound() {
   return (
     // eslint-disable-next-line tailwindcss/no-arbitrary-value -- viewport unit
     <div className="grid min-h-[60vh] w-full place-items-center p-8">
-      <div className="flex max-w-md flex-col items-center gap-6 text-center">
+      <Card className="w-full max-w-md items-center gap-6 border-0 bg-transparent py-0 text-center shadow-none">
         <div className="border-border flex size-16 items-center justify-center rounded-full border-2">
           <FileQuestion className="text-muted-foreground size-8" />
         </div>
@@ -35,7 +35,7 @@ export default function AppNotFound() {
         <Button asChild>
           <Link href="/">{t('goHome')}</Link>
         </Button>
-      </div>
+      </Card>
     </div>
   );
 }

--- a/apps/product/src/app/[locale]/(app)/settings/page.tsx
+++ b/apps/product/src/app/[locale]/(app)/settings/page.tsx
@@ -4,7 +4,7 @@ import { Link, useRouter } from '@/lib/i18n/navigation';
 import { useEffect, useState } from 'react';
 
 import { createDayoptUrl, dayoptUrls } from '@dayopt/config';
-import { Badge } from '@dayopt/ui';
+import { Badge, Card } from '@dayopt/ui';
 import {
   Book,
   ChevronDown,
@@ -126,7 +126,7 @@ export default function SettingsPage() {
     <ScrollArea className="flex-1">
       {/* B. ヒーローエリア */}
       <div className="px-4 pt-8 pb-6">
-        <div className="border-border-subtle overflow-hidden rounded-lg border shadow-sm">
+        <Card className="border-border-subtle gap-0 overflow-hidden rounded-lg py-0 shadow-sm">
           {/* Row 1: Avatar + Name/Email + Plan Badge */}
           <Link
             href="/settings/profile"
@@ -172,7 +172,7 @@ export default function SettingsPage() {
               <ChevronRight className="text-muted-foreground size-4 shrink-0" />
             </button>
           )}
-        </div>
+        </Card>
       </div>
 
       {/* 設定カテゴリ */}

--- a/apps/product/src/app/[locale]/error.tsx
+++ b/apps/product/src/app/[locale]/error.tsx
@@ -13,8 +13,8 @@
 import { AlertCircle } from 'lucide-react';
 import { useEffect } from 'react';
 
-import { Button } from '@/lib/components/ui/button';
 import { logger } from '@/lib/logger';
+import { Button, Card } from '@dayopt/ui';
 
 interface ErrorProps {
   error: Error & { digest?: string };
@@ -28,7 +28,7 @@ export default function LocaleError({ error, reset }: ErrorProps) {
 
   return (
     <div className="bg-background fixed inset-0 flex items-center justify-center overflow-auto p-4">
-      <div className="flex max-w-md flex-col items-center gap-6 text-center">
+      <Card className="w-full max-w-md items-center gap-6 border-0 bg-transparent py-0 text-center shadow-none">
         <div className="border-destructive flex size-16 items-center justify-center rounded-full border-2">
           <AlertCircle className="text-destructive size-8" />
         </div>
@@ -54,7 +54,7 @@ export default function LocaleError({ error, reset }: ErrorProps) {
         </div>
 
         <p className="text-muted-foreground text-xs">This error has been automatically reported.</p>
-      </div>
+      </Card>
     </div>
   );
 }

--- a/apps/product/src/app/error.tsx
+++ b/apps/product/src/app/error.tsx
@@ -9,7 +9,7 @@
 
 import { useEffect } from 'react';
 
-import { Button } from '@/lib/components/ui/button';
+import { Button, Card } from '@dayopt/ui';
 import * as Sentry from '@sentry/nextjs';
 
 interface ErrorProps {
@@ -46,7 +46,7 @@ export default function RootError({ error, reset }: ErrorProps) {
 
   return (
     <div className="bg-background fixed inset-0 flex items-center justify-center overflow-auto p-4">
-      <div className="bg-card border-border-subtle w-full max-w-md rounded-2xl border p-8 shadow-sm">
+      <Card className="border-border-subtle bg-card w-full max-w-md gap-0 rounded-2xl p-8 py-8 shadow-sm">
         <div className="mb-6">
           <h1 className="text-destructive mb-2 text-2xl font-medium">{ERROR_TEXT.title}</h1>
           <p className="text-muted-foreground">{ERROR_TEXT.description}</p>
@@ -85,7 +85,7 @@ export default function RootError({ error, reset }: ErrorProps) {
         </div>
 
         <p className="text-muted-foreground mt-6 text-center text-xs">{ERROR_TEXT.sentryReport}</p>
-      </div>
+      </Card>
     </div>
   );
 }

--- a/apps/product/src/app/not-found.tsx
+++ b/apps/product/src/app/not-found.tsx
@@ -7,12 +7,12 @@
  */
 'use client';
 
-import { Button } from '@dayopt/ui';
+import { Button, Card } from '@dayopt/ui';
 
 export default function RootNotFound() {
   return (
     <div className="bg-background fixed inset-0 flex items-center justify-center overflow-auto p-4">
-      <div className="bg-card border-border-subtle w-full max-w-md rounded-2xl border p-8 shadow-sm">
+      <Card className="border-border-subtle bg-card w-full max-w-md gap-0 rounded-2xl p-8 py-8 shadow-sm">
         <div className="mb-6">
           <h1 className="text-foreground mb-2 text-2xl font-medium">Page not found</h1>
           <p className="text-muted-foreground">
@@ -23,7 +23,7 @@ export default function RootNotFound() {
         <Button onClick={() => (window.location.href = '/')} className="w-full">
           Go to Home
         </Button>
-      </div>
+      </Card>
     </div>
   );
 }

--- a/apps/product/src/app/offline/page.tsx
+++ b/apps/product/src/app/offline/page.tsx
@@ -2,6 +2,8 @@
 
 import { WifiOff } from 'lucide-react';
 
+import { Button, Card } from '@dayopt/ui';
+
 const messages = {
   en: {
     title: "You're offline",
@@ -31,20 +33,16 @@ export default function OfflinePage() {
 
   return (
     <div className="bg-background flex min-h-screen flex-col items-center justify-center p-4">
-      <div className="text-center">
+      <Card className="items-center border-0 bg-transparent py-0 text-center shadow-none">
         <div className="bg-muted mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-full">
           <WifiOff className="text-muted-foreground h-10 w-10" />
         </div>
         <h1 className="text-foreground mb-2 text-2xl font-medium">{t.title}</h1>
         <p className="text-muted-foreground mb-6 max-w-sm">{t.description}</p>
-        <button
-          type="button"
-          onClick={() => window.location.reload()}
-          className="bg-primary text-primary-foreground hover:bg-primary-hover inline-flex items-center justify-center rounded-2xl px-6 py-4 font-normal transition-colors"
-        >
+        <Button onClick={() => window.location.reload()} className="rounded-2xl px-6 py-4">
           {t.reload}
-        </button>
-      </div>
+        </Button>
+      </Card>
     </div>
   );
 }

--- a/apps/product/src/features/settings/components/account-settings.tsx
+++ b/apps/product/src/features/settings/components/account-settings.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useState } from 'react';
 
 import { toast } from '@/lib/toast';
-import { Badge } from '@dayopt/ui';
+import { Badge, Button as SharedButton } from '@dayopt/ui';
 import { LogOut } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
@@ -100,9 +100,9 @@ export function AccountSettings({ _MFASectionProps }: AccountSettingsProps = {})
           }
           description={t('settings.account.notConnected')}
         >
-          <Button variant="outline" disabled>
+          <SharedButton variant="outline" disabled>
             {t('settings.account.connect')}
-          </Button>
+          </SharedButton>
         </LabeledRow>
         <LabeledRow
           label={
@@ -118,9 +118,9 @@ export function AccountSettings({ _MFASectionProps }: AccountSettingsProps = {})
           }
           description={t('settings.account.notConnected')}
         >
-          <Button variant="outline" disabled>
+          <SharedButton variant="outline" disabled>
             {t('settings.account.connect')}
-          </Button>
+          </SharedButton>
         </LabeledRow>
         <LabeledRow
           label={
@@ -136,9 +136,9 @@ export function AccountSettings({ _MFASectionProps }: AccountSettingsProps = {})
           }
           description={t('settings.account.notConnected')}
         >
-          <Button variant="outline" disabled>
+          <SharedButton variant="outline" disabled>
             {t('settings.account.connect')}
-          </Button>
+          </SharedButton>
         </LabeledRow>
         <p className="text-muted-foreground text-xs">
           <Badge variant="secondary" className="mr-1">

--- a/apps/product/src/features/settings/components/billing-settings.tsx
+++ b/apps/product/src/features/settings/components/billing-settings.tsx
@@ -9,6 +9,7 @@ import {
   getPlanIdForSubscriptionStatus,
   type DayoptPlanId,
 } from '@dayopt/billing';
+import { Badge } from '@dayopt/ui';
 import { AlertTriangle, Check, CreditCard, Crown } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useRouter, useSearchParams } from 'next/navigation';
@@ -27,7 +28,6 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/lib/components/ui/alert-dialog';
-import { Badge } from '@/lib/components/ui/badge';
 import { Button } from '@/lib/components/ui/button';
 import { Skeleton } from '@/lib/components/ui/skeleton';
 import { api } from '@/lib/trpc';

--- a/apps/product/src/features/settings/components/data-settings.tsx
+++ b/apps/product/src/features/settings/components/data-settings.tsx
@@ -4,6 +4,7 @@ import { useCallback, useRef, useState } from 'react';
 
 import { toast } from '@/lib/toast';
 import { dayoptUrls } from '@dayopt/config';
+import { Button as SharedButton } from '@dayopt/ui';
 import {
   AlertTriangle,
   Check,
@@ -227,14 +228,14 @@ function RestoreSection() {
           disabled
           aria-hidden="true"
         />
-        <Button
+        <SharedButton
           variant="ghost"
           className="mt-4"
           disabled
           onClick={() => fileInputRef.current?.click()}
         >
           {t('selectFile')}
-        </Button>
+        </SharedButton>
       </div>
 
       <div className="mt-4 flex items-start gap-2">

--- a/apps/storybook/docs/dev/architecture/PackagesOverview.mdx
+++ b/apps/storybook/docs/dev/architecture/PackagesOverview.mdx
@@ -83,7 +83,7 @@ Storybook 表示:
 ### `packages/ui`
 
 Domain logic を持たない React UI primitive の置き場。Button, Badge, Card, Logo のように複数 app で使える部品だけを入れる。
-`apps/product` では settings / common feedback states / not-found pages の低リスク surface から runtime 利用を開始している。より広い移行は submit / mutation / billing flow を避けながら段階的に進める。
+`apps/product` では settings / account / fallback surfaces で Button, Badge, Card の runtime 利用を段階的に広げている。Interactive core surfaces は app-local のままにし、submit / mutation / billing flow は避けながら進める。
 
 知ってよいもの:
 


### PR DESCRIPTION
## Summary
- expand `@dayopt/ui` Button/Badge/Card adoption in product fallback, settings, account, data, billing display, and PWA update surfaces
- use shared Card for static error/not-found/offline/mobile settings wrappers with visual-preserving class overrides
- keep submit, mutation, auth, billing checkout/portal, Calendar, Entry, Review, and drag surfaces app-local
- update Storybook package docs to reflect broader product runtime adoption

## Out of scope
- Calendar / Entry / Review surfaces
- Auth forms / MFA flows
- Billing checkout/customer portal mutation buttons
- destructive/export/delete mutation buttons
- `packages/ui` API changes

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm build:packages`
- `pnpm typecheck:packages`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:boundaries`
- `pnpm build`
- `pnpm build:web`
- `pnpm build-storybook`
- `pnpm check:workspace`
- `rg '@dayopt/ui' apps/product packages/ui`
- `rg 'next/navigation|@supabase|stripe|process.env|@/|features/' packages/ui/src`
- confirmed product CSS still imports `@dayopt/design/theme.css` and scans `packages/ui/src`
