### PR TITLE
chore(product): adopt shared billing display model

### DIFF
--- a/apps/product/src/app/[locale]/(app)/settings/page.tsx
+++ b/apps/product/src/app/[locale]/(app)/settings/page.tsx
@@ -3,6 +3,11 @@
 import { Link, useRouter } from '@/lib/i18n/navigation';
 import { useEffect, useState } from 'react';
 
+import {
+  canUseEntitlement,
+  entitlementKeys,
+  getPlanIdForSubscriptionStatus,
+} from '@dayopt/billing';
 import { createDayoptUrl, dayoptUrls } from '@dayopt/config';
 import { Badge, Card } from '@dayopt/ui';
 import {
@@ -57,7 +62,8 @@ export default function SettingsPage() {
 
   const billingOverview = api.billing.getOverview.useQuery(undefined, { retry: false });
   const subStatus = billingOverview.data?.billingInfo.subscriptionStatus;
-  const isPro = subStatus === 'active' || subStatus === 'trialing' || subStatus === 'past_due';
+  const currentPlan = getPlanIdForSubscriptionStatus(subStatus);
+  const canAccessPro = canUseEntitlement(currentPlan, entitlementKeys.proAccess);
   const isLoadingBilling = billingOverview.isLoading;
 
   // PC: ホームにリダイレクトし、設定モーダルを開く
@@ -147,8 +153,8 @@ export default function SettingsPage() {
             {isLoadingBilling ? (
               <Skeleton className="h-6 w-10 rounded-lg" />
             ) : (
-              <Badge variant={isPro ? 'primary' : 'outline'}>
-                {isPro
+              <Badge variant={canAccessPro ? 'primary' : 'outline'}>
+                {canAccessPro
                   ? t('settings.subscription.plans.pro.name')
                   : t('settings.subscription.plans.free.name')}
               </Badge>
@@ -156,7 +162,7 @@ export default function SettingsPage() {
           </Link>
 
           {/* Row 2: Upgrade CTA（Free時のみ） */}
-          {!isLoadingBilling && !isPro && (
+          {!isLoadingBilling && !canAccessPro && (
             <button
               type="button"
               onClick={() => router.push('/settings/billing')}

--- a/apps/product/src/features/settings/components/billing-settings.tsx
+++ b/apps/product/src/features/settings/components/billing-settings.tsx
@@ -4,8 +4,11 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { toast } from '@/lib/toast';
 import {
+  canUseEntitlement,
   dayoptPlanIds,
-  getMonthlyUsd,
+  dayoptPlans,
+  dayoptPricing,
+  entitlementKeys,
   getPlanIdForSubscriptionStatus,
   type DayoptPlanId,
 } from '@dayopt/billing';
@@ -42,7 +45,7 @@ interface Plan {
 
 const PLANS: Plan[] = [
   {
-    id: dayoptPlanIds.free,
+    id: dayoptPlans.free.id,
     nameKey: 'settings.subscription.plans.free.name',
     featureKeys: [
       'settings.subscription.plans.free.features.timeboxing',
@@ -52,7 +55,7 @@ const PLANS: Plan[] = [
     ],
   },
   {
-    id: dayoptPlanIds.pro,
+    id: dayoptPlans.pro.id,
     nameKey: 'settings.subscription.plans.pro.name',
     featureKeys: [
       'settings.subscription.plans.pro.features.fullAnalytics',
@@ -101,6 +104,7 @@ export function BillingSettings() {
 
   const subscriptionStatus = overview.data?.billingInfo.subscriptionStatus;
   const currentPlan = getPlanIdForSubscriptionStatus(subscriptionStatus);
+  const canAccessPro = canUseEntitlement(currentPlan, entitlementKeys.proAccess);
 
   // Checkout Session 作成
   const createCheckout = api.billing.createCheckoutSession.useMutation({
@@ -206,7 +210,7 @@ export function BillingSettings() {
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
               <h4 className="text-lg font-medium">
-                {currentPlan === 'pro'
+                {canAccessPro
                   ? t('settings.subscription.plans.pro.name')
                   : t('settings.subscription.freePlanLabel')}
               </h4>
@@ -218,12 +222,12 @@ export function BillingSettings() {
             <p className="text-muted-foreground text-base md:text-sm">
               {subscriptionStatus === 'trialing'
                 ? t('settings.subscription.trialDescription')
-                : currentPlan === 'pro'
+                : canAccessPro
                   ? t('settings.subscription.proPlanDescription')
                   : t('settings.subscription.freePlanDescription')}
             </p>
           </div>
-          {currentPlan === 'pro' && (
+          {canAccessPro && (
             <Button
               variant="outline"
               onClick={handleManageSubscription}
@@ -285,7 +289,7 @@ export function BillingSettings() {
       )}
 
       {/* プラン変更（Free ユーザーのみ — canceled は上で専用UIを表示） */}
-      {currentPlan === 'free' && subscriptionStatus !== 'canceled' && (
+      {currentPlan === dayoptPlanIds.free && subscriptionStatus !== 'canceled' && (
         <SectionCard title={t('settings.subscription.selectPlan')}>
           <div className="grid gap-4 md:grid-cols-2">
             {PLANS.map((plan) => (
@@ -313,7 +317,7 @@ export function BillingSettings() {
                       {new Intl.NumberFormat(undefined, {
                         style: 'currency',
                         currency: 'usd',
-                      }).format(getMonthlyUsd(plan.id))}
+                      }).format(dayoptPricing[plan.id].monthlyUsdCents / 100)}
                     </span>
                     <span className="text-muted-foreground text-base md:text-sm">
                       {t('settings.subscription.perMonth')}
@@ -330,7 +334,7 @@ export function BillingSettings() {
                   ))}
                 </ul>
 
-                {plan.id === dayoptPlanIds.pro ? (
+                {canUseEntitlement(plan.id, entitlementKeys.proAccess) ? (
                   <Button
                     className="w-full"
                     variant="primary"
@@ -353,7 +357,7 @@ export function BillingSettings() {
       )}
 
       {/* お支払い方法（Pro ユーザーのみ表示） */}
-      {currentPlan === 'pro' && (
+      {canAccessPro && (
         <SectionCard title={t('settings.subscription.paymentMethod')}>
           <LabeledRow
             label={
@@ -381,7 +385,7 @@ export function BillingSettings() {
       )}
 
       {/* 請求履歴 — overflow-x-auto でモバイル対応（P1-5） */}
-      {currentPlan === 'pro' && (
+      {canAccessPro && (
         <SectionCard title={t('settings.subscription.billingHistory')}>
           {invoicesData.length > 0 ? (
             <div className="overflow-x-auto">
@@ -436,7 +440,7 @@ export function BillingSettings() {
       )}
 
       {/* キャンセル — 確認ダイアログ付き（P0-1） */}
-      {currentPlan === 'pro' && (
+      {canAccessPro && (
         <SectionCard title={t('settings.subscription.cancelTitle')}>
           <LabeledRow label={t('settings.subscription.cancelDescription')}>
             <AlertDialog open={cancelDialogOpen} onOpenChange={setCancelDialogOpen}>

--- a/apps/product/src/features/settings/components/data-settings.tsx
+++ b/apps/product/src/features/settings/components/data-settings.tsx
@@ -3,6 +3,11 @@
 import { useCallback, useRef, useState } from 'react';
 
 import { toast } from '@/lib/toast';
+import {
+  canUseEntitlement,
+  entitlementKeys,
+  getPlanIdForSubscriptionStatus,
+} from '@dayopt/billing';
 import { dayoptUrls } from '@dayopt/config';
 import { Button as SharedButton } from '@dayopt/ui';
 import {
@@ -257,7 +262,8 @@ function McpApiSection() {
   // Pro判定: billing overview の subscription status から判定
   const billingOverview = api.billing.getOverview.useQuery(undefined, { retry: false });
   const subStatus = billingOverview.data?.billingInfo.subscriptionStatus;
-  const isPro = subStatus === 'active' || subStatus === 'trialing' || subStatus === 'past_due';
+  const currentPlan = getPlanIdForSubscriptionStatus(subStatus);
+  const canAccessPro = canUseEntitlement(currentPlan, entitlementKeys.proAccess);
   // TODO: Replace with actual API key from backend
   const apiKey: string | null = null;
 
@@ -275,7 +281,7 @@ function McpApiSection() {
     [t],
   );
 
-  if (!isPro) {
+  if (!canAccessPro) {
     return (
       <SectionCard title={t('title')}>
         <p className="text-muted-foreground mb-4 text-base md:text-sm">{t('description')}</p>

--- a/apps/storybook/docs/dev/architecture/PackagesOverview.mdx
+++ b/apps/storybook/docs/dev/architecture/PackagesOverview.mdx
@@ -162,6 +162,7 @@ Supabase/Postgres 上の形を扱う境界。generated types, table names, row h
 ### `packages/billing`
 
 公開してよい plan / subscription / entitlement 定義を置く境界。client import できる public-safe な billing model だけを扱う。
+`apps/product` では billing / settings の表示判定で利用を広げている。Stripe runtime は product-local のままにする。
 
 例:
 


### PR DESCRIPTION
## Summary
- extend `@dayopt/billing` usage in product billing/settings display surfaces
- derive Pro access from `getPlanIdForSubscriptionStatus` + `pro_access` entitlement in settings account summary, billing settings, and data/MCP notice
- source plan IDs and pricing cents from the shared billing model while preserving existing i18n text and price formatting
- update package docs to clarify product display adoption while keeping Stripe runtime product-local

## Not changed
- Stripe SDK/runtime, checkout, customer portal, webhook, env/secrets, DB writes, and server actions
- payment error/trial-ended dialogs and inline banner behavior
- apps/web and `@dayopt/billing` package public API

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm build:packages`
- `pnpm typecheck:packages`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:boundaries`
- `pnpm build`
- `pnpm build:web`
- `pnpm build-storybook`
- `pnpm check:workspace`
- `rg "@dayopt/billing" apps/product packages/billing`
- `rg "stripe|STRIPE|process.env|@supabase|next/" packages/billing/src`
- `rg '"free"|"pro"|SubscriptionStatus|Entitlement|planId|price' apps/product/src packages/billing`
