### PR TITLE
feat(assets): @dayopt/assets パッケージを新設し Logo を連携

### DIFF
--- a/apps/product/src/app/opengraph-image.tsx
+++ b/apps/product/src/app/opengraph-image.tsx
@@ -65,16 +65,15 @@ export default function OgImage() {
           boxShadow: `0 8px 32px ${OG_COLORS.primaryGlow30}`,
         }}
       >
-        <div
-          style={{
-            fontSize: 40,
-            fontWeight: 700,
-            color: OG_COLORS.foreground,
-            lineHeight: 1,
-          }}
+        <svg
+          width={48}
+          height={48}
+          viewBox="0 0 24 24"
+          fill={OG_COLORS.foreground}
+          xmlns="http://www.w3.org/2000/svg"
         >
-          D
-        </div>
+          <path d="M12 3.5c4.69 0 8.5 3.81 8.5 8.5s-3.81 8.5-8.5 8.5S3.5 16.69 3.5 12 7.31 3.5 12 3.5Zm0 3.2A5.31 5.31 0 0 0 6.7 12c0 2.92 2.38 5.3 5.3 5.3s5.3-2.38 5.3-5.3h-3.1a2.2 2.2 0 1 1-2.2-2.2V6.7Z" />
+        </svg>
       </div>
 
       {/* App name */}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@dayopt/billing": "workspace:*",
     "@dayopt/config": "workspace:*",
+    "@dayopt/ui": "workspace:*",
     "@hookform/resolvers": "^5.1.1",
     "@marsidev/react-turnstile": "^1.5.0",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/apps/web/src/features/docs/components/DocsHeader.tsx
+++ b/apps/web/src/features/docs/components/DocsHeader.tsx
@@ -5,6 +5,7 @@ import { Input } from '@/components/ui/input';
 import { LanguageSwitcher } from '@/components/ui/language-switcher';
 import { ThemeToggle } from '@/components/ui/theme-toggle';
 import { Link } from '@/platform/i18n/navigation';
+import { Logo } from '@dayopt/ui';
 import { Menu, Search, X } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
@@ -38,7 +39,7 @@ export function DocsHeader({ onMobileMenuToggle, mobileMenuOpen }: DocsHeaderPro
           {/* Logo → marketing home, Docs badge → docs home */}
           <div className="flex items-center gap-2">
             <Link href="/" className="flex items-center">
-              <span className="text-foreground text-lg font-medium">Dayopt</span>
+              <Logo variant="wordmark" size="md" />
             </Link>
             <Link
               href="/docs"

--- a/apps/web/src/features/docs/components/DocsHeader.tsx
+++ b/apps/web/src/features/docs/components/DocsHeader.tsx
@@ -39,7 +39,7 @@ export function DocsHeader({ onMobileMenuToggle, mobileMenuOpen }: DocsHeaderPro
           {/* Logo → marketing home, Docs badge → docs home */}
           <div className="flex items-center gap-2">
             <Link href="/" className="flex items-center">
-              <Logo variant="wordmark" size="md" />
+              <Logo variant="wordmark" size="md" className="text-foreground" />
             </Link>
             <Link
               href="/docs"

--- a/apps/web/src/shell/layout/Footer.tsx
+++ b/apps/web/src/shell/layout/Footer.tsx
@@ -3,6 +3,7 @@
 import { LanguageSwitcher } from '@/components/ui/language-switcher';
 import { ThemeToggle } from '@/components/ui/theme-toggle';
 import { Link } from '@/platform/i18n/navigation';
+import { Logo } from '@dayopt/ui';
 import { useTranslations } from 'next-intl';
 
 // SNS Icons
@@ -78,7 +79,7 @@ export function Footer() {
           {/* Logo */}
           <div>
             <Link href="/" className="inline-block">
-              <span className="text-foreground text-2xl font-medium">Dayopt</span>
+              <Logo variant="wordmark" size="lg" />
             </Link>
           </div>
 

--- a/apps/web/src/shell/layout/Footer.tsx
+++ b/apps/web/src/shell/layout/Footer.tsx
@@ -79,7 +79,7 @@ export function Footer() {
           {/* Logo */}
           <div>
             <Link href="/" className="inline-block">
-              <Logo variant="wordmark" size="lg" />
+              <Logo variant="wordmark" size="lg" className="text-foreground" />
             </Link>
           </div>
 

--- a/apps/web/src/shell/layout/Header.tsx
+++ b/apps/web/src/shell/layout/Header.tsx
@@ -51,7 +51,7 @@ export function Header() {
         {/* Logo */}
         <div className="flex lg:flex-1">
           <Link href="/" className="flex items-center gap-2">
-            <Logo variant="wordmark" size="md" />
+            <Logo variant="wordmark" size="md" className="text-foreground" />
           </Link>
         </div>
 
@@ -114,7 +114,7 @@ export function Header() {
                 className="flex items-center gap-2"
                 onClick={() => setMobileMenuOpen(false)}
               >
-                <Logo variant="wordmark" size="md" />
+                <Logo variant="wordmark" size="md" className="text-foreground" />
               </Link>
               <DialogPrimitive.Close className="text-muted-foreground hover:bg-state-hover hover:text-foreground -m-2 rounded-lg p-2 transition-colors">
                 <span className="sr-only">{t('aria.closeMenu')}</span>

--- a/apps/web/src/shell/layout/Header.tsx
+++ b/apps/web/src/shell/layout/Header.tsx
@@ -3,6 +3,7 @@
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { Link } from '@/platform/i18n/navigation';
+import { Logo } from '@dayopt/ui';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { Menu, X } from 'lucide-react';
 import { useTranslations } from 'next-intl';
@@ -50,7 +51,7 @@ export function Header() {
         {/* Logo */}
         <div className="flex lg:flex-1">
           <Link href="/" className="flex items-center gap-2">
-            <span className="text-foreground text-lg font-medium">Dayopt</span>
+            <Logo variant="wordmark" size="md" />
           </Link>
         </div>
 
@@ -113,7 +114,7 @@ export function Header() {
                 className="flex items-center gap-2"
                 onClick={() => setMobileMenuOpen(false)}
               >
-                <span className="text-foreground text-lg font-medium">Dayopt</span>
+                <Logo variant="wordmark" size="md" />
               </Link>
               <DialogPrimitive.Close className="text-muted-foreground hover:bg-state-hover hover:text-foreground -m-2 rounded-lg p-2 transition-colors">
                 <span className="sr-only">{t('aria.closeMenu')}</span>

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dayopt/ui",
+  "name": "@dayopt/assets",
   "version": "0.0.0",
   "private": true,
   "type": "module",
@@ -13,13 +13,6 @@
   },
   "peerDependencies": {
     "react": "^19"
-  },
-  "dependencies": {
-    "@dayopt/assets": "workspace:*",
-    "@radix-ui/react-slot": "^1.2.4",
-    "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
-    "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
     "@types/react": "^19",

--- a/packages/assets/src/index.ts
+++ b/packages/assets/src/index.ts
@@ -1,0 +1,2 @@
+export { SYMBOL_PATH_D, SYMBOL_VIEW_BOX, Symbol, type SymbolProps } from './symbol';
+export { BRAND_WORDMARK, Wordmark, type WordmarkProps } from './wordmark';

--- a/packages/assets/src/symbol.tsx
+++ b/packages/assets/src/symbol.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+export type SymbolProps = React.SVGProps<SVGSVGElement>;
+
+export function Symbol({ viewBox = '0 0 24 24', focusable = false, ...props }: SymbolProps) {
+  return (
+    <svg viewBox={viewBox} focusable={focusable} aria-hidden="true" {...props}>
+      <path
+        fill="currentColor"
+        d="M12 3.5c4.69 0 8.5 3.81 8.5 8.5s-3.81 8.5-8.5 8.5S3.5 16.69 3.5 12 7.31 3.5 12 3.5Zm0 3.2A5.31 5.31 0 0 0 6.7 12c0 2.92 2.38 5.3 5.3 5.3s5.3-2.38 5.3-5.3h-3.1a2.2 2.2 0 1 1-2.2-2.2V6.7Z"
+      />
+    </svg>
+  );
+}
+
+export const SYMBOL_PATH_D =
+  'M12 3.5c4.69 0 8.5 3.81 8.5 8.5s-3.81 8.5-8.5 8.5S3.5 16.69 3.5 12 7.31 3.5 12 3.5Zm0 3.2A5.31 5.31 0 0 0 6.7 12c0 2.92 2.38 5.3 5.3 5.3s5.3-2.38 5.3-5.3h-3.1a2.2 2.2 0 1 1-2.2-2.2V6.7Z';
+
+export const SYMBOL_VIEW_BOX = '0 0 24 24';

--- a/packages/assets/src/wordmark.tsx
+++ b/packages/assets/src/wordmark.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+export interface WordmarkProps extends React.ComponentProps<'span'> {}
+
+const BRAND_NAME = 'Dayopt';
+
+export function Wordmark({ className, children, ...props }: WordmarkProps) {
+  return (
+    <span
+      className={['font-medium tracking-tight', className].filter(Boolean).join(' ')}
+      {...props}
+    >
+      {children ?? BRAND_NAME}
+    </span>
+  );
+}
+
+export const BRAND_WORDMARK = BRAND_NAME;

--- a/packages/assets/tsconfig.json
+++ b/packages/assets/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "jsx": "react-jsx",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/ui/src/logo.tsx
+++ b/packages/ui/src/logo.tsx
@@ -1,3 +1,4 @@
+import { Symbol, Wordmark } from '@dayopt/assets';
 import * as React from 'react';
 
 import { cn } from './cn';
@@ -48,17 +49,10 @@ export function Logo({
             markSize[size],
           )}
         >
-          <svg viewBox="0 0 24 24" className="size-2/3" focusable="false" aria-hidden="true">
-            <path
-              fill="currentColor"
-              d="M12 3.5c4.69 0 8.5 3.81 8.5 8.5s-3.81 8.5-8.5 8.5S3.5 16.69 3.5 12 7.31 3.5 12 3.5Zm0 3.2A5.31 5.31 0 0 0 6.7 12c0 2.92 2.38 5.3 5.3 5.3s5.3-2.38 5.3-5.3h-3.1a2.2 2.2 0 1 1-2.2-2.2V6.7Z"
-            />
-          </svg>
+          <Symbol className="size-2/3" />
         </span>
       ) : null}
-      {showWordmark ? (
-        <span className={cn('font-medium tracking-tight', textSize[size])}>{label}</span>
-      ) : null}
+      {showWordmark ? <Wordmark className={textSize[size]}>{label}</Wordmark> : null}
     </div>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -687,6 +687,9 @@ importers:
       '@dayopt/config':
         specifier: workspace:*
         version: link:../../packages/config
+      '@dayopt/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       '@hookform/resolvers':
         specifier: ^5.1.1
         version: 5.2.2(react-hook-form@7.76.1(react@19.2.6))
@@ -897,6 +900,19 @@ importers:
         specifier: ^1.32.0
         version: 1.32.0
 
+  packages/assets:
+    dependencies:
+      react:
+        specifier: ^19
+        version: 19.2.6
+    devDependencies:
+      '@types/react':
+        specifier: ^19
+        version: 19.2.15
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+
   packages/billing: {}
 
   packages/config:
@@ -933,6 +949,9 @@ importers:
 
   packages/ui:
     dependencies:
+      '@dayopt/assets':
+        specifier: workspace:*
+        version: link:../assets
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.15)(react@19.2.6)


### PR DESCRIPTION
## Summary

- `@dayopt/assets` パッケージを新設し、`Symbol` (SVG mark) / `Wordmark` (text) を一元化
- `@dayopt/ui` の `Logo` がインライン SVG / `<span>` から `@dayopt/assets` 参照に変更
- `apps/web` の Header / Footer / DocsHeader を `<Logo variant="wordmark" />` に置き換え
- `apps/product` の OG image の "D" 文字を symbol SVG path に差し替え（Satori 互換のため直書き）

## Test plan

- [x] `pnpm --filter @dayopt/assets typecheck`
- [x] `pnpm --filter @dayopt/ui typecheck`
- [x] `pnpm --filter @dayopt/web typecheck` / `lint`
- [x] `pnpm --filter @dayopt/product typecheck`
- [x] `pnpm --filter @dayopt/storybook build`
- [ ] Storybook で `UI/Logo` Variants/Sizes が崩れないことを目視確認
- [ ] `apps/web` Header / Footer / DocsHeader の Dayopt 表記を目視確認
- [ ] `apps/product` の `/opengraph-image` で symbol が描画されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)