### PR TITLE
docs(architecture): code organization / domain vs server / src/lib policy を追加

### DIFF
--- a/.claude/rules/feature-boundaries.md
+++ b/.claude/rules/feature-boundaries.md
@@ -14,9 +14,9 @@ Layer 0 (基盤):    tags, chronotype             ← 他featureに依存しな�
 Layer 1 (中核):    entry                        ← Layer 0 の barrel を使える
 Layer 2 (体験):    calendar, review, ai,        ← Layer 0+1 を使える
                    palette
-Cross-cutting:     settings                     ← 全feature の barrel を使える
 Independent:       auth, notifications,         ← 他featureに依存しない
                    contact, onboarding, tour
+Composition:       settings                     ← DAG 除外。通常feature扱いしない
 ```
 
 ## 依存ルール（ESLint `error` で強制）
@@ -26,6 +26,49 @@ Independent:       auth, notifications,         ← 他featureに依存しない
 - 同層間・下位→上位の参照は禁止
 - 共有層から `@/features/*` をimportすると **error**
 - `ai/server` はサーバー合成層として例外
+- **settings は DAG から除外** — 後述 [Composition Feature: settings](#composition-feature-settings) を参照
+
+## domain は全 feature に作らない
+
+`features/{name}/domain/` は **pure logic（DB / React / Zustand / TZ 非依存）が複数箇所で参照される or 単体テストで凍結すべき挙動を持つ場合のみ** 作る。
+
+- 例: `features/entry/domain/`、`features/tags/domain/`、`features/review/domain/`
+- domain を作らない feature: `chronotype`（pure logic が薄い）、`settings`（composition なので rule は外部）
+
+「全 feature に domain を作る」は **方針ではない**。pure rule が無い feature には domain は無いのが正しい状態。
+
+## RPC / DB response transformer は domain ではなく server
+
+RPC row の snake_case shape に密結合した変換（snake → camel rename / null → undefined 変換 / outer key rename など）は **`features/{name}/server/` に server transformer として置く**。
+
+- 命名規則: `aggregate{Subject}` (pure) / `transform{Subject}` (snake→camel) / `unpack{Subject}` (RPC field default 埋め)
+- 1 procedure 1 file が原則。同ドメインの subset shape は 1 file に集約してよい（例: `statistics-kpi-unpackers.ts`）
+- domain には RPC / DB shape を持ち込まない（境界を明確に保つ）
+
+## Composition Feature: settings
+
+`settings` は通常 feature の DAG には乗せず、**cross-cutting composition** として扱う。
+
+### 特徴
+
+- ESLint の feature boundary 制約から **除外**（`features/settings/` 配下は他 feature の deep import を許容）
+- 他 feature の store / barrel を組み合わせて「設定」UI を合成する composition feature
+- **自身の domain は持たない**（business rule は composing される側の feature が持つ）
+- server route (`userSettingsRouter`, `billingRouter`) は settings UI からの書き込み入口として settings 配下に同居
+
+### deep import 優先順
+
+settings → 他 feature の deep import は composition の責務上必要なので許容するが、優先順を守る:
+
+1. **`src/lib/stores/*` から取得できる場合は lib 経由を優先**（例: `useUserPreferenceStore`）
+2. **feature の barrel に export されている場合は barrel 経由を優先**（例: `@/features/chronotype` 経由の `useChronotypeSettingsStore`）
+3. **本当に deep import が必要なケースに限定**（例: barrel に出ていない `useCalendarSettingsStore`）
+
+### Layer 1 → Layer 2 は不可（adapter は source 側に置く）
+
+`features/entry`（Layer 1）から `features/review`（Layer 2）の import は DAG 違反のため不可。
+
+「review UI で消費される transformer だから review/domain に置きたい」と思っても、**adapter は source 側 (entry) に置く**のが正解。consumer 側 (review) は tRPC 経由で受ける。
 
 ## Barrel Export
 

--- a/apps/product/src/features/settings/index.ts
+++ b/apps/product/src/features/settings/index.ts
@@ -3,6 +3,17 @@
  *
  * ユーザー設定（カレンダー設定、タイムゾーン、日付フォーマットなど）の管理。
  * 内部モジュールへの直接参照（deep import）は避け、ここからのみ import すること。
+ *
+ * ## このfeatureは通常featureではなく cross-cutting composition
+ *
+ * - ESLint feature DAG から除外されている（`apps/product/eslint.config.mjs` 参照）
+ * - 他 feature の store を deep import するのは composition の責務として許容される例外運用
+ *   （優先順: `@/lib/stores/*` > feature barrel > deep import）
+ * - 自身の domain は持たない（business rule は calendar / chronotype / billing 等が持つ）
+ * - `userSettingsRouter` / `billingRouter` は settings UI からの書き込み入口として
+ *   server を同居（billing は launch 後に独立 feature 化を検討）
+ *
+ * 詳細: `.claude/rules/feature-boundaries.md` の Composition Feature セクション
  */
 
 // =============================================================================

--- a/apps/storybook/docs/dev/architecture/CodeOrganization.mdx
+++ b/apps/storybook/docs/dev/architecture/CodeOrganization.mdx
@@ -1,0 +1,112 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Architecture/Code Organization" />
+
+# Code Organization
+
+Dayopt の feature / lib / shell の責務と、それぞれに「何を置き / 何を置かないか」のルール。
+
+`ADR-002 Feature-Sliced Architecture` と `Feature Boundaries`（`.claude/rules/feature-boundaries.md`）の運用面を補完するドキュメント。
+
+---
+
+## 3 つの結論（前提）
+
+この docs は cross-layer types owner cleanup シリーズ（#1222〜#1232）で確定した 3 原則を前提に書かれている。
+
+1. **domain は全 feature 必須ではない** — pure logic が無い feature には domain は無いのが正しい状態
+2. **RPC / DB response transformer は domain ではなく server** — shape 密結合の adapter は server サブレイヤーに置く
+3. **`src/lib` は便利箱ではなく feature 非依存の基盤** — feature を import しない一方向ルールを死守
+
+---
+
+## Feature 標準ディレクトリ構造
+
+```
+features/{name}/
+  index.ts          # barrel（公開 API、明示的 named export のみ）
+  components/       # React component（feature 固有 UI）
+  hooks/            # React hook（feature 固有）
+  stores/           # Zustand store（feature 内 client-side state）
+  domain/           # pure logic（DB / React / store / TZ 非依存）
+  lib/              # feature 固有の helper（色 const / utility）
+  server/           # tRPC router / service / adapter（DB access あり）
+  schemas/          # Zod schema（必要時のみ）
+  types/            # 型定義（DB row / domain type の re-export 含む）
+```
+
+**全部存在する必要はない。必要なサブディレクトリだけ作る** のが原則。
+
+### 各サブディレクトリの責務
+
+| サブディレクトリ | 置くもの                                                | 置かないもの                                                |
+| ---------------- | ------------------------------------------------------- | ----------------------------------------------------------- |
+| `components/`    | feature 固有の React component                          | shadcn 系の primitive（→ `lib/components/ui/`）             |
+| `hooks/`         | feature 固有の React hook                               | 他 feature でも使う汎用 hook（→ `lib/hooks/`）              |
+| `stores/`        | feature 内で完結する client state                       | 複数 feature が参照する UI state（→ `lib/stores/`）         |
+| `domain/`        | pure logic（業務 rule、計算、validation）               | DB / RPC / React に依存するもの、shape 密結合の transformer |
+| `lib/`           | feature 固有の helper（色 const、enum mapping、helper） | pure business rule（→ `domain/`）                           |
+| `server/`        | tRPC router、service、RPC↔tRPC adapter                  | UI / hook / store                                           |
+| `schemas/`       | Zod schema                                              | TypeScript 型のみ（→ `types/`）                             |
+| `types/`         | DB row / domain type の re-export                       | 実装を伴う logic                                            |
+
+---
+
+## なぜ全 feature に domain を作らないか
+
+> domain を作ること自体が目的ではない。「テストしたい挙動 / 共有したいルール」がそこにあるかで判断する。
+
+### domain を作る基準
+
+- pure aggregation / pure transformation / pure validation が **複数箇所で参照される** または **単体テストで凍結すべき挙動を持つ**
+- feature の business rule（merge 制約、streak 計算、planned vs actual 判定）が pure logic として表現できる
+
+### domain を作らない判断（実例）
+
+| Feature      | 理由                                                                              |
+| ------------ | --------------------------------------------------------------------------------- |
+| `chronotype` | UI と store だけで完結。pure logic がほぼ存在しない                               |
+| `settings`   | composition なので business rule は外部 feature が持つ。settings 自体は rule なし |
+
+「pure logic が無い feature には domain が無い」のが正しい状態。無理に domain を切ると逆に追跡コストが増える。
+
+### domain を作った判断（実例）
+
+| Feature  | domain の中身                                                                                               |
+| -------- | ----------------------------------------------------------------------------------------------------------- |
+| `entry`  | `entry-time-model` / `monthly-trend` / `streak-calculator` / `estimation-accuracy` / `tag-stats` ほか 10 件 |
+| `tags`   | `tag-colon` / `tag-tree` / `tag-merge` / `tag-ungroup`                                                      |
+| `review` | `variance` / `timePL/`（薄い構成）                                                                          |
+
+---
+
+## DAG Layer
+
+```
+Layer 0 (基盤):       tags, chronotype
+Layer 1 (中核):       entry
+Layer 2 (体験):       calendar, review, ai, palette
+Independent:          auth, notifications, contact, onboarding, tour
+Composition:          settings  (= 通常 feature DAG には乗せない)
+```
+
+詳細は `Feature Boundaries`（`.claude/rules/feature-boundaries.md`）を参照。
+
+---
+
+## Calendar Hub（暫定運用）
+
+`features/calendar` は views / tag-filter / navigation / interaction を内部に同居させた hub feature。launch 前の解体リスクを避けるため、blast radius を hub 内部に閉じる運用。
+
+- barrel は「ページから見た public API」のみを export
+- 子 feature 化（`calendar-view` / `calendar-filter` / `calendar-interaction`）は launch 後に検討
+- decomposition plan: `~/.claude/plans/p1-5-calendar-decomposition.md`
+
+---
+
+## 参考
+
+- `Feature Boundaries`（`.claude/rules/feature-boundaries.md`）
+- `Domain vs Server`（このディレクトリ内）
+- `src/lib Policy`（このディレクトリ内）
+- `ADR-002 Feature-Sliced Architecture`

--- a/apps/storybook/docs/dev/architecture/DomainVsServer.mdx
+++ b/apps/storybook/docs/dev/architecture/DomainVsServer.mdx
@@ -1,0 +1,179 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Architecture/Domain vs Server" />
+
+# Domain vs Server
+
+`features/{name}/domain/` と `features/{name}/server/` の境界。
+
+「いつ domain に置き、いつ server に置くか」を判断するためのドキュメント。
+
+---
+
+## 結論
+
+- **domain = TZ / DB / React 非依存の pure logic**
+- **server = DB orchestration + RPC↔tRPC adapter**
+- **RPC / DB shape を domain に持ち込まない**
+
+---
+
+## 判断基準
+
+### domain に置く
+
+- DB / Supabase / tRPC / React / Zustand / TZ に **依存しない pure logic**
+- 入力 → 出力が決定論的、副作用なし
+- unit test で完結する（mock 不要）
+- 例: business rule、validation、計算、変換（domain type → domain type）
+
+### server に置く
+
+- RPC / DB row の snake_case shape に密結合
+- snake → camel rename / outer key rename を含む
+- `null → undefined` 変換など RPC↔tRPC 契約差分の adapter
+- DB error code を持つ Error class に依存（例: `TagServiceError`）
+
+### どちらにも置かない
+
+- React hook が必要なロジック → `hooks/`
+- Zustand store のロジック → `stores/`
+- 1-5 LOC の trivial mapper → inline で OK（独立ファイル化の ROI が低い）
+
+---
+
+## domain と server transformer の違い
+
+| 観点   | domain                    | server transformer                                |
+| ------ | ------------------------- | ------------------------------------------------- |
+| 入力   | feature の domain type    | RPC row / `unknown`                               |
+| 出力   | feature の domain type    | tRPC response shape                               |
+| 依存   | 他 domain function のみ   | RPC shape の型を直接握る                          |
+| テスト | TZ / 副作用なしで pass    | RPC mock 不要、pure                               |
+| 場所   | `features/{name}/domain/` | `features/{name}/server/{procedure}-transform.ts` |
+
+---
+
+## Naming 規則
+
+確立済みの命名規則:
+
+| プレフィックス | 用途                                           | 例                            |
+| -------------- | ---------------------------------------------- | ----------------------------- |
+| `aggregate`    | pure aggregation（複数行 → 集計）              | `aggregateTagStats`           |
+| `transform`    | pure transform（snake → camel、shape 変換）    | `transformEstimationAccuracy` |
+| `unpack`       | RPC field の default 埋め（単一 RPC field 用） | `unpackEntryRate`             |
+| `calculate`    | pure 計算（streak、平均、差分など）            | `calculateStreak`             |
+| `build`        | 入力から構造化された出力を構築                 | `buildTagDashboard`           |
+
+---
+
+## 1 procedure 1 file 原則
+
+server transformer は基本的に **1 procedure 1 file**。
+
+```
+features/entry/server/
+  statistics-overview-transform.ts
+  statistics-time-by-tag-transform.ts
+  statistics-energy-map-transform.ts
+  statistics-kpi-unpackers.ts          # ← 例外: 5 unpacker を集約
+```
+
+**例外**: 同ドメインの subset shape を扱う関連 unpacker は 1 file に集約してよい。
+
+例: `statistics-kpi-unpackers.ts` は 5 つの KPI unpacker (`unpackCumulativeTime` / `unpackAvgFulfillment` / `unpackEntryRate` / `unpackContextSwitches` / `unpackBlankRate`) を集約。これらは:
+
+- 全て `get_stats_kpi_summary` の subset shape を扱う
+- 全て同じ default / rename ロジックを共有
+- 個別 KPI procedure と `transformStatsOverviewResponse` の両方から呼ばれる
+
+「同じ shape を返すから」だけで統合しない。**同じ default / rename / 変換ルールを共有しているか** で判断する。
+
+---
+
+## 共通化の判断（#1232 の教訓）
+
+同一ロジックが 2 箇所以上で重複していたら統合する。
+
+### 重複の典型例
+
+`get_plan_rate` を直接読む procedure と `get_stats_kpi_summary.planRate` から読む procedure が、**同じ default + rename ロジックを別々に書いていた**:
+
+```ts
+// getEntryRate (flat, 個別 RPC)
+return {
+  totalEntries: result?.totalEntries ?? 0,
+  plannedEntries: result?.plannedEntries ?? 0,
+  entryRate: result?.planRate ?? 0,  // ← rename
+};
+
+// transformStatsOverviewResponse (nested, summary RPC)
+entryRate: {
+  totalEntries: result?.planRate?.totalEntries ?? 0,
+  plannedEntries: result?.planRate?.plannedEntries ?? 0,
+  entryRate: result?.planRate?.planRate ?? 0,  // ← rename
+}
+```
+
+これは `unpackEntryRate(data)` を共通化することで両方から再利用可能になり、片方だけ挙動が乖離するリスクを排除できる。
+
+### 統合しない判断
+
+「同じ shape を返すから」だけでは統合しない。判断軸:
+
+- ✅ 同じ default 値を共有
+- ✅ 同じ rename ロジック
+- ✅ 同じ null/undefined 変換
+- ❌ shape が偶然一致しているだけ（rule は別物）
+
+---
+
+## 実例
+
+### domain の例: `aggregateMonthlyTrend`
+
+```ts
+// features/entry/domain/monthly-trend.ts
+export function aggregateMonthlyTrend(
+  rows: MonthlyTrendRow[],
+  nowYear: number,
+  nowMonth: number,
+  monthCount: number,
+): MonthTrendSlot[] {
+  // 月跨ぎ / leap year / 負数 modulo 補正を含む pure logic
+  // ...
+}
+```
+
+- TZ 形式化は呼び出し元 (server procedure) が行い、`nowYear` / `nowMonth` を引数で受ける
+- domain は TZ 非依存に保たれる
+- unit test で leap year / 年跨ぎ を網羅できる
+
+### server transformer の例: `transformStatsOverviewResponse`
+
+```ts
+// features/entry/server/statistics-overview-transform.ts
+export function transformStatsOverviewResponse(data: unknown): StatsOverviewResult {
+  const result = data as Partial<StatsKpiSummaryRpcResult> | null | undefined;
+  return {
+    cumulativeTime: unpackCumulativeTime(result?.cumulativeTime),
+    avgFulfillment: unpackAvgFulfillment(result?.avgFulfillment),
+    entryRate: unpackEntryRate(result?.planRate), // ← outer key rename
+    contextSwitches: unpackContextSwitches(result?.contextSwitches),
+    blankRate: unpackBlankRate(result?.blankRate),
+  };
+}
+```
+
+- RPC `get_stats_kpi_summary` の response shape (camelCase + `planRate` 構造) に密結合
+- `planRate → entryRate` の rename は RPC↔tRPC adapter の役割
+- domain には置けない（RPC shape を握っている）
+
+---
+
+## 参考
+
+- `Code Organization`（このディレクトリ内）
+- `Feature Boundaries`（`.claude/rules/feature-boundaries.md`）
+- `src/lib Policy`（このディレクトリ内）

--- a/apps/storybook/docs/dev/architecture/SrcLibPolicy.mdx
+++ b/apps/storybook/docs/dev/architecture/SrcLibPolicy.mdx
@@ -1,0 +1,125 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Architecture/src/lib Policy" />
+
+# `src/lib` Policy
+
+`apps/product/src/lib/` の役割と「何を置き / 何を置かないか」のルール。
+
+---
+
+## 結論
+
+- `src/lib` は **feature 横断の再利用コードと shell-level state** のみ
+- `src/lib → features/*` の import は **禁止**（一方向ルール）
+- `src/lib` は便利箱ではない。feature 非依存の基盤として扱う
+
+---
+
+## 置いてよいもの
+
+| カテゴリ                          | 例                                                                                                                |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| **feature 非依存の pure utility** | `logger` / `safe-redirect` / `date-utils` / `breakpoints` / `cn`                                                  |
+| **infrastructure adapter**        | `supabase/` / `trpc/` / `sentry/` / `rate-limit/` / `i18n/` / `stripe/`                                           |
+| **cross-cutting UI state**        | `lib/stores/useShellStore` / `useCalendarSettingsStore` / `useCalendarNavigationStore` / `useUserPreferenceStore` |
+| **shared UI primitive**           | `lib/components/ui/`（shadcn-style primitive）                                                                    |
+| **横断的な型**                    | `lib/types/settings.ts`（複数 feature 参照、明確な残存理由あり）                                                  |
+| **shell-level orchestration**     | `lib/auth/domain/`（middleware / tRPC / proxy で共有される access policy）                                        |
+
+---
+
+## 置かないもの
+
+| カテゴリ                       | 正しい配置先                            |
+| ------------------------------ | --------------------------------------- |
+| feature 固有の logic / 型      | `features/{name}/`                      |
+| feature 固有の component       | `features/{name}/components/`           |
+| 自動生成 artifact の re-export | DB 型は `@dayopt/database` から直接引く |
+
+---
+
+## 一方向ルール（ESLint `error` で強制）
+
+```
+src/lib/*  ✕→  @/features/*
+features/*  ✓→  src/lib/*
+```
+
+`src/lib` から `@/features/*` を import するのは **禁止**。逆依存が発生するため。
+
+例外（ESLint で許可されているもの）:
+
+- `src/lib/trpc/root.ts` — Server Composition Layer（router aggregator）
+- `src/lib/hooks/useTheme.ts` — `app/_providers/theme-provider` からの re-export
+- `src/lib/components/dnd/**` — DnD (stories only)
+- `src/lib/**/*.stories.*` — Storybook files
+- `src/lib/test/**` — Integration / E2E tests
+
+---
+
+## 例外運用の実例
+
+### `lib/types/settings.ts`
+
+`SettingsCategory` 型が以下の **3 箇所** から参照される:
+
+- `lib/stores/useShellStore.ts` — SheetType union の一部
+- `lib/components/shell/sidebar/UserMenu.tsx` — 引数型
+- `features/settings/types/index.ts` — settings 自身が re-export
+
+なぜ `lib/` に残すか:
+
+- `useShellStore` / `UserMenu` は **lib 層**（feature 非依存の shell UI）
+- ここから `features/settings` を import すると lib → features の逆依存になる
+- **本体は lib に置き、settings は re-export で扱う** ことで逆依存を回避
+
+これは settings 固有のテクニックではなく、**lib 層と feature 層が同じ型を共有する場合の参照パターン**として残す。
+
+### `lib/auth/domain/`
+
+`lib/auth/domain/` には access policy / identity / permissions / roles が置かれる。
+
+- これは **`features/auth/domain` ではなく、アプリ全体の認証・認可 policy domain**
+- 利用者:
+  - `middleware (proxy.ts)` — リクエストごとの access check
+  - `tRPC procedures.ts` — endpoint ごとの access check
+  - 各 endpoint
+- `features/auth/domain/index.ts` は `lib/auth/domain` を re-export（feature 側からも同じ API で見える）
+
+`features/auth` と `lib/auth/domain` は責務が異なる:
+
+| 場所                  | 責務                                                                 | 利用者                       |
+| --------------------- | -------------------------------------------------------------------- | ---------------------------- |
+| `features/auth`       | ログイン UI / Auth store / 認証体験                                  | UI ページ・コンポーネント    |
+| `src/lib/auth/domain` | アプリ全体の認証・認可 policy（access-policy / permissions / roles） | middleware / tRPC / endpoint |
+
+「auth feature の domain」ではなく「**アプリ全体で共有される access policy**」として lib に置くことで、proxy と tRPC が同じ policy を参照できる。
+
+---
+
+## Composition Feature
+
+通常 feature とは別カテゴリの **composition feature** が 2 つある:
+
+### `features/settings`
+
+- ESLint feature DAG から **除外**
+- 他 feature の store / barrel を組み合わせて「設定」UI を合成
+- 自身の domain は持たない
+- deep import 優先順: **`@/lib/stores/*` > feature barrel > deep import**
+- 詳細: `features/settings/index.ts` 冒頭コメント / `.claude/rules/feature-boundaries.md`
+
+### `features/auth`（部分的）
+
+- UI 部分は `features/auth`
+- policy 部分は `src/lib/auth/domain`（上述）
+- 2 つの責務を意図的に分離している
+
+---
+
+## 参考
+
+- `Code Organization`（このディレクトリ内）
+- `Domain vs Server`（このディレクトリ内）
+- `Feature Boundaries`（`.claude/rules/feature-boundaries.md`）


### PR DESCRIPTION
## Summary

cross-layer types owner cleanup シリーズ (#1222〜#1232) で確定した **3 原則** を architecture docs として正式化。

1. **domain は全 feature 必須ではない** — pure logic が無い feature には domain は無いのが正しい状態
2. **RPC / DB response transformer は domain ではなく server** — shape 密結合の adapter は server サブレイヤーに置く
3. **`src/lib` は便利箱ではなく feature 非依存の基盤** — feature を import しない一方向ルールを死守

## 新規 docs (3 本)

`apps/storybook/docs/dev/architecture/` 配下:

- **`CodeOrganization.mdx`** — feature 標準ディレクトリ構造 / domain を作る・作らない判断 / DAG Layer / calendar hub 暫定運用
- **`DomainVsServer.mdx`** — domain と server transformer の判断基準 / 命名規則 (aggregate / transform / unpack) / 1 procedure 1 file 原則 / #1232 DRY 教訓
- **`SrcLibPolicy.mdx`** — lib に置く・置かない / 一方向ルール / `lib/types/settings.ts` 例外 / `lib/auth/domain` の特殊性 / composition feature (settings / auth)

## 既存ファイル更新

### `.claude/rules/feature-boundaries.md`

- DAG: `Cross-cutting: settings` → `Composition: settings`
- 「**domain は全 feature に作らない**」「**RPC transformer は server**」セクション追加
- 「**Composition Feature: settings**」セクション新設 (DAG 除外 / deep import 優先順 / Layer 1→2 不可 / adapter は source 側)

### `apps/product/src/features/settings/index.ts`

- 冒頭コメントに「cross-cutting composition」を明記
- deep import 優先順 (`@/lib/stores/*` > feature barrel > deep import) と詳細リンクを追記

## 補足

- コード機能変更なし
- ESLint / build / test に影響なし
- Storybook docs として `Architecture/` ナビ配下に表示される（titleフィールド設定済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
