### PR TITLE
[codex] Fix calendar drag, resize, and empty-slot creation

### DIFF
--- a/apps/product/src/features/calendar/components/tag-filter/components/TagEntryCreatePopover/TagEntryCreatePopover.tsx
+++ b/apps/product/src/features/calendar/components/tag-filter/components/TagEntryCreatePopover/TagEntryCreatePopover.tsx
@@ -6,6 +6,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { isSameDay, startOfDay } from 'date-fns';
 import { useTranslations } from 'next-intl';
 
+import { buildNewEntryOverlapTarget } from '@/features/calendar/lib/overlap';
 import { useEntryMutations } from '@/features/entry';
 import { Drawer, DrawerContent, DrawerTitle } from '@/lib/components/ui/drawer';
 import { Popover, PopoverAnchor, PopoverContent } from '@/lib/components/ui/popover';
@@ -152,16 +153,6 @@ export function TagEntryCreatePopover({
     closeDraft();
   }, [closeDraft, onOpenChange]);
 
-  // past 時間帯は保存時に unplanned になるため、判定も actual として渡す。
-  // useMemo の外で計算しないと react-hooks/purity に引っかかる。
-  // eslint-disable-next-line react-hooks/purity -- transient form, no observable side effect
-  const nowForPastCheck = Date.now();
-  const willBeUnplanned = (() => {
-    if (!startTime || !endTime) return false;
-    const endDate = combineDateAndHHMM(selectedDate, endTime);
-    return endDate.getTime() <= nowForPastCheck;
-  })();
-
   // クライアント側で時間重複を判定（drag / Inspector と同じ規範）。
   // 重複時は inline alert + submit disabled で hard-block し、mutation を発火させない。
   const hasConflict = useMemo(() => {
@@ -203,14 +194,8 @@ export function TagEntryCreatePopover({
       }
     }
 
-    return hasTwoLayerTimeConflict(events, {
-      id: '',
-      plannedStart: willBeUnplanned ? null : startDate.toISOString(),
-      plannedEnd: willBeUnplanned ? null : endDate.toISOString(),
-      actualStart: willBeUnplanned ? startDate.toISOString() : null,
-      actualEnd: willBeUnplanned ? endDate.toISOString() : null,
-    });
-  }, [queryClient, selectedDate, startTime, endTime, willBeUnplanned]);
+    return hasTwoLayerTimeConflict(events, buildNewEntryOverlapTarget(startDate, endDate));
+  }, [queryClient, selectedDate, startTime, endTime]);
 
   const handleSubmit = useCallback(() => {
     if (hasConflict) return; // defensive: button is already disabled

--- a/apps/product/src/features/calendar/components/views/shared/components/CalendarGridContent.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/CalendarGridContent.tsx
@@ -70,6 +70,13 @@ function minutesToDate(date: Date, minutes: number): Date {
   return result;
 }
 
+export function getGhostEntryHeight(style: React.CSSProperties | undefined): number {
+  const rawHeight = style?.height;
+  const height =
+    typeof rawHeight === 'number' ? rawHeight : parseFloat(rawHeight?.toString() ?? '');
+  return Number.isFinite(height) && height > 0 ? height : 20;
+}
+
 /** CalendarGridContent コンポーネントのプロパティ */
 export interface CalendarGridContentProps {
   /** この列が担当する日付 */
@@ -207,19 +214,21 @@ export const CalendarGridContent = React.memo(function CalendarGridContent({
       const tag = entry.tagId ? getTagById(entry.tagId) : null;
       // ゴーストは予定部分のみ表示（実績時間を除外してオーバーレイを抑制）
       const ghostEntry = { ...entry, actualStartDate: null, actualEndDate: null };
+      const ghostHeight = getGhostEntryHeight(entryStyles[entryId]);
       return (
         <EntryCard
           entry={ghostEntry}
           tagName={tag?.name ?? null}
           tagColor={tag?.color ?? null}
           isMobile={isMobile}
-          position={{ top: 0, left: 0, width: 100, height: 9999 }}
+          position={{ top: 0, left: 0, width: 100, height: ghostHeight }}
+          plannedHeight={ghostHeight}
           previewTime={previewTime}
           style={{ position: 'relative', height: '100%' }}
         />
       );
     },
-    [entries, getTagById, isMobile],
+    [entries, entryStyles, getTagById, isMobile],
   );
 
   // 時間グリッド

--- a/apps/product/src/features/calendar/components/views/shared/components/DraftEntryBlock.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/DraftEntryBlock.tsx
@@ -5,6 +5,7 @@ import { useCallback, useMemo } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslations } from 'next-intl';
 
+import { buildNewEntryOverlapTarget } from '@/features/calendar/lib/overlap';
 import { getTagColorClasses } from '@/features/tags';
 import { ColonTagLabel } from '@/lib/components/ui/colon-tag-label';
 import { formatTimeString } from '@/lib/date';
@@ -110,16 +111,21 @@ export function DraftEntryBlock({ draft, hourHeight }: DraftEntryBlockProps) {
       }
     }
 
-    // past 時間帯は保存時に unplanned になるため、判定も actual として渡す。
-    // isPast は render 上部で算出済み（Date.now() を useMemo の外に出す）
-    return hasTwoLayerTimeConflict(events, {
-      id: '',
-      plannedStart: isPast ? null : startDate.toISOString(),
-      plannedEnd: isPast ? null : endDate.toISOString(),
-      actualStart: isPast ? startDate.toISOString() : null,
-      actualEnd: isPast ? endDate.toISOString() : null,
-    });
-  }, [queryClient, draft.date, startH, startM, endH, endM, startMinutes, endMinutes, isPast]);
+    return hasTwoLayerTimeConflict(
+      events,
+      buildNewEntryOverlapTarget(startDate, endDate, nowForPastCheck),
+    );
+  }, [
+    queryClient,
+    draft.date,
+    startH,
+    startM,
+    endH,
+    endM,
+    startMinutes,
+    endMinutes,
+    nowForPastCheck,
+  ]);
 
   const handleResizeStart = useCallback(
     (clientY: number) => {

--- a/apps/product/src/features/calendar/components/views/shared/components/EntryRenderer.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/EntryRenderer.tsx
@@ -112,6 +112,10 @@ export const EntryRenderer = React.memo(function EntryRenderer({
   // 予定 vs 記録の差分オーバーレイ（multi-column ビューのみ）
   let finalStyle: React.CSSProperties = adjustedStyle;
   let finalHeight: number;
+  const previewPlannedHeight =
+    entryResizing && interactionState.mode === 'resizing'
+      ? interactionState.snappedHeight
+      : currentHeight;
 
   if (enableCrossDayDrag) {
     const overlay = computeActualTimeDiffOverlay(entry, hourHeight);
@@ -128,15 +132,9 @@ export const EntryRenderer = React.memo(function EntryRenderer({
       ? { ...overlayAdjustedStyle, opacity: 0.65 }
       : overlayAdjustedStyle;
 
-    finalHeight =
-      entryResizing && interactionState.mode === 'resizing'
-        ? interactionState.snappedHeight
-        : currentHeight + overlay.heightDelta;
+    finalHeight = previewPlannedHeight + overlay.heightDelta;
   } else {
-    finalHeight =
-      entryResizing && interactionState.mode === 'resizing'
-        ? interactionState.snappedHeight
-        : currentHeight;
+    finalHeight = previewPlannedHeight;
   }
 
   const handleContextMenu = (p: CalendarEvent, e: React.MouseEvent) => {
@@ -200,7 +198,7 @@ export const EntryRenderer = React.memo(function EntryRenderer({
           onAnchorRect={setAnchorRect}
           isMobile={isMobile}
           position={{ top: 0, left: 0, width: 100, height: finalHeight }}
-          plannedHeight={currentHeight}
+          plannedHeight={previewPlannedHeight}
           onContextMenu={handleContextMenu}
           onResizeStart={(
             p: CalendarEvent,

--- a/apps/product/src/features/calendar/components/views/shared/components/InlineTagPalette/InlineTagPalette.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/InlineTagPalette/InlineTagPalette.tsx
@@ -16,6 +16,7 @@ import { format, isSameDay } from 'date-fns';
 import { enUS, ja } from 'date-fns/locale';
 import { useLocale, useTranslations } from 'next-intl';
 
+import { buildNewEntryOverlapTarget } from '@/features/calendar/lib/overlap';
 import { useEntryMutations } from '@/features/entry';
 import type { HoveredTagInfo } from '@/features/tags';
 import {
@@ -144,15 +145,10 @@ export function InlineTagPalette({ hourHeight, date }: InlineTagPaletteProps) {
           });
         }
       }
-      // past 時間帯は保存時に unplanned になるため、overlap 判定も actual として渡す。
-      const createWillBeUnplanned = utcEnd.getTime() <= Date.now();
-      const hasOverlap = hasTwoLayerTimeConflict(events, {
-        id: '',
-        plannedStart: createWillBeUnplanned ? null : utcStart.toISOString(),
-        plannedEnd: createWillBeUnplanned ? null : utcEnd.toISOString(),
-        actualStart: createWillBeUnplanned ? utcStart.toISOString() : null,
-        actualEnd: createWillBeUnplanned ? utcEnd.toISOString() : null,
-      });
+      const hasOverlap = hasTwoLayerTimeConflict(
+        events,
+        buildNewEntryOverlapTarget(utcStart, utcEnd),
+      );
       if (hasOverlap) {
         toast.error(tEntry('errors.timeOverlap'));
         clearPendingSelection();
@@ -349,17 +345,8 @@ export function InlineTagPalette({ hourHeight, date }: InlineTagPaletteProps) {
       }
     }
 
-    // past は unplanned で planned 範囲なし、future は planned で planned/actual 両方持つ。
-    // hasTwoLayerTimeConflict は target.actualStart/End が必須なので future planned 作成でも
-    // 同じ範囲を actual に mirror する（server も create 時に actual を planned に mirror する）。
-    return hasTwoLayerTimeConflict(events, {
-      id: '',
-      plannedStart: isPast ? null : utcStart.toISOString(),
-      plannedEnd: isPast ? null : utcEnd.toISOString(),
-      actualStart: utcStart.toISOString(),
-      actualEnd: utcEnd.toISOString(),
-    });
-  }, [queryClient, pendingSelection, timezone, isPast]);
+    return hasTwoLayerTimeConflict(events, buildNewEntryOverlapTarget(utcStart, utcEnd));
+  }, [queryClient, pendingSelection, timezone]);
 
   // 日付が指定されている場合、対象日と一致するカラムのみ表示
   if (!pendingSelection) return null;

--- a/apps/product/src/features/calendar/components/views/shared/components/__tests__/CalendarGridContent.test.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/__tests__/CalendarGridContent.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { getGhostEntryHeight } from '../CalendarGridContent';
+
+describe('CalendarGridContent', () => {
+  it('drag ghost uses the rendered entry height instead of a full-day sentinel height', () => {
+    expect(getGhostEntryHeight({ height: '60px' })).toBe(60);
+    expect(getGhostEntryHeight({ height: 58 })).toBe(58);
+  });
+
+  it('falls back to a compact height when entry style is unavailable', () => {
+    expect(getGhostEntryHeight(undefined)).toBe(20);
+    expect(getGhostEntryHeight({ height: 'auto' })).toBe(20);
+  });
+});

--- a/apps/product/src/features/calendar/components/views/shared/components/__tests__/EntryRenderer.test.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/__tests__/EntryRenderer.test.tsx
@@ -1,0 +1,89 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { InteractionState } from '../../../../../domain/interaction/types';
+import type { CalendarEvent } from '../../../../../types/calendar.types';
+
+import { EntryRenderer } from '../EntryRenderer';
+
+vi.mock('@/features/tags', () => ({
+  getTagColorClasses: () => ({
+    cssVar: 'var(--entry-default)',
+    cssVarTint: 'var(--entry-default-tint)',
+    dot: 'bg-entry-default',
+  }),
+  useTagsMap: () => ({
+    getTagById: () => undefined,
+  }),
+}));
+
+const baseEntry: CalendarEvent = {
+  id: 'entry-1',
+  title: 'Resize target',
+  description: '',
+  startDate: new Date('2026-01-15T10:00:00.000Z'),
+  endDate: new Date('2026-01-15T11:00:00.000Z'),
+  actualStartDate: new Date('2026-01-15T10:00:00.000Z'),
+  actualEndDate: new Date('2026-01-15T11:00:00.000Z'),
+  displayStartDate: new Date('2026-01-15T10:00:00.000Z'),
+  displayEndDate: new Date('2026-01-15T11:00:00.000Z'),
+  status: 'open',
+  color: 'blue',
+  tagId: null,
+  createdAt: new Date('2026-01-15T09:00:00.000Z'),
+  updatedAt: new Date('2026-01-15T09:00:00.000Z'),
+  duration: 60,
+  isMultiDay: false,
+  origin: 'planned',
+};
+
+const resizingState: InteractionState = {
+  mode: 'resizing',
+  entryId: 'entry-1',
+  startPoint: { clientX: 0, clientY: 0 },
+  currentPoint: { clientX: 0, clientY: 60 },
+  originalPosition: { top: 100, height: 60, left: 0, width: 100 },
+  direction: 'bottom',
+  snappedHeight: 120,
+  previewTime: {
+    start: new Date('2026-01-15T10:00:00.000Z'),
+    end: new Date('2026-01-15T12:00:00.000Z'),
+  },
+  isOverlapping: false,
+};
+
+function renderEntryRenderer() {
+  return render(
+    <EntryRenderer
+      entry={baseEntry}
+      style={{ top: '100px', height: '60px' }}
+      hourHeight={60}
+      enableCrossDayDrag={false}
+      dayIndex={0}
+      isDragging={false}
+      isResizing={true}
+      entryDragging={false}
+      entryResizing={true}
+      interactionState={resizingState}
+      globalDraggedEntryId={null}
+      isSourceColumnMovingAway={false}
+      onPointerDown={vi.fn()}
+      onTouchStart={vi.fn()}
+      onResizeStart={vi.fn()}
+      entries={[baseEntry]}
+    />,
+  );
+}
+
+describe('EntryRenderer', () => {
+  it('リサイズ中はplanned layerとresize frameをpreview高さへ追従させる', () => {
+    const { container } = renderEntryRenderer();
+
+    expect(container.querySelector<HTMLElement>('[data-entry-planned-layer]')).toHaveStyle({
+      height: '120px',
+    });
+    expect(container.querySelector<HTMLElement>('[data-entry-resize-frame]')).toHaveStyle({
+      height: '120px',
+    });
+  });
+});

--- a/apps/product/src/features/calendar/domain/interaction/__tests__/machine.test.ts
+++ b/apps/product/src/features/calendar/domain/interaction/__tests__/machine.test.ts
@@ -545,6 +545,33 @@ describe('RESIZE_START', () => {
       expect(state.isOverlapping).toBe(true);
     }
   });
+
+  it('keeps initial resize preview duration positive for short off-grid entries', () => {
+    const { state } = dispatch(
+      IDLE,
+      {
+        type: 'RESIZE_START',
+        entryId: 'a',
+        direction: 'bottom',
+        point: origin,
+        originalPosition: { top: 608, left: 0, width: 200, height: 8 },
+      },
+      createCtx({
+        checkOverlap: (_entryId, start, end) => end.getTime() <= start.getTime(),
+      }),
+    );
+
+    if (state.mode === 'resizing') {
+      const durationMs = state.previewTime.end.getTime() - state.previewTime.start.getTime();
+      expect(state.snappedHeight).toBe(15);
+      expect(state.previewTime.start.getHours()).toBe(10);
+      expect(state.previewTime.start.getMinutes()).toBe(15);
+      expect(state.previewTime.end.getHours()).toBe(10);
+      expect(state.previewTime.end.getMinutes()).toBe(30);
+      expect(durationMs).toBe(15 * 60 * 1000);
+      expect(state.isOverlapping).toBe(false);
+    }
+  });
 });
 
 // ========================================

--- a/apps/product/src/features/calendar/domain/interaction/__tests__/machine.test.ts
+++ b/apps/product/src/features/calendar/domain/interaction/__tests__/machine.test.ts
@@ -523,6 +523,28 @@ describe('RESIZE_START', () => {
     }
     expect(effects).toHaveLength(0);
   });
+
+  it('computes overlap for the snapped resize preview before any pointer move', () => {
+    const { state } = dispatch(
+      IDLE,
+      {
+        type: 'RESIZE_START',
+        entryId: 'a',
+        direction: 'bottom',
+        point: origin,
+        originalPosition: { top: 607, left: 0, width: 200, height: 60 },
+      },
+      createCtx({
+        checkOverlap: (_entryId, start, end) =>
+          start.getHours() === 10 && start.getMinutes() === 0 && end.getHours() === 11,
+      }),
+    );
+
+    if (state.mode === 'resizing') {
+      expect(state.previewTime.start.getMinutes()).toBe(0);
+      expect(state.isOverlapping).toBe(true);
+    }
+  });
 });
 
 // ========================================

--- a/apps/product/src/features/calendar/domain/interaction/__tests__/machine.test.ts
+++ b/apps/product/src/features/calendar/domain/interaction/__tests__/machine.test.ts
@@ -602,14 +602,14 @@ describe('POINTER_UP while resizing', () => {
 });
 
 // ========================================
-// Precision regression — relative offset snap (Project A-2 / D-7)
+// Precision regression — drag/resize absolute grid snap
 // ========================================
 
-describe('precision regression: relative offset snap preserves :07 minutes', () => {
+describe('precision regression: drag/resize snaps off-grid times to the absolute grid', () => {
   // 10:07 entry を表す originalPosition: top=607（hourHeight=60 で 10*60+7=607）
   const off607: EntryRect = { top: 607, left: 0, width: 200, height: 60 };
 
-  it('LONGPRESS_FIRED on 10:07 entry → preview start stays 10:07 (not snapped to 10:00)', () => {
+  it('LONGPRESS_FIRED on 10:07 entry → preview start snaps to 10:00', () => {
     const longpressState: InteractionState = {
       mode: 'longpress-pending',
       entryId: 'a',
@@ -621,13 +621,13 @@ describe('precision regression: relative offset snap preserves :07 minutes', () 
 
     expect(state.mode).toBe('dragging');
     if (state.mode === 'dragging') {
-      expect(state.snappedTop).toBe(607);
+      expect(state.snappedTop).toBe(600);
       expect(state.previewTime.start.getHours()).toBe(10);
-      expect(state.previewTime.start.getMinutes()).toBe(7);
+      expect(state.previewTime.start.getMinutes()).toBe(0);
     }
   });
 
-  it('drag 10:07 → +30min → 10:37 (precision preserved, NOT snapped to 10:30)', () => {
+  it('drag 10:07 → +30px → 10:30', () => {
     const draggingState: InteractionState = {
       mode: 'dragging',
       entryId: 'a',
@@ -647,14 +647,13 @@ describe('precision regression: relative offset snap preserves :07 minutes', () 
     const { state } = dispatch(draggingState, { type: 'POINTER_MOVE', point: movedPoint });
 
     if (state.mode === 'dragging') {
-      // deltaY=30 は 15 分 snap で 30 のまま、original top=607 に加えて 637 → 10:37
-      expect(state.snappedTop).toBe(637);
+      expect(state.snappedTop).toBe(630);
       expect(state.previewTime.start.getHours()).toBe(10);
-      expect(state.previewTime.start.getMinutes()).toBe(37);
+      expect(state.previewTime.start.getMinutes()).toBe(30);
     }
   });
 
-  it('drag 10:07 → +7px (snap interval 未満) → 動かない (start stays 10:07)', () => {
+  it('drag 10:07 → +7px → 10:15', () => {
     const draggingState: InteractionState = {
       mode: 'dragging',
       entryId: 'a',
@@ -674,12 +673,116 @@ describe('precision regression: relative offset snap preserves :07 minutes', () 
     const { state } = dispatch(draggingState, { type: 'POINTER_MOVE', point: movedPoint });
 
     if (state.mode === 'dragging') {
-      expect(state.snappedTop).toBe(607);
-      expect(state.previewTime.start.getMinutes()).toBe(7);
+      expect(state.snappedTop).toBe(615);
+      expect(state.previewTime.start.getMinutes()).toBe(15);
     }
   });
 
-  it('RESIZE_START on 10:07 entry → preview start stays 10:07', () => {
+  it('5分snap設定では15:13 entryをdragすると15:15へ揃える', () => {
+    const off913: EntryRect = { top: 913, left: 0, width: 200, height: 60 };
+    const draggingState: InteractionState = {
+      mode: 'dragging',
+      entryId: 'a',
+      startPoint: origin,
+      currentPoint: origin,
+      originalPosition: off913,
+      dateIndex: 0,
+      targetDateIndex: 0,
+      snappedTop: 913,
+      previewTime: {
+        start: new Date('2026-01-15T15:13:00'),
+        end: new Date('2026-01-15T16:13:00'),
+      },
+      isOverlapping: false,
+    };
+    const { state } = dispatch(
+      draggingState,
+      { type: 'POINTER_MOVE', point: origin },
+      createCtx({ snapIntervalMinutes: 5 }),
+    );
+
+    if (state.mode === 'dragging') {
+      expect(state.snappedTop).toBe(915);
+      expect(state.previewTime.start.getHours()).toBe(15);
+      expect(state.previewTime.start.getMinutes()).toBe(15);
+      expect(state.previewTime.end.getHours()).toBe(16);
+      expect(state.previewTime.end.getMinutes()).toBe(15);
+    }
+  });
+
+  it('5分snap設定ではdrag時にoff-grid durationも丸めて終了時刻をグリッドへ揃える', () => {
+    const off913: EntryRect = { top: 913, left: 0, width: 200, height: 47 };
+    const draggingState: InteractionState = {
+      mode: 'dragging',
+      entryId: 'a',
+      startPoint: origin,
+      currentPoint: origin,
+      originalPosition: off913,
+      dateIndex: 0,
+      targetDateIndex: 0,
+      snappedTop: 913,
+      previewTime: {
+        start: new Date('2026-01-15T15:13:00'),
+        end: new Date('2026-01-15T16:00:00'),
+      },
+      isOverlapping: false,
+    };
+    const { state } = dispatch(
+      draggingState,
+      { type: 'POINTER_MOVE', point: origin },
+      createCtx({
+        snapIntervalMinutes: 5,
+        getEntryDurationMs: () => 47 * 60 * 1000,
+      }),
+    );
+
+    if (state.mode === 'dragging') {
+      const durationMs = state.previewTime.end.getTime() - state.previewTime.start.getTime();
+      expect(state.previewTime.start.getHours()).toBe(15);
+      expect(state.previewTime.start.getMinutes()).toBe(15);
+      expect(state.previewTime.end.getHours()).toBe(16);
+      expect(state.previewTime.end.getMinutes()).toBe(0);
+      expect(durationMs).toBe(45 * 60 * 1000);
+    }
+  });
+
+  it('drag時は終了境界もsnapし、48分entryを不要に50分へ伸ばさない', () => {
+    const off913: EntryRect = { top: 913, left: 0, width: 200, height: 48 };
+    const draggingState: InteractionState = {
+      mode: 'dragging',
+      entryId: 'a',
+      startPoint: origin,
+      currentPoint: origin,
+      originalPosition: off913,
+      dateIndex: 0,
+      targetDateIndex: 0,
+      snappedTop: 913,
+      previewTime: {
+        start: new Date('2026-01-15T15:13:00'),
+        end: new Date('2026-01-15T16:01:00'),
+      },
+      isOverlapping: false,
+    };
+    const { state } = dispatch(
+      draggingState,
+      { type: 'POINTER_MOVE', point: origin },
+      createCtx({
+        snapIntervalMinutes: 5,
+        getEntryDurationMs: () => 48 * 60 * 1000,
+      }),
+    );
+
+    if (state.mode === 'dragging') {
+      const durationMs = state.previewTime.end.getTime() - state.previewTime.start.getTime();
+      expect(state.previewTime.start.getHours()).toBe(15);
+      expect(state.previewTime.start.getMinutes()).toBe(15);
+      expect(state.previewTime.end.getHours()).toBe(16);
+      expect(state.previewTime.end.getMinutes()).toBe(0);
+      expect(durationMs).toBe(45 * 60 * 1000);
+    }
+  });
+
+  it('RESIZE_START on 10:07 entry → preview range snaps to 10:00-11:00', () => {
     const { state } = dispatch(IDLE, {
       type: 'RESIZE_START',
       entryId: 'a',
@@ -690,13 +793,13 @@ describe('precision regression: relative offset snap preserves :07 minutes', () 
 
     if (state.mode === 'resizing') {
       expect(state.previewTime.start.getHours()).toBe(10);
-      expect(state.previewTime.start.getMinutes()).toBe(7);
+      expect(state.previewTime.start.getMinutes()).toBe(0);
       expect(state.previewTime.end.getHours()).toBe(11);
-      expect(state.previewTime.end.getMinutes()).toBe(7);
+      expect(state.previewTime.end.getMinutes()).toBe(0);
     }
   });
 
-  it('resize 10:07-11:07 entry を +15min → 10:07-11:22 (start stays, end shifts by snap delta)', () => {
+  it('resize 10:07-11:07 entry を +15px → 10:00-11:15', () => {
     const resizingState: InteractionState = {
       mode: 'resizing',
       entryId: 'a',
@@ -717,9 +820,82 @@ describe('precision regression: relative offset snap preserves :07 minutes', () 
     if (state.mode === 'resizing') {
       expect(state.snappedHeight).toBe(75);
       expect(state.previewTime.start.getHours()).toBe(10);
-      expect(state.previewTime.start.getMinutes()).toBe(7);
+      expect(state.previewTime.start.getMinutes()).toBe(0);
       expect(state.previewTime.end.getHours()).toBe(11);
-      expect(state.previewTime.end.getMinutes()).toBe(22);
+      expect(state.previewTime.end.getMinutes()).toBe(15);
+    }
+  });
+});
+
+// ========================================
+// Day-end boundary regression
+// ========================================
+
+describe('day-end boundary regression', () => {
+  it('dragging a 1-hour entry to 23:00 keeps the end at next-day 00:00', () => {
+    const draggingState: InteractionState = {
+      mode: 'dragging',
+      entryId: 'a',
+      startPoint: origin,
+      currentPoint: origin,
+      originalPosition: { top: 1320, left: 0, width: 200, height: 60 },
+      dateIndex: 0,
+      targetDateIndex: 0,
+      snappedTop: 1320,
+      previewTime: {
+        start: new Date('2026-01-15T22:00:00'),
+        end: new Date('2026-01-15T23:00:00'),
+      },
+      isOverlapping: false,
+    };
+    const movedPoint = { clientX: origin.clientX, clientY: origin.clientY + 60 };
+    const { state } = dispatch(draggingState, { type: 'POINTER_MOVE', point: movedPoint });
+
+    if (state.mode === 'dragging') {
+      expect(state.snappedTop).toBe(1380);
+      expect(state.previewTime.start.getHours()).toBe(23);
+      expect(state.previewTime.start.getMinutes()).toBe(0);
+      expect(state.previewTime.end.getDate()).toBe(16);
+      expect(state.previewTime.end.getHours()).toBe(0);
+      expect(state.previewTime.end.getMinutes()).toBe(0);
+      expect(state.previewTime.end.getTime() - state.previewTime.start.getTime()).toBe(
+        60 * 60 * 1000,
+      );
+    }
+  });
+
+  it('RESIZE_START supports a 23:00-24:00 range instead of collapsing to one interval', () => {
+    const { state } = dispatch(IDLE, {
+      type: 'RESIZE_START',
+      entryId: 'a',
+      direction: 'bottom',
+      point: origin,
+      originalPosition: { top: 1380, left: 0, width: 200, height: 60 },
+    });
+
+    if (state.mode === 'resizing') {
+      expect(state.snappedHeight).toBe(60);
+      expect(state.previewTime.start.getHours()).toBe(23);
+      expect(state.previewTime.end.getDate()).toBe(16);
+      expect(state.previewTime.end.getHours()).toBe(0);
+      expect(state.previewTime.end.getMinutes()).toBe(0);
+    }
+  });
+
+  it('grid selection at 23:45 ends at next-day 00:00', () => {
+    const { state } = dispatch(IDLE, {
+      type: 'GRID_POINTER_DOWN',
+      point: origin,
+      dateIndex: 0,
+      gridY: 1425,
+    });
+
+    if (state.mode === 'selecting') {
+      expect(state.selectionRange.start.getHours()).toBe(23);
+      expect(state.selectionRange.start.getMinutes()).toBe(45);
+      expect(state.selectionRange.end.getDate()).toBe(16);
+      expect(state.selectionRange.end.getHours()).toBe(0);
+      expect(state.selectionRange.end.getMinutes()).toBe(0);
     }
   });
 });

--- a/apps/product/src/features/calendar/domain/interaction/__tests__/machine.test.ts
+++ b/apps/product/src/features/calendar/domain/interaction/__tests__/machine.test.ts
@@ -190,6 +190,28 @@ describe('LONGPRESS_FIRED', () => {
     });
   });
 
+  it('computes overlap for the snapped long-press preview before any pointer move', () => {
+    const { state } = dispatch(
+      {
+        mode: 'longpress-pending',
+        entryId: 'a',
+        startPoint: origin,
+        originalPosition: { top: 607, left: 0, width: 200, height: 60 },
+        dateIndex: 0,
+      },
+      { type: 'LONGPRESS_FIRED' },
+      createCtx({
+        checkOverlap: (_entryId, start, end) =>
+          start.getHours() === 10 && start.getMinutes() === 0 && end.getHours() === 11,
+      }),
+    );
+
+    if (state.mode === 'dragging') {
+      expect(state.previewTime.start.getMinutes()).toBe(0);
+      expect(state.isOverlapping).toBe(true);
+    }
+  });
+
   it('ignores when not in longpress-pending mode', () => {
     const { state } = dispatch(IDLE, { type: 'LONGPRESS_FIRED' });
     expect(state.mode).toBe('idle');

--- a/apps/product/src/features/calendar/domain/interaction/machine.ts
+++ b/apps/product/src/features/calendar/domain/interaction/machine.ts
@@ -197,6 +197,7 @@ export function interactionReducer(
       );
       const targetDate = resolveTargetDate(ctx, state.dateIndex);
       const previewTime = buildDragTimeRange(targetDate, startSnap, endSnap, interval);
+      const isOverlapping = ctx.checkOverlap(state.entryId, previewTime.start, previewTime.end);
 
       effects.push({ type: 'HAPTIC', pattern: 'impact' });
       effects.push({
@@ -216,7 +217,7 @@ export function interactionReducer(
           targetDateIndex: state.dateIndex,
           snappedTop: startSnap.snappedTop,
           previewTime,
-          isOverlapping: false,
+          isOverlapping,
         },
         effects,
       };

--- a/apps/product/src/features/calendar/domain/interaction/machine.ts
+++ b/apps/product/src/features/calendar/domain/interaction/machine.ts
@@ -78,6 +78,21 @@ function snapEndToGrid(yPx: number, hourHeight: number, intervalMin: number): Gr
   };
 }
 
+function ensureEndAfterStartSnap(
+  startSnap: GridSnap,
+  endSnap: GridSnap,
+  hourHeight: number,
+  intervalMin: number,
+): GridSnap {
+  if (endSnap.snappedTop > startSnap.snappedTop) return endSnap;
+
+  const minEndTop = Math.min(
+    24 * hourHeight,
+    startSnap.snappedTop + (hourHeight / 60) * intervalMin,
+  );
+  return snapEndToGrid(minEndTop, hourHeight, intervalMin);
+}
+
 /** Dragging snaps both boundaries so drop time and visual length stay on the active grid. */
 function buildDragTimeRange(
   targetDate: Date,
@@ -117,13 +132,7 @@ function buildSelectionRange(
   // 下方向のみ: endY が startY より上なら startY に固定
   const clampedEndY = Math.max(endY, startY);
   let endSnap = snapEndToGrid(clampedEndY, hourHeight, intervalMin);
-  const minEndTop = Math.min(
-    24 * hourHeight,
-    startSnap.snappedTop + (hourHeight / 60) * intervalMin,
-  );
-  if (endSnap.snappedTop <= startSnap.snappedTop) {
-    endSnap = snapEndToGrid(minEndTop, hourHeight, intervalMin);
-  }
+  endSnap = ensureEndAfterStartSnap(startSnap, endSnap, hourHeight, intervalMin);
 
   const start = new Date(targetDate);
   start.setHours(startSnap.hour, startSnap.minute, 0, 0);
@@ -230,7 +239,12 @@ export function interactionReducer(
 
       const startSnap = snapToGrid(action.originalPosition.top, ctx.hourHeight, interval);
       const endTop = action.originalPosition.top + action.originalPosition.height;
-      const endSnap = snapEndToGrid(endTop, ctx.hourHeight, interval);
+      const endSnap = ensureEndAfterStartSnap(
+        startSnap,
+        snapEndToGrid(endTop, ctx.hourHeight, interval),
+        ctx.hourHeight,
+        interval,
+      );
 
       const start = new Date(ctx.date);
       start.setHours(startSnap.hour, startSnap.minute, 0, 0);

--- a/apps/product/src/features/calendar/domain/interaction/machine.ts
+++ b/apps/product/src/features/calendar/domain/interaction/machine.ts
@@ -6,7 +6,7 @@
  */
 
 import { DEFAULT_DRAG_SNAP_MINUTES } from '../precision';
-import { pixelsToTimeUnsnapped, snapDeltaToGrid, snapToGrid } from './time-math';
+import { snapToGrid } from './time-math';
 import type {
   InteractionAction,
   InteractionContext,
@@ -57,16 +57,43 @@ function maxAbsDelta(a: Point, b: Point): number {
   return Math.max(Math.abs(a.clientX - b.clientX), Math.abs(a.clientY - b.clientY));
 }
 
-/** Build a TimeRange from hour/minute + duration */
-function buildTimeRange(
+type GridSnap = ReturnType<typeof snapToGrid>;
+
+function snapEndToGrid(yPx: number, hourHeight: number, intervalMin: number): GridSnap {
+  const pxPerInterval = (hourHeight / 60) * intervalMin;
+  if (pxPerInterval <= 0) return snapToGrid(yPx, hourHeight, intervalMin);
+
+  const dayHeight = 24 * hourHeight;
+  const clampedY = Math.max(0, Math.min(yPx, dayHeight));
+  const snappedTop = Math.max(
+    0,
+    Math.min(dayHeight, Math.round(clampedY / pxPerInterval) * pxPerInterval),
+  );
+  const totalMinutes = Math.min(24 * 60, Math.round((snappedTop / hourHeight) * 60));
+
+  return {
+    snappedTop,
+    hour: Math.floor(totalMinutes / 60),
+    minute: totalMinutes % 60,
+  };
+}
+
+/** Dragging snaps both boundaries so drop time and visual length stay on the active grid. */
+function buildDragTimeRange(
   targetDate: Date,
-  hour: number,
-  minute: number,
-  durationMs: number,
+  startSnap: GridSnap,
+  endSnap: GridSnap,
+  intervalMin: number,
 ): TimeRange {
   const start = new Date(targetDate);
-  start.setHours(hour, minute, 0, 0);
-  const end = new Date(start.getTime() + durationMs);
+  start.setHours(startSnap.hour, startSnap.minute, 0, 0);
+  const end = new Date(targetDate);
+  end.setHours(endSnap.hour, endSnap.minute, 0, 0);
+
+  if (end.getTime() <= start.getTime()) {
+    end.setTime(start.getTime() + intervalMin * 60_000);
+  }
+
   return { start, end };
 }
 
@@ -89,23 +116,19 @@ function buildSelectionRange(
   const startSnap = snapToGrid(startY, hourHeight, intervalMin);
   // 下方向のみ: endY が startY より上なら startY に固定
   const clampedEndY = Math.max(endY, startY);
-  const endSnap = snapToGrid(clampedEndY, hourHeight, intervalMin);
-
-  // Ensure minimum one-interval selection
-  let endHour = endSnap.hour;
-  let endMinute = endSnap.minute;
-  if (startSnap.hour === endHour && startSnap.minute === endMinute) {
-    endMinute += intervalMin;
-    if (endMinute >= 60) {
-      endMinute = 0;
-      endHour = Math.min(23, endHour + 1);
-    }
+  let endSnap = snapEndToGrid(clampedEndY, hourHeight, intervalMin);
+  const minEndTop = Math.min(
+    24 * hourHeight,
+    startSnap.snappedTop + (hourHeight / 60) * intervalMin,
+  );
+  if (endSnap.snappedTop <= startSnap.snappedTop) {
+    endSnap = snapEndToGrid(minEndTop, hourHeight, intervalMin);
   }
 
   const start = new Date(targetDate);
   start.setHours(startSnap.hour, startSnap.minute, 0, 0);
   const end = new Date(targetDate);
-  end.setHours(endHour, endMinute, 0, 0);
+  end.setHours(endSnap.hour, endSnap.minute, 0, 0);
 
   return { start, end };
 }
@@ -164,12 +187,16 @@ export function interactionReducer(
     case 'LONGPRESS_FIRED': {
       if (state.mode !== 'longpress-pending') return { state, effects };
 
-      // 移動前なので元の位置をそのまま使う（snap で 10:07 → 10:00 に潰さない）
-      const { hour, minute } = pixelsToTimeUnsnapped(state.originalPosition.top, ctx.hourHeight);
-      const snappedTop = state.originalPosition.top;
-      const targetDate = resolveTargetDate(ctx, state.dateIndex);
       const durationMs = ctx.getEntryDurationMs(state.entryId);
-      const previewTime = buildTimeRange(targetDate, hour, minute, durationMs);
+      const durationPx = (durationMs / 60_000) * (ctx.hourHeight / 60);
+      const startSnap = snapToGrid(state.originalPosition.top, ctx.hourHeight, interval);
+      const endSnap = snapEndToGrid(
+        state.originalPosition.top + durationPx,
+        ctx.hourHeight,
+        interval,
+      );
+      const targetDate = resolveTargetDate(ctx, state.dateIndex);
+      const previewTime = buildDragTimeRange(targetDate, startSnap, endSnap, interval);
 
       effects.push({ type: 'HAPTIC', pattern: 'impact' });
       effects.push({
@@ -187,7 +214,7 @@ export function interactionReducer(
           originalPosition: state.originalPosition,
           dateIndex: state.dateIndex,
           targetDateIndex: state.dateIndex,
-          snappedTop,
+          snappedTop: startSnap.snappedTop,
           previewTime,
           isOverlapping: false,
         },
@@ -200,18 +227,18 @@ export function interactionReducer(
     case 'RESIZE_START': {
       if (state.mode !== 'idle') return { state, effects };
 
-      // resize 開始時はまだ移動していないので、元の位置をそのまま preview にする
-      const { hour: sH, minute: sM } = pixelsToTimeUnsnapped(
-        action.originalPosition.top,
-        ctx.hourHeight,
-      );
+      const startSnap = snapToGrid(action.originalPosition.top, ctx.hourHeight, interval);
       const endTop = action.originalPosition.top + action.originalPosition.height;
-      const { hour: eH, minute: eM } = pixelsToTimeUnsnapped(endTop, ctx.hourHeight);
+      const endSnap = snapEndToGrid(endTop, ctx.hourHeight, interval);
 
       const start = new Date(ctx.date);
-      start.setHours(sH, sM, 0, 0);
+      start.setHours(startSnap.hour, startSnap.minute, 0, 0);
       const end = new Date(ctx.date);
-      end.setHours(eH, eM, 0, 0);
+      end.setHours(endSnap.hour, endSnap.minute, 0, 0);
+      const snappedHeight = Math.max(
+        (ctx.hourHeight / 60) * interval,
+        endSnap.snappedTop - startSnap.snappedTop,
+      );
 
       return {
         state: {
@@ -221,7 +248,7 @@ export function interactionReducer(
           currentPoint: action.point,
           originalPosition: action.originalPosition,
           direction: action.direction,
-          snappedHeight: action.originalPosition.height,
+          snappedHeight,
           previewTime: { start, end },
           isOverlapping: false,
         },
@@ -346,20 +373,19 @@ function handlePointerMove(
         return { state, effects };
       }
       // Threshold crossed → transition to dragging
-      // relative offset snap: deltaY だけを snap し、original の :07 などを保持する
       const deltaY = action.point.clientY - state.startPoint.clientY;
-      const snappedDeltaY = snapDeltaToGrid(deltaY, ctx.hourHeight, interval);
       const durationMs = ctx.getEntryDurationMs(state.entryId);
       const durationPx = (durationMs / 60_000) * (ctx.hourHeight / 60);
-      const snappedTop = clampSnappedTopToDay(
-        state.originalPosition.top + snappedDeltaY,
+      const rawTop = clampSnappedTopToDay(
+        state.originalPosition.top + deltaY,
         ctx.hourHeight,
         durationPx,
       );
-      const { hour, minute } = pixelsToTimeUnsnapped(snappedTop, ctx.hourHeight);
+      const startSnap = snapToGrid(rawTop, ctx.hourHeight, interval);
+      const endSnap = snapEndToGrid(rawTop + durationPx, ctx.hourHeight, interval);
       const targetDateIndex = action.targetDateIndex ?? state.dateIndex;
       const targetDate = resolveTargetDate(ctx, targetDateIndex);
-      const previewTime = buildTimeRange(targetDate, hour, minute, durationMs);
+      const previewTime = buildDragTimeRange(targetDate, startSnap, endSnap, interval);
       const isOverlapping = ctx.checkOverlap(state.entryId, previewTime.start, previewTime.end);
 
       effects.push({
@@ -377,7 +403,7 @@ function handlePointerMove(
           originalPosition: state.originalPosition,
           dateIndex: state.dateIndex,
           targetDateIndex,
-          snappedTop,
+          snappedTop: startSnap.snappedTop,
           previewTime,
           isOverlapping,
         },
@@ -394,23 +420,22 @@ function handlePointerMove(
     }
 
     case 'dragging': {
-      // relative offset snap: deltaY だけを snap し、original の :07 などを保持する
       const deltaY = action.point.clientY - state.startPoint.clientY;
-      const snappedDeltaY = snapDeltaToGrid(deltaY, ctx.hourHeight, interval);
       const durationMs = ctx.getEntryDurationMs(state.entryId);
       const durationPx = (durationMs / 60_000) * (ctx.hourHeight / 60);
-      const snappedTop = clampSnappedTopToDay(
-        state.originalPosition.top + snappedDeltaY,
+      const rawTop = clampSnappedTopToDay(
+        state.originalPosition.top + deltaY,
         ctx.hourHeight,
         durationPx,
       );
-      const { hour, minute } = pixelsToTimeUnsnapped(snappedTop, ctx.hourHeight);
+      const startSnap = snapToGrid(rawTop, ctx.hourHeight, interval);
+      const endSnap = snapEndToGrid(rawTop + durationPx, ctx.hourHeight, interval);
       const targetDateIndex = action.targetDateIndex ?? state.targetDateIndex;
       const targetDate = resolveTargetDate(ctx, targetDateIndex);
-      const previewTime = buildTimeRange(targetDate, hour, minute, durationMs);
+      const previewTime = buildDragTimeRange(targetDate, startSnap, endSnap, interval);
       const isOverlapping = ctx.checkOverlap(state.entryId, previewTime.start, previewTime.end);
 
-      if (snappedTop !== state.snappedTop) {
+      if (startSnap.snappedTop !== state.snappedTop) {
         effects.push({ type: 'HAPTIC', pattern: 'tap' });
       }
       effects.push({ type: 'DRAG_STORE_UPDATE', targetDateIndex });
@@ -420,7 +445,7 @@ function handlePointerMove(
           ...state,
           currentPoint: action.point,
           targetDateIndex,
-          snappedTop,
+          snappedTop: startSnap.snappedTop,
           previewTime,
           isOverlapping,
         },
@@ -429,33 +454,32 @@ function handlePointerMove(
     }
 
     case 'resizing': {
-      // relative offset snap: 開始位置は元の値を保持、resize の delta だけを snap する
       const deltaY = action.point.clientY - state.startPoint.clientY;
-      const snappedDeltaY = snapDeltaToGrid(deltaY, ctx.hourHeight, interval);
       const minHeight = (ctx.hourHeight / 60) * interval;
-      // upper cap: end が当日内に収まる範囲（pixelsToTimeUnsnapped が 23:59 で clamp する分と整合）
-      const maxHeight = Math.max(minHeight, 24 * ctx.hourHeight - state.originalPosition.top);
+      // upper cap: end が当日内に収まる範囲
+      const startSnap = snapToGrid(state.originalPosition.top, ctx.hourHeight, interval);
+      const maxHeight = Math.max(minHeight, 24 * ctx.hourHeight - startSnap.snappedTop);
+      const rawEndTop = Math.min(
+        24 * ctx.hourHeight,
+        Math.max(
+          startSnap.snappedTop + minHeight,
+          state.originalPosition.top + state.originalPosition.height + deltaY,
+        ),
+      );
+      const endSnap = snapEndToGrid(rawEndTop, ctx.hourHeight, interval);
       const newHeight = Math.min(
         maxHeight,
-        Math.max(minHeight, state.originalPosition.height + snappedDeltaY),
+        Math.max(minHeight, endSnap.snappedTop - startSnap.snappedTop),
       );
 
       if (newHeight !== state.snappedHeight) {
         effects.push({ type: 'HAPTIC', pattern: 'tap' });
       }
 
-      // start は元の位置をそのまま使い、:07 などを保持
-      const { hour: sH, minute: sM } = pixelsToTimeUnsnapped(
-        state.originalPosition.top,
-        ctx.hourHeight,
-      );
-      const endTop = state.originalPosition.top + newHeight;
-      const { hour: eH, minute: eM } = pixelsToTimeUnsnapped(endTop, ctx.hourHeight);
-
       const start = new Date(ctx.date);
-      start.setHours(sH, sM, 0, 0);
+      start.setHours(startSnap.hour, startSnap.minute, 0, 0);
       const end = new Date(ctx.date);
-      end.setHours(eH, eM, 0, 0);
+      end.setHours(endSnap.hour, endSnap.minute, 0, 0);
 
       const previewTime: TimeRange = { start, end };
       const isOverlapping = ctx.checkOverlap(state.entryId, start, end);

--- a/apps/product/src/features/calendar/domain/interaction/machine.ts
+++ b/apps/product/src/features/calendar/domain/interaction/machine.ts
@@ -240,6 +240,7 @@ export function interactionReducer(
         (ctx.hourHeight / 60) * interval,
         endSnap.snappedTop - startSnap.snappedTop,
       );
+      const isOverlapping = ctx.checkOverlap(action.entryId, start, end);
 
       return {
         state: {
@@ -251,7 +252,7 @@ export function interactionReducer(
           direction: action.direction,
           snappedHeight,
           previewTime: { start, end },
-          isOverlapping: false,
+          isOverlapping,
         },
         effects,
       };

--- a/apps/product/src/features/calendar/interaction/__tests__/useInteraction.test.ts
+++ b/apps/product/src/features/calendar/interaction/__tests__/useInteraction.test.ts
@@ -101,3 +101,45 @@ describe('useInteraction handleResizeStart guard', () => {
     expect(result.current.state.mode).toBe('resizing');
   });
 });
+
+describe('useInteraction selection completion', () => {
+  it('passes day-end selection as 24:00 instead of next-day 0:00', () => {
+    let selection: {
+      date: Date;
+      startHour: number;
+      startMinute: number;
+      endHour: number;
+      endMinute: number;
+    } | null = null;
+    const { result } = renderHook(() =>
+      useInteraction(
+        makeProps({
+          onTimeRangeSelect: (next) => {
+            selection = next;
+          },
+        }),
+      ),
+    );
+
+    act(() => {
+      result.current.dispatch({
+        type: 'GRID_POINTER_DOWN',
+        point: { clientX: 100, clientY: 1425 },
+        dateIndex: 0,
+        gridY: 1425,
+      });
+      result.current.dispatch({
+        type: 'POINTER_MOVE',
+        point: { clientX: 100, clientY: 1445 },
+      });
+      result.current.dispatch({ type: 'POINTER_UP' });
+    });
+
+    expect(selection).toMatchObject({
+      startHour: 23,
+      startMinute: 45,
+      endHour: 24,
+      endMinute: 0,
+    });
+  });
+});

--- a/apps/product/src/features/calendar/interaction/useInteraction.ts
+++ b/apps/product/src/features/calendar/interaction/useInteraction.ts
@@ -102,6 +102,12 @@ export interface InteractionHandlers {
   ) => void;
 }
 
+function getMinutesFromDayStart(date: Date, time: Date): number {
+  const dayStart = new Date(date);
+  dayStart.setHours(0, 0, 0, 0);
+  return Math.max(0, Math.min(24 * 60, Math.round((time.getTime() - dayStart.getTime()) / 60_000)));
+}
+
 // ========================================
 // Hook
 // ========================================
@@ -243,12 +249,13 @@ export function useInteraction(props: UseInteractionProps): UseInteractionReturn
 
         case 'SELECT_COMPLETE': {
           const selDate = r.displayDates?.[effect.dateIndex] ?? r.date;
+          const endMinutes = getMinutesFromDayStart(selDate, effect.range.end);
           r.onTimeRangeSelect?.({
             date: selDate,
             startHour: effect.range.start.getHours(),
             startMinute: effect.range.start.getMinutes(),
-            endHour: effect.range.end.getHours(),
-            endMinute: effect.range.end.getMinutes(),
+            endHour: Math.floor(endMinutes / 60),
+            endMinute: endMinutes % 60,
           });
           break;
         }

--- a/apps/product/src/features/calendar/interaction/useInteraction.ts
+++ b/apps/product/src/features/calendar/interaction/useInteraction.ts
@@ -103,9 +103,13 @@ export interface InteractionHandlers {
 }
 
 function getMinutesFromDayStart(date: Date, time: Date): number {
-  const dayStart = new Date(date);
-  dayStart.setHours(0, 0, 0, 0);
-  return Math.max(0, Math.min(24 * 60, Math.round((time.getTime() - dayStart.getTime()) / 60_000)));
+  const dayOffset =
+    (Date.UTC(time.getFullYear(), time.getMonth(), time.getDate()) -
+      Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())) /
+    (24 * 60 * 60 * 1000);
+  const wallClockMinutes =
+    Math.round(dayOffset) * 24 * 60 + time.getHours() * 60 + time.getMinutes();
+  return Math.max(0, Math.min(24 * 60, wallClockMinutes));
 }
 
 // ========================================

--- a/apps/product/src/features/calendar/lib/__tests__/overlap.test.ts
+++ b/apps/product/src/features/calendar/lib/__tests__/overlap.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
+import { hasTwoLayerTimeConflict } from '@/lib/time/two-layer-overlap';
+
 import type { CalendarEvent } from '../../types/calendar.types';
 
-import { checkClientSideOverlap } from '../overlap';
+import { buildNewEntryOverlapTarget, checkClientSideOverlap } from '../overlap';
 
 function createEvent(
   overrides: Partial<CalendarEvent> & { id: string; startDate: Date; endDate: Date },
@@ -22,6 +24,38 @@ function createEvent(
     ...overrides,
   } as CalendarEvent;
 }
+
+describe('buildNewEntryOverlapTarget', () => {
+  it('未来の新規予定はplanned/actualに同じ範囲を入れる', () => {
+    const start = new Date('2030-01-15T10:00');
+    const end = new Date('2030-01-15T11:00');
+    const target = buildNewEntryOverlapTarget(start, end, new Date('2026-01-15T09:00').getTime());
+
+    expect(target).toMatchObject({
+      id: '',
+      plannedStart: start,
+      plannedEnd: end,
+      actualStart: start,
+      actualEnd: end,
+    });
+    expect(hasTwoLayerTimeConflict([], target)).toBe(false);
+  });
+
+  it('過去の新規記録はplannedなし、actualありにする', () => {
+    const start = new Date('2026-01-15T10:00');
+    const end = new Date('2026-01-15T11:00');
+    const target = buildNewEntryOverlapTarget(start, end, new Date('2026-01-15T12:00').getTime());
+
+    expect(target).toMatchObject({
+      id: '',
+      plannedStart: null,
+      plannedEnd: null,
+      actualStart: start,
+      actualEnd: end,
+    });
+    expect(hasTwoLayerTimeConflict([], target)).toBe(false);
+  });
+});
 
 describe('checkClientSideOverlap', () => {
   it('Plan↔Plan の重複はtrue', () => {
@@ -183,6 +217,36 @@ describe('checkClientSideOverlap', () => {
         new Date('2030-01-15T10:45'),
       ),
     ).toBe(true);
+  });
+
+  it('未来の新規作成は空き枠ならfalse', () => {
+    expect(
+      checkClientSideOverlap([], '', new Date('2030-01-15T10:00'), new Date('2030-01-15T11:00')),
+    ).toBe(false);
+  });
+
+  it('未来の新規作成は既存予定の終端に接していてもfalse', () => {
+    const events = [
+      createEvent({
+        id: 'a',
+        startDate: new Date('2030-01-15T09:00'),
+        endDate: new Date('2030-01-15T10:00'),
+        plannedStartDate: new Date('2030-01-15T09:00'),
+        plannedEndDate: new Date('2030-01-15T10:00'),
+        actualStartDate: new Date('2030-01-15T09:00'),
+        actualEndDate: new Date('2030-01-15T10:00'),
+        origin: 'planned',
+      }),
+    ];
+
+    expect(
+      checkClientSideOverlap(
+        events,
+        '',
+        new Date('2030-01-15T10:00'),
+        new Date('2030-01-15T11:00'),
+      ),
+    ).toBe(false);
   });
 
   it('過去の新規作成はplanned gap内ならactual重複がなければ許可する', () => {

--- a/apps/product/src/features/calendar/lib/overlap.ts
+++ b/apps/product/src/features/calendar/lib/overlap.ts
@@ -5,8 +5,24 @@
  * 全エントリ間で重複を禁止する。
  */
 
-import { hasTwoLayerTimeConflict } from '@/lib/time/two-layer-overlap';
+import { hasTwoLayerTimeConflict, type TwoLayerOverlapTarget } from '@/lib/time/two-layer-overlap';
 import type { CalendarEvent } from '../types/calendar.types';
+
+export function buildNewEntryOverlapTarget(
+  startTime: Date,
+  endTime: Date,
+  now: number = Date.now(),
+): TwoLayerOverlapTarget {
+  const willBeUnplanned = endTime.getTime() <= now;
+
+  return {
+    id: '',
+    plannedStart: willBeUnplanned ? null : startTime,
+    plannedEnd: willBeUnplanned ? null : endTime,
+    actualStart: startTime,
+    actualEnd: endTime,
+  };
+}
 
 /**
  * クライアント側で時間重複をチェックする
@@ -25,12 +41,23 @@ export function checkClientSideOverlap(
 ): boolean {
   const now = Date.now();
   const draggedEvent = events.find((event) => event.id === draggedEventId);
-  const isNewFutureEntry = draggedEventId === '' && previewEndTime.getTime() > now;
   // planned entry は upcoming だけでなく active 状態でも planned 範囲を持つので
   // 移動先の planned 範囲 overlap を check する。
   // (サーバー側 ensureNoOverlaps も `origin === 'planned'` で planned 重複を検証する。
   //  client 側で skip すると server 拒否で snap-back / TIME_OVERLAP toast が出るため UX が悪化する)
-  const shouldCheckPlanned = isNewFutureEntry || draggedEvent?.origin === 'planned';
+  const shouldCheckPlanned = draggedEvent?.origin === 'planned';
+  const target =
+    draggedEventId === ''
+      ? buildNewEntryOverlapTarget(previewStartTime, previewEndTime, now)
+      : {
+          id: draggedEventId,
+          plannedStart: shouldCheckPlanned ? previewStartTime : null,
+          plannedEnd: shouldCheckPlanned ? previewEndTime : null,
+          actualStart: previewStartTime,
+          actualEnd: previewEndTime,
+          forbidFutureActual: draggedEvent?.origin === 'unplanned',
+          now,
+        };
 
   return hasTwoLayerTimeConflict(
     events.map((event) => {
@@ -49,14 +76,6 @@ export function checkClientSideOverlap(
         actualEnd,
       };
     }),
-    {
-      id: draggedEventId,
-      plannedStart: shouldCheckPlanned ? previewStartTime : null,
-      plannedEnd: shouldCheckPlanned ? previewEndTime : null,
-      actualStart: previewStartTime,
-      actualEnd: previewEndTime,
-      forbidFutureActual: draggedEvent?.origin === 'unplanned',
-      now,
-    },
+    target,
   );
 }

--- a/apps/product/src/features/entry/components/card/EntryCard.tsx
+++ b/apps/product/src/features/entry/components/card/EntryCard.tsx
@@ -583,6 +583,7 @@ export const EntryCard = memo<EntryCardProps>(function EntryCard({
            card 本体の overflow-hidden 外に置くことで pill icon が短い card でも visible。 */}
       {!isDraft && (!isMobile || isActive) && (
         <div
+          data-entry-resize-frame
           className="pointer-events-none absolute right-0 left-0"
           style={{
             top: `${isUnplanned ? 0 : plannedLayerTop}px`,


### PR DESCRIPTION
## Summary
- Fix false overlap blocking when creating entries in empty calendar slots.
- Stabilize calendar drag and resize snapping so entries land on the active grid.
- Fix cross-day drag ghost rendering so one-hour entries do not visually stretch to a full day.
- Preserve day-end behavior such as 23:00-24:00 and 23:45-24:00 instead of collapsing to 23:00.

## Root Cause
- New planned-entry overlap checks did not mirror server create normalization for future entries.
- Dragging snapped the start boundary but carried unsnapped duration/end behavior, allowing off-grid or distorted previews.
- The cross-day drag ghost passed a large sentinel height into `EntryCard`, which leaked into internal planned-layer rendering.
- End-boundary snapping reused start-boundary logic that clamps 24:00 back to 23:00.

## Validation
- `pnpm test:run src/features/calendar/interaction/__tests__/useInteraction.test.ts src/features/calendar/domain/interaction/__tests__/machine.test.ts src/features/calendar/domain/interaction/__tests__/time-math.test.ts src/features/calendar/components/views/shared/components/__tests__/CalendarGridContent.test.tsx src/features/calendar/components/views/shared/components/__tests__/EntryRenderer.test.tsx src/features/entry/components/card/EntryCard.test.tsx`
- `pnpm eslint src/features/calendar/interaction/useInteraction.ts src/features/calendar/interaction/__tests__/useInteraction.test.ts src/features/calendar/components/views/shared/components/CalendarGridContent.tsx src/features/calendar/components/views/shared/components/__tests__/CalendarGridContent.test.tsx src/features/calendar/domain/interaction/machine.ts src/features/calendar/domain/interaction/__tests__/machine.test.ts src/features/calendar/components/views/shared/components/EntryRenderer.tsx src/features/calendar/components/views/shared/components/__tests__/EntryRenderer.test.tsx src/features/entry/components/card/EntryCard.tsx`
- `pnpm typecheck`

## Notes
- Left the unrelated local doc modification out of this PR: `apps/storybook/docs/product/decisions/002-record-feature-design.mdx`.