### PR TITLE
test(settings): I-03 ユーザー設定 gate の characterization test (#1294)

### DIFF
--- a/apps/product/src/features/settings/components/UserSettingsInitializer.test.tsx
+++ b/apps/product/src/features/settings/components/UserSettingsInitializer.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { UserSettingsInitializer } from './UserSettingsInitializer';
+
+/**
+ * I-03 characterization test（gate semantics + data integrity 境界）
+ *
+ * 目的: Phase 4（server-state store の TanStack Query 移行）の前に、
+ * UserSettingsInitializer の「現在の公開挙動」を固定する。store の内部実装
+ * （Zustand）に依存せず、`useUserSettings` の返り値 → render 結果の契約だけを
+ * 検証するため、移行後も同じ assertion が成立する（= 回帰検知になる）。
+ *
+ * 固定する不変条件:
+ * 1. hydrated まで children を render しない（loading=null / error=alert / paused=status）
+ * 2. data integrity: hydration 前は children が mount されないため、children 内の
+ *    timezone 依存 mutation（entry 作成等）が defaults のまま発火しない
+ */
+
+type UserSettingsState = {
+  hydrated: boolean;
+  isPaused: boolean;
+  error: unknown;
+};
+
+// useUserSettings の返り値をテストごとに差し替える
+let mockState: UserSettingsState = { hydrated: false, isPaused: false, error: null };
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('../hooks/useUserSettings', () => ({
+  useUserSettings: () => mockState,
+}));
+
+// children が mount された時に呼ばれる spy（timezone 依存 mutation の代理）
+const childMountSpy = vi.fn();
+
+function Child() {
+  childMountSpy();
+  return <div data-testid="app-content">app content</div>;
+}
+
+function renderGate() {
+  return render(
+    <UserSettingsInitializer>
+      <Child />
+    </UserSettingsInitializer>,
+  );
+}
+
+describe('UserSettingsInitializer（gate semantics）', () => {
+  beforeEach(() => {
+    mockState = { hydrated: false, isPaused: false, error: null };
+    childMountSpy.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('hydrated=true: children を render する', () => {
+    mockState = { hydrated: true, isPaused: false, error: null };
+    renderGate();
+
+    expect(screen.getByTestId('app-content')).toBeInTheDocument();
+    expect(childMountSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('loading（hydrated=false, error=null, paused=false）: null を返し children を mount しない', () => {
+    mockState = { hydrated: false, isPaused: false, error: null };
+    const { container } = renderGate();
+
+    expect(screen.queryByTestId('app-content')).not.toBeInTheDocument();
+    expect(childMountSpy).not.toHaveBeenCalled();
+    // loading は完全な blank（role を持たない）
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(container.querySelector('[role="status"]')).toBeNull();
+  });
+
+  it('error: role="alert" の再試行 UI を出し children を mount しない', () => {
+    mockState = { hydrated: false, isPaused: false, error: new Error('load failed') };
+    renderGate();
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toBeInTheDocument();
+    expect(screen.queryByTestId('app-content')).not.toBeInTheDocument();
+    expect(childMountSpy).not.toHaveBeenCalled();
+  });
+
+  it('paused（offline, cache なし）: role="status" のオフライン UI を出し children を mount しない', () => {
+    mockState = { hydrated: false, isPaused: true, error: null };
+    renderGate();
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.queryByTestId('app-content')).not.toBeInTheDocument();
+    expect(childMountSpy).not.toHaveBeenCalled();
+  });
+
+  it('error は paused より優先される（両方真でも alert を出す）', () => {
+    mockState = { hydrated: false, isPaused: true, error: new Error('load failed') };
+    renderGate();
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('hydrated は error/paused より優先される（hydrated 真なら children を出す）', () => {
+    mockState = { hydrated: true, isPaused: true, error: new Error('load failed') };
+    renderGate();
+
+    expect(screen.getByTestId('app-content')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});
+
+describe('UserSettingsInitializer（data integrity 境界）', () => {
+  beforeEach(() => {
+    mockState = { hydrated: false, isPaused: false, error: null };
+    childMountSpy.mockClear();
+  });
+
+  it('hydration 完了まで children（timezone 依存 mutation を含む）が mount されない', () => {
+    // 初期: 未 hydrate → child は mount されない
+    mockState = { hydrated: false, isPaused: false, error: null };
+    const { rerender } = renderGate();
+    expect(childMountSpy).not.toHaveBeenCalled();
+
+    // hydration 完了 → 初めて child が mount される
+    mockState = { hydrated: true, isPaused: false, error: null };
+    rerender(
+      <UserSettingsInitializer>
+        <Child />
+      </UserSettingsInitializer>,
+    );
+    expect(childMountSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/product/src/features/settings/hooks/useUserSettings.test.ts
+++ b/apps/product/src/features/settings/hooks/useUserSettings.test.ts
@@ -1,0 +1,217 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useUserSettings } from './useUserSettings';
+
+/**
+ * I-03 characterization test（consumer hook の公開挙動）
+ *
+ * 目的: Phase 4（server-state store の TanStack Query 移行）の前に、
+ * `useUserSettings` の「返り値の契約」と「hydration 前に timezone 依存の
+ * apply（dispatchUserSettings）を発火しない」data integrity 境界を固定する。
+ *
+ * store 実装（Zustand）は移行で置き換わるため、store の内部状態ではなく
+ * (1) 返り値の shape (2) query state → hydrated/isPaused/error の写像
+ * (3) apply effect の発火条件、という移行後も維持されるべき契約を検証する。
+ */
+
+// query 返り値をテストごとに差し替える
+type QueryResult = {
+  data: unknown;
+  isPending: boolean;
+  fetchStatus: 'fetching' | 'paused' | 'idle';
+  error: unknown;
+};
+let mockQuery: QueryResult = {
+  data: undefined,
+  isPending: true,
+  fetchStatus: 'fetching',
+  error: null,
+};
+
+const mockInvalidate = vi.fn();
+const mockEntriesInvalidate = vi.fn();
+const mockMutate = vi.fn();
+const mockDispatchUserSettings = vi.fn();
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('@/lib/toast', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock('@/lib/date', () => ({
+  CACHE_5_MINUTES: 5 * 60 * 1000,
+}));
+
+vi.mock('@/lib/trpc', () => ({
+  api: {
+    useUtils: () => ({
+      userSettings: { get: { invalidate: mockInvalidate } },
+      entries: { invalidate: mockEntriesInvalidate },
+    }),
+    userSettings: {
+      get: {
+        useQuery: () => mockQuery,
+      },
+      update: {
+        useMutation: () => ({ mutate: mockMutate, isPending: false }),
+      },
+    },
+  },
+}));
+
+vi.mock('@/features/calendar/stores/userSettings', () => ({
+  dispatchUserSettings: (settings: unknown) => mockDispatchUserSettings(settings),
+}));
+
+// merge 元の 3 store は固定値を返す（返り値 shape の検証用）
+vi.mock('@/features/calendar/stores/useCalendarSettingsStore', () => ({
+  useCalendarSettingsStore: () => ({ timezone: 'Asia/Tokyo', weekStartsOn: 1 }),
+}));
+vi.mock('@/features/chronotype', () => ({
+  useChronotypeSettingsStore: () => ({ chronotype: null }),
+}));
+vi.mock('@/lib/stores/useUserPreferenceStore', () => ({
+  useUserPreferenceStore: () => ({ dateFormat: 'yyyy/MM/dd' }),
+}));
+
+const DB_SETTINGS = {
+  timezone: 'America/New_York',
+  timeFormat: '24h',
+  preferredLocale: 'en',
+  weekStartsOn: 0,
+  showWeekends: true,
+  showWeekNumbers: false,
+  defaultDuration: 30,
+  snapInterval: 15,
+  chronotype: null,
+  defaultView: 'week',
+  hourHeightDensity: 'comfortable',
+};
+
+describe('useUserSettings（返り値の契約）', () => {
+  beforeEach(() => {
+    mockQuery = { data: undefined, isPending: true, fetchStatus: 'fetching', error: null };
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('公開する key の契約を維持する', () => {
+    const { result } = renderHook(() => useUserSettings());
+    expect(Object.keys(result.current).sort()).toEqual(
+      ['error', 'hydrated', 'isPaused', 'isPending', 'isSaving', 'saveSettings', 'settings'].sort(),
+    );
+    expect(typeof result.current.saveSettings).toBe('function');
+  });
+
+  it('3 store を merge した settings を返す', () => {
+    mockQuery = { data: DB_SETTINGS, isPending: false, fetchStatus: 'idle', error: null };
+    const { result } = renderHook(() => useUserSettings());
+    expect(result.current.settings).toMatchObject({
+      timezone: 'Asia/Tokyo',
+      weekStartsOn: 1,
+      chronotype: null,
+      dateFormat: 'yyyy/MM/dd',
+    });
+  });
+});
+
+describe('useUserSettings（query state → flag の写像）', () => {
+  beforeEach(() => {
+    mockQuery = { data: undefined, isPending: true, fetchStatus: 'fetching', error: null };
+    vi.clearAllMocks();
+  });
+
+  it('isPending 中は hydrated=false（gate が children を出さない state）', () => {
+    mockQuery = { data: undefined, isPending: true, fetchStatus: 'fetching', error: null };
+    const { result } = renderHook(() => useUserSettings());
+    expect(result.current.hydrated).toBe(false);
+    expect(result.current.isPending).toBe(true);
+  });
+
+  it('data 解決後は hydrated=true', () => {
+    mockQuery = { data: DB_SETTINGS, isPending: false, fetchStatus: 'idle', error: null };
+    const { result } = renderHook(() => useUserSettings());
+    expect(result.current.hydrated).toBe(true);
+  });
+
+  it('data=null（row なし新規ユーザー）でも hydrated=true（confirmed state として通過）', () => {
+    mockQuery = { data: null, isPending: false, fetchStatus: 'idle', error: null };
+    const { result } = renderHook(() => useUserSettings());
+    expect(result.current.hydrated).toBe(true);
+  });
+
+  it('fetchStatus="paused" を isPaused=true に写像する', () => {
+    mockQuery = { data: undefined, isPending: true, fetchStatus: 'paused', error: null };
+    const { result } = renderHook(() => useUserSettings());
+    expect(result.current.isPaused).toBe(true);
+  });
+
+  it('error をそのまま passthrough する', () => {
+    const err = new Error('load failed');
+    mockQuery = { data: undefined, isPending: false, fetchStatus: 'idle', error: err };
+    const { result } = renderHook(() => useUserSettings());
+    expect(result.current.error).toBe(err);
+  });
+});
+
+describe('useUserSettings（data integrity: apply 発火条件）', () => {
+  beforeEach(() => {
+    mockQuery = { data: undefined, isPending: true, fetchStatus: 'fetching', error: null };
+    vi.clearAllMocks();
+  });
+
+  it('isPending 中は dispatchUserSettings（timezone 依存 apply）を発火しない', () => {
+    mockQuery = { data: undefined, isPending: true, fetchStatus: 'fetching', error: null };
+    renderHook(() => useUserSettings());
+    expect(mockDispatchUserSettings).not.toHaveBeenCalled();
+  });
+
+  it('data 解決後は dbSettings を timezone 込みで store へ apply する', () => {
+    mockQuery = { data: DB_SETTINGS, isPending: false, fetchStatus: 'idle', error: null };
+    renderHook(() => useUserSettings());
+    expect(mockDispatchUserSettings).toHaveBeenCalledTimes(1);
+    expect(mockDispatchUserSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ timezone: 'America/New_York', weekStartsOn: 0 }),
+    );
+  });
+
+  it('data=null（新規ユーザー）では apply せず defaults を維持する', () => {
+    mockQuery = { data: null, isPending: false, fetchStatus: 'idle', error: null };
+    renderHook(() => useUserSettings());
+    expect(mockDispatchUserSettings).not.toHaveBeenCalled();
+  });
+});
+
+describe('useUserSettings（saveSettings の楽観的更新契約）', () => {
+  beforeEach(() => {
+    mockQuery = { data: DB_SETTINGS, isPending: false, fetchStatus: 'idle', error: null };
+    vi.clearAllMocks();
+  });
+
+  it('saveSettings は store を即時 dispatch し DB mutation を mutate する', () => {
+    const { result } = renderHook(() => useUserSettings());
+    // 初回 apply 分の dispatch をクリアしてから saveSettings を検証
+    mockDispatchUserSettings.mockClear();
+
+    result.current.saveSettings({ timezone: 'Europe/London' });
+
+    expect(mockDispatchUserSettings).toHaveBeenCalledWith({ timezone: 'Europe/London' });
+    expect(mockMutate).toHaveBeenCalledWith({ timezone: 'Europe/London' });
+  });
+
+  it('変更フィールドが無い場合は mutate しない', () => {
+    const { result } = renderHook(() => useUserSettings());
+    mockDispatchUserSettings.mockClear();
+
+    result.current.saveSettings({});
+
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/storybook/docs/product/projects/codebase-refactoring/i03-characterization.md
+++ b/apps/storybook/docs/product/projects/codebase-refactoring/i03-characterization.md
@@ -1,0 +1,51 @@
+# I-03: characterization tests + データモデル小確認（2026-06-12）
+
+> **目的**: Phase 4（server-state store の TanStack Query 移行）の前に、`UserSettingsInitializer` の gate semantics と `useUserSettings` の公開挙動を「現挙動として」固定する。store 実装に依存しない契約テストなので移行後も回帰検知になる。
+> **対象**: `apps/product/src/features/settings/components/UserSettingsInitializer.tsx` / `apps/product/src/features/settings/hooks/useUserSettings.ts`
+
+## 追加したテスト
+
+| ファイル                                      | 件数 | 固定する契約                                                                                                                                                         |
+| --------------------------------------------- | ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `components/UserSettingsInitializer.test.tsx` | 7    | gate semantics（hydrated→children / loading→null / error→alert / paused→status）+ 優先順位 + data integrity（hydration 前は children を mount しない）               |
+| `hooks/useUserSettings.test.ts`               | 12   | 返り値 key 契約 / query state→flag 写像（hydrated/isPaused/error）/ apply 発火条件（isPending 中・null 時は dispatchUserSettings 非発火）/ saveSettings の楽観的更新 |
+
+合計 19 件。store の内部状態（Zustand）ではなく **「query state → 返り値 → render の写像」** を検証しているため、Phase 4 で store を TanStack Query に置換しても同じ assertion が成立すべき（成立しなければ挙動変化＝要注意）。
+
+### 固定した data integrity 不変条件（最重要）
+
+`UserSettingsInitializer` のコメントに明記された境界:
+
+> `dbSettings` が確定するまで children を render しない。timezone / weekStartsOn 等が defaults（browser timezone）のまま timezone 依存 mutation が動くと UTC 変換がズレ、誤ったタイムスタンプで server に書き込まれる data integrity 問題になる。
+
+テストでの固定:
+
+- component 側: hydration 完了まで children（timezone 依存 mutation を含む）が mount されない（`childMountSpy` で検証）
+- hook 側: `isPending` 中および `data=null`（新規ユーザー）では `dispatchUserSettings`（timezone 込み apply）が発火しない
+
+**Phase 4 の移行（I-13/I-14）はこの 2 テストが green のままであることを必須ゲートにする。**
+
+## データモデル小確認（メモのみ・変更しない）
+
+### ④ `entries.duration_minutes` の整合性不変条件の所在
+
+- **DB 側に enforce は無い**: generated column でも trigger でも check 制約でもない。単なる stored value（migration で確認）。集計関数内では `COALESCE(duration_minutes, 0)` で null 許容に扱われる。
+- **domain でソフトに fallback**: `features/entry/domain/entry-time-model.ts:41-47` の `getPlannedDurationMinutes` が「`duration_minutes` が保存済みなら優先、なければ planned range（`start_time`/`end_time` の差）から算出」。つまり **planned duration の denormalized cache であり、null なら range から再計算**。
+- **actual は別**: actual 所要時間は常に `actual_start_time`/`actual_end_time` から算出（`entry-time-model.ts:92-96`）。`duration_minutes` は planned 専用。
+- **結論**: 「導出可能値の実体化（L7）」は事実だが、null 許容 + fallback で integrity は破綻しない設計。**既存 issue [#1285](https://github.com/Dayopt/dayopt/issues/1285)（`planned_duration_minutes` への rename）が意味の明確化として妥当**。本リファクタの範囲外（schema 変更）。
+
+### ⑤ `user_settings` の Json 列の Zod ランタイム検証
+
+- **Zod 検証は無い**: `features/settings/server/router.ts` の `userSettings.get` で、`chronotype_settings`（:102）と `personalization`（:119-130）はいずれも `as { type: string }` / `as Record<string, unknown>` の **型キャストのみ**で読み出している。DB-stored Json を信頼している。
+- **緩和**: `personalization` は `?? false` / `?? null` で各フィールドを defensive にデフォルトしている。`chronotype_settings` は `null` チェックのみ。
+- **リスク**: Json が破損形状の場合、ランタイム検証なしで cast されるため不正値が UI まで流れうる（低頻度・自己所有データなので実害は小）。
+- **結論**: 将来 issue 化候補（Json 列読み出しに Zod `safeParse` を入れる）。H7（ロジックの DB 沈降）と同根。本リファクタでは触らない（schema/挙動に踏み込むため）。
+
+## 検証
+
+```bash
+pnpm --filter @dayopt/product exec vitest run \
+  src/features/settings/components/UserSettingsInitializer.test.tsx \
+  src/features/settings/hooks/useUserSettings.test.ts
+# → 19 passed
+```


### PR DESCRIPTION
## 概要

codebase-refactoring project の **I-03**（[#1294](https://github.com/Dayopt/dayopt/issues/1294)）。Phase 4（server-state store の TanStack Query 移行 = I-13/I-14）の**前に**、`UserSettingsInitializer` の gate semantics と `useUserSettings` の公開挙動を「現挙動」として固定する。

store 実装（Zustand）ではなく **「query state → 返り値 → render の写像」** を検証するため、Phase 4 で store を置換しても同じ assertion が成立すべき（成立しなければ挙動変化＝回帰）。

## 追加テスト（19 件）

| ファイル | 件数 | 固定する契約 |
| --- | --- | --- |
| `UserSettingsInitializer.test.tsx` | 7 | gate semantics（hydrated→children / loading→null / error→alert / paused→status）+ 優先順位 + **data integrity**（hydration 前は children を mount しない） |
| `useUserSettings.test.ts` | 12 | 返り値 key 契約 / query state→flag 写像 / apply 発火条件（isPending・null 時は `dispatchUserSettings` 非発火）/ saveSettings の楽観的更新 |

### 最重要: data integrity 不変条件

「dbSettings 確定まで children を render しない（timezone defaults のまま mutation が走ると誤タイムスタンプで書き込まれる）」という境界を、component 側（`childMountSpy`）と hook 側（`dispatchUserSettings` 非発火）の両方で固定。**I-13/I-14 はこの 2 テスト green を必須ゲートにする。**

## データモデル小確認（メモのみ・変更なし）

- `entries.duration_minutes`: DB enforce 無し、domain で range から fallback する planned duration cache（issue #1285 の rename と整合）
- `user_settings` の Json 列（chronotype_settings / personalization）: Zod 検証なしの `as` キャスト読み出し（将来 issue 候補）

詳細: `apps/storybook/docs/product/projects/codebase-refactoring/i03-characterization.md`

## 検証

- `pnpm typecheck` / `pnpm lint` pass
- 新規 19 テスト pass（コード本体の変更なし、テスト追加のみ＝挙動変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)