### PR TITLE
[codex] docs(projects): project summaryを3件追加

### DIFF
--- a/apps/storybook/docs/product/projects/cleanup-2026-04-26/summary.md
+++ b/apps/storybook/docs/product/projects/cleanup-2026-04-26/summary.md
@@ -1,0 +1,62 @@
+# cleanup-2026-04-26 クローズサマリー
+
+クローズ日: 2026-04-27
+
+状態: **部分完了で中断**
+
+> **overview**: [overview.mdx](./overview.mdx)。実行ログと entry ごとの判断は overview を正とする。
+
+## Project ゴール
+
+`src/` を dead code、barrel export、cast residue、Storybook gap、JSDoc drift の観点で監査し、機械的に安全な cleanup を進める。参照が動的なファイルや設計判断を伴う項目は、削除を強行せず停止条件に従って分離する。
+
+## 到達点
+
+| 区分                  | 結果                                                        |
+| --------------------- | ----------------------------------------------------------- |
+| 監査                  | C-001〜C-057 を列挙                                         |
+| barrel cleanup        | C-005〜C-018、C-068〜C-076 を実施                           |
+| 連鎖して孤立した file | C-062〜C-067 を削除                                         |
+| Storybook             | C-041 を追加                                                |
+| API / route docs      | C-058〜C-061 を追加                                         |
+| 完了 entry            | **33 件**                                                   |
+| 変更規模              | cleanup **-1,116 行** / docs **+260 行** / story **+38 行** |
+
+実行当時の細分化された 41 commit は後続の squash / batch 取り込み後の現在の履歴では個別 SHA を参照できない。現在追跡可能な docs 履歴は次のとおり。
+
+| SHA        | 日付       | 役割                                  |
+| ---------- | ---------- | ------------------------------------- |
+| `7550e81e` | 2026-04-26 | cleanup overview を含む当日状態を記録 |
+| `e54b3c96` | 2026-04-27 | v0.27.0 時点の最終実行ログを記録      |
+| `43b2b969` | 2026-05-21 | docs を Storybook 配下へ集約          |
+| `0f6ef04d` | 2026-06-15 | 散文 docs の配置整理                  |
+
+## 技術的成果
+
+- feature / lib barrel から未参照 re-export を削減し、公開面を縮小
+- barrel cleanup 後に外部参照が消えた wrapper、hook、grid helper を追加削除
+- `api-overview.mdx` と `app-routes.mdx` の原型を追加し、API と route group の責務を一覧化
+- knip の検出をそのまま削除根拠にせず、Next.js / next-intl の動的参照と意図的 scaffolding を false positive として切り分け
+- 連続 skip と design decision 発生時に停止する運用を実際に適用
+
+## 中断理由
+
+残りは機械的 cleanup ではなく、mock 戦略や feature 公開面の設計判断を必要とした。
+
+- C-019〜C-029: 実体 export の削除は型 import・外部参照の再監査が必要
+- C-042〜C-056: initializer / provider / mutation component の Storybook mock 方針が未確定
+- C-057: JSDoc drift 70 file は独立 project 相当
+- C-001〜C-004: 動的参照または当時の scaffolding による knip false positive
+
+その後 AI、chronotype、tour など複数 feature が削除されており、当時の残件をそのまま再開することはできない。
+
+## ハマり点 / 学び
+
+- 静的解析の unused 判定は、framework config や動的 import を含む repository では削除証明にならない
+- barrel export を先に減らすと、相互参照だけで残っていた孤立 file が次の knip 実行で見える
+- UI を持たない initializer に Story を必須化すると、価値より mock 維持コストが上回る場合がある
+- 長期 cleanup は granular commit を後から追跡できる形で PR に残す。ローカル commit を batch 取り込みすると close-out の証拠が弱くなる
+
+## 引き継ぎ
+
+再開する場合は旧 C 番号を消化するのではなく、現行 main で `knip` と参照検索を取り直して新しい project として起票する。特に Storybook gap は「描画可能な user-facing component」に対象を絞り、provider / initializer は unit test で扱う方針を先に確定する。

--- a/apps/storybook/docs/product/projects/mcp-server/summary.md
+++ b/apps/storybook/docs/product/projects/mcp-server/summary.md
@@ -1,0 +1,68 @@
+# mcp-server クローズサマリー
+
+初回実装日: 2026-05-01
+
+最終監査日: 2026-06-15
+
+状態: **Phase 1 実装済み、Phase 1.5 以降は部分実装で保留**
+
+> **overview**: [overview.mdx](./overview.mdx)。overview の Phase 分割を基準に、現在の repository で確認できる実装だけを到達済みと判定した。
+
+## Project ゴール
+
+Pro user が `mcp.dayopt.app` を Custom Connector に登録し、Dayopt が発行する OAuth 2.1 token で read-only MCP tool を利用できるようにする。Phase 1 は Tomoya の solo dogfood、Phase 1.5 は最初の有料 user 受け入れ、Phase 2 は DCR と複数 client 対応、Phase 3 は公開 docs を対象とした。
+
+## 主要コミット
+
+| SHA        | 日付       | 内容                                                                                         |
+| ---------- | ---------- | -------------------------------------------------------------------------------------------- |
+| `e461a126` | 2026-05-01 | Remote MCP server + OAuth 2.1 Phase 1 PoC（PR #1117、66 files / +4,231 / -628）              |
+| `0f3a36a8` | 2026-05-01 | `oauth_tokens` の user UPDATE policy を削除し RLS を強化（PR #1118）                         |
+| `63c86aca` | 2026-05-01 | migration workflow の Production environment 名を修正（PR #1119）                            |
+| `cca5f30d` | 2026-05-01 | DB types 再生成と OAuth service-role client の型絞り込み（PR #1121）                         |
+| `a0e0ebdb` | 2026-05-01 | AS / RS metadata URL を固定し issuer 一致を確保（PR #1127）                                  |
+| `2b14484e` | 2026-05-01 | production rewrite 問題を避け、実体 `/api/mcp` / `/api/oauth/token` を advertise（PR #1128） |
+| `d55e3203` | 2026-06-04 | production に存在していた Phase 1.5 migration 履歴を repository に復元（PR #1257）           |
+
+## 現在確認できる成果
+
+- OAuth authorization code + PKCE S256、refresh token rotation、opaque access token を実装
+- `oauth_tokens` / `oauth_authorization_codes` schema と RLS を実装
+- AS / protected-resource metadata endpoint を実装
+- Streamable HTTP MCP endpoint と `entries.list` read-only tool を実装
+- bearer token を DB lookup し、expiry / revoke / scope を確認する認証経路を実装
+- MCP URL を Settings に表示し、Pro entitlement で gate
+- token hash のみを DB 保存し、生 token を保存しない設計を維持
+- `oauth_audit_log` と atomic token pair RPC の migration は repository に存在
+
+## 未完・現行コードとの不一致
+
+Phase 1 の実機完了基準と Phase 1.5 以降は、現在の repository だけでは完了を証明できない。
+
+- Claude.ai connector からの end-to-end dogfood 成功記録が summary / test として残っていない
+- `verifyAccessToken` と OAuth mode の `proProcedure` を覆う専用 unit test が現存しない
+- Settings は接続済み client 一覧 / revoke UI ではなく、`apiKey: null` の vestige を残す
+- `mcp.revokeToken`、`entries.daily_summary`、DCR `/oauth/register` は未実装
+- `/oauth/authorize` / MCP endpoint の専用 rate limit は現行コードで確認できない
+- `oauth_audit_log` table はあるが、MCP tool call からの audit insert は確認できない
+- atomic `issue_oauth_token_pair` RPC は migration にある一方、`code-exchange.ts` は未置換 TODO を残す
+- production rewrite 問題により、overview の versionless public URL ではなく実体 API path を advertise する follow-up が入っている
+
+2026-05-14 journal には Phase 1.5 完了とあるが、上記の current code と一致しないため、本 summary では repository の現状を優先して **部分実装** と判定する。
+
+## ハマり点 / 学び
+
+- OAuth metadata の issuer / endpoint は環境変数任せにせず、公開 origin と厳密一致させる必要がある
+- Vercel rewrite を public contract に含める場合、production での実 URL smoke test が不可欠
+- migration が production に存在しても git history から欠落すると、実装状態と schema state の監査が難しくなる
+- journal の「完了」だけでは完了証拠にならない。E2E、専用 test、current UI、route wiring を揃えて close-out する必要がある
+
+## 残課題 / 再開条件
+
+再開時は Phase 1.5 の旧 checklist をそのまま消化せず、現在の MCP SDK / OAuth metadata / connector 要件を再調査する。その上で次を独立 issue に分ける。
+
+1. OAuth / MCP auth unit test と connector E2E の復元
+2. atomic token pair RPC への接続
+3. audit log、rate limit、subscription revoke の現行要件確認
+4. connected client 一覧と user revoke UI
+5. DCR、ChatGPT / Cursor 対応、tool 拡充は利用実績を確認してから判断

--- a/apps/storybook/docs/product/projects/mcp-server/summary.md
+++ b/apps/storybook/docs/product/projects/mcp-server/summary.md
@@ -43,7 +43,7 @@ Phase 1 の実機完了基準と Phase 1.5 以降は、現在の repository だ�
 - `verifyAccessToken` と OAuth mode の `proProcedure` を覆う専用 unit test が現存しない
 - Settings は接続済み client 一覧 / revoke UI ではなく、`apiKey: null` の vestige を残す
 - `mcp.revokeToken`、`entries.daily_summary`、DCR `/oauth/register` は未実装
-- `/oauth/authorize` / MCP endpoint の専用 rate limit は現行コードで確認できない
+- `/oauth/authorize` / `/oauth/token` / MCP endpoint の専用 rate limit は現行コードで確認できない
 - `oauth_audit_log` table はあるが、MCP tool call からの audit insert は確認できない
 - atomic `issue_oauth_token_pair` RPC は migration にある一方、`code-exchange.ts` は未置換 TODO を残す
 - production rewrite 問題により、overview の versionless public URL ではなく実体 API path を advertise する follow-up が入っている

--- a/apps/storybook/docs/product/projects/review-granularity-redesign/summary.md
+++ b/apps/storybook/docs/product/projects/review-granularity-redesign/summary.md
@@ -1,0 +1,61 @@
+# review-granularity-redesign 完了サマリー
+
+完了日: 2026-06-12
+
+最終整理日: 2026-06-15
+
+状態: **完了後、core-slim 方針で日次・週次へ縮小**
+
+> **overview**: [overview.md](./overview.md)。overview は全 4 粒度を実装した時点の設計記録であり、現在の製品仕様は本 summary の「現行到達点」を正とする。
+
+## Project ゴール
+
+Review を「同じ画面のズーム切替」から、粒度ごとに異なる問いへ答える composition に再設計する。計画と実績の 2-layer data、rule-based 所見、Calendar への還流導線を Review の中心に据える。
+
+## 主要コミット
+
+| SHA        | 日付       | 内容                                                                                                 |
+| ---------- | ---------- | ---------------------------------------------------------------------------------------------------- |
+| `956532fe` | 2026-06-12 | 4 粒度 dispatcher、日次 / 週次 / 月次 / 年次 view、URL 復元、prefetch、Story、E2E を実装（PR #1290） |
+| `e943d5d3` | 2026-06-14 | core-slim 方針で月次・年次 view を削除し、見積精度を週次へ移設（PR #1339）                           |
+| `8d4be20b` | 2026-06-14 | fulfillment 軸の削除に伴い日次 KPI / 操作を整理（PR #1342）                                          |
+| `72a4270b` | 2026-06-15 | Time P/L を 1 view に縮小し、未参照統計 procedure を削除（PR #1358）                                 |
+
+初回実装 `956532fe`: **53 files / +4,108 / -590**。後続の core-slim 整理では月次・年次関連を約 1,145 行、Time P/L variant と未参照統計を約 1,816 行削減した。
+
+## 実装時の成果
+
+- `ReviewView` を粒度 dispatcher 化し、Daily Close / Weekly Review / Monthly Patterns / Year Map を独立 composition として実装
+- 週次に rule-based 所見、KPI、Time P/L、曜日・時間帯 rhythm、次週 Calendar CTA を配置
+- 日次に planned / actual 2 列 timeline、見積ずれ所見、翌日 Calendar CTA を配置
+- `?g=&d=` の deep link 復元と粒度別 SSR prefetch を実装
+- shared component と Storybook story、4 粒度 deep-link E2E を追加
+- データが少ない期間では断定しない confidence guard を追加
+
+## 現行到達点
+
+2026-06-15 時点では、Review の価値を日次と週次に集中する core-slim 方針へ変更済み。
+
+- `ReviewGranularity`: `day | week`
+- `ReviewView`: `DailyReview` / `WeeklyReview` の 2 composition
+- 維持: `InsightSlot`、`RuleInsightSlot`、`SummaryCard`、`NextActionLink`、URL 復元、粒度別 prefetch
+- 維持: 日次 planned / actual 比較、週次見積精度・rhythm・タグ構成
+- 削除: `MonthlyReview`、`YearlyReview`、年間 heatmap、月別 trend、月次用 tag balance chain
+- 削除: fulfillment KPI / 採点 UI
+- 縮小: Time P/L 6 variant から製品で使う core view のみへ
+
+## 設計から変更した理由
+
+- 月次・年次は launch core に対して情報量と保守面が大きく、日次・週次より利用価値の証明が弱かった
+- fulfillment / chronotype を含む周辺軸が製品から削除され、元設計の KPI と所見入力が成立しなくなった
+- 未参照 procedure と Storybook-only variant を保持するより、実利用経路に絞る方針へ変更した
+
+## ハマり点 / 学び
+
+- 大きな設計を一度実装しても、core value の再評価で削る判断は失敗ではなく close-out の一部
+- overview を過去の意思決定記録として残す場合、current contract を summary に明記しないと「4 粒度が現仕様」と誤読される
+- URL state、prefetch key、client store の 3 箇所は同じ粒度集合を共有するため、粒度削除時にまとめて更新する必要がある
+
+## 引き継ぎ
+
+本 project を再開して月次・年次を戻す予定はない。追加分析は、日次・週次で user value が確認できた metric のみを独立 issue で検討する。overview 内の 4 粒度 roadmap は履歴資料として扱う。


### PR DESCRIPTION
## Summary

- cleanup project を部分完了・中断として close-out
- Review redesign の初回完成と core-slim 後の現行仕様を記録
- MCP server の Phase 1 完了と Phase 1.5 以降の未完項目を現行 repository 基準で整理

## Verification

- `pnpm --filter @dayopt/storybook build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:boundaries`
- `git diff --check`

Closes #1315
