### PR TITLE
refactor(calendar): drag選択の無効ガードを削除

### DIFF
--- a/apps/product/src/features/calendar/components/views/shared/components/CalendarDragSelection/CalendarDragSelection.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/CalendarDragSelection/CalendarDragSelection.tsx
@@ -61,10 +61,7 @@ export const CalendarDragSelection = ({
         className="absolute inset-0"
         onMouseDown={(e) => {
           // Googleカレンダー互換: クリックした日付を記憶（Cmd+Vでペーストする日付として使用）
-          const target = e.target as HTMLElement;
-          if (!target.closest('[data-plan-card]') && !target.closest('[data-plan-block]')) {
-            useEntryClipboardStore.getState().setLastClickedPosition({ date });
-          }
+          useEntryClipboardStore.getState().setLastClickedPosition({ date });
           handleMouseDown(e);
         }}
         onDoubleClick={handleDoubleClick}

--- a/apps/product/src/features/calendar/components/views/shared/components/CalendarDragSelection/useDragSelection.ts
+++ b/apps/product/src/features/calendar/components/views/shared/components/CalendarDragSelection/useDragSelection.ts
@@ -237,8 +237,6 @@ export function useDragSelection({
   const handleDoubleClick = useCallback(
     (e: React.MouseEvent) => {
       if (disabled || e.button !== 0) return;
-      const target = e.target as HTMLElement;
-      if (target.closest('[data-event-block]') || target.closest('[data-plan-block]')) return;
 
       const rect = e.currentTarget.getBoundingClientRect();
       const time = pixelsToTime(e.clientY - rect.top);
@@ -269,8 +267,6 @@ export function useDragSelection({
         e.stopPropagation();
         return;
       }
-      const target = e.target as HTMLElement;
-      if (target.closest('[data-event-block]') || target.closest('[data-plan-block]')) return;
 
       const rect = e.currentTarget.getBoundingClientRect();
       const y = e.clientY - rect.top;
@@ -288,8 +284,6 @@ export function useDragSelection({
       if (disabled) return;
       const touch = e.touches[0];
       if (!touch) return;
-      const target = e.target as HTMLElement;
-      if (target.closest('[data-event-block]') || target.closest('[data-plan-block]')) return;
 
       const rect = e.currentTarget.getBoundingClientRect();
       const y = touch.clientY - rect.top;


### PR DESCRIPTION
## 概要

`PlanCard → EntryCard` リネームの名残で残っていた、ドラッグ選択ハンドラ内の `closest` ガードを削除する純粋な整理。UI 挙動は不変。

## 背景

[useDragSelection.ts](apps/product/src/features/calendar/components/views/shared/components/CalendarDragSelection/useDragSelection.ts) と [CalendarDragSelection.tsx](apps/product/src/features/calendar/components/views/shared/components/CalendarDragSelection/CalendarDragSelection.tsx) には `data-event-block` / `data-plan-block` / `data-plan-card` への `closest` ガードがあったが、これらの属性はソース全体のどこにも set されていない（実際に描画されるのは `data-entry-block` のみ）。

さらに調査の結果、単なる属性名の不一致ではなく **構造上常に false のデッドコード** であることが判明:

- drag-selection 層（z-10）と entry 表示層（z-20）は [CalendarGridContent.tsx](apps/product/src/features/calendar/components/views/shared/components/CalendarGridContent.tsx) で **兄弟の別サブツリー** として配置される
- entry block は drag-selection のイベントハンドラが付く div の子孫ではない
- したがって属性名を `data-entry-block` に直しても `closest` がマッチすることはない

リネームでは「load-bearing に見えて実は dead」という誤解が残るため、削除を選択。

## 変更内容

- `useDragSelection.ts`: `handleDoubleClick` / `handleMouseDown` / `handleTouchStart` の3ハンドラからガード行と専用の `target` 変数を削除
- `CalendarDragSelection.tsx`: `onMouseDown` 内の `data-plan-card` / `data-plan-block` ガードを削除し `setLastClickedPosition` を無条件呼び出しに（Google カレンダー互換コメントは維持）

## 検証

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm lint:boundaries` ✅
- UI 挙動: 不変（ガードは元々一度も発火しないため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)