### PR TITLE
[codex] refactor(settings): settings service層を抽出

### DIFF
--- a/apps/product/src/features/settings/server/__tests__/settings-service.test.ts
+++ b/apps/product/src/features/settings/server/__tests__/settings-service.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createChainableMock } from '@/lib/test/trpc-test-helpers';
+
+import { SettingsService, SettingsServiceError } from '../settings-service';
+
+const invalidateUserTimezoneCache = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/server/user-timezone-cache', () => ({
+  invalidateUserTimezoneCache,
+}));
+
+const USER_ID = 'user-1';
+
+const settingsRow = {
+  id: 'settings-1',
+  user_id: USER_ID,
+  timezone: 'Asia/Tokyo',
+  time_format: '24h',
+  week_starts_on: 1,
+  show_weekends: true,
+  show_week_numbers: false,
+  default_duration: 30,
+  snap_interval: 15,
+  chronotype_settings: null,
+  default_view: 'week',
+  hour_height_density: 'default',
+  theme: 'system',
+  personalization: {
+    dismissedTrialEndedDialog: true,
+    paymentErrorDialogLastShownAt: '2026-06-15T00:00:00.000Z',
+  },
+  preferred_locale: 'ja',
+  created_at: '2026-06-01T00:00:00.000Z',
+  updated_at: '2026-06-15T00:00:00.000Z',
+};
+
+function createService(
+  queries: Array<ReturnType<typeof createChainableMock>>,
+  rpc = vi.fn().mockResolvedValue({ data: null, error: null }),
+) {
+  const from = vi.fn(() => {
+    const query = queries.shift();
+    if (!query) throw new Error('Unexpected Supabase query');
+    return query;
+  });
+
+  return {
+    service: new SettingsService({ from, rpc } as never),
+    from,
+    rpc,
+  };
+}
+
+describe('SettingsService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('get', () => {
+    it('snake_case の設定を既存のレスポンス形へ変換する', async () => {
+      const query = createChainableMock(settingsRow);
+      const { service } = createService([query]);
+
+      const result = await service.get(USER_ID);
+
+      expect(result).toMatchObject({
+        timezone: 'Asia/Tokyo',
+        timeFormat: '24h',
+        weekStartsOn: 1,
+        defaultDuration: 30,
+        snapInterval: 15,
+        defaultView: 'week',
+        hourHeightDensity: 'default',
+        theme: 'system',
+        preferredLocale: 'ja',
+        personalization: {
+          dismissedTrialEndedDialog: true,
+          paymentErrorDialogLastShownAt: '2026-06-15T00:00:00.000Z',
+        },
+      });
+      expect(query.eq).toHaveBeenCalledWith('user_id', USER_ID);
+    });
+
+    it('設定未作成の PGRST116 は null を返す', async () => {
+      const query = createChainableMock(null, { message: 'No rows', code: 'PGRST116' });
+      const { service } = createService([query]);
+
+      await expect(service.get(USER_ID)).resolves.toBeNull();
+    });
+
+    it('取得エラーは SettingsServiceError にする', async () => {
+      const query = createChainableMock(null, { message: 'Fetch failed', code: 'PGRST000' });
+      const { service } = createService([query]);
+
+      await expect(service.get(USER_ID)).rejects.toMatchObject({
+        name: 'SettingsServiceError',
+        code: 'FETCH_FAILED',
+        message: 'Fetch failed',
+      });
+    });
+  });
+
+  describe('update', () => {
+    it('camelCase input を upsert payload に変換し timezone cache を無効化する', async () => {
+      const query = createChainableMock(settingsRow);
+      const { service } = createService([query]);
+
+      const result = await service.update(USER_ID, {
+        timezone: 'America/New_York',
+        timeFormat: '12h',
+        weekStartsOn: 0,
+        showWeekends: false,
+        showWeekNumbers: true,
+        defaultDuration: 45,
+        snapInterval: 5,
+        defaultView: '3day',
+        hourHeightDensity: 'compact',
+        theme: 'dark',
+        preferredLocale: 'en',
+      });
+
+      expect(query.upsert).toHaveBeenCalledWith(
+        {
+          user_id: USER_ID,
+          timezone: 'America/New_York',
+          time_format: '12h',
+          week_starts_on: 0,
+          show_weekends: false,
+          show_week_numbers: true,
+          default_duration: 45,
+          snap_interval: 5,
+          default_view: '3day',
+          hour_height_density: 'compact',
+          theme: 'dark',
+          preferred_locale: 'en',
+        },
+        { onConflict: 'user_id' },
+      );
+      expect(invalidateUserTimezoneCache).toHaveBeenCalledWith(USER_ID);
+      expect(result).toEqual({ success: true, settings: settingsRow });
+    });
+
+    it('personalization を2つの atomic RPC で部分更新する', async () => {
+      const query = createChainableMock(settingsRow);
+      const rpc = vi.fn().mockResolvedValue({ data: null, error: null });
+      const { service } = createService([query], rpc);
+
+      await service.update(USER_ID, {
+        dismissedTrialEndedDialog: true,
+        paymentErrorDialogLastShownAt: '2026-06-15T00:00:00.000Z',
+      });
+
+      expect(rpc).toHaveBeenNthCalledWith(1, 'update_personalization', {
+        p_user_id: USER_ID,
+        p_path: 'dismissedTrialEndedDialog',
+        p_value: true,
+      });
+      expect(rpc).toHaveBeenNthCalledWith(2, 'update_personalization', {
+        p_user_id: USER_ID,
+        p_path: 'paymentErrorDialogLastShownAt',
+        p_value: '2026-06-15T00:00:00.000Z',
+      });
+    });
+
+    it('upsert エラーでは cache を無効化せず UPDATE_FAILED を投げる', async () => {
+      const query = createChainableMock(null, { message: 'Update failed', code: 'PGRST000' });
+      const { service } = createService([query]);
+
+      await expect(service.update(USER_ID, { timezone: 'UTC' })).rejects.toBeInstanceOf(
+        SettingsServiceError,
+      );
+      expect(invalidateUserTimezoneCache).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('iCal token', () => {
+    it('保存済みtokenを返す', async () => {
+      const query = createChainableMock({ ...settingsRow, ical_feed_token: 'token-1' });
+      const { service } = createService([query]);
+
+      await expect(service.getICalToken(USER_ID)).resolves.toEqual({ token: 'token-1' });
+    });
+
+    it('設定未作成なら null token を返す', async () => {
+      const query = createChainableMock(null, { message: 'No rows', code: 'PGRST116' });
+      const { service } = createService([query]);
+
+      await expect(service.getICalToken(USER_ID)).resolves.toEqual({ token: null });
+    });
+
+    it('rowを確保してから新しいtokenへ更新する', async () => {
+      const upsertQuery = createChainableMock(settingsRow);
+      const updateQuery = createChainableMock({ ...settingsRow, ical_feed_token: 'token-new' });
+      const { service } = createService([upsertQuery, updateQuery]);
+      vi.spyOn(crypto, 'randomUUID').mockReturnValue('00000000-0000-4000-8000-000000000001');
+
+      const result = await service.regenerateICalToken(USER_ID);
+
+      expect(upsertQuery.upsert).toHaveBeenCalledWith(
+        { user_id: USER_ID },
+        { onConflict: 'user_id' },
+      );
+      expect(updateQuery.update).toHaveBeenCalledWith({
+        ical_feed_token: '00000000-0000-4000-8000-000000000001',
+      });
+      expect(result).toEqual({ token: 'token-new' });
+    });
+
+    it('token更新エラーは UPDATE_FAILED を投げる', async () => {
+      const upsertQuery = createChainableMock(settingsRow);
+      const updateQuery = createChainableMock(null, {
+        message: 'Token update failed',
+        code: 'PGRST000',
+      });
+      const { service } = createService([upsertQuery, updateQuery]);
+
+      await expect(service.regenerateICalToken(USER_ID)).rejects.toMatchObject({
+        code: 'UPDATE_FAILED',
+        message: 'Token update failed',
+      });
+    });
+  });
+});

--- a/apps/product/src/features/settings/server/router.ts
+++ b/apps/product/src/features/settings/server/router.ts
@@ -6,13 +6,9 @@
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
-import { logger } from '@/lib/logger';
-import { invalidateUserTimezoneCache } from '@/lib/server/user-timezone-cache';
 import { handleServiceError } from '@/lib/trpc/errors';
 import { createTRPCRouter, protectedProcedure } from '@/lib/trpc/procedures';
-import type { Insert } from '@dayopt/database';
-
-type UserSettingsInsert = Insert<'user_settings'>;
+import { createSettingsService } from './settings-service';
 
 // バリデーションスキーマ
 const userSettingsSchema = z.object({
@@ -63,53 +59,7 @@ export const userSettingsRouter = createTRPCRouter({
           });
         }
 
-        const { data, error } = await ctx.supabase
-          .from('user_settings')
-          .select('*')
-          .eq('user_id', userId)
-          .single();
-
-        if (error && error.code !== 'PGRST116') {
-          // PGRST116 = no rows returned（設定がまだない場合）
-          logger.error('UserSettings fetch error', { error });
-          handleServiceError(error);
-        }
-
-        // 設定がない場合はnullを返す（クライアント側でデフォルト値を使用）
-        if (!data) {
-          return null;
-        }
-
-        // snake_case → camelCase に変換
-        return {
-          timezone: data.timezone,
-          timeFormat: data.time_format as '24h' | '12h',
-          weekStartsOn: data.week_starts_on as 0 | 1 | 6,
-          showWeekends: data.show_weekends,
-          showWeekNumbers: data.show_week_numbers,
-          defaultDuration: data.default_duration,
-          snapInterval: data.snap_interval as 5 | 10 | 15 | 30,
-          defaultView: data.default_view as 'day' | '3day' | '5day' | 'week' | undefined,
-          hourHeightDensity: data.hour_height_density as
-            | 'compact'
-            | 'default'
-            | 'spacious'
-            | undefined,
-          theme: data.theme as 'light' | 'dark' | 'system',
-          personalization: (() => {
-            const p = (data as Record<string, unknown>).personalization as Record<
-              string,
-              unknown
-            > | null;
-            return {
-              dismissedTrialEndedDialog: (p?.dismissedTrialEndedDialog ?? false) as boolean,
-              paymentErrorDialogLastShownAt: (p?.paymentErrorDialogLastShownAt ?? null) as
-                | string
-                | null,
-            };
-          })(),
-          preferredLocale: (data.preferred_locale as 'en' | 'ja' | undefined) ?? 'en',
-        };
+        return await createSettingsService(ctx.supabase).get(userId);
       } catch (error) {
         return handleServiceError(error);
       }
@@ -132,74 +82,7 @@ export const userSettingsRouter = createTRPCRouter({
           });
         }
 
-        // camelCase → snake_case に変換
-        const updateData: UserSettingsInsert = {
-          user_id: userId,
-        };
-
-        if (input.timezone !== undefined) updateData.timezone = input.timezone;
-        if (input.timeFormat !== undefined) updateData.time_format = input.timeFormat;
-        if (input.weekStartsOn !== undefined) updateData.week_starts_on = input.weekStartsOn;
-        if (input.showWeekends !== undefined) updateData.show_weekends = input.showWeekends;
-        if (input.showWeekNumbers !== undefined)
-          updateData.show_week_numbers = input.showWeekNumbers;
-        if (input.defaultDuration !== undefined)
-          updateData.default_duration = input.defaultDuration;
-        if (input.snapInterval !== undefined) updateData.snap_interval = input.snapInterval;
-        if (input.defaultView !== undefined) updateData.default_view = input.defaultView;
-        if (input.hourHeightDensity !== undefined)
-          updateData.hour_height_density = input.hourHeightDensity;
-        if (input.theme !== undefined) updateData.theme = input.theme;
-        if (input.preferredLocale !== undefined)
-          updateData.preferred_locale = input.preferredLocale;
-
-        // base columns を先に upsert。personalization RPC は UPDATE ... WHERE user_id なので
-        // 初回ユーザーでは row が無いと no-op になり、dismissedTrialEndedDialog 等が永続化されない
-        const { data, error } = await ctx.supabase
-          .from('user_settings')
-          .upsert(updateData, {
-            onConflict: 'user_id',
-          })
-          .select()
-          .single();
-
-        // timezone を更新した場合は entry router 側の tz cache を即時 invalidate。
-        // 30 秒 TTL を待たずに新しい timezone で entry が作成されるようにする。
-        if (!error && input.timezone !== undefined) {
-          invalidateUserTimezoneCache(userId);
-        }
-
-        // personalization は RPC で atomic に部分更新（並行保存の競合を回避）
-        if (input.dismissedTrialEndedDialog !== undefined) {
-          await ctx.supabase.rpc(
-            'update_personalization' as never,
-            {
-              p_user_id: userId,
-              p_path: 'dismissedTrialEndedDialog',
-              p_value: true,
-            } as never,
-          );
-        }
-        if (input.paymentErrorDialogLastShownAt !== undefined) {
-          await ctx.supabase.rpc(
-            'update_personalization' as never,
-            {
-              p_user_id: userId,
-              p_path: 'paymentErrorDialogLastShownAt',
-              p_value: input.paymentErrorDialogLastShownAt,
-            } as never,
-          );
-        }
-
-        if (error) {
-          logger.error('UserSettings update error', { error });
-          handleServiceError(error);
-        }
-
-        return {
-          success: true,
-          settings: data,
-        };
+        return await createSettingsService(ctx.supabase).update(userId, input);
       } catch (error) {
         return handleServiceError(error);
       }
@@ -224,20 +107,7 @@ export const userSettingsRouter = createTRPCRouter({
           });
         }
 
-        const { data, error } = await ctx.supabase
-          .from('user_settings')
-          .select('*')
-          .eq('user_id', userId)
-          .single();
-
-        if (error && error.code !== 'PGRST116') {
-          logger.error('iCal token fetch error:', error);
-          handleServiceError(error);
-        }
-
-        // ical_feed_token は生成型に未反映のため Record 経由で取得
-        const token = (data as Record<string, unknown> | null)?.ical_feed_token;
-        return { token: (token as string) ?? null };
+        return await createSettingsService(ctx.supabase).getICalToken(userId);
       } catch (error) {
         return handleServiceError(error);
       }
@@ -259,35 +129,7 @@ export const userSettingsRouter = createTRPCRouter({
           });
         }
 
-        // user_settingsにレコードがなければ作成、あれば更新
-        const newToken = crypto.randomUUID();
-        const { error } = await ctx.supabase.from('user_settings').upsert(
-          {
-            user_id: userId,
-          },
-          { onConflict: 'user_id' },
-        );
-
-        if (error) {
-          logger.error('iCal token upsert error:', error);
-          handleServiceError(error);
-        }
-
-        // ical_feed_tokenは生成型に未反映のためSQL実行
-        const { data: updated, error: updateError } = await ctx.supabase
-          .from('user_settings')
-          .update({ ical_feed_token: newToken } as never)
-          .eq('user_id', userId)
-          .select('*')
-          .single();
-
-        if (updateError) {
-          logger.error('iCal token update error:', updateError);
-          handleServiceError(updateError);
-        }
-
-        const token = (updated as Record<string, unknown>).ical_feed_token;
-        return { token: token as string };
+        return await createSettingsService(ctx.supabase).regenerateICalToken(userId);
       } catch (error) {
         return handleServiceError(error);
       }

--- a/apps/product/src/features/settings/server/settings-service.ts
+++ b/apps/product/src/features/settings/server/settings-service.ts
@@ -1,0 +1,174 @@
+import 'server-only';
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { logger } from '@/lib/logger';
+import { invalidateUserTimezoneCache } from '@/lib/server/user-timezone-cache';
+import { ServiceError } from '@/lib/trpc/errors';
+import type { Database, Insert } from '@dayopt/database';
+
+type UserSettingsInsert = Insert<'user_settings'>;
+
+interface UserSettingsUpdateInput {
+  timezone?: string | undefined;
+  timeFormat?: '24h' | '12h' | undefined;
+  weekStartsOn?: 0 | 1 | 6 | undefined;
+  showWeekends?: boolean | undefined;
+  showWeekNumbers?: boolean | undefined;
+  defaultDuration?: number | undefined;
+  snapInterval?: 5 | 10 | 15 | 30 | undefined;
+  defaultView?: 'day' | '3day' | '5day' | 'week' | undefined;
+  hourHeightDensity?: 'compact' | 'default' | 'spacious' | undefined;
+  theme?: 'light' | 'dark' | 'system' | undefined;
+  dismissedTrialEndedDialog?: true | undefined;
+  paymentErrorDialogLastShownAt?: string | undefined;
+  preferredLocale?: 'en' | 'ja' | undefined;
+}
+
+export class SettingsService {
+  constructor(private readonly supabase: SupabaseClient<Database>) {}
+
+  async get(userId: string) {
+    const { data, error } = await this.supabase
+      .from('user_settings')
+      .select('*')
+      .eq('user_id', userId)
+      .single();
+
+    if (error && error.code !== 'PGRST116') {
+      logger.error('UserSettings fetch error', { error });
+      throw new SettingsServiceError('FETCH_FAILED', error.message);
+    }
+
+    if (!data) return null;
+
+    return {
+      timezone: data.timezone,
+      timeFormat: data.time_format as '24h' | '12h',
+      weekStartsOn: data.week_starts_on as 0 | 1 | 6,
+      showWeekends: data.show_weekends,
+      showWeekNumbers: data.show_week_numbers,
+      defaultDuration: data.default_duration,
+      snapInterval: data.snap_interval as 5 | 10 | 15 | 30,
+      defaultView: data.default_view as 'day' | '3day' | '5day' | 'week' | undefined,
+      hourHeightDensity: data.hour_height_density as 'compact' | 'default' | 'spacious' | undefined,
+      theme: data.theme as 'light' | 'dark' | 'system',
+      personalization: (() => {
+        const personalization = (data as Record<string, unknown>).personalization as Record<
+          string,
+          unknown
+        > | null;
+        return {
+          dismissedTrialEndedDialog: (personalization?.dismissedTrialEndedDialog ??
+            false) as boolean,
+          paymentErrorDialogLastShownAt: (personalization?.paymentErrorDialogLastShownAt ??
+            null) as string | null,
+        };
+      })(),
+      preferredLocale: (data.preferred_locale as 'en' | 'ja' | undefined) ?? 'en',
+    };
+  }
+
+  async update(userId: string, input: UserSettingsUpdateInput) {
+    const updateData: UserSettingsInsert = { user_id: userId };
+
+    if (input.timezone !== undefined) updateData.timezone = input.timezone;
+    if (input.timeFormat !== undefined) updateData.time_format = input.timeFormat;
+    if (input.weekStartsOn !== undefined) updateData.week_starts_on = input.weekStartsOn;
+    if (input.showWeekends !== undefined) updateData.show_weekends = input.showWeekends;
+    if (input.showWeekNumbers !== undefined) updateData.show_week_numbers = input.showWeekNumbers;
+    if (input.defaultDuration !== undefined) updateData.default_duration = input.defaultDuration;
+    if (input.snapInterval !== undefined) updateData.snap_interval = input.snapInterval;
+    if (input.defaultView !== undefined) updateData.default_view = input.defaultView;
+    if (input.hourHeightDensity !== undefined)
+      updateData.hour_height_density = input.hourHeightDensity;
+    if (input.theme !== undefined) updateData.theme = input.theme;
+    if (input.preferredLocale !== undefined) updateData.preferred_locale = input.preferredLocale;
+
+    const { data, error } = await this.supabase
+      .from('user_settings')
+      .upsert(updateData, { onConflict: 'user_id' })
+      .select()
+      .single();
+
+    if (!error && input.timezone !== undefined) {
+      invalidateUserTimezoneCache(userId);
+    }
+
+    if (input.dismissedTrialEndedDialog !== undefined) {
+      await this.supabase.rpc('update_personalization', {
+        p_user_id: userId,
+        p_path: 'dismissedTrialEndedDialog',
+        p_value: true,
+      });
+    }
+    if (input.paymentErrorDialogLastShownAt !== undefined) {
+      await this.supabase.rpc('update_personalization', {
+        p_user_id: userId,
+        p_path: 'paymentErrorDialogLastShownAt',
+        p_value: input.paymentErrorDialogLastShownAt,
+      });
+    }
+
+    if (error) {
+      logger.error('UserSettings update error', { error });
+      throw new SettingsServiceError('UPDATE_FAILED', error.message);
+    }
+
+    return { success: true, settings: data };
+  }
+
+  async getICalToken(userId: string) {
+    const { data, error } = await this.supabase
+      .from('user_settings')
+      .select('*')
+      .eq('user_id', userId)
+      .single();
+
+    if (error && error.code !== 'PGRST116') {
+      logger.error('iCal token fetch error:', error);
+      throw new SettingsServiceError('FETCH_FAILED', error.message);
+    }
+
+    const token = (data as Record<string, unknown> | null)?.ical_feed_token;
+    return { token: (token as string) ?? null };
+  }
+
+  async regenerateICalToken(userId: string) {
+    const newToken = crypto.randomUUID();
+    const { error } = await this.supabase
+      .from('user_settings')
+      .upsert({ user_id: userId }, { onConflict: 'user_id' });
+
+    if (error) {
+      logger.error('iCal token upsert error:', error);
+      throw new SettingsServiceError('UPDATE_FAILED', error.message);
+    }
+
+    const { data: updated, error: updateError } = await this.supabase
+      .from('user_settings')
+      .update({ ical_feed_token: newToken } as never)
+      .eq('user_id', userId)
+      .select('*')
+      .single();
+
+    if (updateError) {
+      logger.error('iCal token update error:', updateError);
+      throw new SettingsServiceError('UPDATE_FAILED', updateError.message);
+    }
+
+    const token = (updated as Record<string, unknown>).ical_feed_token;
+    return { token: token as string };
+  }
+}
+
+export class SettingsServiceError extends ServiceError {
+  constructor(code: string, message: string) {
+    super(code, message);
+    this.name = 'SettingsServiceError';
+  }
+}
+
+export function createSettingsService(supabase: SupabaseClient<Database>): SettingsService {
+  return new SettingsService(supabase);
+}


### PR DESCRIPTION
## Summary

- settings router内のSupabase操作を`SettingsService`へ抽出
- routerを認証・Zod validation・service呼び出し・エラー変換に限定
- 設定取得・更新・iCal token処理のservice単体テストを追加
- 最新mainで削除されたchronotype設定には追従し、再導入しない

## Why

settings routerにデータアクセスと変換処理が集中していたため、service層へ分離して責務とテスト容易性を改善します。procedureの入出力と既存挙動は維持します。

## Validation

- `pnpm test:run` (139 files / 1795 tests passed)
- `pnpm test:integration` (4 files / 43 passed / 1 skipped)
- `pnpm --filter @dayopt/product typecheck`
- `pnpm --filter @dayopt/product lint:boundaries`

Closes #1304