### PR TITLE
refactor(db): I-16 RLS snapshot 自動生成 + drift check / ロジック置き場方針 (#1312)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -76,6 +76,20 @@ apps/product/src/features/{feature}/server/
 - 共通: `@/lib/trpc/procedures`（createTRPCRouter, protectedProcedure）、`@/lib/trpc/errors`（handleServiceError）
 - 詳細: `.claude/skills/trpc-router-creating/SKILL.md`
 
+## ロジックの置き場（新規は TS / 既存 PL/pgSQL は凍結）
+
+DB にロジックが沈むと型安全・ユニットテスト・dead-code 検出（knip）の網の外に出る。
+migration churn（pre_drop/post_drop の踊り）の温床にもなる。そのため:
+
+- **新規の集計・ビジネスロジックは TS の service 層に書く**（`features/{feature}/server/{feature}-service.ts`）。
+  RPC を新設してよいのは「RLS で表現できない原子的バッチ操作」に限る（例: `bulk_soft_delete_entries`）。
+- **既存の PL/pgSQL 関数は凍結資産**: 修正は bug fix のみ。機能追加は TS 側に寄せ、DB 関数を肥大化させない。
+- DB 関数を drop する時は、コード側（呼び出し元）削除を先に production へ deploy → 静穏確認 →
+  drop migration の順を守る（呼び出し中の関数を消すと 500 になる）。
+- 「現在有効な RLS / テーブル」は全 migration を読まず
+  [`apps/storybook/docs/dev/db/rls-snapshot.md`](../../apps/storybook/docs/dev/db/rls-snapshot.md)
+  （`pnpm rls:snapshot` で再生成、CI で drift 検出）を参照する。
+
 ## 楽観的更新
 
 ユーザー操作mutationは全て楽観的更新を実装。不可逆操作は除く。

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -77,6 +77,13 @@ jobs:
           NODE_ENV: test
           CI: true
 
+      # migration から構築した DB の RLS が、committed snapshot と一致するか検証する。
+      # drift（migration 変更で snapshot 未更新）を CI で検出する。更新は `pnpm rls:snapshot`。
+      - name: Check RLS snapshot drift
+        run: pnpm rls:snapshot:check
+        env:
+          DATABASE_URL: ${{ steps.supabase.outputs.db_url }}
+
       - name: Stop Supabase
         if: always()
         run: supabase stop

--- a/apps/storybook/docs/dev/db/rls-snapshot.md
+++ b/apps/storybook/docs/dev/db/rls-snapshot.md
@@ -1,0 +1,109 @@
+# RLS / schema snapshot（自動生成）
+
+> **生成元**: `scripts/generate-rls-snapshot.ts`（`pnpm rls:snapshot`）。DB の `pg_policies` /
+> RLS 有効状態を deterministic に書き出した snapshot。**手で編集しない**。migration 変更時は
+> CI（`pnpm rls:snapshot:check`）が drift を検出する。再生成で更新すること。
+>
+> 集計: public スキーマの policy 29 件 / RLS 対象テーブル 11 件。
+
+## RLS 有効状態（public テーブル）
+
+| table                     | RLS enabled | forced |
+| ------------------------- | ----------- | ------ |
+| email_suppressions        | ✅          | —      |
+| entries                   | ✅          | —      |
+| mfa_recovery_codes        | ✅          | —      |
+| oauth_audit_log           | ✅          | —      |
+| oauth_authorization_codes | ✅          | —      |
+| oauth_tokens              | ✅          | —      |
+| profiles                  | ✅          | —      |
+| reports                   | ✅          | —      |
+| stripe_webhook_events     | ✅          | —      |
+| tags                      | ✅          | —      |
+| user_settings             | ✅          | —      |
+
+## ポリシー一覧（table 別）
+
+### email_suppressions
+
+| policy                   | cmd | permissive | roles                | USING | WITH CHECK |
+| ------------------------ | --- | ---------- | -------------------- | ----- | ---------- |
+| No browser client access | ALL | PERMISSIVE | {anon,authenticated} | false | false      |
+
+### entries
+
+| policy                     | cmd    | permissive | roles    | USING                                                              | WITH CHECK                              |
+| -------------------------- | ------ | ---------- | -------- | ------------------------------------------------------------------ | --------------------------------------- |
+| Users can delete own plans | DELETE | PERMISSIVE | {public} | (( SELECT auth.uid() AS uid) = user_id)                            | —                                       |
+| Users can insert own plans | INSERT | PERMISSIVE | {public} | —                                                                  | (( SELECT auth.uid() AS uid) = user_id) |
+| Users can view own plans   | SELECT | PERMISSIVE | {public} | ((( SELECT auth.uid() AS uid) = user_id) AND (deleted_at IS NULL)) | —                                       |
+| Users can update own plans | UPDATE | PERMISSIVE | {public} | (( SELECT auth.uid() AS uid) = user_id)                            | (( SELECT auth.uid() AS uid) = user_id) |
+
+### mfa_recovery_codes
+
+| policy                              | cmd    | permissive | roles    | USING                                   | WITH CHECK                              |
+| ----------------------------------- | ------ | ---------- | -------- | --------------------------------------- | --------------------------------------- |
+| Users can delete own recovery codes | DELETE | PERMISSIVE | {public} | (( SELECT auth.uid() AS uid) = user_id) | —                                       |
+| Users can insert own recovery codes | INSERT | PERMISSIVE | {public} | —                                       | (( SELECT auth.uid() AS uid) = user_id) |
+| Users can view own recovery codes   | SELECT | PERMISSIVE | {public} | (( SELECT auth.uid() AS uid) = user_id) | —                                       |
+
+### oauth_audit_log
+
+| policy                       | cmd    | permissive | roles    | USING                                   | WITH CHECK |
+| ---------------------------- | ------ | ---------- | -------- | --------------------------------------- | ---------- |
+| Users can view own audit log | SELECT | PERMISSIVE | {public} | (( SELECT auth.uid() AS uid) = user_id) | —          |
+
+### oauth_authorization_codes
+
+| policy                   | cmd | permissive | roles                | USING | WITH CHECK |
+| ------------------------ | --- | ---------- | -------------------- | ----- | ---------- |
+| No browser client access | ALL | PERMISSIVE | {anon,authenticated} | false | false      |
+
+### oauth_tokens
+
+| policy                          | cmd    | permissive | roles    | USING                                   | WITH CHECK |
+| ------------------------------- | ------ | ---------- | -------- | --------------------------------------- | ---------- |
+| Users can view own oauth_tokens | SELECT | PERMISSIVE | {public} | (( SELECT auth.uid() AS uid) = user_id) | —          |
+
+### profiles
+
+| policy                                   | cmd    | permissive | roles           | USING                              | WITH CHECK                         |
+| ---------------------------------------- | ------ | ---------- | --------------- | ---------------------------------- | ---------------------------------- |
+| Service role has full access to profiles | ALL    | PERMISSIVE | {service_role}  | true                               | true                               |
+| Users can delete own profile             | DELETE | PERMISSIVE | {authenticated} | (( SELECT auth.uid() AS uid) = id) | —                                  |
+| Service role can insert profiles         | INSERT | PERMISSIVE | {service_role}  | —                                  | true                               |
+| Users can insert own profile             | INSERT | PERMISSIVE | {authenticated} | —                                  | (( SELECT auth.uid() AS uid) = id) |
+| Users can view own profile               | SELECT | PERMISSIVE | {authenticated} | (( SELECT auth.uid() AS uid) = id) | —                                  |
+| Users can update own profile             | UPDATE | PERMISSIVE | {authenticated} | (( SELECT auth.uid() AS uid) = id) | —                                  |
+
+### reports
+
+| policy                       | cmd    | permissive | roles          | USING                                   | WITH CHECK |
+| ---------------------------- | ------ | ---------- | -------------- | --------------------------------------- | ---------- |
+| Users can delete own reports | DELETE | PERMISSIVE | {public}       | (( SELECT auth.uid() AS uid) = user_id) | —          |
+| System can create reports    | INSERT | PERMISSIVE | {service_role} | —                                       | true       |
+| Users can view own reports   | SELECT | PERMISSIVE | {public}       | (( SELECT auth.uid() AS uid) = user_id) | —          |
+
+### stripe_webhook_events
+
+| policy                   | cmd | permissive | roles                | USING | WITH CHECK |
+| ------------------------ | --- | ---------- | -------------------- | ----- | ---------- |
+| No browser client access | ALL | PERMISSIVE | {anon,authenticated} | false | false      |
+
+### tags
+
+| policy                    | cmd    | permissive | roles    | USING                                   | WITH CHECK                              |
+| ------------------------- | ------ | ---------- | -------- | --------------------------------------- | --------------------------------------- |
+| Users can delete own tags | DELETE | PERMISSIVE | {public} | (( SELECT auth.uid() AS uid) = user_id) | —                                       |
+| Users can insert own tags | INSERT | PERMISSIVE | {public} | —                                       | (( SELECT auth.uid() AS uid) = user_id) |
+| Users can view own tags   | SELECT | PERMISSIVE | {public} | (( SELECT auth.uid() AS uid) = user_id) | —                                       |
+| Users can update own tags | UPDATE | PERMISSIVE | {public} | (( SELECT auth.uid() AS uid) = user_id) | (( SELECT auth.uid() AS uid) = user_id) |
+
+### user_settings
+
+| policy                        | cmd    | permissive | roles           | USING                                   | WITH CHECK                              |
+| ----------------------------- | ------ | ---------- | --------------- | --------------------------------------- | --------------------------------------- |
+| Users can delete own settings | DELETE | PERMISSIVE | {authenticated} | (( SELECT auth.uid() AS uid) = user_id) | —                                       |
+| Users can insert own settings | INSERT | PERMISSIVE | {authenticated} | —                                       | (( SELECT auth.uid() AS uid) = user_id) |
+| Users can view own settings   | SELECT | PERMISSIVE | {authenticated} | (( SELECT auth.uid() AS uid) = user_id) | —                                       |
+| Users can update own settings | UPDATE | PERMISSIVE | {authenticated} | (( SELECT auth.uid() AS uid) = user_id) | (( SELECT auth.uid() AS uid) = user_id) |

--- a/apps/storybook/docs/product/projects/codebase-refactoring/migration-squash-assessment.md
+++ b/apps/storybook/docs/product/projects/codebase-refactoring/migration-squash-assessment.md
@@ -1,0 +1,40 @@
+# migration squash 判断資料（I-16 / Q3: 今回は見送り）
+
+> **結論（2026-06-13）**: 今回は **見送り**。本資料は将来再検討するための手順・リスク・所要見積もり。
+
+## 現状
+
+- active migration: 115 件（`supabase/migrations/*.sql`、`00000000000000_baseline.sql` 起点）
+- 前回 squash: 2026-03-17 に 117 migration を baseline へ圧縮（[`_archive/`](../../../../../supabase/migrations/_archive/README.md) に旧履歴を保管）
+- baseline 以降に 114 migration が積み上がっている。`drop`/`remove` 系・`pre_drop`/`post_drop` の連鎖を含み、新規参加者・AI が「現在有効なスキーマ」を把握するコストが高い
+
+## なぜ今回見送るか
+
+- baseline は本番適用済み。再 squash は「新 baseline 生成 → 既存環境で `migration repair --status applied` → 新規環境は reset」という手順で、**操作ミス時の blast radius が production schema**。pre-launch の単一 project 運用では事故コストが見合わない
+- 「現在有効な RLS / schema を読みやすくする」目的は、squash しなくても **自動生成 snapshot**（[`rls-snapshot.md`](../../../dev/db/rls-snapshot.md)）+ `pnpm types:generate` で達成できる。snapshot 整備（I-16）で当面の可読性ニーズは満たされる
+
+## 将来 squash する場合の手順（参考）
+
+1. ローカルで現行スキーマから新 baseline を生成（`supabase db dump` 系 / 旧 baseline と同方式）
+2. 旧 active migration 114 件を `_archive/` へ git mv（履歴保持）
+3. 新 baseline を `00000000000000_baseline.sql` に置換（または新タイムスタンプ baseline）
+4. **既存 production**: `supabase migration repair --status applied <新baseline>` で適用済みマーク（DDL は実行しない）
+5. **新規環境**: `supabase db reset` が新 baseline からスキーマ構築
+6. `pnpm rls:snapshot` / `pnpm types:generate` で snapshot・型を再生成し差分ゼロを確認
+
+## リスク
+
+- `migration repair` の対象・順序を誤ると production の migration 履歴が壊れ、以降の migration 適用が詰まる（`[irreversible]` 寄り）
+- squash 中に他の migration PR が merge されると baseline と衝突する（squash 専用の merge freeze が必要）
+- preview branch（Supabase Branching）と baseline の整合確認が追加で必要
+
+## 所要見積もり
+
+- 設計 + 検証込みで 0.5〜1 日。merge freeze の調整コストを含むと実質はもう少し
+- 推奨タイミング: **launch 後**、persistent staging branch を持てるようになってから（architecture.md「将来計画」と整合）
+
+## 再検討トリガー
+
+- active migration が 200 件を大きく超える
+- 「現在有効な schema 把握」が snapshot だけでは追いつかなくなる
+- staging branch 運用が整い、production と分離して squash を検証できるようになる

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "docs:check": "pnpm --filter @dayopt/product docs:check",
     "api:spec": "pnpm --filter @dayopt/product api:spec",
     "api:spec:check": "pnpm --filter @dayopt/product api:spec:check",
+    "rls:snapshot": "tsx scripts/generate-rls-snapshot.ts",
+    "rls:snapshot:check": "tsx scripts/generate-rls-snapshot.ts --check",
     "license:check": "pnpm --filter @dayopt/product license:check",
     "license:check-risks": "pnpm --filter @dayopt/product license:check-risks",
     "license:audit": "pnpm --filter @dayopt/product license:audit",

--- a/scripts/generate-rls-snapshot.ts
+++ b/scripts/generate-rls-snapshot.ts
@@ -21,6 +21,8 @@ import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
+import { format as formatWithPrettier } from 'prettier';
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
 const OUTPUT_PATH = resolve(ROOT, 'apps/storybook/docs/dev/db/rls-snapshot.md');
@@ -130,10 +132,13 @@ function render(policies: PolicyRow[], rlsTables: RlsRow[]): string {
   return lines.join('\n');
 }
 
-function main(): void {
+async function main(): Promise<void> {
   let content: string;
   try {
-    content = render(fetchPolicies(), fetchRlsTables());
+    const raw = render(fetchPolicies(), fetchRlsTables());
+    // commit 時の lint-staged prettier と同一整形を施し、--check の drift を防ぐ
+    // （raw のままだと prettier がテーブルを整列して常に差分になる）
+    content = await formatWithPrettier(raw, { parser: 'markdown', printWidth: 100 });
   } catch (error) {
     console.error(
       '❌ RLS snapshot 生成に失敗しました。DATABASE_URL と DB 起動を確認してください。',
@@ -153,8 +158,8 @@ function main(): void {
     return;
   }
 
-  writeFileSync(OUTPUT_PATH, content + '\n');
+  writeFileSync(OUTPUT_PATH, content);
   console.log(`✅ RLS snapshot を生成しました: ${OUTPUT_PATH}`);
 }
 
-main();
+void main();

--- a/scripts/generate-rls-snapshot.ts
+++ b/scripts/generate-rls-snapshot.ts
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+/**
+ * RLS / schema snapshot 生成スクリプト（I-16）
+ *
+ * 「現在有効な RLS ポリシー」を migration を全部読まずに把握できるよう、
+ * DB の pg_policies / RLS 有効状態を 1 コマンドで deterministic な markdown に
+ * 書き出す。`api:spec` と同型で、--check で CI ドリフト検出を行う。
+ *
+ * 入力 DB:
+ *   DATABASE_URL（無ければ local supabase の既定 postgresql://postgres:postgres@127.0.0.1:54322/postgres）
+ *   migration から構築された DB を読むため、「migration が定義する RLS」を反映する。
+ *
+ * Usage:
+ *   pnpm rls:snapshot          # docs を生成/更新
+ *   pnpm rls:snapshot:check    # 既存 snapshot と比較（CI 用ドリフト検出。差分で exit 1）
+ */
+
+import { execFileSync } from 'child_process';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const OUTPUT_PATH = resolve(ROOT, 'apps/storybook/docs/dev/db/rls-snapshot.md');
+const CHECK_MODE = process.argv.includes('--check');
+const DATABASE_URL =
+  process.env.DATABASE_URL ?? 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
+
+type PolicyRow = {
+  tablename: string;
+  policyname: string;
+  cmd: string;
+  permissive: string;
+  roles: string;
+  using_expr: string;
+  check_expr: string;
+};
+
+type RlsRow = { table: string; rls: boolean; forced: boolean };
+
+/** psql で 1 行 JSON を取り出す（複数行・特殊文字に強い） */
+function queryJson<T>(sql: string): T {
+  const out = execFileSync('psql', [DATABASE_URL, '-t', '-A', '-c', sql], {
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+  }).trim();
+  return JSON.parse(out || 'null') as T;
+}
+
+function fetchPolicies(): PolicyRow[] {
+  return (
+    queryJson<PolicyRow[] | null>(
+      `SELECT coalesce(json_agg(row_to_json(t) ORDER BY t.tablename, t.cmd, t.policyname), '[]'::json)
+       FROM (
+         SELECT tablename, policyname, cmd, permissive, roles::text AS roles,
+                coalesce(qual, '') AS using_expr, coalesce(with_check, '') AS check_expr
+         FROM pg_policies WHERE schemaname = 'public'
+       ) t;`,
+    ) ?? []
+  );
+}
+
+function fetchRlsTables(): RlsRow[] {
+  return (
+    queryJson<RlsRow[] | null>(
+      `SELECT coalesce(json_agg(json_build_object(
+                'table', c.relname, 'rls', c.relrowsecurity, 'forced', c.relforcerowsecurity
+              ) ORDER BY c.relname), '[]'::json)
+       FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+       WHERE n.nspname = 'public' AND c.relkind = 'r';`,
+    ) ?? []
+  );
+}
+
+/** markdown 1 セル用に改行・パイプを無害化 */
+function cell(value: string): string {
+  return value.replace(/\s+/g, ' ').replace(/\|/g, '\\|').trim() || '—';
+}
+
+function render(policies: PolicyRow[], rlsTables: RlsRow[]): string {
+  const policyByTable = new Map<string, PolicyRow[]>();
+  for (const p of policies) {
+    const list = policyByTable.get(p.tablename) ?? [];
+    list.push(p);
+    policyByTable.set(p.tablename, list);
+  }
+
+  const lines: string[] = [];
+  lines.push('# RLS / schema snapshot（自動生成）');
+  lines.push('');
+  lines.push(
+    '> **生成元**: `scripts/generate-rls-snapshot.ts`（`pnpm rls:snapshot`）。DB の `pg_policies` /',
+  );
+  lines.push(
+    '> RLS 有効状態を deterministic に書き出した snapshot。**手で編集しない**。migration 変更時は',
+  );
+  lines.push('> CI（`pnpm rls:snapshot:check`）が drift を検出する。再生成で更新すること。');
+  lines.push('>');
+  lines.push(
+    `> 集計: public スキーマの policy ${policies.length} 件 / RLS 対象テーブル ${rlsTables.length} 件。`,
+  );
+  lines.push('');
+
+  lines.push('## RLS 有効状態（public テーブル）');
+  lines.push('');
+  lines.push('| table | RLS enabled | forced |');
+  lines.push('| --- | --- | --- |');
+  for (const r of rlsTables) {
+    lines.push(`| ${r.table} | ${r.rls ? '✅' : '❌'} | ${r.forced ? '✅' : '—'} |`);
+  }
+  lines.push('');
+
+  lines.push('## ポリシー一覧（table 別）');
+  lines.push('');
+  for (const table of [...policyByTable.keys()].sort()) {
+    lines.push(`### ${table}`);
+    lines.push('');
+    lines.push('| policy | cmd | permissive | roles | USING | WITH CHECK |');
+    lines.push('| --- | --- | --- | --- | --- | --- |');
+    for (const p of policyByTable.get(table) ?? []) {
+      lines.push(
+        `| ${cell(p.policyname)} | ${p.cmd} | ${p.permissive} | ${cell(p.roles)} | ${cell(p.using_expr)} | ${cell(p.check_expr)} |`,
+      );
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+function main(): void {
+  let content: string;
+  try {
+    content = render(fetchPolicies(), fetchRlsTables());
+  } catch (error) {
+    console.error(
+      '❌ RLS snapshot 生成に失敗しました。DATABASE_URL と DB 起動を確認してください。',
+    );
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(2);
+  }
+
+  if (CHECK_MODE) {
+    const existing = existsSync(OUTPUT_PATH) ? readFileSync(OUTPUT_PATH, 'utf8') : '';
+    if (existing.trim() !== content.trim()) {
+      console.error('❌ RLS snapshot が最新ではありません。');
+      console.error('   pnpm rls:snapshot を実行して更新してください。');
+      process.exit(1);
+    }
+    console.log('✅ RLS snapshot は最新です。');
+    return;
+  }
+
+  writeFileSync(OUTPUT_PATH, content + '\n');
+  console.log(`✅ RLS snapshot を生成しました: ${OUTPUT_PATH}`);
+}
+
+main();

--- a/supabase/migrations/_archive/README.md
+++ b/supabase/migrations/_archive/README.md
@@ -1,0 +1,22 @@
+# `_archive/` — 歴史的 migration 記録（適用対象外）
+
+このディレクトリには、`00000000000000_baseline.sql` へ squash される前の migration 116 件が
+保管されている（日付レンジ: `00000000000000` 〜 `20260317000001`）。
+
+## 位置づけ
+
+- **適用されない**: Supabase CLI は `supabase/migrations/` 直下の `*.sql` のみを適用する。
+  サブディレクトリの本ファイル群は migration 実行の対象外。
+- **baseline に統合済み**: 2026-03-17 に 117 migration を `00000000000000_baseline.sql`
+  へ圧縮した（baseline ファイル冒頭コメント参照）。本ディレクトリはその squash 前の履歴。
+- **参照されない**: コード / CI / 他 migration からの参照はゼロ（grep 確認済み）。
+
+## 運用ルール
+
+- **復元・再適用しない**。現在有効なスキーマは `00000000000000_baseline.sql` 以降の
+  active migration が定義する。過去の意図を辿る調査目的でのみ読む。
+- 新規環境は `supabase db reset` が baseline からスキーマを構築する。既存環境は
+  `supabase migration repair --status applied` で baseline 適用済みとしてマーク済み。
+- 現在有効な RLS / テーブル構成を把握したい時は、全 migration を読まず
+  [`apps/storybook/docs/dev/db/rls-snapshot.md`](../../../apps/storybook/docs/dev/db/rls-snapshot.md)
+  （自動生成 snapshot）を参照する。


### PR DESCRIPTION
## 概要

codebase-refactoring project の **I-16**（[#1312](https://github.com/Dayopt/dayopt/issues/1312)、Phase 5 残）。「現在有効な RLS / schema を migration を全部読まずに把握できる」状態にし、ロジックの DB 沈降（診断 H7）への方針を rules に固定する。

## 変更

| 項目 | 内容 |
|---|---|
| **RLS snapshot 自動生成** | `scripts/generate-rls-snapshot.ts`（psql 経由・新規依存なし）。`pnpm rls:snapshot` で `apps/storybook/docs/dev/db/rls-snapshot.md` を生成（public: policy 29 / table 11）。`--check` で drift 検出 |
| **CI drift check** | `integration.yml`（supabase 起動済み workflow）に `rls:snapshot:check` step を追加。migration から構築した DB の RLS が committed snapshot と一致するか検証 |
| **ロジック置き場方針** | `.claude/rules/architecture.md` に「新規ロジックは TS service / 既存 PL/pgSQL は凍結 / RPC 新設は原子的バッチのみ / drop は呼び出し元削除 deploy 後」を明文化 |
| **_archive README** | `supabase/migrations/_archive/README.md`（116 件は baseline 統合済み・適用対象外・復元しない） |
| **squash 判断資料（Q3）** | `migration-squash-assessment.md`（今回見送りの手順・リスク・所要・再検討トリガー） |

## 検証

- `pnpm rls:snapshot:check` green（生成直後 = 一致）
- product typecheck / docs:check pass
- script は tsx 実行（scripts/ は product typecheck・eslint 対象外）
- 本 PR は `supabase/migrations/**` 配下（_archive/README.md）を含むため **integration workflow がトリガーされ、新 drift check step が CI で実検証**される

## 未実施（後続）

- **advisors 棚卸し（②）**: production supabase MCP が必要だが本セッションは token 期限切れ（ターミナル CLI claude 経由が必要）。`mcp__supabase__get_advisors` で security/performance を確認し対応を issue 化する作業を follow-up に回す

🤖 Generated with [Claude Code](https://claude.com/claude-code)