### PR TITLE
feat(calendar): ドラッグ新規作成プレビューの見た目統一 & 未来予定の「予定外にする」非表示

### DIFF
--- a/apps/product/src/features/calendar/components/views/shared/components/CalendarDragSelection/DragSelectionPreview.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/CalendarDragSelection/DragSelectionPreview.tsx
@@ -11,6 +11,8 @@ import { memo } from 'react';
 
 import { useTranslations } from 'next-intl';
 
+import { entryTintColor } from '@/features/entry';
+
 import { HOUR_HEIGHT } from '../../constants/grid.constants';
 
 import type { TimeRange } from './types';
@@ -60,7 +62,7 @@ export const DragSelectionPreview = memo(function DragSelectionPreview({
     const isCompact = height < 40;
     return (
       <div
-        className="bg-destructive-tint text-destructive pointer-events-none absolute right-2 left-0 overflow-hidden rounded-lg"
+        className="bg-destructive-tint text-destructive pointer-events-none absolute right-0 left-0 overflow-hidden rounded-lg"
         style={{ top, height, zIndex: 1000 }}
       >
         {isCompact ? (
@@ -86,7 +88,7 @@ export const DragSelectionPreview = memo(function DragSelectionPreview({
   if (isPast) {
     return (
       <div
-        className="border-entry-default pointer-events-none absolute right-2 left-0 overflow-hidden rounded-lg border-2 border-dashed"
+        className="border-entry-default pointer-events-none absolute right-0 left-0 overflow-hidden rounded-lg border-2 border-dashed"
         style={{ top, height, zIndex: 1000 }}
       >
         {isCompact ? (
@@ -109,17 +111,20 @@ export const DragSelectionPreview = memo(function DragSelectionPreview({
 
   return (
     <div
-      className="pointer-events-none absolute right-2 left-0 flex rounded-r-lg"
+      className="pointer-events-none absolute right-0 left-0 flex rounded-r-lg"
       style={{
         top,
         height,
         zIndex: 1000,
       }}
     >
-      {/* 左アクセントストリップ */}
-      <div className="bg-entry-default shrink-0" style={{ width: '3px' }} />
-      {/* カード本体 */}
-      <div className="bg-muted min-w-0 flex-1 overflow-hidden rounded-r-lg">
+      {/* 左アクセントストリップ — タグ未選択なので entry-default。確定後カードと同じ opacity-70 */}
+      <div className="bg-entry-default shrink-0 opacity-70" style={{ width: '3px' }} />
+      {/* カード本体 — EntryCard と同じ 18% color-mix tint（neutral base） */}
+      <div
+        className="min-w-0 flex-1 overflow-hidden rounded-r-lg"
+        style={{ backgroundColor: entryTintColor('var(--entry-default)') }}
+      >
         {isCompact ? (
           <div className="flex h-full items-center px-2">
             <span className="text-muted-foreground truncate text-xs tabular-nums">{timeLabel}</span>

--- a/apps/product/src/features/calendar/components/views/shared/components/DraftEntryBlock.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/DraftEntryBlock.tsx
@@ -6,6 +6,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useTranslations } from 'next-intl';
 
 import { buildNewEntryOverlapTarget } from '@/features/calendar/lib/overlap';
+import { entryTintColor } from '@/features/entry';
 import { getTagColorClasses } from '@/features/tags';
 import { ColonTagLabel } from '@/lib/components/ui/colon-tag-label';
 import { formatTimeString } from '@/lib/date';
@@ -58,7 +59,8 @@ export function DraftEntryBlock({ draft, hourHeight }: DraftEntryBlockProps) {
   const height = Math.max(20, (endMinutes - startMinutes) * (hourHeight / 60));
 
   const accentColor = getTagColorClasses(draft.tag.color).cssVar;
-  const tintColor = getTagColorClasses(draft.tag.color).cssVarTint;
+  // EntryCard と同じ 18% color-mix tint を使い、確定後カードと背景色を揃える
+  const tintColor = entryTintColor(accentColor);
 
   const timeLabel = `${formatTimeString(startH, startM, timeFormat)} – ${formatTimeString(endH, endM, timeFormat)}`;
 
@@ -160,7 +162,7 @@ export function DraftEntryBlock({ draft, hourHeight }: DraftEntryBlockProps) {
   return (
     <div
       data-tag-draft-block
-      className="pointer-events-none absolute right-2 left-0"
+      className="pointer-events-none absolute right-0 left-0"
       style={{ zIndex: Z_INDEX.POPOVER }}
     >
       <div
@@ -179,7 +181,7 @@ export function DraftEntryBlock({ draft, hourHeight }: DraftEntryBlockProps) {
         {/* 左 accent strip — past unplanned 風の時は描画しない */}
         {!(isPast && !hasConflict) && (
           <div
-            className={cn('shrink-0', hasConflict && 'bg-destructive')}
+            className={cn('shrink-0', hasConflict ? 'bg-destructive' : 'opacity-70')}
             style={{ width: '3px', ...(hasConflict ? {} : { backgroundColor: accentColor }) }}
           />
         )}

--- a/apps/product/src/features/calendar/components/views/shared/components/EntryContextMenu.stories.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/EntryContextMenu.stories.tsx
@@ -53,10 +53,19 @@ const noTagEntry: CalendarEvent = {
   tagId: null,
 };
 
-/** 未完了 entry（actualEnd 未確定、計画外にする非表示） */
-const inProgressEntry: CalendarEvent = {
+/** 未来の planned entry（記録が存在し得ないため「予定外にする」非表示） */
+const futureStart = new Date('2099-01-01T10:00:00');
+const futureEnd = new Date('2099-01-01T11:00:00');
+const upcomingPlannedEntry: CalendarEvent = {
   ...completedPlannedEntry,
   id: 'entry-3',
+  startDate: futureStart,
+  endDate: futureEnd,
+  displayStartDate: futureStart,
+  displayEndDate: futureEnd,
+  plannedStartDate: futureStart,
+  plannedEndDate: futureEnd,
+  actualStartDate: null,
   actualEndDate: null,
 };
 
@@ -171,10 +180,10 @@ export const AllPatterns: Story = {
         </div>
       </div>
       <div className="flex flex-col gap-2">
-        <span className="text-muted-foreground text-xs">未完了（計画外にする非表示）</span>
+        <span className="text-muted-foreground text-xs">未来の予定（予定外にする非表示）</span>
         <div className="relative" style={{ height: 140 }}>
           <EventContextMenu
-            entry={inProgressEntry}
+            entry={upcomingPlannedEntry}
             position={{ x: 0, y: 0 }}
             onClose={fn()}
             {...allHandlers}

--- a/apps/product/src/features/calendar/components/views/shared/components/EntryContextMenu.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/EntryContextMenu.tsx
@@ -107,10 +107,17 @@ export const EventContextMenu = ({
     onClose();
   };
 
+  // 未来の予定は記録が存在し得ないため「予定外にする」を出さない。
+  // planned の予定開始が現在より後（または時刻未設定）なら upcoming 扱い。
+  const plannedStartMs = (entry.plannedStartDate ?? entry.startDate)?.getTime();
+  // eslint-disable-next-line react-hooks/purity -- transient context menu, 右クリック時点の now で十分
+  const isUpcoming = plannedStartMs === undefined || plannedStartMs > Date.now();
+
   // 共通の menu items 定義から取得（Inspector の TagRow と同じ source）
   const menuItems = getEntryMenuItems({
     origin: entry.origin,
     tagId: entry.tagId,
+    isUpcoming,
     onViewStats: onViewStats ? () => onViewStats(entry) : undefined,
     onMarkUnplanned: onMarkUnplanned ? () => onMarkUnplanned(entry) : undefined,
     onRestorePlanned: onRestorePlanned ? () => onRestorePlanned(entry) : undefined,

--- a/apps/product/src/features/calendar/components/views/shared/components/InlineTagPalette/InlineTagPalette.stories.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/InlineTagPalette/InlineTagPalette.stories.tsx
@@ -20,8 +20,15 @@ import { InlineTagPalette } from './InlineTagPalette';
 /** 1時間あたりのデフォルト高さ（px） */
 const DEFAULT_HOUR_HEIGHT = 60;
 
-/** 今日の日付（ストーリー固定値） */
-const TODAY = new Date('2026-03-18T00:00:00.000Z');
+/**
+ * 未来日付（ストーリー固定値）。
+ * 過去日付だと unplanned 風の破線プレビューになるため、通常の tinted
+ * ハイライト（確定後カードと同じ見た目）を見せる目的で未来に固定する。
+ */
+const FUTURE_DAY = new Date('2099-01-01T00:00:00.000Z');
+
+/** 過去日付（unplanned 風の破線プレビューを確認する用） */
+const PAST_DAY = new Date('2020-01-01T00:00:00.000Z');
 
 // ─────────────────────────────────────────────────────────
 // Meta
@@ -63,7 +70,7 @@ export const Default: Story = {
     (Story) => {
       useInlineCreateStore.setState({
         pendingSelection: {
-          date: TODAY,
+          date: FUTURE_DAY,
           startHour: 9,
           startMinute: 0,
           endHour: 10,
@@ -92,7 +99,7 @@ export const ShortSelection: Story = {
     (Story) => {
       useInlineCreateStore.setState({
         pendingSelection: {
-          date: TODAY,
+          date: FUTURE_DAY,
           startHour: 9,
           startMinute: 0,
           endHour: 9,
@@ -118,7 +125,7 @@ export const LongSelection: Story = {
     (Story) => {
       useInlineCreateStore.setState({
         pendingSelection: {
-          date: TODAY,
+          date: FUTURE_DAY,
           startHour: 9,
           startMinute: 0,
           endHour: 11,
@@ -147,10 +154,37 @@ export const EmptyTags: Story = {
     (Story) => {
       useInlineCreateStore.setState({
         pendingSelection: {
-          date: TODAY,
+          date: FUTURE_DAY,
           startHour: 14,
           startMinute: 0,
           endHour: 15,
+          endMinute: 0,
+        },
+      });
+      return (
+        <div className="relative h-[1440px] w-full">
+          <Story />
+        </div>
+      );
+    },
+  ],
+};
+
+/**
+ * 過去の時間帯（unplanned 風の破線プレビュー）
+ *
+ * 過去に確定すると保存時に自動で unplanned 扱いになるため、
+ * プレビューもタグ色なしの破線枠で表示される。
+ */
+export const PastSelection: Story = {
+  decorators: [
+    (Story) => {
+      useInlineCreateStore.setState({
+        pendingSelection: {
+          date: PAST_DAY,
+          startHour: 9,
+          startMinute: 0,
+          endHour: 10,
           endMinute: 0,
         },
       });

--- a/apps/product/src/features/calendar/components/views/shared/components/InlineTagPalette/InlineTagPalette.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/InlineTagPalette/InlineTagPalette.tsx
@@ -17,7 +17,7 @@ import { enUS, ja } from 'date-fns/locale';
 import { useLocale, useTranslations } from 'next-intl';
 
 import { buildNewEntryOverlapTarget } from '@/features/calendar/lib/overlap';
-import { useEntryMutations } from '@/features/entry';
+import { entryTintColor, useEntryMutations } from '@/features/entry';
 import type { HoveredTagInfo } from '@/features/tags';
 import {
   getTagColorClasses,
@@ -372,9 +372,8 @@ export function InlineTagPalette({ hourHeight, date }: InlineTagPaletteProps) {
   const accentColor = hoveredTag
     ? getTagColorClasses(hoveredTag.color).cssVar
     : 'var(--entry-default)';
-  const tintColor = hoveredTag
-    ? getTagColorClasses(hoveredTag.color).cssVarTint
-    : 'color-mix(in oklch, var(--entry-default) 12%, var(--background))';
+  // EntryCard と同じ 18% color-mix tint を使い、確定後カードと背景色を揃える
+  const tintColor = entryTintColor(accentColor);
   const displayName = hoveredTag?.name ?? tCalendar('event.selectTag');
 
   // 下端 handle: end time だけを 15 分単位で更新
@@ -471,13 +470,13 @@ export function InlineTagPalette({ hourHeight, date }: InlineTagPaletteProps) {
       {/* 選択範囲ハイライト（カレンダーグリッド上） */}
       <div
         data-tag-palette
-        className="pointer-events-none absolute right-2 left-0"
+        className="pointer-events-none absolute right-0 left-0"
         style={{ zIndex: Z_INDEX.POPOVER }}
       >
         <div
           ref={highlightRef}
           className={cn(
-            'animate-in fade-in-0 zoom-in-95 pointer-events-auto absolute right-0 left-0 flex transition-colors duration-150 motion-reduce:animate-none',
+            'animate-in fade-in-0 pointer-events-auto absolute right-0 left-0 flex transition-colors duration-150 motion-reduce:animate-none',
             isPast && !hasConflict ? 'rounded-lg' : 'rounded-r-lg',
           )}
           style={{
@@ -495,7 +494,7 @@ export function InlineTagPalette({ hourHeight, date }: InlineTagPaletteProps) {
             <div
               className={cn(
                 'shrink-0 transition-colors duration-150',
-                hasConflict && 'bg-destructive',
+                hasConflict ? 'bg-destructive' : 'opacity-70',
               )}
               style={{
                 width: '3px',
@@ -518,8 +517,12 @@ export function InlineTagPalette({ hourHeight, date }: InlineTagPaletteProps) {
               <div className="flex h-full items-center px-2">
                 <span
                   className={cn(
-                    'truncate text-xs font-normal',
-                    hasConflict ? 'text-destructive' : 'text-foreground',
+                    'truncate text-xs',
+                    hasConflict
+                      ? 'text-destructive font-normal'
+                      : hoveredTag
+                        ? 'text-foreground font-normal'
+                        : 'text-muted-foreground tabular-nums',
                   )}
                 >
                   {hasConflict ? (
@@ -536,7 +539,11 @@ export function InlineTagPalette({ hourHeight, date }: InlineTagPaletteProps) {
                 <span
                   className={cn(
                     'text-sm leading-tight font-normal',
-                    hasConflict ? 'text-destructive' : 'text-foreground',
+                    hasConflict
+                      ? 'text-destructive'
+                      : hoveredTag
+                        ? 'text-foreground'
+                        : 'text-muted-foreground',
                   )}
                 >
                   {hasConflict ? (

--- a/apps/product/src/features/entry/components/inspector/EntryInspectorForm.tsx
+++ b/apps/product/src/features/entry/components/inspector/EntryInspectorForm.tsx
@@ -16,6 +16,7 @@ import { useTranslations } from 'next-intl';
 import { getTagColorClasses, resolveTagColor, useCreateTag, useTagsMap } from '@/features/tags';
 import { useAutoAdjustEndTime } from '../../hooks/useAutoAdjustEndTime';
 import { getEntryMenuItems } from '../../lib/entry-menu-items';
+import { getEntryState } from '../../lib/entry-status';
 import type { FulfillmentScore } from '../../types/entry';
 
 import {
@@ -186,6 +187,7 @@ export function EntryInspectorForm({ onViewStats, onCloseInspector }: EntryInspe
   const menuItems = getEntryMenuItems({
     origin: entry.origin,
     tagId: selectedTagId,
+    isUpcoming: getEntryState(entry) === 'upcoming',
     onViewStats: onViewStats && selectedTagId ? handleViewStats : undefined,
     onMarkUnplanned: isPlanned ? handleMarkUnplanned : undefined,
     onRestorePlanned: isUnplanned ? handleRestorePlanned : undefined,

--- a/apps/product/src/features/entry/components/inspector/fields/TagRow.stories.tsx
+++ b/apps/product/src/features/entry/components/inspector/fields/TagRow.stories.tsx
@@ -78,6 +78,16 @@ const deleteOnlyMenu = getEntryMenuItems({
   onDelete: fn(),
 });
 
+/** 未来の予定: まだ記録が存在し得ないため「予定外にする」は出ない。 */
+const upcomingPlannedMenu = getEntryMenuItems({
+  origin: 'planned',
+  tagId: 'tag-1',
+  isUpcoming: true,
+  onViewStats: fn(),
+  onMarkUnplanned: fn(),
+  onDelete: fn(),
+});
+
 // ---------------------------------------------------------------------------
 // Stories
 // ---------------------------------------------------------------------------
@@ -146,6 +156,22 @@ export const Unplanned: Story = {
   ),
 };
 
+/** 未来の予定（planned）。「予定外にする」は非表示。 */
+export const UpcomingPlanned: Story = {
+  render: () => (
+    <div className="w-72">
+      <TagRow
+        tagId="tag-blue-id"
+        tagName="仕事"
+        tagColorClasses={blueTag}
+        onTagChange={fn()}
+        onCreateAndSelect={fn()}
+        menuItems={upcomingPlannedMenu}
+      />
+    </div>
+  ),
+};
+
 /** メニューなし（タグのみ）。 */
 export const NoMenu: Story = {
   render: () => (
@@ -185,6 +211,17 @@ export const AllPatterns: Story = {
           onTagChange={fn()}
           onCreateAndSelect={fn()}
           menuItems={unplannedMenu}
+        />
+      </div>
+      <div className="space-y-1">
+        <p className="text-muted-foreground text-xs">未来の予定（予定外にする非表示）</p>
+        <TagRow
+          tagId="tag-upcoming"
+          tagName="会議"
+          tagColorClasses={blueTag}
+          onTagChange={fn()}
+          onCreateAndSelect={fn()}
+          menuItems={upcomingPlannedMenu}
         />
       </div>
       <div className="space-y-1">

--- a/apps/product/src/features/entry/index.ts
+++ b/apps/product/src/features/entry/index.ts
@@ -25,6 +25,7 @@ export { useEntryInspectorStore } from './stores/useEntryInspectorStore';
 // Lib (actual-time overlay)
 // =============================================================================
 export { computeActualTimeDiffOverlay } from './lib/actual-time-overlay';
+export { entryTintColor } from './lib/entry-tint';
 
 // =============================================================================
 // Domain (Entry 時間モデル — 純粋関数、DB/tRPC/React 非依存)

--- a/apps/product/src/features/entry/lib/__tests__/entry-menu-items.test.ts
+++ b/apps/product/src/features/entry/lib/__tests__/entry-menu-items.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Entry Menu Items Unit Tests
+ *
+ * getEntryMenuItems の表示条件をテストする。
+ * 特に「予定外にする」(markUnplanned) が origin / isUpcoming でどう出し分けられるか。
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { getEntryMenuItems } from '../entry-menu-items';
+
+describe('getEntryMenuItems', () => {
+  const noop = vi.fn();
+
+  const baseArgs = {
+    tagId: 'tag-1',
+    onViewStats: noop,
+    onMarkUnplanned: noop,
+    onRestorePlanned: noop,
+    onDelete: noop,
+  };
+
+  const keys = (args: Parameters<typeof getEntryMenuItems>[0]) =>
+    getEntryMenuItems(args).map((item) => item.key);
+
+  describe('markUnplanned', () => {
+    it('planned かつ未来でなければ markUnplanned を出す', () => {
+      expect(keys({ ...baseArgs, origin: 'planned', isUpcoming: false })).toContain(
+        'markUnplanned',
+      );
+    });
+
+    it('planned でも未来(upcoming)なら markUnplanned を出さない', () => {
+      expect(keys({ ...baseArgs, origin: 'planned', isUpcoming: true })).not.toContain(
+        'markUnplanned',
+      );
+    });
+
+    it('isUpcoming 未指定（デフォルト false）では planned に markUnplanned を出す', () => {
+      expect(keys({ ...baseArgs, origin: 'planned' })).toContain('markUnplanned');
+    });
+
+    it('unplanned では isUpcoming に関わらず markUnplanned を出さない', () => {
+      expect(keys({ ...baseArgs, origin: 'unplanned', isUpcoming: false })).not.toContain(
+        'markUnplanned',
+      );
+    });
+  });
+
+  describe('restorePlanned', () => {
+    it('unplanned では restorePlanned を出す（isUpcoming の影響を受けない）', () => {
+      expect(keys({ ...baseArgs, origin: 'unplanned', isUpcoming: true })).toContain(
+        'restorePlanned',
+      );
+    });
+  });
+});

--- a/apps/product/src/features/entry/lib/entry-menu-items.ts
+++ b/apps/product/src/features/entry/lib/entry-menu-items.ts
@@ -27,6 +27,11 @@ export interface EntryMenuItem {
 interface EntryMenuItemsArgs {
   origin: EntryOrigin | undefined;
   tagId: string | null | undefined;
+  /**
+   * 未来（upcoming）の予定か。
+   * 未来の予定はまだ記録が存在し得ないため「予定外にする」を表示しない。
+   */
+  isUpcoming?: boolean | undefined;
   onViewStats?: (() => void) | undefined;
   onMarkUnplanned?: (() => void) | undefined;
   onRestorePlanned?: (() => void) | undefined;
@@ -36,6 +41,7 @@ interface EntryMenuItemsArgs {
 export function getEntryMenuItems({
   origin,
   tagId,
+  isUpcoming = false,
   onViewStats,
   onMarkUnplanned,
   onRestorePlanned,
@@ -54,7 +60,7 @@ export function getEntryMenuItems({
           onSelect: onViewStats,
         }
       : null,
-    onMarkUnplanned && isPlanned
+    onMarkUnplanned && isPlanned && !isUpcoming
       ? {
           key: 'markUnplanned',
           labelKey: 'entry.inspector.markUnplanned',

--- a/apps/product/src/features/entry/lib/entry-tint.ts
+++ b/apps/product/src/features/entry/lib/entry-tint.ts
@@ -1,0 +1,12 @@
+/**
+ * Entry カードの本体背景 tint を計算する純粋関数。
+ *
+ * EntryCard の actual layer 背景（`color-mix(in oklch, accentColor 18%, var(--background))`）と
+ * 同一の式を、ドラッグ／タグパレット／ドラフトのプレビュー側でも共有するための single source。
+ * プレビューと確定後カードの背景色がズレないよう、必ずこの関数経由で算出する。
+ *
+ * @param color - tint のベース色（`var(--tag-blue)` などの CSS color トークン）
+ */
+export function entryTintColor(color: string): string {
+  return `color-mix(in oklch, ${color} 18%, var(--background))`;
+}


### PR DESCRIPTION
## 概要

カレンダーのエントリー作成まわりの2つの改善をまとめた PR です。

### 1. ドラッグ新規作成プレビューの見た目統一
ドラッグ中プレビュー・タグ選択プレビュー・タグドラフトの3つを、確定後の `EntryCard` を正準として揃えました。確定時に幅や背景色がカクッと変わる段差を解消します。

- **本体tint**: 固定パステル token / 12% → `EntryCard` と同じ 18% color-mix に統一（`entryTintColor` を新設し single source 化）
- **左ストライプ**: `opacity-70` を付与して濃度を一致
- **右余白**: `right-2`(8px隙間) → `right-0` で全幅化、確定時の幅ジャンプを解消
- **プレースホルダー文言**「タグを選択」は muted、実タグ名は foreground に統一
- `InlineTagPalette` の出現アニメ `zoom-in-95` を除去し、ドラッグ中からの段差を軽減

### 2. 未来の予定では「予定外にする」を非表示
「予定外にする」は planned を unplanned（記録扱い）へ変換する操作ですが、未来(upcoming)の予定にはまだ記録が存在し得ないため不可。右クリックメニューと Inspector の両方で非表示にしました。

- `getEntryMenuItems` に `isUpcoming` 引数を追加し markUnplanned を gate（単一ソース）
- Inspector は canonical な `getEntryState()` で判定、ContextMenu は `CalendarEvent` の planned 開始時刻から判定
- `active`(進行中) / `past`(過去) の planned では従来どおり表示

### 3. Storybook 反映
- `InlineTagPalette`: 過去日付固定で破線表示になっていた stale を未来日付に変更し、tinted ハイライトを表示。破線確認用に `PastSelection` story を追加
- `EntryContextMenu`: 実態と乖離していた `inProgressEntry` を `upcomingPlannedEntry` に差し替え、「予定外にする」非表示を demonstrate
- `TagRow`: `UpcomingPlanned` story を追加

## テスト

- `pnpm typecheck` / `pnpm lint` / `pnpm lint:boundaries` 通過
- `entry-menu-items` ユニットテスト 5/5（新規追加）
- 実機での視覚確認（ドラッグ→確定の連続性、未来予定のメニュー）は要レビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)