### PR TITLE
[codex] Make Knip CI blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,13 @@ jobs:
         run: pnpm lint:i18n
 
       - name: Dead code check
-        run: pnpm quality:deadcode:ci 2>&1 | tee /dev/stderr | head -3 >> "$GITHUB_STEP_SUMMARY"
+        run: |
+          set +e
+          pnpm quality:deadcode:ci 2>&1 | tee /tmp/knip-output
+          status=${PIPESTATUS[0]}
+          set -e
+          head -3 /tmp/knip-output >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"
 
   typecheck:
     name: "\U0001F524 TypeScript"

--- a/apps/product/package.json
+++ b/apps/product/package.json
@@ -35,7 +35,7 @@
     "perf:lighthouse": "lhci autorun",
     "quality:full": "pnpm lint && pnpm license:check && pnpm perf:lighthouse && pnpm typecheck",
     "quality:deadcode": "knip --config knip.json --reporter json",
-    "quality:deadcode:ci": "knip --config knip.json --no-exit-code",
+    "quality:deadcode:ci": "knip --config knip.json --exclude files,unlisted,binaries",
     "test": "vitest --project unit",
     "test:run": "vitest --project unit run",
     "test:ui": "vitest --ui",

--- a/apps/product/src/lib/date/format.ts
+++ b/apps/product/src/lib/date/format.ts
@@ -201,6 +201,8 @@ export function formatDurationMinutes(totalMinutes: number): string {
   return `${hours}h ${minutes}m`;
 }
 
+export const KNIP_CI_PROBE = true;
+
 // ========================================
 // 曜日
 // ========================================

--- a/apps/product/src/lib/date/format.ts
+++ b/apps/product/src/lib/date/format.ts
@@ -201,8 +201,6 @@ export function formatDurationMinutes(totalMinutes: number): string {
   return `${hours}h ${minutes}m`;
 }
 
-export const KNIP_CI_PROBE = true;
-
 // ========================================
 // 曜日
 // ========================================


### PR DESCRIPTION
## Summary
- make the Knip CI command return a non-zero exit code for unused exports, types, dependencies, and duplicates
- preserve the Knip exit status across the workflow's output/summary pipeline
- keep known deferred categories (`files`, `unlisted`, and external `binaries`) excluded until their owning follow-up issues resolve them

## Root cause
`quality:deadcode:ci` used `--no-exit-code`. After removing it, the workflow still masked Knip's failure because the `tee | head` pipeline returned success. The workflow now captures `PIPESTATUS[0]` and exits with Knip's status.

## Verification
- `pnpm quality:deadcode:ci`: pass on the clean baseline
- temporary `KNIP_CI_PROBE` export: local exit 1
- [failure proof](https://github.com/Dayopt/dayopt/actions/runs/27448041264): `Dead code check` failed and Quality Gate blocked downstream jobs
- probe commit reverted
- [final CI](https://github.com/Dayopt/dayopt/actions/runs/27448156110): all 12 checks passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:boundaries`

Closes #1300