### PR TITLE
refactor(db): I-15 孤児 tag-detail RPC 9 個を drop (#1311)

### DIFF
--- a/packages/database/src/generated/database.types.ts
+++ b/packages/database/src/generated/database.types.ts
@@ -502,20 +502,6 @@ export type Database = {
         };
         Returns: Json;
       };
-      get_child_tag_breakdown: {
-        Args: {
-          p_end_date?: string;
-          p_parent_tag_id: string;
-          p_start_date?: string;
-          p_user_id: string;
-        };
-        Returns: {
-          hours: number;
-          tag_color: string;
-          tag_id: string;
-          tag_name: string;
-        }[];
-      };
       get_context_switches: {
         Args: { p_end_date?: string; p_start_date?: string; p_user_id: string };
         Returns: Json;
@@ -607,95 +593,6 @@ export type Database = {
           p_year: number;
         };
         Returns: Json;
-      };
-      get_tag_accuracy_trend: {
-        Args: {
-          p_bucket?: string;
-          p_end_date?: string;
-          p_start_date?: string;
-          p_tag_id: string;
-          p_user_id: string;
-        };
-        Returns: {
-          avg_deviation: number;
-          bucket: string;
-          entry_count: number;
-        }[];
-      };
-      get_tag_avg_fulfillment: {
-        Args: {
-          p_end_date?: string;
-          p_start_date?: string;
-          p_tag_id: string;
-          p_user_id: string;
-        };
-        Returns: Json;
-      };
-      get_tag_cumulative_time: {
-        Args: {
-          p_end_date?: string;
-          p_start_date?: string;
-          p_tag_id: string;
-          p_user_id: string;
-        };
-        Returns: Json;
-      };
-      get_tag_dow_distribution: {
-        Args: {
-          p_end_date?: string;
-          p_start_date?: string;
-          p_tag_id: string;
-          p_user_id: string;
-        };
-        Returns: {
-          dow: number;
-          total_minutes: number;
-        }[];
-      };
-      get_tag_fulfillment_distribution: {
-        Args: {
-          p_end_date?: string;
-          p_start_date?: string;
-          p_tag_id: string;
-          p_user_id: string;
-        };
-        Returns: {
-          count: number;
-          score: number;
-        }[];
-      };
-      get_tag_hourly_distribution: {
-        Args: {
-          p_end_date?: string;
-          p_start_date?: string;
-          p_tag_id: string;
-          p_user_id: string;
-        };
-        Returns: {
-          hour: number;
-          total_minutes: number;
-        }[];
-      };
-      get_tag_plan_rate: {
-        Args: {
-          p_end_date?: string;
-          p_start_date?: string;
-          p_tag_id: string;
-          p_user_id: string;
-        };
-        Returns: Json;
-      };
-      get_tag_recent_entries: {
-        Args: { p_limit?: number; p_tag_id: string; p_user_id: string };
-        Returns: {
-          duration_minutes: number;
-          end_time: string;
-          entry_id: string;
-          fulfillment_score: number;
-          planned_minutes: number;
-          start_time: string;
-          title: string;
-        }[];
       };
       get_tag_stats: {
         Args: { p_user_id: string };

--- a/supabase/migrations/20260613000000_drop_orphan_tag_detail_rpcs.sql
+++ b/supabase/migrations/20260613000000_drop_orphan_tag_detail_rpcs.sql
@@ -1,0 +1,35 @@
+-- I-15: tag-detail dead chain の DB 側（孤児 RPC）を drop する
+--
+-- 背景:
+--   PR #1290（粒度適応型 Review 再設計）でタグ詳細チャートが孤児化し、
+--   I-04（PR #1320）でそれらを呼ぶ tRPC procedure（getTagOverview /
+--   getTagTimeline / 個別 tag stats）と client hook をコード側から削除した。
+--   その結果、以下 9 個の RPC は呼び出し元が存在しなくなった。
+--   liveness 表: apps/storybook/docs/product/projects/codebase-refactoring/tag-detail-liveness.md
+--
+-- 安全性の根拠:
+--   - コード全域（apps/product/src・supabase/functions・scripts）の grep で
+--     これら関数の呼び出し元ゼロを確認済み（唯一の呼び出し元 tag-statistics.ts
+--     の該当 procedure は I-04 で削除、main に merge 済み＝production deploy 済み）
+--   - getTagDashboard（LIVE）はこれら RPC を呼ばない（直接 table query）
+--
+-- 入力シグネチャは初出（20260330000000 / 20260330100000 / 20260513000000）から
+-- 最新定義（20260610000000）まで一貫しており、オーバーロード残存はない。
+--
+-- ROLLBACK 手順（復元する場合・所要数分）:
+--   1. 20260610000000_entry_auto_record_model.sql 内の以下 9 関数の
+--      `CREATE OR REPLACE FUNCTION public.get_tag_*` / `get_child_tag_breakdown`
+--      ブロックを新規 migration として再適用する
+--   2. 20260604230607_harden_function_execute_privileges.sql と同様に
+--      各関数へ `GRANT EXECUTE ON FUNCTION ... TO authenticated` を再付与する
+--      （これら 9 関数は同 migration の authenticated_functions 配列に含まれる）
+
+DROP FUNCTION IF EXISTS public.get_tag_cumulative_time(uuid, uuid, timestamptz, timestamptz);
+DROP FUNCTION IF EXISTS public.get_tag_avg_fulfillment(uuid, uuid, timestamptz, timestamptz);
+DROP FUNCTION IF EXISTS public.get_tag_plan_rate(uuid, uuid, timestamptz, timestamptz);
+DROP FUNCTION IF EXISTS public.get_tag_hourly_distribution(uuid, uuid, timestamptz, timestamptz);
+DROP FUNCTION IF EXISTS public.get_tag_dow_distribution(uuid, uuid, timestamptz, timestamptz);
+DROP FUNCTION IF EXISTS public.get_child_tag_breakdown(uuid, uuid, timestamptz, timestamptz);
+DROP FUNCTION IF EXISTS public.get_tag_fulfillment_distribution(uuid, uuid, timestamptz, timestamptz);
+DROP FUNCTION IF EXISTS public.get_tag_accuracy_trend(uuid, uuid, timestamptz, timestamptz, text);
+DROP FUNCTION IF EXISTS public.get_tag_recent_entries(uuid, uuid, integer);


### PR DESCRIPTION
## 概要

codebase-refactoring project の **I-15**（[#1311](https://github.com/Dayopt/dayopt/issues/1311)、Phase 5）。I-04（PR #1320、merged）で**コード側**（tRPC procedure + client hook）を削除した tag-detail dead chain の **DB 側**（孤児 RPC 9 個）を drop する。

## 対象 9 関数

`get_tag_cumulative_time` / `get_tag_avg_fulfillment` / `get_tag_plan_rate` / `get_tag_hourly_distribution` / `get_tag_dow_distribution` / `get_child_tag_breakdown` / `get_tag_fulfillment_distribution` / `get_tag_accuracy_trend` / `get_tag_recent_entries`

根拠（liveness 表 Layer 4）: コード全域（src/functions/scripts）で呼び出し元ゼロ。唯一の呼び出し元だった tag-statistics.ts の該当 procedure は I-04 で削除・main merge 済み（= production deploy 済み）。`getTagDashboard`（LIVE）はこれらを呼ばない。

## 変更

- `supabase/migrations/20260613000000_drop_orphan_tag_detail_rpcs.sql`（`DROP FUNCTION IF EXISTS` × 9、rollback 手順をファイル冒頭に記載）
- 生成型から該当 9 RPC を除去（**本番生成型から手術的に削除**。`types:generate:local` は local DB が prod と乖離するため不使用、103行削除のみ）

## 検証

- local DB へ全 migration 適用成功（20260613000000 含む、関数 drop 確認）
- product / `@dayopt/database` の typecheck pass
- 入力シグネチャは初出（20260330000000 等）→ 最新（20260610000000）まで一貫、オーバーロード残存なし

## ⚠️ merge 前の必須確認（production 適用のため）

このリポジトリは **main merge で migration が production に自動適用**される。merge する前に:

1. **Sentry で `get_tag_*` 起因のエラーがゼロ**であることを確認（本セッションは Sentry MCP の token 期限切れで未実施。コード grep による呼び出し元ゼロは確定済みなので構造的には到達不能だが、ダメ押し確認を推奨）
2. rollback が必要になった場合は migration 冒頭の手順（CREATE OR REPLACE 再適用 + harden migration の GRANT 再付与）に従う。所要数分

🤖 Generated with [Claude Code](https://claude.com/claude-code)