### PR TITLE
chore(supabase): harden RPC execute privileges

### DIFF
--- a/supabase/migrations/20260604230607_harden_function_execute_privileges.sql
+++ b/supabase/migrations/20260604230607_harden_function_execute_privileges.sql
@@ -1,0 +1,118 @@
+-- Supabase Pro security advisor hardening.
+--
+-- Goals:
+-- - Do not expose public RPC functions to anon/PUBLIC by default.
+-- - Keep only app-facing RPCs callable by authenticated users.
+-- - Keep service-only tables intentionally inaccessible to browser clients.
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE EXECUTE ON FUNCTIONS FROM anon;
+
+REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA public FROM PUBLIC;
+REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA public FROM anon;
+REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA public FROM authenticated;
+
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO service_role;
+
+DO $$
+DECLARE
+  fn text;
+  target regprocedure;
+  authenticated_functions text[] := ARRAY[
+    'public.use_recovery_code(uuid,text)',
+    'public.count_unused_recovery_codes(uuid)',
+    'public.update_personalization(uuid,text,jsonb)',
+    'public.batch_reorder_tags_hierarchy(uuid,uuid[],uuid[],integer[])',
+    'public.batch_rename_tags(uuid,uuid[],text[])',
+    'public.rename_tag_group(uuid,text,text)',
+    'public.merge_tags(uuid,uuid,uuid)',
+    'public.merge_tags(uuid,uuid[],uuid)',
+    'public.merge_tags_with_hierarchy(uuid,uuid,uuid)',
+    'public.get_tag_stats(uuid)',
+    'public.bulk_soft_delete_entries(uuid[],uuid)',
+    'public.soft_delete_entry(uuid,uuid)',
+    'public.restore_entry(uuid,uuid)',
+    'public.get_time_by_tag(uuid,timestamp with time zone,timestamp with time zone)',
+    'public.get_daily_hours(uuid,integer)',
+    'public.get_hourly_distribution(uuid,timestamp with time zone,timestamp with time zone)',
+    'public.get_dow_distribution(uuid,timestamp with time zone,timestamp with time zone)',
+    'public.get_monthly_hours(uuid,integer)',
+    'public.get_energy_map(uuid,date,date)',
+    'public.get_active_dates(uuid,date,date)',
+    'public.get_plan_rate(uuid,timestamp with time zone,timestamp with time zone)',
+    'public.get_estimation_accuracy(uuid,timestamp with time zone,timestamp with time zone)',
+    'public.get_context_switches(uuid,timestamp with time zone,timestamp with time zone)',
+    'public.get_blank_rate(uuid,timestamp with time zone,timestamp with time zone,integer,integer)',
+    'public.get_cumulative_time(uuid,timestamp with time zone,timestamp with time zone)',
+    'public.get_avg_fulfillment(uuid,timestamp with time zone,timestamp with time zone)',
+    'public.get_stats_kpi_summary(uuid,timestamp with time zone,timestamp with time zone,integer,integer)',
+    'public.get_time_pl_data(uuid,timestamp with time zone,timestamp with time zone,timestamp with time zone,timestamp with time zone,integer,integer)',
+    'public.get_stats_page_data(uuid,timestamp with time zone,timestamp with time zone,timestamp with time zone,timestamp with time zone,integer,integer,integer,integer)',
+    'public.get_timeboxing_adherence(uuid,date,date)',
+    'public.get_total_time(uuid)',
+    'public.get_weekly_focus_score(uuid,integer)',
+    'public.get_tag_cumulative_time(uuid,uuid,timestamp with time zone,timestamp with time zone)',
+    'public.get_tag_avg_fulfillment(uuid,uuid,timestamp with time zone,timestamp with time zone)',
+    'public.get_tag_plan_rate(uuid,uuid,timestamp with time zone,timestamp with time zone)',
+    'public.get_tag_fulfillment_distribution(uuid,uuid,timestamp with time zone,timestamp with time zone)',
+    'public.get_tag_hourly_distribution(uuid,uuid,timestamp with time zone,timestamp with time zone)',
+    'public.get_tag_dow_distribution(uuid,uuid,timestamp with time zone,timestamp with time zone)',
+    'public.get_child_tag_breakdown(uuid,uuid,timestamp with time zone,timestamp with time zone)',
+    'public.get_tag_accuracy_trend(uuid,uuid,timestamp with time zone,timestamp with time zone,text)',
+    'public.get_tag_recent_entries(uuid,uuid,integer)'
+  ];
+BEGIN
+  FOREACH fn IN ARRAY authenticated_functions LOOP
+    target := to_regprocedure(fn);
+    IF target IS NOT NULL THEN
+      EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO authenticated', target);
+    END IF;
+  END LOOP;
+
+  target := to_regprocedure('public.custom_access_token_hook(jsonb)');
+  IF target IS NOT NULL THEN
+    EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO supabase_auth_admin', target);
+  END IF;
+
+  target := to_regprocedure('public.update_personalization(uuid,text,jsonb)');
+  IF target IS NOT NULL THEN
+    EXECUTE format('ALTER FUNCTION %s SET search_path = public', target);
+  END IF;
+
+  target := to_regprocedure('public.trunc_week_tz(timestamp with time zone,text,integer)');
+  IF target IS NOT NULL THEN
+    EXECUTE format('ALTER FUNCTION %s SET search_path = public', target);
+  END IF;
+END $$;
+
+CREATE POLICY "No browser client access"
+  ON public.email_suppressions
+  FOR ALL
+  TO anon, authenticated
+  USING (false)
+  WITH CHECK (false);
+
+CREATE POLICY "No browser client access"
+  ON public.oauth_authorization_codes
+  FOR ALL
+  TO anon, authenticated
+  USING (false)
+  WITH CHECK (false);
+
+CREATE POLICY "No browser client access"
+  ON public.stripe_webhook_events
+  FOR ALL
+  TO anon, authenticated
+  USING (false)
+  WITH CHECK (false);
+
+COMMENT ON TABLE public.email_suppressions IS
+  'Service-role only suppression list populated by Resend webhook handling. Browser clients are denied by RLS.';
+COMMENT ON TABLE public.oauth_authorization_codes IS
+  'Service-role only OAuth PKCE intermediate state. Browser clients are denied by RLS.';
+COMMENT ON TABLE public.stripe_webhook_events IS
+  'Service-role only Stripe webhook idempotency table. Browser clients are denied by RLS.';
+
+UPDATE storage.buckets
+SET public = false
+WHERE id = 'attachments';

--- a/supabase/migrations/20260604232051_grant_authenticated_rpc_helpers.sql
+++ b/supabase/migrations/20260604232051_grant_authenticated_rpc_helpers.sql
@@ -1,0 +1,18 @@
+-- Keep helper functions callable by browser-authenticated RPCs after the
+-- security hardening migration revokes function EXECUTE by default.
+DO $$
+DECLARE
+  fn text;
+  target regprocedure;
+  authenticated_helper_functions text[] := ARRAY[
+    'public.get_user_timezone(uuid)',
+    'public.trunc_week_tz(timestamp with time zone,text,integer)'
+  ];
+BEGIN
+  FOREACH fn IN ARRAY authenticated_helper_functions LOOP
+    target := to_regprocedure(fn);
+    IF target IS NOT NULL THEN
+      EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO authenticated', target);
+    END IF;
+  END LOOP;
+END $$;


### PR DESCRIPTION
## Summary\n- Revoke broad PUBLIC/anon/authenticated execute grants from public functions\n- Re-grant authenticated access only to app-facing RPCs\n- Preserve service_role / Supabase Auth hook execution\n- Add deny-all RLS policies for service-only tables\n- Mark attachments bucket private\n\n## Validation\n- supabase db reset --local\n- local audit: security_definer_anon = 0\n- local audit: rls_enabled_no_policy = []\n- local audit: attachments_public = false\n- pnpm lint\n- pnpm typecheck\n- pnpm secrets:check\n- pnpm env:check\n\n## Notes\n- pnpm 1password:check still fails on existing EMPTY optional fields; no secret values were printed or changed.\n- supabase db lint --local exits 0 but reports pre-existing function lint issues unrelated to this migration.