### PR TITLE
fix(env): allow local dev without Stripe webhook secret

### DIFF
--- a/apps/product/src/env.ts
+++ b/apps/product/src/env.ts
@@ -63,12 +63,15 @@ const serverSchema = z
   })
   .refine(
     (data) => {
+      if (!(data.NODE_ENV === 'production' && process.env.VERCEL_ENV === 'production')) {
+        return true;
+      }
       const hasKey = !!data.STRIPE_SECRET_KEY;
       const hasWebhook = !!data.STRIPE_WEBHOOK_SECRET;
       return hasKey === hasWebhook;
     },
     {
-      message: 'STRIPE_SECRET_KEY と STRIPE_WEBHOOK_SECRET はペアで設定してください',
+      message: 'STRIPE_SECRET_KEY と STRIPE_WEBHOOK_SECRET は本番環境ではペアで設定してください',
       path: ['STRIPE_WEBHOOK_SECRET'],
     },
   )


### PR DESCRIPTION
## Summary\n- Scope Stripe secret pair validation to Vercel production deployments\n- Keep local and PR preview usable when Stripe webhook is not configured\n\n## Validation\n- pnpm --filter @dayopt/product typecheck\n- pnpm --filter @dayopt/product lint\n\nUnrelated local Storybook docs change is intentionally not included.