### PR TITLE
fix(auth): use current password for secure password changes

### DIFF
--- a/apps/product/src/features/settings/components/password-change-dialog.test.tsx
+++ b/apps/product/src/features/settings/components/password-change-dialog.test.tsx
@@ -1,0 +1,142 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PasswordChangeDialog } from './password-change-dialog';
+
+const mockUpdateUser = vi.fn();
+const mockSignInWithPassword = vi.fn();
+const mockSignOut = vi.fn();
+const mockCheckPasswordPwned = vi.fn();
+const mockSendPasswordChangedEmail = vi.fn();
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('@/features/auth', () => ({
+  useAuthStore: (selector: (state: { user: { email: string } }) => unknown) =>
+    selector({ user: { email: 'user@example.com' } }),
+}));
+
+vi.mock('@/lib/auth/pwned-password', () => ({
+  checkPasswordPwned: (password: string) => mockCheckPasswordPwned(password),
+}));
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    auth: {
+      signInWithPassword: mockSignInWithPassword,
+      signOut: mockSignOut,
+      updateUser: mockUpdateUser,
+    },
+  }),
+}));
+
+vi.mock('@/lib/trpc', () => ({
+  api: {
+    email: {
+      sendPasswordChanged: {
+        useMutation: () => ({ mutate: mockSendPasswordChangedEmail }),
+      },
+    },
+  },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/user', () => ({
+  getDisplayName: () => 'User',
+}));
+
+function renderDialog() {
+  const onOpenChange = vi.fn();
+  render(<PasswordChangeDialog open onOpenChange={onOpenChange} />);
+  return { onOpenChange };
+}
+
+describe('PasswordChangeDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCheckPasswordPwned.mockResolvedValue(false);
+    mockSignInWithPassword.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mockUpdateUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mockSignOut.mockResolvedValue({ error: null });
+  });
+
+  it('verifies the current password and updates password with current_password', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByLabelText('settings.account.currentPassword'), 'old-password');
+    await user.type(screen.getByLabelText('settings.account.newPassword'), 'new-password-1');
+    await user.type(screen.getByLabelText('settings.account.confirmPassword'), 'new-password-1');
+    await user.click(screen.getByRole('button', { name: 'settings.account.updatePassword' }));
+
+    await waitFor(() => {
+      expect(mockSignInWithPassword).toHaveBeenCalledWith({
+        email: 'user@example.com',
+        password: 'old-password',
+      });
+      expect(mockUpdateUser).toHaveBeenCalledWith({
+        password: 'new-password-1',
+        current_password: 'old-password',
+      });
+    });
+
+    expect(mockSignOut).toHaveBeenCalledWith({ scope: 'others' });
+    expect(mockSendPasswordChangedEmail).toHaveBeenCalledWith({
+      email: 'user@example.com',
+      userName: 'User',
+    });
+  });
+
+  it('shows the current password error when Supabase rejects current_password', async () => {
+    const user = userEvent.setup();
+    mockUpdateUser.mockResolvedValue({
+      data: { user: null },
+      error: new Error('Current password is incorrect'),
+    });
+
+    renderDialog();
+
+    await user.type(screen.getByLabelText('settings.account.currentPassword'), 'wrong-password');
+    await user.type(screen.getByLabelText('settings.account.newPassword'), 'new-password-1');
+    await user.type(screen.getByLabelText('settings.account.confirmPassword'), 'new-password-1');
+    await user.click(screen.getByRole('button', { name: 'settings.account.updatePassword' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('settings.account.passwordIncorrect');
+    });
+
+    expect(mockSignOut).not.toHaveBeenCalled();
+    expect(mockSendPasswordChangedEmail).not.toHaveBeenCalled();
+  });
+
+  it('does not update the password when explicit current password verification fails', async () => {
+    const user = userEvent.setup();
+    mockSignInWithPassword.mockResolvedValue({
+      data: { user: null },
+      error: new Error('Invalid login credentials'),
+    });
+
+    renderDialog();
+
+    await user.type(screen.getByLabelText('settings.account.currentPassword'), 'wrong-password');
+    await user.type(screen.getByLabelText('settings.account.newPassword'), 'new-password-1');
+    await user.type(screen.getByLabelText('settings.account.confirmPassword'), 'new-password-1');
+    await user.click(screen.getByRole('button', { name: 'settings.account.updatePassword' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('settings.account.passwordIncorrect');
+    });
+
+    expect(mockUpdateUser).not.toHaveBeenCalled();
+    expect(mockSignOut).not.toHaveBeenCalled();
+    expect(mockSendPasswordChangedEmail).not.toHaveBeenCalled();
+  });
+});

--- a/apps/product/src/features/settings/components/password-change-dialog.tsx
+++ b/apps/product/src/features/settings/components/password-change-dialog.tsx
@@ -28,6 +28,16 @@ interface PasswordChangeDialogProps {
   onOpenChange: (open: boolean) => void;
 }
 
+function isCurrentPasswordError(error: Error): boolean {
+  const message = error.message.toLowerCase();
+  return (
+    message.includes('current_password') ||
+    message.includes('current password') ||
+    message.includes('invalid password') ||
+    message.includes('incorrect password')
+  );
+}
+
 /**
  * パスワード変更ダイアログ
  *
@@ -83,11 +93,12 @@ export function PasswordChangeDialog({ open, onOpenChange }: PasswordChangeDialo
       setIsLoading(true);
 
       try {
-        // Step 1: Re-authenticate with current password
         if (!user?.email) {
           throw new Error(t('common.errors.auth.emailNotFound'));
         }
 
+        // Step 1: Verify current password explicitly so preview/local
+        // environments stay safe even if Auth config has not been synced yet.
         const { error: reAuthError } = await supabase.auth.signInWithPassword({
           email: user.email,
           password: currentPassword,
@@ -103,12 +114,17 @@ export function PasswordChangeDialog({ open, onOpenChange }: PasswordChangeDialo
           throw new Error(t('settings.account.passwordPwned'));
         }
 
-        // Step 3: Update password
+        // Step 3: Update password. Supabase secure password change validates
+        // the current password server-side when `current_password` is provided.
         const { error: updateError } = await supabase.auth.updateUser({
           password: newPassword,
+          current_password: currentPassword,
         });
 
         if (updateError) {
+          if (isCurrentPasswordError(updateError)) {
+            throw new Error(t('settings.account.passwordIncorrect'));
+          }
           throw new Error(updateError.message);
         }
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -188,7 +188,7 @@ enable_signup = true
 double_confirm_changes = true
 # ローカルではメール確認不要（Inbucket使用）。本番はAuth Hook経由でResendから送信
 enable_confirmations = false
-# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+# If enabled, users must provide their current password when changing to a new password.
 secure_password_change = true
 # ローカルでは即送信（テスト用）。本番ではレート制限で保護
 max_frequency = "1s"


### PR DESCRIPTION
## Summary
- update settings password changes to call Supabase updateUser with current_password
- stop re-signing in just to validate the current password
- add regression tests for the secure password change payload and current-password error handling

## Validation
- pnpm --filter @dayopt/product exec vitest --project unit run src/features/settings/components/password-change-dialog.test.tsx
- pnpm --filter @dayopt/product lint
- pnpm --filter @dayopt/product typecheck
- pnpm secrets:check