### PR TITLE
docs(strategy): 競合調査 8 件を strategy/research にアーカイブ

### DIFF
--- a/apps/storybook/docs/product/strategy/research/competitors/README.md
+++ b/apps/storybook/docs/product/strategy/research/competitors/README.md
@@ -1,0 +1,30 @@
+# 競合調査（詳細メモ）
+
+タイムボクシング × タスク × カレンダー領域の競合について、機能・コンセプト・差別化を深掘りした調査メモのアーカイブ。各ファイルは GitHub Issue（label: `競合`）の内容を取り込んだもの。
+
+俯瞰のポジショニング・差別化軸は [`../competitors.mdx`](../competitors.mdx)（Strategy/Competitors）を参照。本フォルダは「個別競合の深掘り」を担う。
+
+## 一覧
+
+| 競合                                        | 分類の重なり                          | メモ                                                   |
+| ------------------------------------------- | ------------------------------------- | ------------------------------------------------------ |
+| [Sunsama](sunsama.md)                       | daily planning ritual の最重要競合    | task-first + ritual-first。planned/actual を一級機能化 |
+| [Super Productivity](super-productivity.md) | OSS / developer / planned-actual 競合 | OSS・開発者向け・time tracking 統合                    |
+| [Akiflow](akiflow.md)                       | タスク集約 + time blocking            | 外部タスク取り込み → today に落とす思想                |
+| [Motion](motion.md)                         | AI 自動スケジューリング               | AI でカレンダーを自動編成                              |
+| [Routine](routine.md)                       | notes + calendar + tasks              | calm な daily planner、ノート統合                      |
+| [TickTick](ticktick.md)                     | タスク管理 + カレンダー + habit       | 多機能・大衆向け                                       |
+| [Ellie](ellie.md)                           | 軽量 daily planner                    | シンプル・軽さで近い                                   |
+| [Amazing Marvin](amazing-marvin.md)         | 高カスタマイズ daily planner          | strategy/system が豊富                                 |
+
+## Dayopt の立ち位置（要約）
+
+Dayopt は **Timebox / Tag-first**。多くの競合が Task-first（タスクを集めて今日に落とす）なのに対し、Dayopt は「時間枠にタグを置き、予定/実績を1エントリで見て、ズレを次の時間設計に戻す」軽いループで差別化する。
+
+- 寄せすぎ注意: Sunsama / Akiflow に寄せると「丁寧な日次計画アプリの劣化版」になりやすい
+- 勝ち筋: より短い儀式・より軽い入力・予定/実績の直接差分
+
+## 運用
+
+- 一次情報（公式サイト・価格）は変動するため、各メモの URL を定期的に確認する
+- 大きな機能変更・価格改定を検知したら該当メモを更新し、必要なら `competitors.mdx` のマトリクスへ反映する

--- a/apps/storybook/docs/product/strategy/research/competitors/akiflow.md
+++ b/apps/storybook/docs/product/strategy/research/competitors/akiflow.md
@@ -1,0 +1,305 @@
+# 競合調査: Akiflow
+
+> アーカイブ元: GitHub Issue #1264（label: 競合）
+> 取り込み日: 2026-06-15
+> このドキュメントは継続観察用の調査メモ。一次情報は各競合の公式サイトを参照。
+
+---
+
+## 概要
+
+Akiflow は、タスク・カレンダー・インボックス・AIアシスタントを統合した time-blocking digital planner。
+Dayopt とは「タスク/予定を1つのカレンダーに集約し、時間ブロックとして日々の計画を作る」という領域で重なる。
+
+Super Productivity が OSS / local-first 寄り、Sunsama が daily planning ritual 寄りだとすると、Akiflow は **integrated productivity hub + time blocking + speed/shortcut** 寄りの競合。
+
+- 公式サイト: https://akiflow.com/
+- Pricing: https://akiflow.com/pricing
+- Integrations: https://akiflow.com/integrations
+- Google Calendar integration: https://akiflow.com/integrations/google-calendar
+- GitHub integration: https://akiflow.com/integrations/github
+- Linear integration: https://akiflow.com/integrations/linear
+- Todoist integration: https://akiflow.com/integrations/todoist
+
+## 競合分類
+
+| 観点           | 評価                                                                     |
+| -------------- | ------------------------------------------------------------------------ |
+| 機能競合       | 高い。calendar / tasks / inbox / time blocking / routines を持つ         |
+| コンセプト競合 | 中〜高。Dayoptより task hub 色が強いが、時間ブロック設計は近い           |
+| ターゲット競合 | 高い。founders / operators / busy professionals / power users 向け       |
+| 価格競合       | 中。月額 $34、年額 $19/月の高価格帯                                      |
+| UX思想         | Task-first + Calendar-first + AI assistant。Dayoptより統合ハブ志向が強い |
+
+## 公式上の主な訴求
+
+- “One app for tasks & calendars powered by AI”
+- calendars, tasks, inbox, assistant を1つにまとめる
+- founders / operators / obsessed doers 向け
+- one calendar that syncs
+- time-block your day automatically
+- plan your day / week automatically
+- universal inbox & integrations
+- emails / Slack messages / issues を task に変換
+- AI assistant: Aki
+- quick capture / natural language / voice / Cmd+K
+- focus time / goals / focus mode / daily rituals
+- 7-day free trial
+
+## 価格
+
+2026-06-07時点の公式 pricing 表記では以下。
+
+| Plan        |   価格 | 備考            |
+| ----------- | -----: | --------------- |
+| Pro Monthly | $34/月 | monthly billing |
+| Pro Yearly  | $19/月 | yearly billing  |
+
+Dayopt の $5 Pro 想定とは価格帯がかなり違う。
+Akiflow は「時間を節約できるなら高くても払う」層を狙っている。
+
+## 主な機能
+
+### One Calendar / Time Blocking
+
+Akiflow は複数カレンダーとタスクを1つのカレンダーに集約し、time-blocking で日・週を組み立てる。
+公式上でも “Time-block your day automatically” “Plan your day, week, automatically” を打ち出している。
+
+Dayoptとの重なり:
+
+```text
+やることを集約する
+↓
+カレンダーに置く
+↓
+日/週の計画にする
+↓
+実行する
+```
+
+ただし Akiflow は自動スケジューリング/AI/統合ハブ寄り。
+Dayoptは手触りの軽い timebox / tag-first に寄せたい。
+
+### Universal Inbox & Integrations
+
+Akiflow は多くの外部ツールからタスクを集約する。
+
+代表例:
+
+- Google Calendar / Outlook Calendar
+- Gmail / Outlook Email
+- Slack
+- GitHub
+- Linear
+- Jira
+- Asana
+- Trello
+- Todoist
+- Notion
+- Zapier / IFTTT
+
+公式 integration ページでは GitHub issues や Linear issues を Akiflow に統合できると説明している。
+
+Dayoptでは、ここを真似ると Todo管理・統合インボックスアプリになる危険がある。
+Dayoptは外部タスクを奪わず、URL添付 / MCP / API-first で「時間記録の器」に徹する方がよい。
+
+### Quick Capture / Cmd+K / Natural Language
+
+Akiflow は「thought speed」で capture できることを訴求している。
+
+- natural language
+- voice mode
+- AI chat
+- Cmd+K
+- mobile shortcuts
+- widgets
+
+Dayoptでも「タグを選ぶだけ」「ショートカットだけで置く」は強く参考になる。
+ただしAIチャットや音声まで初期に持つ必要はない。
+
+### AI Assistant: Aki
+
+Akiflow は AI assistant をかなり前面に出している。
+
+- 空き時間を見つける
+- 予定を作る
+- 優先順位付け
+- next actions 抽出
+- recurring tasks の処理
+- daily briefings / reminders
+
+Dayoptでは、AIをアプリ内価値として前面に出しすぎるより、MCP/API経由で外部AIが読める・書ける設計の方が合う。
+
+### Productivity Toolbox
+
+- Focus Time
+- Goals
+- Focus Mode
+- Daily Rituals
+- Privacy
+- Analytics on Productivity / Tasks
+- recurring tasks
+- labels
+- list / categories
+- time slots
+- availability slots
+
+Dayoptには不要なものも多いが、「time slots」「daily rituals」「shortcuts / hotkeys」は参考になる。
+
+## Dayoptとの違い
+
+```text
+Akiflow:
+外部ツールからタスク/メール/Issueを集める
+↓
+AIやインボックスで整理する
+↓
+カレンダーに時間ブロックする
+↓
+日/週の計画として実行する
+↓
+必要に応じてAIが調整する
+```
+
+```text
+Dayopt:
+時間枠がある
+↓
+タグを置く
+↓
+予定と実績が1つのエントリになる
+↓
+ズレを見る
+↓
+次の時間設計に戻る
+```
+
+Akiflow は **Productivity Hub / Task-first / AI-first**。
+Dayopt は **Timebox / Tag-first / Minimal-first**。
+
+DayoptがAkiflowに寄せすぎると、統合ハブ・AIアシスタント・タスク管理の重い競争になる。
+Dayoptは「統合しない」「奪わない」「ただ時間に戻す」で差別化したい。
+
+## 盗めそうな部分
+
+### P1: Capture / 操作速度の訴求
+
+Akiflow は “Capture tasks at the speed of thoughts” として、すぐ入力できることを強く打ち出している。
+Dayoptも「タグを選ぶだけ」「Enterで確定」「数字で最近使ったタグ」など、操作速度を明確な価値にしたい。
+
+Dayopt訳:
+
+```text
+タグを選ぶだけで、今日の時間が形になる。
+```
+
+### P1: Calendar + Task を一画面で扱う見せ方
+
+Akiflowは task と calendar を1つの flow として見せるのがうまい。
+Dayoptでは task ではなく tag / entry で同じ構造を作る。
+
+Dayopt訳:
+
+```text
+予定と記録が、同じ時間ブロックに閉じる。
+```
+
+### P1: Time slots / availability の考え方
+
+Akiflowの time slots / availability slots は、Dayoptの「空白時間」「差分」「未配置時間」の見せ方に応用できる。
+
+例:
+
+```text
+今日の空き時間
+- 10:30–11:00 30分
+- 15:00–15:45 45分
+```
+
+Dayoptでは、この空白を「新しいタスクを入れる」より「時間のズレを把握する」用途に寄せる。
+
+### P2: Cmd+K / Command Palette
+
+開発者向けならかなり参考になる。
+
+候補:
+
+```text
+Cmd+K: コマンドパレット
+T: タグ選択
+P: 今日の予定作成
+R: Reviewを開く
+Space: 現在の記録開始/停止
+Enter: 確定
+```
+
+### P2: AIを“内蔵チャット”ではなく“操作補助”として見る
+
+AkiflowはAI assistantを前面に出している。
+Dayoptでは、AIそのものを価値にするより、MCP/APIで外部AIが `今日の予定/実績/差分` を読める方が合う。
+
+Dayopt訳:
+
+```text
+AIと話すアプリではなく、AIが読める時間データの器。
+```
+
+### P3: high price competitor としてのポジショニング参考
+
+Akiflowは $19〜$34/月でも成立している。
+Dayoptの $5 Pro はかなり軽い価格帯なので、「少機能・低価格・高速入力」の対比が作れる。
+
+## 盗まない方がいい部分
+
+| 機能/思想                      | 理由                                      |
+| ------------------------------ | ----------------------------------------- |
+| Universal Inbox                | タスク管理/統合ハブ化してDayoptが重くなる |
+| GitHub/Linear/Jira import      | 外部タスク管理を奪う方向になる            |
+| AI assistant front-and-center  | Dayoptの価値がAIチャットに見えてしまう    |
+| 自動スケジューリングの作り込み | Dayoptの手触り・自己決定感と衝突しやすい  |
+| Recurring tasks                | 削る方針と衝突                            |
+| Goals / focus mode の拡張      | 別機能が増えすぎる                        |
+| team scheduling                | Dayoptの初期ターゲットではない            |
+| email/slack to task            | Todoアプリ化する                          |
+
+## Dayoptの差別化メッセージ候補
+
+避けたい表現:
+
+```text
+すべてのタスクを1つに集約
+AIがあなたの予定を自動調整
+メールやIssueをタスク化
+生産性ハブ
+```
+
+使いたい表現:
+
+```text
+Todoを集めず、時間だけを整える
+タグを置くだけで、予定と実績がつながる
+AIに任せる前に、自分の時間のズレを見える化する
+外部ツールはそのまま。Dayoptは使った時間だけを受け止める
+```
+
+## Dayoptへの示唆
+
+Akiflowは「全部集めて、AIも使って、カレンダーで実行する」競合。
+Dayoptはその逆に、**集約しすぎないこと**が差別化になる。
+
+```text
+Akiflow = 仕事の入口を全部集めてカレンダーに流す productivity hub
+Dayopt = 今日の時間ブロックを軽く置き、実績差分で明日を補正する timebox tool
+```
+
+DayoptはAkiflowから操作速度・time blocking・command palette を盗む。
+ただし、universal inbox / task import / AI assistant は盗まない。
+
+## 次に検討したいこと
+
+- [ ] Dayoptのショートカット初期セットを決める
+- [ ] Cmd+K / command palette を初期から入れるか検討する
+- [ ] 空白時間 / availability 的な表示を Review に入れるか検討する
+- [ ] 外部URL添付は入れるが、GitHub/Linear import は非採用でよいか整理する
+- [ ] AI訴求を「内蔵AI」ではなく「MCP/APIで読める」に寄せるか明文化する
+- [ ] LPで「統合ハブではない」ポジションを言語化する

--- a/apps/storybook/docs/product/strategy/research/competitors/amazing-marvin.md
+++ b/apps/storybook/docs/product/strategy/research/competitors/amazing-marvin.md
@@ -1,0 +1,268 @@
+# 競合調査: Amazing Marvin
+
+> アーカイブ元: GitHub Issue #1268（label: 競合）
+> 取り込み日: 2026-06-15
+> このドキュメントは継続観察用の調査メモ。一次情報は各競合の公式サイトを参照。
+
+---
+
+## 概要
+
+Amazing Marvin は、ADHD / procrastination / overwhelm に強く寄せた、非常にカスタマイズ性の高い personal productivity app。
+Dayopt とは「day planning」「calendar view」「time blocking」「time tracking」「time estimates」「analytics」などの領域で重なる。
+
+ただし、Amazing Marvin は **Task-first + Workflow customization-first**。Dayoptがこの方向へ寄せると、機能数・設定数・ワークフロー自由度で勝つのは難しい。
+むしろ、Dayoptが「設定を増やさず、時間ブロックと予定/実績差分だけに絞る」理由を明確にするための競合として見る。
+
+- 公式サイト: https://amazingmarvin.com/
+- Pricing: https://amazingmarvin.com/pricing/
+- Help Center: https://help.amazingmarvin.com/en/
+- Feature Overview: https://amazingmarvin.com/features
+- Day Planning: https://amazingmarvin.com/features/day-planning
+- Time Tracking: https://amazingmarvin.com/features/time-tracking
+- Time Estimates: https://amazingmarvin.com/features/time-estimates
+
+## 競合分類
+
+| 観点           | 評価                                                                                  |
+| -------------- | ------------------------------------------------------------------------------------- |
+| 機能競合       | 高い。day planning / calendar / time blocking / time tracking / time estimates を持つ |
+| コンセプト競合 | 中。Dayoptよりタスク管理・行動支援・ADHD支援色が強い                                  |
+| ターゲット競合 | 中〜高。ADHD傾向、procrastination、個人 productivity ユーザーに強い                   |
+| 価格競合       | 中。年間 $96、月換算 $8。Free plan はなし、14日trial                                  |
+| UX思想         | Task-first + Customizable workflow。Dayoptとは思想が違う                              |
+
+## 公式上の主な訴求
+
+- “The to-do app that works with your brain, not against it.”
+- Built for ADHD minds
+- customizable / 100+ features
+- To-do lists, day planner, calendar, habits, goals, and more
+- Super Focus Mode
+- Accountability Pledge
+- Task Jar
+- Spotlight
+- Day Planning
+- Pomodoro Timer
+- Time Tracking
+- Procrastination Wizard
+- Color coding / gamification / time estimates / recurring tasks / work sessions
+- 300+ customizable settings
+- Multiple layout options: list / calendar / kanban
+- Enable/disable any feature
+- Import from Todoist, TickTick, Things 3, Microsoft ToDo, OmniFocus, Asana, ClickUp, Google Calendar, Sunsama, CSV など
+
+## 価格
+
+2026-06-07時点の公式 pricing 表記では以下。
+
+| Plan              |  価格 | 備考                                          |
+| ----------------- | ----: | --------------------------------------------- |
+| Marvin Pro Annual | $8/月 | billed as $96/year                            |
+| Free Trial        |  14日 | no credit card required                       |
+| Free Plan         |  なし | cost barrier がある場合は相談可能との説明あり |
+
+公式 pricing では “One plan. Everything included. No feature gates or upsells.” と説明している。
+Dayoptの $5 Pro 想定よりやや高いが、機能量は非常に多い。
+
+## 主な機能
+
+### Day Planning / Calendar / Time Blocking
+
+Amazing Marvin は、1日の計画を minute-level schedule から simple today list まで柔軟に作れる。
+公式では Day Planning の workflow に以下を含めている。
+
+- Calendar view
+- Time blocking
+- Daily schedules
+- Capacity estimator
+
+Dayoptとの重なり:
+
+```text
+タスクを選ぶ
+↓
+今日の予定に入れる
+↓
+カレンダー/タイムブロックで見る
+↓
+実行する
+```
+
+Dayoptでは task ではなく tag / entry を直接置くことで、より軽くする。
+
+### Time Tracking / Time Estimates
+
+Amazing Marvin は、各タスクにどれだけ時間を使ったかを tracking できる。
+また、time estimates を持ち、予定時間・見積もりと実績の比較に近い体験ができる。
+
+Dayoptの planned / actual と近いが、Marvinはtaskごとの productivity pattern / billing / reporting 寄り。
+Dayoptは「予定と実績が1つの時間ブロックに閉じる」ことを核にする。
+
+### Super Focus Mode / Spotlight / Task Jar
+
+Amazing Marvinは、行動開始の難しさや分析麻痺に対して多くの支援機能を持つ。
+
+- Super Focus Mode: 1つのタスクだけを見る
+- Spotlight: 1〜3時間の作業セッションを作る
+- Task Jar: ランダムに次のタスクを選ぶ
+- Procrastination Wizard: タスク着手をステップで支援する
+
+Dayoptではここをそのまま入れない。
+ただし「今見るものを1つに絞る」「今日の時間だけに集中する」という考え方は参考になる。
+
+### Custom Workflows / Feature Toggles
+
+Amazing Marvinの最大の特徴は、100+ features / 300+ settings / enable-disable any feature という極端なカスタマイズ性。
+
+Dayoptではこれは逆方向。
+設定や戦略を増やさず、最初から意見のある設計にした方がよい。
+
+### Gamification / Accountability
+
+Gamification、Accountability Pledge、Habits、Goals なども持つ。
+Dayoptの核ではない。
+タグごとの時間実績が結果的に習慣のように見える程度で十分。
+
+## Dayoptとの違い
+
+```text
+Amazing Marvin:
+大量のタスクを管理する
+↓
+自分に合うworkflow/strategyを選ぶ
+↓
+日次計画・focus mode・time trackingで実行支援する
+↓
+analyticsやgamificationで改善する
+```
+
+```text
+Dayopt:
+時間枠がある
+↓
+タグを置く
+↓
+予定と実績が1つのエントリになる
+↓
+ズレを見る
+↓
+次の時間設計に戻る
+```
+
+Amazing Marvin は **Task-first / Strategy-first / Customization-first**。
+Dayopt は **Timebox / Tag-first / Minimal-first**。
+
+DayoptがMarvinに寄せすぎると、カスタマイズ可能なタスク管理アプリの劣化版になる。
+Dayoptは「選択肢を減らす」「入力を減らす」「時間のズレだけを見る」で差別化する。
+
+## 盗めそうな部分
+
+### P1: Capacity estimator の考え方
+
+Marvinの Day Planning は、計画が現実的かどうかを判断する capacity estimator を持つ。
+Dayoptでも、計画時間が詰まりすぎている/空白が多い/実績との差が大きい、という見せ方に応用できる。
+
+Dayopt訳:
+
+```text
+今日の計画は、現実の時間に収まっているか。
+```
+
+### P1: Focus を1つに絞る発想
+
+Super Focus Mode / Spotlight は、Dayoptの「今の記録中タグ」「今日だけに集中」に翻訳できる。
+
+Dayopt訳:
+
+```text
+いま何に時間を使っているかだけが見える。
+```
+
+### P1: Time estimates / tracking から planned actual 表示を強める
+
+Marvinは見積もりと実績の考え方を持つ。
+Dayoptではこれをもっと直接的にする。
+
+```text
+予定 2h
+実績 1h30m
+差分 -30m
+```
+
+### P2: Feature toggles を“やらないこと”として学ぶ
+
+Marvinは enable/disable any feature が強み。
+Dayoptは逆に、設定を増やさないことを強みにする。
+
+Dayopt訳:
+
+```text
+選べる設定を増やすのではなく、迷わない体験を固定する。
+```
+
+### P2: Import/Export の安心感
+
+Marvinは多くのツールからimportできる。
+Dayoptではimport競争は不要だが、CSV export / データを閉じ込めない訴求は参考になる。
+
+### P3: ADHD/procrastination文脈の観察
+
+DayoptをADHD支援ツールとして打ち出す必要はないが、「やることが多すぎて動けない」層には刺さる可能性がある。
+その場合も、Dayoptはタスクを増やすのではなく、時間を1つずつ置く方向で対応する。
+
+## 盗まない方がいい部分
+
+| 機能/思想              | 理由                   |
+| ---------------------- | ---------------------- |
+| 100+ features          | Dayoptの軽さが壊れる   |
+| 300+ settings          | 設定疲れを生む         |
+| Custom workflows       | 迷わない体験と衝突     |
+| Gamification           | 核ではない             |
+| Accountability Pledge  | 別プロダクト感が強い   |
+| Task Jar               | タスク管理に寄りすぎる |
+| Procrastination Wizard | 行動支援アプリ化する   |
+| Habits / Goals         | 習慣・目標管理に広がる |
+| Recurring tasks        | 削る方針と衝突         |
+| Kanban / GTD強化       | Todo管理に寄りすぎる   |
+
+## Dayoptの差別化メッセージ候補
+
+避けたい表現:
+
+```text
+自分だけの生産性システムを作る
+100以上の機能から選べる
+タスクを始めるための行動支援
+習慣・目標・ゲーム化で継続
+```
+
+使いたい表現:
+
+```text
+設定を増やさず、今日の時間だけを整える
+Todoではなく、時間を置く
+予定と実績を、1つの時間ブロックで見る
+がんばりを測るのではなく、ズレを次の計画に戻す
+```
+
+## Dayoptへの示唆
+
+Amazing Marvinは、自由度・機能量・行動支援で非常に強い。
+Dayoptはそこに寄せず、もっと意見のある最小ツールにする。
+
+```text
+Amazing Marvin = 自分に合う生産性システムを組み立てる task manager
+Dayopt = タグを時間に置き、予定と実績の差分で明日を補正する timebox tool
+```
+
+DayoptはMarvinから、capacity estimator / focus narrowing / time estimates の見せ方を学ぶ。
+ただし、custom workflows / 大量設定 / gamification / ADHD支援機能は盗まない。
+
+## 次に検討したいこと
+
+- [ ] Reviewで「予定が現実的だったか」を見る最小指標を検討する
+- [ ] 記録中タグの見せ方を「今これだけ」に寄せる
+- [ ] 設定を増やさない方針を明文化する
+- [ ] Gamification / Goals / Habits は非採用方針として整理する
+- [ ] CSV export / データ所有の安心感をLPに入れるか検討する

--- a/apps/storybook/docs/product/strategy/research/competitors/ellie.md
+++ b/apps/storybook/docs/product/strategy/research/competitors/ellie.md
@@ -1,0 +1,258 @@
+# 競合調査: Ellie
+
+> アーカイブ元: GitHub Issue #1266（label: 競合）
+> 取り込み日: 2026-06-15
+> このドキュメントは継続観察用の調査メモ。一次情報は各競合の公式サイトを参照。
+
+---
+
+## 概要
+
+Ellie は、brain dump / daily Kanban / timebox view を中核にしたシンプルな daily planner。
+Dayopt とは「今日の予定を軽く作る」「タスクを時間に置く」「時間の使い方を可視化する」という領域で重なる。
+
+Sunsama / Akiflow / Routine が高機能・統合ハブ寄りなのに対して、Ellie はより軽量で、Dayoptに近い **simple daily planner / timeboxing app** として観察価値が高い。
+
+- 公式サイト: https://ellieplanner.com/
+- Pricing: https://ellieplanner.com/pricing
+- Features guide: https://guide.ellieplanner.com/
+- Web App: https://app.ellieplanner.com/
+- iOS App: https://apps.apple.com/app/ellie-planner/id1626821560
+- Changelog: https://feedback.ellieplanner.com/changelog
+
+## 競合分類
+
+| 観点           | 評価                                                                   |
+| -------------- | ---------------------------------------------------------------------- |
+| 機能競合       | 高い。daily planner / time blocking / time tracking / analytics を持つ |
+| コンセプト競合 | 高い。シンプルな日次計画・timeboxing という思想がDayoptに近い          |
+| ターゲット競合 | 中〜高。学生、創業者、個人ユーザー、シンプル派に刺さる                 |
+| 価格競合       | 中。Freeあり、Proは $9.99/月、買い切り $299.99                         |
+| UX思想         | Brain dump + Daily Kanban + Timebox。Dayoptよりtask-firstだが軽量      |
+
+## 公式上の主な訴求
+
+- “A better daily planner”
+- thoughts を整理し、1日を beautiful and simple app で計画する
+- timeboxing your day
+- brain dump
+- recurring tasks
+- analytics + built-in time tracker
+- native iOS app
+- Google / Apple / Outlook calendar integrations
+- Time tracking / Email forwarding / Subtasks
+- Notion integration / Zapier integration / Siri shortcuts
+- Labels & filtering / Week calendar view / Today only mode / Rituals
+- Mac app / Windows app
+
+## 価格
+
+2026-06-07時点の公式 pricing 表記では以下。
+
+| Plan               |             価格 | 備考                                                                                                           |
+| ------------------ | ---------------: | -------------------------------------------------------------------------------------------------------------- |
+| Free               |             Free | unlimited task creation / iOS & Web App / Braindump                                                            |
+| Ellie Pro          |         $9.99/月 | Timebox mode / Google Calendar / Apple Calendar / unlimited labels & subtasks / recurring tasks / due dates 等 |
+| Ellie Pro Lifetime | $299.99 一回払い | Pro subscription と同等の買い切り                                                                              |
+
+Freeでは基本の task creation / braindump が使えるが、Timebox mode はPro側。
+Dayoptの核をFreeに置くかProに置くかを考えるうえで参考になる。
+
+## 主な機能
+
+### Daily Planner / Brain Dump
+
+Ellie は、頭の中のタスクを brain dump し、それを日次のKanban/Plannerに整理する設計。
+公式FAQでも、Ellieは day planner / brain dump として作られていると説明している。
+
+Dayoptとの重なり:
+
+```text
+頭の中のタスクを出す
+↓
+今日の計画に整理する
+↓
+時間に置く
+↓
+実行する
+```
+
+ただしDayoptは brain dump / task list を持たず、tag / timebox を直接置く方が軽い。
+
+### Time Blocking / Timebox View
+
+Ellie は time blocking を主要機能として打ち出し、タスクをKanbanからカレンダーへドラッグして1日を可視化する。
+公式FAQでも “great timebox view” を差別化点として挙げている。
+
+Dayoptとの競合度が高い部分。
+ただし Ellie は task-first、Dayoptは timebox / tag-first。
+
+### Time Tracking / Analytics
+
+Ellie は built-in time tracker と analytics を持ち、時間の使い方を可視化できる。
+Dayoptの Review と重なる。
+
+Dayoptでは analytics を重くせず、予定/実績/差分に絞ると差別化できる。
+
+### Calendar Integrations / Platforms
+
+- Google Calendar
+- Apple Calendar
+- Outlook Calendar
+- Web / iOS / Mac / Windows
+
+DayoptはPWA firstでよいが、「すぐ開ける」「常駐に近い軽さ」は参考になる。
+
+### Today Only Mode / Rituals
+
+Today only mode や rituals は、Dayoptの「今日の時間だけに集中する」思想と近い。
+ここはかなり参考になる。
+
+## Dayoptとの違い
+
+```text
+Ellie:
+タスクをbrain dumpする
+↓
+Daily Kanbanに並べる
+↓
+必要なものをtimebox viewへ置く
+↓
+時間追跡・analyticsで見る
+```
+
+```text
+Dayopt:
+時間枠がある
+↓
+タグを置く
+↓
+予定と実績が1つのエントリになる
+↓
+ズレを見る
+↓
+次の時間設計に戻る
+```
+
+Ellie は **Simple Task-first / Daily Planner / Timebox**。
+Dayopt は **Timebox / Tag-first / Planned-Actual-first**。
+
+EllieはDayoptに近いが、Dayoptがtask list / Kanban / braindump を持たない設計を守れば、より削られた体験として差別化できる。
+
+## 盗めそうな部分
+
+### P1: “simple daily planner” の見せ方
+
+Ellieは高機能SaaSではなく、シンプルな日次プランナーとして見せている。
+Dayoptも「生産性オールインワン」ではなく、軽い日次timeboxとして打ち出したい。
+
+Dayopt訳:
+
+```text
+今日の時間を、タグで軽く整える。
+```
+
+### P1: Today only mode
+
+Ellieの today only mode はDayoptと相性が良い。
+DayoptのモバイルはDay表示のみ方針なので、「今日だけに集中する」価値をLPやUIで言語化できる。
+
+Dayopt訳:
+
+```text
+まずは今日だけ。今日の予定と実績だけを整える。
+```
+
+### P1: Timebox view の視覚的わかりやすさ
+
+EllieはKanbanからcalendar/timeboxにドラッグする形。
+Dayoptでは、タグから時間ブロックを作る操作として翻訳できる。
+
+```text
+タグを押す
+↓
+時間に置く
+↓
+予定と記録が同じブロックになる
+```
+
+### P1: Analytics を「軽い可視化」として扱う
+
+Ellieはanalyticsを持つが、Dayoptはもっと軽くてよい。
+
+Dayopt訳:
+
+```text
+統計ではなく、ズレを見る。
+```
+
+### P2: Brain dump を“やらないこと”として学ぶ
+
+Ellieのbrain dumpは便利だが、Dayoptに入れるとTodo管理に寄る。
+ここは盗むより、明確に非採用方針として整理した方がよい。
+
+Dayopt訳:
+
+```text
+Todoは集めない。時間だけを整える。
+```
+
+### P2: Native app 的な即時性
+
+EllieのiOS/Mac/Windows展開から、Dayoptも「すぐ開ける」ことの重要性は学べる。
+ただし初期はPWAで十分。
+
+## 盗まない方がいい部分
+
+| 機能/思想                              | 理由                              |
+| -------------------------------------- | --------------------------------- |
+| Brain dump                             | Todo管理アプリ化する              |
+| Daily Kanban                           | Dayoptのtimebox/tag-firstが薄まる |
+| Subtasks                               | 複雑化する                        |
+| Recurring tasks                        | 削る方針と衝突                    |
+| Email forwarding                       | タスク集約アプリになる            |
+| Notion / Zapier integration の作り込み | 初期には運用コストが高い          |
+| Week calendar view の強化              | モバイルDay中心方針とズレる       |
+| Analyticsの高度化                      | Reviewが重くなる                  |
+
+## Dayoptの差別化メッセージ候補
+
+避けたい表現:
+
+```text
+タスクをbrain dumpする
+Kanbanで今日のタスクを整理する
+タスクを時間に割り当てる
+```
+
+使いたい表現:
+
+```text
+Todoではなく、時間を整える
+タグを置くだけで、予定と実績がつながる
+今日の予定と記録を、1つの時間ブロックにする
+統計ではなく、ズレを見る
+```
+
+## Dayoptへの示唆
+
+Ellieは、上位競合の中でもDayoptにかなり近い「軽量 daily planner / timeboxing」系。
+ただし、Ellieは still task-first。
+Dayoptは tag-first / planned-actual-first に寄せることで、より削られた体験にできる。
+
+```text
+Ellie = タスクをbrain dumpして、今日のtimeboxに置く daily planner
+Dayopt = タグを時間に置き、予定と実績の差分で明日を補正する timebox tool
+```
+
+DayoptはEllieから、simple daily planner / today only / timebox view / light analytics を盗む。
+ただし、brain dump / Kanban / subtasks / recurring tasks は盗まない。
+
+## 次に検討したいこと
+
+- [ ] LPで「今日だけに集中する」訴求を入れるか検討する
+- [ ] モバイルDay表示のみ方針をプロダクト価値として言語化する
+- [ ] Reviewを「Analytics」ではなく「ズレを見る」に固定する
+- [ ] タグ→時間ブロック作成の最短導線を決める
+- [ ] Brain dump / Kanban / subtasks は非採用方針として明文化する
+- [ ] Free/Proで timebox / planned actual をどう分けるか検討する

--- a/apps/storybook/docs/product/strategy/research/competitors/motion.md
+++ b/apps/storybook/docs/product/strategy/research/competitors/motion.md
@@ -1,0 +1,243 @@
+# 競合調査: Motion
+
+> アーカイブ元: GitHub Issue #1269（label: 競合）
+> 取り込み日: 2026-06-15
+> このドキュメントは継続観察用の調査メモ。一次情報は各競合の公式サイトを参照。
+
+---
+
+## 概要
+
+Motion は、AIによる自動スケジューリングを中心に、タスク・カレンダー・プロジェクト管理を統合する productivity app。
+Dayopt とは「タスク/予定をカレンダーに配置する」「時間ブロックで一日を設計する」「予定変更に応じて再配置する」という領域で重なる。
+
+ただし、Motion は **AI Scheduler / Auto Planning-first**。Dayoptは、AIに全部任せる方向ではなく、ユーザーが軽くタグを置き、予定と実績のズレを見て補正する方向で差別化したい。
+
+- 公式サイト: https://www.usemotion.com/
+- Pricing: https://www.usemotion.com/pricing
+- AI Calendar: https://www.usemotion.com/ai-calendar
+- AI Task Manager: https://www.usemotion.com/ai-task-manager
+- AI Project Manager: https://www.usemotion.com/ai-project-manager
+- Meeting Scheduler: https://www.usemotion.com/meeting-scheduler
+- Integrations: https://www.usemotion.com/integrations
+
+## 競合分類
+
+| 観点           | 評価                                                               |
+| -------------- | ------------------------------------------------------------------ |
+| 機能競合       | 高い。AI calendar / tasks / project manager / time blocking を持つ |
+| コンセプト競合 | 中〜高。時間ブロックは近いが、自動スケジューリング思想が強い       |
+| ターゲット競合 | 高い。busy professionals / teams / managers / founders 向け        |
+| 価格競合       | 中。高価格帯。Individual $34/月または年払い $19/月程度のレンジ     |
+| UX思想         | AI-first / Auto-scheduling-first。Dayoptとは対照的                 |
+
+## 公式上の主な訴求
+
+- AI calendar / AI task manager / AI project manager
+- automatically plan your day
+- auto-schedule tasks into calendar
+- reprioritize and rebuild schedule when things change
+- tasks, calendar, meetings, projects を1つにまとめる
+- deadline / priority / duration をもとにスケジュール化
+- meeting scheduler
+- team project planning
+- integrations with Google Calendar / Outlook / Zoom / Zapier 等
+
+## 価格
+
+2026-06-07時点で確認した公式pricingでは、高価格帯のSaaSとして位置づけられる。
+
+| Plan            |                            価格感 | 備考                               |
+| --------------- | --------------------------------: | ---------------------------------- |
+| Individual      | 約 $34/月 または年払いで約 $19/月 | 個人向け                           |
+| Team / Business |           個人より高い user/month | team planning / collaboration 向け |
+
+Dayoptの $5 Pro 想定とは価格帯が大きく違う。
+Motionは「AIが予定を自動で組むなら高くても払う」層を狙っている。
+
+## 主な機能
+
+### AI Calendar / Auto Scheduling
+
+Motionの中核は、AIがタスクをカレンダーに自動配置すること。
+タスクの期限・優先度・所要時間・空き時間をもとに、カレンダー上へ自動でtime blockする。
+予定が変わると、残りタスクを再スケジュールする。
+
+Dayoptとの重なり:
+
+```text
+タスクを作る
+↓
+所要時間/期限/優先度を入れる
+↓
+AIがカレンダーに配置する
+↓
+予定変更時に再配置する
+```
+
+Dayoptでは、AIが全部決めるのではなく、ユーザーがタグを軽く置き、実績差分から次の計画を補正する。
+
+### AI Task Manager
+
+Motionはタスク管理も強く、deadline / priority / duration をもとにスケジュールへ反映する。
+Dayoptでは、タスク管理自体は外部ツールに任せたい。
+
+Dayopt訳:
+
+```text
+タスクを管理しない。時間を受け止める。
+```
+
+### AI Project Manager
+
+Motionはプロジェクト管理領域にも広がっており、team workflows / project planning / task dependencies に近い機能を持つ。
+Dayoptではこれは盗まない。初期ターゲットは個人の時間ブロック・記録・Review。
+
+### Meeting Scheduler
+
+会議候補時間の共有や scheduling も持つ。
+Dayoptの核ではない。
+将来的にカレンダー連携があっても、会議調整プロダクトには寄せない。
+
+### Integrations
+
+Motionは Google Calendar / Outlook Calendar / Zoom / Zapier などと連携する。
+Dayoptでも外部連携はあり得るが、タスクの集約や自動配置より、MCP/API-firstで時間データを読める・書ける方向が合う。
+
+## Dayoptとの違い
+
+```text
+Motion:
+タスクを作る
+↓
+期限・優先度・所要時間を設定する
+↓
+AIがカレンダーに自動配置する
+↓
+予定変更に応じてAIが再配置する
+```
+
+```text
+Dayopt:
+時間枠がある
+↓
+タグを置く
+↓
+予定と実績が1つのエントリになる
+↓
+ズレを見る
+↓
+次の時間設計に戻る
+```
+
+Motion は **AI-first / Task-first / Auto-scheduling-first**。
+Dayopt は **Timebox / Tag-first / Manual-lightweight / Review-first**。
+
+DayoptがMotionに寄せすぎると、複雑な自動スケジューリング競争になる。
+Dayoptは「AIが勝手に決める」のではなく、「自分で置いて、ズレを見る」方向を守る。
+
+## 盗めそうな部分
+
+### P1: 予定変更時に“残り時間”を意識する発想
+
+Motionは予定が変わると残りタスクを再配置する。
+Dayoptでは自動再配置までは不要だが、「予定からズレたあと、残り時間がどう変わったか」をReviewに出すのは有効。
+
+Dayopt訳:
+
+```text
+予定が崩れたあと、どこに時間が残ったかを見る。
+```
+
+### P1: duration / deadline より “時間枠に収まるか” の見せ方
+
+Motionは duration を軸に自動配置する。
+Dayoptでは、durationを複雑に扱わず、予定/実績/差分で現実性を見る。
+
+例:
+
+```text
+今日の計画: 6h
+実績: 4h30m
+差分: -1h30m
+空白: 45m
+```
+
+### P1: AI競合への対比コピー
+
+MotionのようなAI自動化競合があるからこそ、Dayoptは「AIが全部決める」ではなく「AIが読める時間データ」として打ち出せる。
+
+Dayopt訳:
+
+```text
+AIに予定を丸投げする前に、自分の時間のズレを見える化する。
+```
+
+または:
+
+```text
+AIが勝手に組むのではなく、あなたの予定と実績をAIが読める形にする。
+```
+
+### P2: Calendar-first の見せ方
+
+Motionはタスクをカレンダー上に置く体験を前面に出している。
+Dayoptも、リストではなくCalendar/Timelineを主画面にする方向は正しい。
+
+### P2: High price competitor としての比較
+
+Motionは高価格帯。
+Dayoptは $5 Pro で、より軽い個人向けtimebox toolとして対比できる。
+
+## 盗まない方がいい部分
+
+| 機能/思想                        | 理由                                     |
+| -------------------------------- | ---------------------------------------- |
+| AI auto-scheduling               | Dayoptの手触り・自己決定感と衝突しやすい |
+| Task priority system             | タスク管理に寄りすぎる                   |
+| Deadline-driven planning         | Todo/PMアプリ化する                      |
+| Project manager                  | 初期スコープ外                           |
+| Team planning                    | 初期ターゲットではない                   |
+| Meeting scheduler                | 別プロダクト領域                         |
+| Auto reprioritization            | ブラックボックス感が増える               |
+| Dependencies / workload planning | Dayoptの軽さが崩れる                     |
+
+## Dayoptの差別化メッセージ候補
+
+避けたい表現:
+
+```text
+AIがあなたの予定を自動で組みます
+タスクの優先度と期限から最適化します
+プロジェクトも会議も全部まとめます
+```
+
+使いたい表現:
+
+```text
+AIに任せる前に、今日の時間を自分で軽く置く
+予定と実績のズレを、1つの時間ブロックで見る
+自動化ではなく、補正するためのReview
+外部AIが読める、きれいな時間データ
+```
+
+## Dayoptへの示唆
+
+Motionは、「AIが計画を自動で作る」方向の代表競合。
+Dayoptはその逆に、**ユーザーが軽く置けること**と**実績差分がきれいに残ること**で差別化する。
+
+```text
+Motion = AIがタスクをカレンダーに自動配置する scheduling assistant
+Dayopt = タグを時間に置き、予定と実績の差分で明日を補正する timebox tool
+```
+
+DayoptはMotionから、残り時間・計画崩れ時の補正・Calendar-firstの見せ方を盗む。
+ただし、AI auto-scheduling / project manager / meeting scheduler は盗まない。
+
+## 次に検討したいこと
+
+- [ ] Reviewで「予定が崩れた後の残り時間」を見せるか検討する
+- [ ] AI訴求を「自動スケジューリング」ではなく「MCP/APIで読める時間データ」に寄せる
+- [ ] LPで「自動化ではなく補正」という表現を検討する
+- [ ] Task priority / deadline / project manager は非採用方針として明文化する
+- [ ] Calendar-first / Timebox-first の主画面価値を整理する

--- a/apps/storybook/docs/product/strategy/research/competitors/routine.md
+++ b/apps/storybook/docs/product/strategy/research/competitors/routine.md
@@ -1,0 +1,261 @@
+# 競合調査: Routine
+
+> アーカイブ元: GitHub Issue #1265（label: 競合）
+> 取り込み日: 2026-06-15
+> このドキュメントは継続観察用の調査メモ。一次情報は各競合の公式サイトを参照。
+
+---
+
+## 概要
+
+Routine は、タスク・カレンダー・会議・プロジェクト・ノート・AIを統合した productivity app。
+Dayopt とは「tasks/events を1画面の planner に集約し、time blocking で日々の計画を作る」という領域で重なる。
+
+Super Productivity が OSS / local-first 寄り、Sunsama が daily planning ritual 寄り、Akiflow が integrated productivity hub + speed 寄りだとすると、Routine は **tasks/calendar/notes/databases/AI を1つに寄せる workspace 型 daily planner** として見たい。
+
+- 公式サイト: https://www.routine.co/
+- Pricing: https://www.routine.co/pricing
+- Integrations: https://www.routine.co/integrations
+- Planner: https://www.routine.co/features/planner
+- Time blocking: https://www.routine.co/features/time-blocking
+- Time tracking: https://www.routine.co/features/time-tracking
+- Keyboard shortcuts: https://www.routine.co/features/keyboard-shortcuts
+- Universal inbox: https://www.routine.co/features/universal-inbox
+
+## 競合分類
+
+| 観点           | 評価                                                                            |
+| -------------- | ------------------------------------------------------------------------------- |
+| 機能競合       | 高い。calendar / tasks / notes / planner / time blocking / time tracking を持つ |
+| コンセプト競合 | 中〜高。Dayoptより workspace / database 色が強いが、時間ブロックは近い          |
+| ターゲット競合 | 高い。executives / freelancers / managers / founders / teams 向け               |
+| 価格競合       | 中。Freeあり。Professional は $12/月予定、Business は $15/user/月予定           |
+| UX思想         | Workspace-first + AI-first + Planner。Dayoptより統合OS志向が強い                |
+
+## 公式上の主な訴求
+
+- “One App for Tasks, Calendar & Notes, Powered by AI”
+- tasks / meetings / projects / notes / AI を1つで管理
+- 100k+ ambitious professionals and teams
+- quick capture via desktop hotkey
+- AI meeting notes
+- universal inbox
+- AI voice assistant
+- AI agents / automations
+- planner / time blocking
+- labels / priorities / projects
+- recurrences
+- menu bar widget
+- time tracking
+- multi-account calendar aggregation
+- databases / custom types / views / workspaces
+- keyboard shortcuts / natural language / offline / smart planning
+
+## 価格
+
+2026-06-07時点の公式 pricing 表記では以下。
+
+| Plan         |           価格 | 備考                                                                                                                          |
+| ------------ | -------------: | ----------------------------------------------------------------------------------------------------------------------------- |
+| Free         |   Free forever | calendars / tasks / contacts / notes / time blocking / natural language / integrations / device sync                          |
+| Professional |      $12/month | Coming Soon。offline / undo / filtered views / automations / availability sharing / smart planning / advanced integrations 等 |
+| Business     | $15/user/month | Coming Soon。workspaces / access control / real-time editing / comments 等                                                    |
+| Enterprise   |   要問い合わせ | Coming Soon。advanced access control / provisioning / dedicated support 等                                                    |
+
+Freeで time blocking まで含めている点は、DayoptのFree/Pro設計に影響がある。
+Dayoptは $5 Pro 想定なので、Routineより軽い価格・軽い機能で差別化できる。
+
+## 主な機能
+
+### Planner / Time Blocking
+
+Routine は planner で tasks and events を1画面にまとめ、time blocking で重要タスクの時間を確保する。
+公式サイトでも “Plan your tasks and events through a single screen” “Block time for your most important tasks” と説明している。
+
+Dayoptとの重なり:
+
+```text
+タスク/イベントを集める
+↓
+Plannerで日/週を見る
+↓
+重要タスクに時間をブロックする
+↓
+実行する
+```
+
+Dayoptでは task ではなく tag / entry を起点にする。
+
+### Time Tracking / Menu Bar Widget
+
+Routine は upcoming meetings や time tracking を menu bar widget で扱える。
+Dayoptも「今なにをしているか」を軽く確認・開始/停止できる導線は参考になる。
+
+ただし Dayoptは menu bar app を初期に作るより、PWAでの軽量開始/停止、キーボード操作、モバイルフッターのタグ選択に集中した方がよい。
+
+### Universal Inbox / Integrations
+
+Routine は tasks, messages, notifications を universal inbox に集約し、多数の外部サービスと bidirectional sync する方向。
+
+Dayoptではこの方向を真似ると、Todo管理/ワークスペースOS化するリスクが大きい。
+外部タスクは GitHub / Linear / Todoist などに残し、Dayoptは「使った時間」だけを受け止める方が合う。
+
+### Notes / Pages / Databases / Custom Types
+
+Routine は notes / pages / databases / custom types / views を持ち、Notion的な workspace 方向にも広がっている。
+
+Dayoptではこれは盗まない。
+仕様・ドキュメントは Storybook / repo docs に集約し、アプリ本体は時間ブロックに集中する。
+
+### AI Meeting Notes / AI Agents / Automations
+
+Routine は AI meeting notes、AI voice assistant、AI agents、automations を前面に出している。
+Dayoptでは内蔵AIを前面に出すより、MCP/API-firstで外部AIが時間データを読める設計の方が合う。
+
+### Keyboard Shortcuts / Natural Language
+
+Routine は keyboard shortcuts、desktop hotkey、natural language を訴求している。
+ここは Dayopt にかなり参考になる。
+
+Dayoptでは自然言語よりも、タグ選択・時間操作・確定/開始停止のショートカットを優先したい。
+
+## Dayoptとの違い
+
+```text
+Routine:
+タスク/会議/メッセージ/ノート/データベースを集める
+↓
+Plannerで日/週に配置する
+↓
+AIやautomationsで整理・委任する
+↓
+workspace全体のOSにする
+```
+
+```text
+Dayopt:
+時間枠がある
+↓
+タグを置く
+↓
+予定と実績が1つのエントリになる
+↓
+ズレを見る
+↓
+次の時間設計に戻る
+```
+
+Routine は **Workspace-first / AI-first / Integration-first**。
+Dayopt は **Timebox / Tag-first / Minimal-first**。
+
+DayoptがRoutineに寄せすぎると、Notion/Akiflow/ClickUp的な統合workspace競争に巻き込まれる。
+Dayoptは「workspaceを作らない」「タスクを集めない」「時間のズレだけに戻す」で差別化する。
+
+## 盗めそうな部分
+
+### P1: Plannerの一画面性
+
+Routine は tasks and events を single screen で扱う。
+Dayoptでも、Calendar上で予定と記録が同じエントリとして見える一画面性を強く出したい。
+
+Dayopt訳:
+
+```text
+予定と記録が、同じ時間ブロックに閉じる。
+```
+
+### P1: Quick capture / desktop hotkey 的な速さ
+
+Routine は desktop hotkey で高速キャプチャできる。
+Dayoptでは、タグ1タップ/ショートカットで時間ブロックを作る体験に翻訳できる。
+
+候補:
+
+```text
+数字: 最近使ったタグを選択
+Enter: 確定
+Space: 現在の記録開始/停止
+T: タグ選択
+R: Reviewへ移動
+```
+
+### P1: Time tracking を「今の状態」として見せる
+
+Routineの menu bar widget 的発想は、Dayoptの「いま何を記録しているか」の視認性に応用できる。
+
+Dayopt訳:
+
+```text
+今の記録中タグが常にわかる。
+開始/停止は1操作。
+```
+
+### P2: URL embeds / references
+
+Routine は references / URL embeds を持つ。
+Dayoptでも、GitHub Issue / PR / Claude / Codex / SlackログなどのURLを entry に貼れると、外部タスクを奪わず文脈だけ接続できる。
+
+### P2: Calendar accounts aggregation の見せ方
+
+Routineは work & personal calendars を集約する。
+DayoptでGoogle Calendar等を扱う場合も、「同期して置き換える」より「時間の文脈として見る」くらいに抑えるのがよさそう。
+
+### P3: Free plan の参考
+
+RoutineはFreeでも time blocking を含めている。
+Dayoptも核である timebox / planned actual はFreeに置き、ProはMCP/API/履歴/高度export等に寄せる方が自然かもしれない。
+
+## 盗まない方がいい部分
+
+| 機能/思想                        | 理由                                     |
+| -------------------------------- | ---------------------------------------- |
+| Universal inbox                  | Todo/通知集約アプリ化する                |
+| Databases / custom types         | Notion/ClickUp方向に重くなる             |
+| AI agents / automations          | Dayoptの初期価値がぼやける               |
+| AI meeting notes                 | 別プロダクト領域。議事録アプリ競争になる |
+| Workspaces / team OS             | 初期ターゲットではない                   |
+| Bidirectional integrations       | 実装・運用コストが大きい                 |
+| Recurrences                      | 削る方針と衝突                           |
+| Project/CRM/knowledge management | Dayoptの核から外れる                     |
+
+## Dayoptの差別化メッセージ候補
+
+避けたい表現:
+
+```text
+仕事を1つのワークスペースに集約
+AIエージェントで業務を自動化
+会議/ノート/タスク/DBを一元管理
+チームのOS
+```
+
+使いたい表現:
+
+```text
+ワークスペースではなく、時間の器
+タスクを集めず、使った時間だけを整える
+タグを置くだけで、予定と実績がつながる
+外部ツールはそのまま。Dayoptは時間のズレを見える化する
+```
+
+## Dayoptへの示唆
+
+Routineは「タスク/カレンダー/ノート/DB/AIを1つにまとめる」方向の競合。
+Dayoptはその逆に、**まとめないこと**を価値にしたい。
+
+```text
+Routine = 仕事の情報を1つに集約する workspace planner
+Dayopt = 今日の時間ブロックを軽く置き、実績差分で明日を補正する timebox tool
+```
+
+DayoptはRoutineから、single-screen planner / quick capture / keyboard shortcuts / references を盗む。
+ただし、universal inbox / databases / AI agents / workspaces は盗まない。
+
+## 次に検討したいこと
+
+- [ ] Dayoptの「Calendar = single-screen planner」としての見せ方を整理する
+- [ ] 記録中タグの常時表示/開始停止UIを検討する
+- [ ] EntryにURL/referenceを持たせるか検討する
+- [ ] Freeで timebox / planned actual をどこまで開放するか検討する
+- [ ] Universal inbox / workspace / database は非採用方針として明文化する
+- [ ] AI訴求を「内蔵AI」ではなく「MCP/APIで読める時間データ」に寄せる

--- a/apps/storybook/docs/product/strategy/research/competitors/sunsama.md
+++ b/apps/storybook/docs/product/strategy/research/competitors/sunsama.md
@@ -1,0 +1,259 @@
+# 競合調査: Sunsama
+
+> アーカイブ元: GitHub Issue #1263（label: 競合）
+> 取り込み日: 2026-06-15
+> このドキュメントは継続観察用の調査メモ。一次情報は各競合の公式サイトを参照。
+
+---
+
+## 概要
+
+Sunsama は、タスク管理・カレンダー・日次計画を統合した有料の daily planner。
+Dayopt とは「今日の計画を立てる → 実行する → planned / actual を確認する → 次の日の計画に戻す」という日次ループが強く重なるため、最重要競合として継続観察したい。
+
+- 公式サイト: https://www.sunsama.com/
+- Pricing / manifesto: https://help.sunsama.com/docs/billing/pricing-manifesto/
+- Planned and Actual Times: https://help.sunsama.com/docs/usage-guides/tasks/planned-and-actual-times/
+- Daily Planning: https://help.sunsama.com/docs/usage-guides/daily-planning/
+- GitHub Integration: https://help.sunsama.com/docs/integrations/github/
+- Command Palette: https://help.sunsama.com/docs/usage-guides/keyboard-driven-actions/command-palette/
+- Export settings: https://help.sunsama.com/docs/settings/user-settings/
+
+## 競合分類
+
+| 観点           | 評価                                                                |
+| -------------- | ------------------------------------------------------------------- |
+| 機能競合       | 非常に高い。task / calendar / daily planner / planned actual を持つ |
+| コンセプト競合 | 非常に高い。Dayoptの日次ループにかなり近い                          |
+| ターゲット競合 | 高い。modern professionals / 知的労働者 / 開発者にも刺さる          |
+| 価格競合       | 中。高価格だが、習慣化できるユーザーには強い                        |
+| UX思想         | calm daily planner。Dayoptより儀式設計が強い                        |
+
+## 公式上の主な訴求
+
+- “Make work-life balance a reality”
+- task manager / calendar / daily planner for modern professionals
+- guided daily planning
+- planned and actual times
+- daily shutdown / weekly planning 系の習慣導線
+- GitHub / Jira / Slack / Gmail / Notion / Trello などとの連携
+- command palette / keyboard driven actions
+- CSV / JSON export
+- 高価格でも burnout を避ける価値を訴求
+
+## 主な機能
+
+### Daily Planning
+
+Sunsama の中核は、毎日の計画を guided flow として作ること。
+単なるタスクリストではなく、「今日どれをやるか」「どれくらい時間を使うか」「カレンダー上にどう置くか」を日次で整理させる。
+
+Dayoptとの重なり:
+
+```text
+今日の計画を作る
+↓
+カレンダー / タイムラインに置く
+↓
+実行する
+↓
+一日の終わりに見直す
+```
+
+Dayoptもこのループを持つが、Sunsamaは儀式性・誘導の丁寧さが強い。
+
+### Planned and Actual Times
+
+Sunsama は planned time と actual time を公式ヘルプで一級機能として扱っている。
+タスクに予定時間を設定し、timer や手入力で実績時間を記録できる。
+設定次第で planned time を actual として扱うこともできる。
+
+Dayopt の planned / actual 1エントリ設計とかなり近い。
+ただし Sunsama は task-first、Dayopt は timebox / tag-first。
+
+### Integrations
+
+- GitHub
+- Jira
+- Slack
+- Gmail
+- Notion
+- Trello
+- Asana
+- Todoist
+- Google Calendar / Outlook Calendar など
+
+外部ツールからタスクを取り込み、Sunsama内で今日の計画に落とす思想。
+Dayoptでは、Issue import を真似るより、URL添付 / MCP / API-first で「タスク管理は外部に残す」方が合いそう。
+
+### Keyboard / Command Palette
+
+Sunsama は command palette を持ち、マウス操作だけでなくキーボード中心で操作できる。
+Dayoptも開発者・パワーユーザー向けなら、ここはかなり参考になる。
+
+### Export
+
+CSV / JSON export が可能。
+時間・タスクの蓄積データを閉じ込めない安心感がある。
+Dayoptでも Free 含めて export は信頼獲得に効きそう。
+
+## Dayoptとの違い
+
+```text
+Sunsama:
+タスクを集める
+↓
+今日やるものを選ぶ
+↓
+予定時間を入れる
+↓
+カレンダーに置く
+↓
+実績を記録する
+↓
+日次/週次で振り返る
+```
+
+```text
+Dayopt:
+時間枠がある
+↓
+タグを置く
+↓
+予定と実績が1つのエントリになる
+↓
+ズレを見る
+↓
+次の時間設計に戻る
+```
+
+Sunsama は Task-first + Ritual-first。
+Dayopt は Timebox / Tag-first。
+
+DayoptがSunsamaに寄せすぎると、「丁寧な日次計画アプリ」の劣化版になりやすい。
+Dayoptはより短い儀式、より軽い入力、より直接的な予定/実績差分で勝つべき。
+
+## 盗めそうな部分
+
+### P1: 日次計画の儀式設計
+
+Sunsama の最大の強みは、毎朝/毎日の計画を自然に始めさせること。
+Dayoptでも、Calendarを単なるカレンダーではなく「今日の時間を整える場所」として見せたい。
+
+Dayopt訳:
+
+```text
+今日、何に時間を使うかを先に置く。
+終わったら、予定と実績のズレだけを見る。
+```
+
+### P1: planned / actual を一級機能として見せる
+
+Dayoptの強みと最も重なる。
+LPやReviewで「予定と実績が1つの時間ブロックで見える」を明確に打ち出す。
+
+例:
+
+```text
+Work
+予定 2h
+実績 1h30m
+差分 -30m
+```
+
+重要なのは、実績記録を「反省」ではなく「補正」として扱うこと。
+
+### P1: calm / burnout 回避のコピー
+
+Sunsama は高価格でも、burnout を避ける価値を強く訴求している。
+Dayoptも「もっと詰め込む」ではなく「今日の時間を現実的に整える」方向のコピーが合う。
+
+Dayopt訳:
+
+```text
+予定を詰め込むためではなく、現実の時間に戻すためのプランナー。
+```
+
+### P2: daily shutdown / review
+
+Dayoptの Review は、Sunsama 的な shutdown をもっと軽量化したものにできる。
+
+例:
+
+```text
+今日のズレだけ見る
+- 予定より長かったタグ
+- 予定より短かったタグ
+- 空白になった時間
+- 明日に戻すもの
+```
+
+### P2: Command Palette
+
+開発者向けなら、command palette / keyboard-first は盗める。
+
+候補:
+
+```text
+P: 今日の計画を開く
+R: Reviewを開く
+Space: 現在の記録開始/停止
+Enter: 選択中エントリ確定
+数字: 最近使ったタグ選択
+```
+
+### P3: Export の安心感
+
+SunsamaがCSV/JSON exportを用意しているように、Dayoptも時間データを閉じ込めないことを明記したい。
+
+## 盗まない方がいい部分
+
+| 機能/思想                    | 理由                           |
+| ---------------------------- | ------------------------------ |
+| 外部タスク import の作り込み | Todo管理アプリに寄りすぎる     |
+| Guided flow の重厚化         | Dayoptの軽さが失われる         |
+| 週次計画・週次目標の作り込み | Reviewが重くなる               |
+| Slack連携前提の運用          | Dayoptの最小Ops方針とズレる    |
+| 高価格SaaS感の強い訴求       | Dayoptの $5 Pro 想定と違う     |
+| タスク中心の語彙             | Timebox / Tag-first がぼやける |
+
+## Dayoptの差別化メッセージ候補
+
+避けたい表現:
+
+```text
+タスクを全部集める
+日次計画をガイドする
+ワークライフバランスを管理する
+生産性を高めるオールインワン
+```
+
+使いたい表現:
+
+```text
+予定と実績を、1つの時間ブロックで見る
+Todoではなく、時間を整える
+計画倒れを責めず、ズレを次の計画に戻す
+タグを選ぶだけで、今日の時間が形になる
+```
+
+## Dayoptへの示唆
+
+Sunsamaは、Dayoptにとって「日次ループのUX完成度」を見るための最重要競合。
+Super Productivity が OSS / developer / planned actual の競合だとすると、Sunsama は **daily planning ritual** の競合。
+
+Dayoptは Sunsama より軽く、短く、時間ブロック中心にすることで差別化できる。
+
+```text
+Sunsama = 今日やるタスクを丁寧に計画するアプリ
+Dayopt = 今日の時間ブロックを軽く置き、実績差分で明日を補正するアプリ
+```
+
+## 次に検討したいこと
+
+- [ ] DayoptのLPで「Todoではなく時間」を明確に打ち出す
+- [ ] Reviewで planned / actual / diff の最小表示パターンを作る
+- [ ] 日次終了時の軽い Review 導線を検討する
+- [ ] Guided planning を入れる場合でも、1〜2ステップに抑える
+- [ ] CSV / JSON export を Free に含めるか検討する
+- [ ] 外部タスク import は非採用、URL添付 / MCP / API-first に寄せるか整理する

--- a/apps/storybook/docs/product/strategy/research/competitors/super-productivity.md
+++ b/apps/storybook/docs/product/strategy/research/competitors/super-productivity.md
@@ -1,0 +1,304 @@
+# 競合調査: Super Productivity
+
+> アーカイブ元: GitHub Issue #1262（label: 競合）
+> 取り込み日: 2026-06-15
+> このドキュメントは継続観察用の調査メモ。一次情報は各競合の公式サイトを参照。
+
+---
+
+## 概要
+
+Super Productivity は、タスク管理・時間記録・集中支援を統合したオープンソースの生産性アプリ。
+Dayopt とは「予定を立てる → 実績を記録する → 振り返る」というループが重なるため、広義の競合として継続観察したい。
+
+- 公式サイト: https://super-productivity.com/
+- Web App: https://app.super-productivity.com/
+- GitHub: https://github.com/super-productivity/super-productivity
+- Pricing: https://super-productivity.com/pricing/
+- Schedule Planner: https://super-productivity.com/use-cases/schedule-planner/
+- Time Tracker: https://super-productivity.com/use-cases/time-tracker/
+- Integrations: https://super-productivity.com/integrations/
+- Privacy / Local-first: https://super-productivity.com/use-cases/privacy-productivity/
+
+## 競合分類
+
+| 観点           | 評価                                                                              |
+| -------------- | --------------------------------------------------------------------------------- |
+| 機能競合       | 高い。タスク、タイムトラッキング、スケジュール、振り返りを持つ                    |
+| コンセプト競合 | 中〜高。計画・実行・実績・改善のループが近い                                      |
+| ターゲット競合 | 高い。開発者、フリーランス、集中作業ユーザーに強い                                |
+| 価格競合       | 高い。完全無料・OSS・ローカルファースト                                           |
+| UX思想         | Dayoptとは異なる。Super Productivity は Task-first / Dayopt は Timebox・Tag-first |
+
+## 公式上の主な訴求
+
+- “Tasks, time tracking, and focus tools in one open-source app”
+- Offline / private / local-first
+- No account required
+- 100% free / no premium tiers / no hidden costs
+- GitHub / GitLab / Jira / Gitea / Google Calendar / CalDAV などとの連携
+- JSON / CSV export
+- Keyboard-first design
+- One-click time tracking
+- Pomodoro / Focus mode
+- Kanban / Eisenhower / custom boards
+- Repeating tasks
+- Work logging / metrics / reports
+
+## 主な機能
+
+### Task Management
+
+- quick add
+- subtasks
+- notes
+- due dates
+- projects / folders / tags
+- custom views
+- Kanban
+- Eisenhower matrix
+- compact list
+
+Dayopt ではここを真似すぎると Todo 管理アプリになるため注意。
+
+### Schedule Planner
+
+公式説明では、タスク一覧を visual timeline に変換し、タスクを時間枠へドラッグして日次スケジュールを作る。
+
+- タスクを作成、または Jira / GitHub / GitLab から import
+- time estimate を設定
+- daily timeline にドラッグ
+- 過負荷の警告
+- タスクごとに timer start
+- 実行中に予定がズレたら残りを再調整
+- planned / finished / remaining capacity を一覧できる
+
+Dayoptとの重なりが一番強い領域。
+
+### Time Tracking
+
+- task / subtask から timer start / pause
+- notes / checklists / tracked time が同じ場所にまとまる
+- daily / weekly summaries
+- CSV / JSON / plain-text export
+- plan vs actual insights
+- estimates と実績を比較して次回計画に活かす
+
+Dayoptの Review とかなり近い。
+ただし Super Productivity はタスク単位、Dayopt は時間ブロック・タグ単位で差別化できる。
+
+### Integrations
+
+- Jira Cloud / Data Center
+- GitHub Issues & PRs
+- GitLab Issues & Time
+- Google Calendar
+- CalDAV
+- Gitea / Forgejo
+- Plugin system / REST API
+
+特徴は、アプリが各サービス API を直接呼ぶ local-first 型。
+認証トークンはローカル保存、middleware server を挟まないと説明している。
+
+Dayoptでは GitHub Issue import を真似るより、URL添付 / MCP / API-first で「外部タスク管理は奪わない」方が合いそう。
+
+### Privacy / Local-first
+
+- no forced account
+- no telemetry
+- no analytics
+- no subscription
+- local storage
+- optional encrypted sync
+- Dropbox / Drive / WebDAV sync
+- data export
+- open source / auditable
+
+Dayoptはクラウド/PWA/API-firstなので同じ主張はできないが、「データを閉じ込めない」「CSV export」「いつでも取り出せる」は盗める。
+
+## Dayoptとの違い
+
+```text
+Super Productivity:
+タスクがある
+↓
+見積もる
+↓
+スケジュールに置く
+↓
+タイマーで実行する
+↓
+ログを見る
+```
+
+```text
+Dayopt:
+時間枠がある
+↓
+タグを置く
+↓
+予定と実績が1つのエントリになる
+↓
+ズレを見る
+↓
+次の時間設計に戻る
+```
+
+Super Productivity は Task-first。
+Dayopt は Timebox / Tag-first。
+
+この違いを崩さないことが重要。
+
+## 盗めそうな部分
+
+### P1: 「Today / 今日」に集約する思想
+
+Super Productivity は calendar というより daily planner として見せている。
+Dayoptも「カレンダーアプリ」ではなく「今日の時間を整える場所」として打ち出すと強い。
+
+Dayopt訳:
+
+```text
+今日、何に時間を使うかを先に置く。
+終わったら、予定と実績のズレだけを見る。
+```
+
+### P1: 1タップ記録 / One-click Time Tracking
+
+Super Productivity は task から timer を開始する。
+Dayoptでは task ではなく tag を起点にする。
+
+Dayopt訳:
+
+```text
+タグを押す
+↓
+今からそのタグの記録が始まる
+```
+
+これは Dayopt の「軽い・早い・少ない」と相性が良い。
+
+### P1: planned vs actual の見せ方
+
+Super Productivity は estimates と actual を比較し、次の計画精度向上に使う。
+Dayoptの Review はここをさらに尖らせる。
+
+例:
+
+```text
+Work
+予定 ████████ 2h
+実績 ██████   1h30m
+差分 -30m
+```
+
+または:
+
+```text
+今日のズレ
+- Work: 30分短い
+- SNS: 20分増えた
+- 空白: 40分
+```
+
+重要なのは「反省」ではなく「補正」として見せること。
+
+### P2: Keyboard-first
+
+開発者向けならかなり盗める。
+
+候補:
+
+```text
+Enter: 確定
+Space: 開始/停止
+J/K: 前後移動
+数字: 最近使ったタグを選択
+Esc: 閉じる
+```
+
+### P2: CSV export / data ownership
+
+時間記録は蓄積データなので、閉じ込め不安が出やすい。
+FreeでもCSV exportを入れると信頼につながる。
+
+Dayopt訳:
+
+```text
+入力した時間データを閉じ込めません。
+```
+
+### P3: URL / Link 添付
+
+GitHub Issue import ではなく、GitHub Issue / PR / Claude / Codex / Slack ログなどのURLを貼れる程度でよさそう。
+
+Dayoptは外部ツールを奪わず、使った時間の器になる。
+
+## 盗まない方がいい部分
+
+| 機能                         | 理由                                          |
+| ---------------------------- | --------------------------------------------- |
+| Kanban                       | タスク管理に寄りすぎる                        |
+| Subtask / Checklist          | 複雑化する                                    |
+| Pomodoro                     | Dayoptの核ではない。必要なら外部でよい        |
+| Repeating tasks              | 削る方針と衝突                                |
+| GitHub/Jira issue import     | Todo管理アプリ化する                          |
+| Project / Folder 多階層      | Dayoptはタグ階層で十分                        |
+| 高度なレポート               | Reviewが重くなる                              |
+| Procrastination helper / CBT | 別プロダクト感が強い                          |
+| Plugin system                | 初期には過剰。MCP/API-firstの方がDayoptらしい |
+
+## Dayoptの差別化メッセージ候補
+
+避けたい表現:
+
+```text
+タスク管理
+生産性オールインワン
+Pomodoro
+プロジェクト管理
+GitHub/Jira連携
+作業効率化ツール
+```
+
+使いたい表現:
+
+```text
+予定と実績を、1つの時間ブロックで見る
+今日の時間の使い方を軽く整える
+Todoではなく、時間を管理する
+計画倒れを責めず、ズレを次の計画に戻す
+タグを選ぶだけで、予定と記録が残る
+```
+
+## Dayoptへの示唆
+
+Super Productivity は「全部できる」競合。
+Dayoptはその逆で、「これしかできないけど、それが一番気持ちいい」に寄せるべき。
+
+Dayoptの核:
+
+```text
+1. タグを選ぶ
+2. 時間に置く
+3. 実績にする
+4. 差分を見る
+5. 次の計画が少し良くなる
+```
+
+一言で言うと:
+
+```text
+Super Productivity = タスクを片付けるための作業OS
+Dayopt = 今日の時間を整えるためのタイムボックスOS
+```
+
+## 次に検討したいこと
+
+- [ ] DayoptのLPで「Todoではなく時間」を明確に打ち出すか検討
+- [ ] Reviewで planned / actual / diff の最小表示パターンを作る
+- [ ] タグ1タップ記録の仕様を整理する
+- [ ] キーボードショートカットの初期セットを決める
+- [ ] CSV export を Free に含めるか検討
+- [ ] 外部URL添付を Entry に持たせるか検討
+- [ ] GitHub/Jira import は非採用方針として明文化するか検討

--- a/apps/storybook/docs/product/strategy/research/competitors/ticktick.md
+++ b/apps/storybook/docs/product/strategy/research/competitors/ticktick.md
@@ -1,0 +1,256 @@
+# 競合調査: TickTick
+
+> アーカイブ元: GitHub Issue #1267（label: 競合）
+> 取り込み日: 2026-06-15
+> このドキュメントは継続観察用の調査メモ。一次情報は各競合の公式サイトを参照。
+
+---
+
+## 概要
+
+TickTick は、ToDoリスト・カレンダー・ポモドーロ・習慣管理・統計・リマインダー・コラボレーションをまとめた all-in-one productivity app。
+Dayopt とは「カレンダー上で予定を組む」「時間を追跡する」「統計で振り返る」という領域で重なる。
+
+ただし、TickTick はかなり **Task-first / All-in-one**。Dayoptはこの方向に寄せると劣化版になりやすい。
+むしろ、Dayoptが「Todoではなく時間」「習慣やタスクではなく予定/実績差分」に集中すべきことを確認するための競合として見る。
+
+- 公式サイト: https://ticktick.com/
+- Premium: https://ticktick.com/about/upgrade
+- Help Center: https://help.ticktick.com/
+- Integrations: https://ticktick.com/integrations
+- Download: https://ticktick.com/about/download
+
+## 競合分類
+
+| 観点           | 評価                                                                  |
+| -------------- | --------------------------------------------------------------------- |
+| 機能競合       | 中〜高。calendar / pomo / statistics / habit / task management を持つ |
+| コンセプト競合 | 中。DayoptよりTodo/習慣/リマインダー色が強い                          |
+| ターゲット競合 | 高い。一般個人、学生、ビジネスユーザー、習慣管理ユーザーまで広い      |
+| 価格競合       | 高い。Annual $35.99 と低価格                                          |
+| UX思想         | Task-first + All-in-one。Dayoptとは思想がかなり違う                   |
+
+## 公式上の主な訴求
+
+- “A To-Do List and Calendar to keep you organized”
+- To-Do List
+- Calendar Views
+- Pomodoro
+- Habit Tracker
+- Countdown
+- Kanban
+- Timeline
+- Eisenhower Matrix
+- Sticky Note
+- Constant Reminder
+- Repeat Reminder
+- NLP
+- Filter
+- Keyboard Shortcuts
+- Collaboration
+- Integration
+- Statistics
+- Theme
+- Sync across all platforms
+
+公式サイトでは、ToDo、カレンダー、ポモドーロ、習慣管理、統計などを「生活と仕事全体を整理する」方向で訴求している。
+
+## 価格
+
+2026-06-07時点の公式 Premium ページでは以下。
+
+| Plan           |        価格 | 備考               |
+| -------------- | ----------: | ------------------ |
+| Free           |        Free | 基本機能           |
+| Premium Annual | $35.99/year | less than $3/month |
+
+Premiumでは、full calendar functionality、custom filters、履歴・統計、estimated Pomo、calendar widgets、premium themes、white noises などが使える。
+Dayoptの $5 Pro 想定より安く、価格競合としては強い。
+
+## 主な機能
+
+### To-Do List / Task Management
+
+TickTickの中心はToDoリスト。
+work projects / personal tasks / study plans などを整理し、期限・リマインダー・繰り返し・チェックリスト・優先度などで管理する。
+
+Dayoptではここを真似ない。
+Todo管理はGitHub Issuesや他のツールに任せ、Dayoptは時間ブロックと実績差分に集中する。
+
+### Calendar Views
+
+TickTickは yearly / monthly / weekly / daily / agenda / multi-day / multi-week など複数のカレンダービューを持つ。
+週表示では busy and free time blocks を見られる。
+
+Dayoptとの重なりはあるが、DayoptはモバイルDay表示を中心に、PCでも「予定と実績が同じブロックで見える」ことに集中した方がよい。
+
+### Pomodoro / Estimated Pomo
+
+TickTickはPomodoroを標準機能として持ち、Premiumではタスクごとに estimated Pomo を設定して時間消費を計算できる。
+
+Dayoptではポモドーロ自体は核ではない。
+盗むなら「見積もりと実績を軽く比較する」部分だけ。
+
+### Habit Tracker
+
+TickTickは習慣管理も強い。
+習慣ライブラリ、柔軟なトラッキング、統計を持つ。
+
+Dayoptは習慣管理に寄せない方がよい。
+タグごとの時間実績が結果的に習慣のように見える程度で十分。
+
+### Statistics
+
+TickTickは tasks / focus duration / habit logs を統計で見られる。
+DayoptのReviewと近いが、Dayoptは「統計を増やす」のではなく「予定/実績/差分を見る」に絞る。
+
+### Keyboard Shortcuts / NLP
+
+TickTickは keyboard shortcuts と command menus、自然言語入力を持つ。
+Dayoptでもここは参考になる。
+
+Dayoptでは自然言語より、タグ選択・時間操作・開始/停止・確定のショートカットを優先したい。
+
+## Dayoptとの違い
+
+```text
+TickTick:
+タスクを作る
+↓
+リスト/カレンダー/習慣/ポモドーロで管理する
+↓
+リマインダーで実行を促す
+↓
+統計で進捗を見る
+```
+
+```text
+Dayopt:
+時間枠がある
+↓
+タグを置く
+↓
+予定と実績が1つのエントリになる
+↓
+ズレを見る
+↓
+次の時間設計に戻る
+```
+
+TickTick は **Task-first / Reminder-first / Habit-first / All-in-one**。
+Dayopt は **Timebox / Tag-first / Planned-Actual-first / Minimal-first**。
+
+TickTickは広く強いが、Dayoptが勝つ場所は「全部管理しない」「時間のズレだけを見る」こと。
+
+## 盗めそうな部分
+
+### P1: 低価格でも多機能に見える価格設計の参考
+
+TickTick Premium は年 $35.99 とかなり安い。
+Dayoptが $5/月なら、機能量では勝てない。
+そのため、LPでは「機能数」ではなく「軽さ・時間ブロック・予定実績差分」に絞る必要がある。
+
+Dayopt訳:
+
+```text
+全部入りではなく、今日の時間だけを整える。
+```
+
+### P1: Calendar上のbusy/free time blocks
+
+TickTickの週表示は busy/free time blocks を見せる。
+DayoptのReviewでも、空白時間・差分・未配置時間の見せ方に応用できる。
+
+例:
+
+```text
+今日の空白
+- 10:30–11:00 30分
+- 15:00–15:45 45分
+```
+
+### P1: Keyboard shortcuts / command menus
+
+Dayoptでもショートカットは重要。
+
+候補:
+
+```text
+T: タグ選択
+Enter: 確定
+Space: 記録開始/停止
+R: Review
+1-9: 最近使ったタグ
+```
+
+### P2: Statistics を「進捗」ではなく「補正」に翻訳する
+
+TickTickは tasks/focus/habit の進捗統計。
+Dayoptは planned/actual/diff の補正情報。
+
+Dayopt訳:
+
+```text
+がんばりを測るのではなく、ズレを次の計画に戻す。
+```
+
+### P2: Cross-platform sync の安心感
+
+TickTickはスマホ・PC・タブレット・Watchまで同期できることを強く訴求している。
+DayoptもPWA firstでよいが、「どこからでも軽く触れる」は価値として言語化したい。
+
+## 盗まない方がいい部分
+
+| 機能/思想             | 理由                        |
+| --------------------- | --------------------------- |
+| ToDo管理全般          | GitHub Issues等と役割が被る |
+| Constant Reminder     | 通知削除方針と衝突          |
+| Repeat Reminder       | 繰り返し削除方針と衝突      |
+| Pomodoro              | Dayoptの核ではない          |
+| Habit Tracker         | 別プロダクト化する          |
+| Kanban                | タスク管理に寄りすぎる      |
+| Eisenhower Matrix     | 優先度管理に寄りすぎる      |
+| Collaboration         | 初期ターゲットではない      |
+| Theme多数             | 初期価値ではない            |
+| Checklist/subtask強化 | 複雑化する                  |
+
+## Dayoptの差別化メッセージ候補
+
+避けたい表現:
+
+```text
+ToDoリストも習慣もポモドーロも全部管理
+リマインダーでタスクを忘れない
+生産性オールインワン
+```
+
+使いたい表現:
+
+```text
+Todoではなく、時間を整える
+通知で追い立てず、予定と実績のズレを見る
+タグを置くだけで、今日の時間が形になる
+統計ではなく、次の計画のための差分
+```
+
+## Dayoptへの示唆
+
+TickTickは、機能量・価格・対応プラットフォームで非常に強い。
+Dayoptは「機能数」では勝てない。
+勝ち筋は、明確に **やらないことを決める** こと。
+
+```text
+TickTick = ToDo / カレンダー / ポモドーロ / 習慣 / 統計をまとめる all-in-one app
+Dayopt = タグを時間に置き、予定と実績の差分で明日を補正する timebox tool
+```
+
+DayoptはTickTickから、busy/free blocks、keyboard shortcuts、低価格競合としての見せ方を学ぶ。
+ただし、ToDo、通知、習慣、ポモドーロ、Kanbanは盗まない。
+
+## 次に検討したいこと
+
+- [ ] LPで「全部入りではない」ことを価値として言語化する
+- [ ] Reviewで空白時間 / busy-free 的な表示を検討する
+- [ ] ショートカット初期セットを決める
+- [ ] 通知/繰り返し/習慣/ポモドーロは非採用方針として明文化する
+- [ ] Dayopt Pro $5 の価値を「機能量」ではなく「核心UX/MCP/API」に寄せる


### PR DESCRIPTION
## Goal
label `競合` の付いた GitHub Issue（#1262-1269）の調査内容を docs に取り込み、リポジトリ内で参照・更新できる形にする。

## 変更内容
`apps/storybook/docs/product/strategy/research/competitors/` を新設し、8 競合の深掘り調査メモをアーカイブ:

- Sunsama / Super Productivity / Akiflow / Motion / Routine / TickTick / Ellie / Amazing Marvin
- 各ファイルに provenance ヘッダ（元 Issue 番号・取り込み日）を付与
- `README.md` で一覧 + Dayopt の立ち位置を要約し、俯瞰の `competitors.mdx` と相互リンク

## Reversibility
全て docs only の新規ファイル追加 — `[minutes]`（git revert で即時）。挙動・UI 変更なし。

## Not Doing
- 元 Issue のクローズ（継続観察用の living issue のため open のまま、各 Issue に doc への導線を別途コメント）
- `competitors.mdx` マトリクスへの統合（俯瞰は現状維持、本 PR は深掘りメモの保管に限定）

Refs #1262, #1263, #1264, #1265, #1266, #1267, #1268, #1269

🤖 Generated with [Claude Code](https://claude.com/claude-code)