### PR TITLE
chore(web): adopt shared packages

### DIFF
--- a/apps/storybook/docs/dev/architecture/PackagesOverview.mdx
+++ b/apps/storybook/docs/dev/architecture/PackagesOverview.mdx
@@ -64,6 +64,7 @@ Apps 側に残る legal / i18n / docs / test fixture の URL, email, price 文�
 Package foundation は第一段階として運用可能な状態にある。root scripts の `build:packages`, `typecheck:packages`, `check:workspace`, `lint:boundaries`, `build`, `build:web`, `build-storybook` は現在の package 構成を検証対象に含め、CI も `packages-build` job で `pnpm build:packages` を実行する。
 
 ここからは新しい package を増やすより、既存 apps が shared package を低リスクに使う段階へ進む。優先順は `packages/ui` の product / web 実利用、`packages/config` の残り hardcode 置換、`packages/database.databaseTables` の段階適用、`packages/billing` の pricing / plan 表示整理とする。
+`apps/web` でも design theme / UI primitives / config social links / billing pricing の採用を始めている。broader UI migration と design token consolidation は段階的な follow-up として扱う。
 
 product 側の product-first adoption は一段落した。config / billing / database / domain / assets / ui の 6 package は逆依存なく product surfaces で利用され、shell のブランド名ラベルも product-local の `APP_NAME`（= `dayoptBrand.name`）経由に揃えた。残るのは `apps/web` への adoption（config → assets → ui → billing の順）と、`.from('table')` の大規模 service sweep など follow-up であり、これらは別 PR で段階的に進める。
 
@@ -86,6 +87,7 @@ Storybook 表示:
 
 Domain logic を持たない React UI primitive の置き場。Button, Badge, Card, Logo のように複数 app で使える部品だけを入れる。
 `apps/product` では settings / account / fallback surfaces で Button, Badge, Card の runtime 利用を段階的に広げている。Interactive core surfaces は app-local のままにし、submit / mutation / billing flow は避けながら進める。
+`apps/web` では marketing / shell / docs header / fallback surfaces から採用し、form / search / content interaction は web-local のままにする。
 
 知ってよいもの:
 
@@ -106,6 +108,7 @@ Domain logic を持たない React UI primitive の置き場。Button, Badge, Ca
 
 Product/web が共有する public constants の置き場。副作用を持たず、Next.js / React / Zod / env / server-only に依存しない。
 `apps/product` では low-risk な public brand / domain / URL / contact constants から利用を広げている。
+`apps/web` では social links と docs repository links から利用を広げ、legal / i18n / content 本文は copy として残す。
 
 入れてよいもの:
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@dayopt/billing": "workspace:*",
     "@dayopt/config": "workspace:*",
+    "@dayopt/design": "workspace:*",
     "@dayopt/ui": "workspace:*",
     "@hookform/resolvers": "^5.1.1",
     "@marsidev/react-turnstile": "^1.5.0",

--- a/apps/web/src/app/403.tsx
+++ b/apps/web/src/app/403.tsx
@@ -1,7 +1,7 @@
-import { Button } from '@/components/ui/button';
 import { Container } from '@/components/ui/container';
 import { Heading, Text } from '@/components/ui/typography';
 import { generateSEOMetadata } from '@/platform/seo/metadata';
+import { Button } from '@dayopt/ui';
 import Link from 'next/link';
 
 export const metadata = generateSEOMetadata({

--- a/apps/web/src/app/500.tsx
+++ b/apps/web/src/app/500.tsx
@@ -1,7 +1,7 @@
-import { Button } from '@/components/ui/button';
 import { Container } from '@/components/ui/container';
 import { Heading, Text } from '@/components/ui/typography';
 import { generateSEOMetadata } from '@/platform/seo/metadata';
+import { Button } from '@dayopt/ui';
 import Link from 'next/link';
 
 export const metadata = generateSEOMetadata({

--- a/apps/web/src/app/[locale]/(docs)/docs/[...slug]/not-found.tsx
+++ b/apps/web/src/app/[locale]/(docs)/docs/[...slug]/not-found.tsx
@@ -1,5 +1,5 @@
-import { Button } from '@/components/ui/button';
 import { Heading, Text } from '@/components/ui/typography';
+import { Button } from '@dayopt/ui';
 import { getTranslations } from 'next-intl/server';
 import { headers } from 'next/headers';
 import Link from 'next/link';

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { ErrorLayout } from '@/components/errors/ErrorLayout';
-import { Button } from '@/components/ui/button';
 import { isDevelopment } from '@/platform/config/env';
+import { Button } from '@dayopt/ui';
 import Link from 'next/link';
 import { useEffect } from 'react';
 

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { Button } from '@/components/ui/button';
 import { Container } from '@/components/ui/container';
 import { Heading, Text } from '@/components/ui/typography';
 import { isDevelopment } from '@/platform/config/env';
+import { Button } from '@dayopt/ui';
 import { useEffect } from 'react';
 
 interface GlobalErrorProps {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,7 +1,9 @@
 @import 'tailwindcss';
+@source '../../../../packages/ui/src';
 @import 'highlight.js/styles/github.css';
 
 /* Design Tokens */
+@import '@dayopt/design/theme.css';
 @import '../styles/tokens/primitives.css';
 @import '../styles/tokens/colors.css';
 @import '../styles/tokens/elevation.css';

--- a/apps/web/src/components/errors/ErrorLayout.tsx
+++ b/apps/web/src/components/errors/ErrorLayout.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button, Logo } from '@dayopt/ui';
 import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 
@@ -29,8 +30,7 @@ export function ErrorLayout({
       {/* Header */}
       <header className="mx-auto w-full max-w-7xl px-6 pt-6 sm:pt-12 lg:col-span-2 lg:col-start-1 lg:row-start-1 lg:px-8">
         <Link href="/" className="inline-block">
-          <span className="sr-only">Dayopt</span>
-          <div className="text-foreground text-2xl font-medium">Dayopt</div>
+          <Logo variant="wordmark" size="lg" className="text-foreground" />
         </Link>
       </header>
 
@@ -47,13 +47,15 @@ export function ErrorLayout({
 
           {showBackButton && (
             <div className="mt-12">
-              <Link
-                href="/"
-                className="text-foreground hover:text-muted-foreground inline-flex items-center gap-2 text-sm font-medium"
-              >
-                <ArrowLeft className="size-4" />
-                {backToHomeLabel}
-              </Link>
+              <Button variant="ghost" size="sm" asChild>
+                <Link
+                  href="/"
+                  className="text-foreground hover:text-muted-foreground inline-flex items-center gap-2 px-0"
+                >
+                  <ArrowLeft className="size-4" />
+                  {backToHomeLabel}
+                </Link>
+              </Button>
             </div>
           )}
         </div>

--- a/apps/web/src/features/docs/components/AutoTableOfContents.tsx
+++ b/apps/web/src/features/docs/components/AutoTableOfContents.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { dayoptBrand } from '@dayopt/config';
 import { useTranslations } from 'next-intl';
 import { useEffect, useState } from 'react';
 import { TocItem, generateTableOfContents, truncateHeading } from '../lib/toc';
@@ -182,7 +183,7 @@ export function AutoTableOfContents({ content, className = '' }: AutoTableOfCont
         <ul className="space-y-2">
           <li>
             <a
-              href="https://github.com/Dayopt/dayopt/issues/new"
+              href={dayoptBrand.githubIssuesNewUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="text-muted-foreground hover:text-foreground text-sm transition-colors"
@@ -192,7 +193,7 @@ export function AutoTableOfContents({ content, className = '' }: AutoTableOfCont
           </li>
           <li>
             <a
-              href="https://github.com/Dayopt/dayopt"
+              href={dayoptBrand.githubRepositoryUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="text-muted-foreground hover:text-foreground text-sm transition-colors"

--- a/apps/web/src/features/docs/components/DocsHeader.tsx
+++ b/apps/web/src/features/docs/components/DocsHeader.tsx
@@ -1,11 +1,10 @@
 'use client';
 
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { LanguageSwitcher } from '@/components/ui/language-switcher';
 import { ThemeToggle } from '@/components/ui/theme-toggle';
 import { Link } from '@/platform/i18n/navigation';
-import { Logo } from '@dayopt/ui';
+import { Button, Logo } from '@dayopt/ui';
 import { Menu, Search, X } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
@@ -29,6 +28,7 @@ export function DocsHeader({ onMobileMenuToggle, mobileMenuOpen }: DocsHeaderPro
           <Button
             variant="ghost"
             icon
+            size="sm"
             onClick={onMobileMenuToggle}
             className="lg:hidden"
             aria-label={mobileMenuOpen ? t('aria.closeMenu') : t('aria.openMenu')}

--- a/apps/web/src/features/marketing/components/FeaturesSection.tsx
+++ b/apps/web/src/features/marketing/components/FeaturesSection.tsx
@@ -1,5 +1,5 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Container } from '@/components/ui/container';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@dayopt/ui';
 import { Brain, Flame, Target } from 'lucide-react';
 import { getTranslations } from 'next-intl/server';
 
@@ -34,7 +34,7 @@ export async function FeaturesSection({ locale }: FeaturesSectionProps) {
             return (
               <Card
                 key={key}
-                className="border-border bg-background surface-flat hover:shadow-elevation-raised transition-shadow"
+                className="border-border bg-background surface-flat hover:shadow-elevation-raised rounded-2xl shadow-none transition-shadow"
               >
                 <CardHeader>
                   <div className="bg-muted mb-4 inline-flex size-12 items-center justify-center rounded-lg">

--- a/apps/web/src/features/marketing/components/HeroSection.tsx
+++ b/apps/web/src/features/marketing/components/HeroSection.tsx
@@ -1,5 +1,5 @@
-import { Button } from '@/components/ui/button';
 import { Container } from '@/components/ui/container';
+import { Button } from '@dayopt/ui';
 import { getTranslations } from 'next-intl/server';
 
 import { HeroProductMocks } from './HeroProductMocks';

--- a/apps/web/src/features/marketing/components/MissionSection.tsx
+++ b/apps/web/src/features/marketing/components/MissionSection.tsx
@@ -1,4 +1,5 @@
 import { Container } from '@/components/ui/container';
+import { dayoptBrand } from '@dayopt/config';
 import { getTranslations } from 'next-intl/server';
 
 interface MissionSectionProps {
@@ -23,7 +24,7 @@ export async function MissionSection({ locale }: MissionSectionProps) {
           <p className="text-muted-foreground mt-4 text-sm">{t('mission.builderNote')}</p>
           <div className="mt-4 flex items-center justify-center gap-x-4">
             <a
-              href="https://x.com/dayoptapp"
+              href={dayoptBrand.xUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="text-muted-foreground hover:text-foreground transition-colors"
@@ -34,7 +35,7 @@ export async function MissionSection({ locale }: MissionSectionProps) {
               </svg>
             </a>
             <a
-              href="https://github.com/dayoptapp"
+              href={dayoptBrand.githubUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="text-muted-foreground hover:text-foreground transition-colors"

--- a/apps/web/src/features/marketing/components/PricingSection.tsx
+++ b/apps/web/src/features/marketing/components/PricingSection.tsx
@@ -1,16 +1,16 @@
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
+import { Container } from '@/components/ui/container';
+import { Link } from '@/platform/i18n/navigation';
+import { dayoptPlans, dayoptPricing } from '@dayopt/billing';
 import {
+  Badge,
+  Button,
   Card,
   CardContent,
   CardDescription,
   CardFooter,
   CardHeader,
   CardTitle,
-} from '@/components/ui/card';
-import { Container } from '@/components/ui/container';
-import { Link } from '@/platform/i18n/navigation';
-import { dayoptPricing } from '@dayopt/billing';
+} from '@dayopt/ui';
 import { Check } from 'lucide-react';
 import { getTranslations } from 'next-intl/server';
 
@@ -23,6 +23,8 @@ interface PricingSectionProps {
 export async function PricingSection({ locale }: PricingSectionProps) {
   const t = await getTranslations({ locale, namespace: 'marketing' });
 
+  const freePlan = dayoptPlans.free;
+  const proPlan = dayoptPlans.pro;
   const freeFeatures = t.raw('pricing.plans.free.features') as string[];
   const proHighlights = t.raw('pricing.plans.pro.highlights') as string[];
 
@@ -59,9 +61,9 @@ export async function PricingSection({ locale }: PricingSectionProps) {
         {/* 2-Card Grid */}
         <div className="mx-auto grid max-w-4xl items-start gap-8 md:grid-cols-2">
           {/* Free Card */}
-          <Card className="border-border flex flex-col">
+          <Card className="border-border flex flex-col rounded-2xl shadow-none">
             <CardHeader className="text-center">
-              <CardTitle className="text-2xl">{t('pricing.plans.free.name')}</CardTitle>
+              <CardTitle className="text-2xl">{t(`pricing.plans.${freePlan.id}.name`)}</CardTitle>
               <CardDescription className="mt-2">
                 {t('pricing.plans.free.description')}
               </CardDescription>
@@ -69,7 +71,7 @@ export async function PricingSection({ locale }: PricingSectionProps) {
             <CardContent className="flex-1">
               <div className="mb-8 text-center">
                 <span className="text-foreground text-4xl font-medium">
-                  {dayoptPricing.free.displayPrice}
+                  {dayoptPricing[freePlan.id].displayPrice}
                 </span>
               </div>
               <ul className="space-y-4">
@@ -89,12 +91,12 @@ export async function PricingSection({ locale }: PricingSectionProps) {
           </Card>
 
           {/* Pro Card (Highlighted) */}
-          <Card className="border-primary ring-primary/20 surface-raised relative flex flex-col ring-2 md:scale-105">
+          <Card className="border-primary ring-primary/20 surface-raised relative flex flex-col rounded-2xl ring-2 md:scale-105">
             <Badge className="bg-primary text-primary-foreground absolute -top-3 left-1/2 -translate-x-1/2">
               {t('pricing.plans.pro.badge')}
             </Badge>
             <CardHeader className="text-center">
-              <CardTitle className="text-2xl">{t('pricing.plans.pro.name')}</CardTitle>
+              <CardTitle className="text-2xl">{t(`pricing.plans.${proPlan.id}.name`)}</CardTitle>
               <CardDescription className="mt-2">
                 {t('pricing.plans.pro.description')}
               </CardDescription>
@@ -102,7 +104,7 @@ export async function PricingSection({ locale }: PricingSectionProps) {
             <CardContent className="flex-1">
               <div className="mb-2 text-center">
                 <span className="text-foreground text-4xl font-medium">
-                  {dayoptPricing.pro.displayPrice}
+                  {dayoptPricing[proPlan.id].displayPrice}
                 </span>
                 <span className="text-muted-foreground">{t('pricing.plans.pro.period')}</span>
               </div>

--- a/apps/web/src/shell/layout/Footer.tsx
+++ b/apps/web/src/shell/layout/Footer.tsx
@@ -3,6 +3,7 @@
 import { LanguageSwitcher } from '@/components/ui/language-switcher';
 import { ThemeToggle } from '@/components/ui/theme-toggle';
 import { Link } from '@/platform/i18n/navigation';
+import { dayoptBrand } from '@dayopt/config';
 import { Logo } from '@dayopt/ui';
 import { useTranslations } from 'next-intl';
 
@@ -56,17 +57,17 @@ export function Footer() {
   const socialLinks = [
     {
       name: 'X',
-      href: 'https://x.com/dayoptapp',
+      href: dayoptBrand.xUrl,
       icon: XIcon,
     },
     {
       name: 'GitHub',
-      href: 'https://github.com/dayoptapp',
+      href: dayoptBrand.githubUrl,
       icon: GitHubIcon,
     },
     {
       name: 'YouTube',
-      href: 'https://youtube.com/@dayoptapp',
+      href: dayoptBrand.youtubeUrl,
       icon: YouTubeIcon,
     },
   ];

--- a/apps/web/src/shell/layout/Header.tsx
+++ b/apps/web/src/shell/layout/Header.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { Link } from '@/platform/i18n/navigation';
-import { Logo } from '@dayopt/ui';
+import { Button, Logo } from '@dayopt/ui';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { Menu, X } from 'lucide-react';
 import { useTranslations } from 'next-intl';
@@ -91,6 +90,7 @@ export function Header() {
             <Button
               variant="ghost"
               icon
+              size="sm"
               onClick={() => setMobileMenuOpen(true)}
               aria-label={t('aria.openMenu')}
             >

--- a/packages/config/src/constants.ts
+++ b/packages/config/src/constants.ts
@@ -27,6 +27,9 @@ export const dayoptBrand = {
   twitterHandle: '@dayoptapp',
   xUrl: 'https://x.com/dayoptapp',
   githubUrl: 'https://github.com/dayoptapp',
+  githubRepositoryUrl: 'https://github.com/Dayopt/dayopt',
+  githubIssuesNewUrl: 'https://github.com/Dayopt/dayopt/issues/new',
+  youtubeUrl: 'https://youtube.com/@dayoptapp',
 } as const;
 
 export type DayoptUrlBase = string;

--- a/packages/ui/src/button.tsx
+++ b/packages/ui/src/button.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { cva, type VariantProps } from 'class-variance-authority';
 import * as React from 'react';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -687,6 +687,9 @@ importers:
       '@dayopt/config':
         specifier: workspace:*
         version: link:../../packages/config
+      '@dayopt/design':
+        specifier: workspace:*
+        version: link:../../packages/design
       '@dayopt/ui':
         specifier: workspace:*
         version: link:../../packages/ui


### PR DESCRIPTION
## Summary
- add `@dayopt/design` to `apps/web` and wire shared design theme/source scanning for `@dayopt/ui`
- expand `@dayopt/ui` usage across marketing, shell/docs headers, and fallback/error surfaces
- source social/docs repository links from `@dayopt/config` and plan labels/pricing from `@dayopt/billing`
- document web adoption status and follow-up boundaries in Storybook package docs

## Not changed
- web local form/search/blog/content interactive UI primitives remain app-local
- legal/i18n/content copy is not mechanically rewritten
- no Stripe runtime, env/secret, checkout, portal, or webhook logic

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm build:packages`
- `pnpm typecheck:packages`
- `pnpm --filter @dayopt/web typecheck`
- `pnpm --filter @dayopt/web lint`
- `pnpm build:web`
- `pnpm build-storybook`
- `pnpm check:workspace`
- `rg "@dayopt/(design|ui|config|billing)" apps/web packages`
- `rg "@/components/ui/(button|badge|card)" apps/web/src`
- `rg "dayopt.app|app.dayopt.app|support@dayopt.app|security@dayopt.app|https://x.com/dayoptapp|https://github.com/dayoptapp|https://youtube.com/@dayoptapp|https://github.com/Dayopt/dayopt" apps/web/src`
- `rg "next/navigation|@supabase|stripe|process.env|@/|features/" packages/ui/src`

## Visual smoke
- `pnpm build:web` completed all static pages.
- Local browser smoke was attempted, but the current web dev server redirects `/en` and `/` in a loop (`307 location: /` + `x-middleware-rewrite: http://localhost:3020/en`), so browser inspection was blocked by existing local dev routing behavior.
