### PR TITLE
chore(product): use shared config constants

### DIFF
--- a/apps/product/src/app/opengraph-image.tsx
+++ b/apps/product/src/app/opengraph-image.tsx
@@ -1,10 +1,12 @@
 import { ImageResponse } from 'next/og';
 
+import { dayoptBrand, dayoptDomains } from '@dayopt/config';
+
 import { OG_COLORS } from '@/lib/og-colors';
 
 export const runtime = 'edge';
 
-export const alt = 'Dayopt';
+export const alt = dayoptBrand.name;
 export const size = {
   width: 1200,
   height: 630,
@@ -86,7 +88,7 @@ export default function OgImage() {
           marginBottom: 16,
         }}
       >
-        Dayopt
+        {dayoptBrand.name}
       </div>
 
       {/* Tagline */}
@@ -118,7 +120,7 @@ export default function OgImage() {
             letterSpacing: '0.05em',
           }}
         >
-          dayopt.app
+          {dayoptDomains.marketing}
         </div>
       </div>
     </div>,

--- a/apps/product/src/features/entry/lib/__tests__/entry-to-ical.test.ts
+++ b/apps/product/src/features/entry/lib/__tests__/entry-to-ical.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { dayoptDomains } from '@dayopt/config';
+
 import { entriesToICal } from '../entry-to-ical';
 
 interface ICalEntryInput {
@@ -25,6 +27,8 @@ function makeEntry(overrides: Partial<ICalEntryInput> & { id: string }): ICalEnt
     ...overrides,
   };
 }
+
+const calendarUid = (entryId: string) => `UID:${entryId}@${dayoptDomains.marketing}`;
 
 describe('entriesToICal', () => {
   describe('VCALENDAR エンベロープ', () => {
@@ -56,7 +60,7 @@ describe('entriesToICal', () => {
       const ical = entriesToICal([makeEntry({ id: 'e1', title: 'Meeting' })]);
       expect(ical).toContain('BEGIN:VEVENT');
       expect(ical).toContain('END:VEVENT');
-      expect(ical).toContain('UID:e1@dayopt.app');
+      expect(ical).toContain(calendarUid('e1'));
       expect(ical).toContain('SUMMARY:Meeting');
     });
 
@@ -73,8 +77,8 @@ describe('entriesToICal', () => {
         makeEntry({ id: 'a', title: 'A' }),
         makeEntry({ id: 'b', title: 'B' }),
       ]);
-      const aIndex = ical.indexOf('UID:a@dayopt.app');
-      const bIndex = ical.indexOf('UID:b@dayopt.app');
+      const aIndex = ical.indexOf(calendarUid('a'));
+      const bIndex = ical.indexOf(calendarUid('b'));
       expect(aIndex).toBeGreaterThan(0);
       expect(bIndex).toBeGreaterThan(aIndex);
     });

--- a/apps/product/src/features/entry/lib/entry-to-ical.ts
+++ b/apps/product/src/features/entry/lib/entry-to-ical.ts
@@ -5,6 +5,8 @@
  * Google Calendar / Apple Calendar などで購読可能。
  */
 
+import { dayoptDomains } from '@dayopt/config';
+
 interface ICalEntry {
   id: string;
   title: string;
@@ -73,7 +75,7 @@ export function entriesToICal(entries: ICalEntry[]): string {
     if (!entry.start_time || !entry.end_time) continue;
 
     const summary = entry.tag_name ?? entry.title;
-    const uid = `${entry.id}@dayopt.app`;
+    const uid = `${entry.id}@${dayoptDomains.marketing}`;
 
     lines.push('BEGIN:VEVENT');
     lines.push(foldLine(`UID:${uid}`));

--- a/apps/product/src/lib/app-info.ts
+++ b/apps/product/src/lib/app-info.ts
@@ -1,3 +1,5 @@
-export const APP_NAME = 'Dayopt';
+import { dayoptBrand } from '@dayopt/config';
+
+export const APP_NAME = dayoptBrand.name;
 export const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION ?? 'unknown';
 export const APP_RELEASES_URL = 'https://github.com/Dayopt/dayopt/releases';

--- a/apps/storybook/docs/dev/architecture/PackagesOverview.mdx
+++ b/apps/storybook/docs/dev/architecture/PackagesOverview.mdx
@@ -103,6 +103,7 @@ Domain logic を持たない React UI primitive の置き場。Button, Badge, Ca
 ### `packages/config`
 
 Product/web が共有する public constants の置き場。副作用を持たず、Next.js / React / Zod / env / server-only に依存しない。
+`apps/product` では low-risk な public brand / domain / URL / contact constants から利用を広げている。
 
 入れてよいもの:
 


### PR DESCRIPTION
## Summary
- use `@dayopt/config` for low-risk product brand/domain constants in OG image, app info, and iCalendar UID generation
- keep product runtime output equivalent: brand remains `Dayopt`, domain remains `dayopt.app`
- update Storybook package docs to note broader product adoption of public config constants

## Not changed
- `APP_RELEASES_URL` remains hardcoded because `@dayopt/config` does not currently expose a Dayopt repository/releases constant
- remaining product matches are comments, stories/tests/fixtures, OAuth examples, or existing text intentionally out of scope
- no `apps/web`, env validation, secrets, Supabase/Stripe config, i18n/legal text, or root docs changes

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm build:packages`
- `pnpm typecheck:packages`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:boundaries`
- `pnpm build`
- `pnpm build:web`
- `pnpm build-storybook`
- `pnpm check:workspace`
- `rg "@dayopt/config" apps/product packages/config`
- `rg "dayopt.app|app.dayopt.app|support@dayopt.app|contact@dayopt.app|security@dayopt.app|Dayopt/dayopt" apps/product/src`
