### PR TITLE
feat(review): タグ詳細見出しのタグスイッチャー化 + 課金 enforcement のフラグ化

### DIFF
--- a/apps/product/src/env.ts
+++ b/apps/product/src/env.ts
@@ -49,6 +49,9 @@ const serverSchema = z
     NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
     NEXT_PUBLIC_APP_URL: z.string().url().optional(),
     NEXT_PUBLIC_MAINTENANCE_MODE: z.enum(['true', 'false']).optional(),
+    // 課金 enforcement。未設定（既定）= 無効＝全機能無料。
+    // Phase B（成熟・ローンチ前）に production を 'true' にして Free/Pro 棲み分けを復活させる。
+    BILLING_ENFORCED: z.enum(['true', 'false']).optional(),
     VERCEL_URL: z.string().optional(),
     VERCEL_ENV: z.string().optional(),
     SKIP_AUTH_IN_DEV: z.string().optional(),

--- a/apps/product/src/features/review/components/tag-detail/TagDetailPage.tsx
+++ b/apps/product/src/features/review/components/tag-detail/TagDetailPage.tsx
@@ -17,6 +17,8 @@ import { formatMetricValue } from '../../lib/metrics';
 import type { ReviewGranularity } from '../../stores/useReviewFilterStore';
 import { useReviewFilterStore } from '../../stores/useReviewFilterStore';
 
+import { TagDetailTitle } from './TagDetailTitle';
+
 interface TagDetailPageProps {
   tagId: string;
   initialGranularity: ReviewGranularity;
@@ -284,10 +286,14 @@ export function TagDetailPage({ tagId, initialGranularity, initialDateStr }: Tag
   return (
     <div className="scrollbar-stable flex-1 overflow-y-auto">
       <div className="flex flex-col gap-5 p-4">
-        <div className="flex min-w-0 items-center gap-2">
-          <TagIcon icon={data.tag.icon} color={data.tag.color} size="md" className="shrink-0" />
-          <h1 className="text-foreground min-w-0 truncate text-xl font-medium">{data.tag.name}</h1>
-        </div>
+        <TagDetailTitle
+          tagId={tagId}
+          tagName={data.tag.name}
+          tagIcon={data.tag.icon}
+          tagColor={data.tag.color}
+          granularity={granularity}
+          dateStr={initialDateStr}
+        />
 
         <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
           <KpiCard

--- a/apps/product/src/features/review/components/tag-detail/TagDetailTitle.tsx
+++ b/apps/product/src/features/review/components/tag-detail/TagDetailTitle.tsx
@@ -93,7 +93,7 @@ export function TagDetailTitle({
         ref={buttonRef}
         type="button"
         onClick={() => setSelectorOpen(true)}
-        className="hover:bg-state-hover -ml-2 flex min-w-0 items-center gap-2 rounded-lg px-2 py-1 transition-colors"
+        className="hover:bg-state-hover -ml-2 flex max-w-full min-w-0 items-center gap-2 self-start rounded-lg px-2 py-1 transition-colors"
         aria-label={`${t('common.tags.change')}: ${tagName}`}
       >
         <TagIcon icon={tagIcon} color={tagColor} size="md" className="shrink-0" />

--- a/apps/product/src/features/review/components/tag-detail/TagDetailTitle.tsx
+++ b/apps/product/src/features/review/components/tag-detail/TagDetailTitle.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+/**
+ * タグ詳細ページの見出し（タグスイッチャー）
+ *
+ * 現在表示中のタグ名をボタンとして描画し、クリックで TagQuickSelector を開く。
+ * 他タグを選ぶとそのタグの詳細ページへ遷移する（= 表示中タグの切り替え）。
+ * Calendar の TagRow と同じ TagQuickSelector / TagIcon を使う。
+ */
+
+import { useCallback, useRef, useState } from 'react';
+
+import { ChevronDown } from 'lucide-react';
+import { useLocale, useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
+
+import { resolveTagColor, TagIcon, TagQuickSelector, useCreateTag } from '@/features/tags';
+import { ColonTagLabel } from '@/lib/components/ui/colon-tag-label';
+import { toast } from '@/lib/toast';
+
+import type { ReviewGranularity } from '../../stores/useReviewFilterStore';
+
+interface TagDetailTitleProps {
+  tagId: string;
+  tagName: string;
+  tagIcon: string | null;
+  tagColor: string | null;
+  granularity: ReviewGranularity;
+  dateStr: string;
+}
+
+/** タグ詳細ページの見出し。クリックで他タグへ切り替える */
+export function TagDetailTitle({
+  tagId,
+  tagName,
+  tagIcon,
+  tagColor,
+  granularity,
+  dateStr,
+}: TagDetailTitleProps) {
+  const t = useTranslations();
+  const tTags = useTranslations('tags');
+  const locale = useLocale();
+  const router = useRouter();
+  const [selectorOpen, setSelectorOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const createTagMutation = useCreateTag({ showToast: false });
+
+  const navigateToTag = useCallback(
+    (nextTagId: string) => {
+      router.push(`/${locale}/review/tags/${nextTagId}?g=${granularity}&d=${dateStr}`);
+    },
+    [router, locale, granularity, dateStr],
+  );
+
+  const handleSelect = useCallback(
+    (selectedId: string) => {
+      setSelectorOpen(false);
+      if (selectedId === tagId) return;
+      navigateToTag(selectedId);
+    },
+    [tagId, navigateToTag],
+  );
+
+  const handleCreateAndSelect = useCallback(
+    async (name: string, color?: string | null, icon?: string | null, parentId?: string | null) => {
+      setSelectorOpen(false);
+      try {
+        const newTag = await createTagMutation.mutateAsync({
+          name,
+          color: resolveTagColor(color),
+          icon: icon ?? undefined,
+          parentId: parentId ?? undefined,
+        });
+        navigateToTag(newTag.id);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (message.includes('GROUP_NAME_CONFLICT') || message.includes('group_conflict')) {
+          toast.error(tTags('errors.groupNameConflict'));
+        } else if (message.includes('duplicate') || message.includes('already exists')) {
+          toast.error(tTags('errors.duplicateName'));
+        } else {
+          toast.error(tTags('errors.createFailed'));
+        }
+      }
+    },
+    [createTagMutation, navigateToTag, tTags],
+  );
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={() => setSelectorOpen(true)}
+        className="hover:bg-state-hover -ml-2 flex min-w-0 items-center gap-2 rounded-lg px-2 py-1 transition-colors"
+        aria-label={`${t('common.tags.change')}: ${tagName}`}
+      >
+        <TagIcon icon={tagIcon} color={tagColor} size="md" className="shrink-0" />
+        <ColonTagLabel
+          name={tagName}
+          className="text-foreground min-w-0 truncate text-xl font-medium"
+        />
+        <ChevronDown className="text-muted-foreground size-4 shrink-0" aria-hidden />
+      </button>
+
+      <TagQuickSelector
+        open={selectorOpen}
+        onOpenChange={setSelectorOpen}
+        onSelect={handleSelect}
+        onCreateAndSelect={handleCreateAndSelect}
+        anchorRef={buttonRef}
+      />
+    </>
+  );
+}

--- a/apps/product/src/features/review/components/tag-detail/__tests__/TagDetailPage.test.tsx
+++ b/apps/product/src/features/review/components/tag-detail/__tests__/TagDetailPage.test.tsx
@@ -16,6 +16,12 @@ vi.mock('../../../hooks/useTagDetailData', () => ({
   useTagDashboardData: mocks.useTagDashboardData,
 }));
 
+// 見出しのタグ切替（TagQuickSelector / useCreateTag / useRouter 依存）は別関心。
+// ここでは TagDetailPage のセクション表示が主眼なので見出しを簡易モックする。
+vi.mock('../TagDetailTitle', () => ({
+  TagDetailTitle: ({ tagName }: { tagName: string }) => <h1>{tagName}</h1>,
+}));
+
 vi.mock('../../../stores/useReviewFilterStore', () => ({
   useReviewFilterStore: (selector: (state: unknown) => unknown) =>
     selector({

--- a/apps/product/src/lib/billing/enforcement.ts
+++ b/apps/product/src/lib/billing/enforcement.ts
@@ -1,0 +1,17 @@
+import 'server-only';
+
+import { env } from '@/env';
+
+/**
+ * 課金 enforcement が有効かどうかの単一判定。
+ *
+ * 未設定（既定）は `false` ＝ enforcement 無効＝全機能を無料提供する。
+ * Pro ゲート（`proProcedure`）はこの関数が `false` の間は素通りする。
+ * `proProcedure` 注釈自体は将来の課金対象マーカーとして温存される。
+ *
+ * Phase B（プロダクト成熟・ローンチ前）に production で `BILLING_ENFORCED='true'`
+ * を設定し、Free/Pro の棲み分けを 1 か所のフラグ反転で復活させる。
+ */
+export function isBillingEnforced(): boolean {
+  return env.BILLING_ENFORCED === 'true';
+}

--- a/apps/product/src/lib/trpc/__tests__/pro-procedure.test.ts
+++ b/apps/product/src/lib/trpc/__tests__/pro-procedure.test.ts
@@ -1,5 +1,5 @@
 import { TRPCError } from '@trpc/server';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createChainableMock } from '@/lib/test/trpc-test-helpers';
 
@@ -48,6 +48,16 @@ function createProTestContext(
 }
 
 describe('proProcedure', () => {
+  // 既定（enforcement 無効）では全 status が素通りするため、enforcement の挙動を
+  // 検証する既存テストは BILLING_ENFORCED='true' を前提にする。
+  beforeEach(() => {
+    vi.stubEnv('BILLING_ENFORCED', 'true');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   describe('アクセス許可（Pro機能利用可能）', () => {
     it.each([
       { status: 'active', label: 'active' },
@@ -162,6 +172,25 @@ describe('proProcedure', () => {
 
     it('支払い失敗→回復中: past_due でアクセス維持', async () => {
       const ctx = createProTestContext('past_due');
+      const caller = createCaller(ctx as never);
+
+      const result = await caller.ping();
+      expect(result).toBe('pong');
+    });
+  });
+
+  describe('enforcement 無効時（既定・全機能無料）', () => {
+    beforeEach(() => {
+      // 親の 'true' を上書き。未設定（既定）相当として 'false' を明示する。
+      vi.stubEnv('BILLING_ENFORCED', 'false');
+    });
+
+    it.each([
+      { status: 'free', label: 'free' },
+      { status: 'canceled', label: 'canceled' },
+      { status: null, label: 'null（未設定）' },
+    ])('$label でも素通りする（Pro ゲートを踏まない）', async ({ status }) => {
+      const ctx = createProTestContext(status);
       const caller = createCaller(ctx as never);
 
       const result = await caller.ping();

--- a/apps/product/src/lib/trpc/procedures.ts
+++ b/apps/product/src/lib/trpc/procedures.ts
@@ -20,6 +20,7 @@ import {
   canAccessProFeatures,
   type ProductAccessLevel,
 } from '@/lib/auth/domain';
+import { isBillingEnforced } from '@/lib/billing/enforcement';
 import { logger } from '@/lib/logger';
 // 循環依存防止: barrel `@/lib/mcp` は trpc-bridge を再 export し、それが appRouter →
 // feature router → procedures.ts と辿るため、ここでは auth.ts を直 import する。
@@ -360,6 +361,12 @@ export const protectedProcedure = t.procedure
  * past_due: Stripe dunning（回収リトライ）期間中はアクセス維持。
  */
 export const proProcedure = protectedProcedure.meta({ auth: 'pro' }).use(async ({ ctx, next }) => {
+  // 課金 enforcement が無効（既定）の間は Pro ゲートを素通りさせ、全機能を無料提供する。
+  // proProcedure 注釈は将来の課金対象マーカーとして温存する（Phase B でフラグを 'true' に）。
+  if (!isBillingEnforced()) {
+    return next({ ctx });
+  }
+
   // OAuth 経路は claim cache を信用せず、毎リクエスト DB lookup を強制する
   let status = ctx.authMode === 'oauth' ? undefined : ctx.subscriptionStatus;
 


### PR DESCRIPTION
## 概要

2つの関連変更を含む（同一セッションで連続実施）。

### 1. review タグ詳細ページの見出しをタグスイッチャー化

タグ詳細ページ（`/review/tags/[tagId]`）の見出しをクリックで `TagQuickSelector` を開き、他タグの詳細へ切り替えられるようにした。Calendar の `TagRow` と同じ `TagQuickSelector` / `TagIcon` を再利用。遷移時に現在の granularity / date を維持。ホバー範囲は内容幅に限定（`self-start`）。

- `apps/product/src/features/review/components/tag-detail/TagDetailTitle.tsx`（新規）
- `TagDetailPage.tsx` の `<h1>` を `TagDetailTitle` に差し替え

### 2. 課金 enforcement をフラグ化し、既定で全機能無料化

Free/Pro の棲み分けが3か所（マーケ / サーバー `proProcedure` / UI）でバラバラなまま運用されており、無料ユーザーの review 概要が `getStatsPageData`(Pro 必須→FORBIDDEN) → 壊れた無料フォールバック → 全崩れするバグが顕在化した。

棲み分けの本設計は機能が揃ってから（#1279）行う方針とし、現状はいったん全機能を無料提供する:

- `BILLING_ENFORCED`（env, 既定=未設定=無効=全機能無料）を追加
- `isBillingEnforced()` を `apps/product/src/lib/billing/enforcement.ts` に新設
- `proProcedure` 先頭で未 enforce なら素通り（MCP も proProcedure 経由のため同時に無料化）。`proProcedure` 注釈は将来の課金対象マーカーとして温存
- `pro-procedure` テストを enforce ON/OFF 両系に拡張

→ 無料ユーザーでも `getStatsPageData` が実行され review 概要が表示される。将来 production を `BILLING_ENFORCED=true` にすれば棲み分けを1か所のフラグ反転で復活できる。

## 検証

- `pnpm typecheck` / `pnpm lint` / `pnpm lint:boundaries` ✅
- フルユニットテスト 136 files / 1872 tests ✅
- dev で `/review` 概要が free(seed) ユーザーで表示されることを確認 ✅

## 補足 / follow-up

- DB マイグレーションは変更なし。
- `apps/product/.env.example` に `BILLING_ENFORCED=false` を手動追記推奨（`.env*` は権限保護のため本 PR では未編集）。
- 壊れた stats RPC（`get_time_pl_data` / `get_time_by_tag`）はフラグ OFF で dormant 化。修正は #1279（Phase B）送り。
- Free/Pro 棲み分けの本設計: #1279

🤖 Generated with [Claude Code](https://claude.com/claude-code)