### PR TITLE
refactor: P7 最終クリーンアップ（eslint-disable 棚卸し + project summary）

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -63,3 +63,18 @@ Server Component をデフォルト。useState / useEffect / イベントハン�
 2. 既存の依存で代替できないか？
 3. GitHub Stars >= 1000、最終コミット6ヶ月以内か？
 4. 1つの機能のためだけに大きなライブラリを追加しない
+
+## eslint-disable の運用
+
+disable は「ルールが誤検知している／意図的に逸脱する」場合の最終手段。まずコード側で解消できないか検討する。やむを得ず disable する場合は次を守る:
+
+1. **必ず inline で `-- 理由` を書く**。前行コメントではなく disable ディレクティブと同じ行に書く（grep で「理由なし disable」を検出できる状態を保つ）。
+
+   ```ts
+   // ✅ react-hooks/exhaustive-deps -- 初回マウント時のみ URL から復元する意図的な mount-only effect
+   // ❌ 理由なし、または前行コメントに分離
+   ```
+
+2. **`eslint-disable`（ファイル全体）より `eslint-disable-next-line`（1 行）を優先**。影響範囲を最小化する。
+3. **未使用 disable は CI で fail する**。`reportUnusedDisableDirectives: 'error'`（`apps/product` / `apps/web` の `eslint.config.mjs`）により、対象ルールが発火しなくなった disable は自動検出される。リファクタで不要になった disable は放置せず削除する。
+4. 新しいルールを `off` にして黙らせるより、`warn` + 段階的解消を検討する（例: `@typescript-eslint/no-unused-vars` は TS 本体 + Prettier が未使用 import を消すため低優先で `off`）。

--- a/apps/product/eslint.config.mjs
+++ b/apps/product/eslint.config.mjs
@@ -13,6 +13,14 @@ const eslintConfig = defineConfig([
   // TypeScript推奨ルール
   ...nextTs,
 
+  // 未使用の eslint-disable ディレクティブを error 扱いにする（再発防止）
+  // 対象ルールが発火しなくなった disable は CI で fail させ、stale な disable の蓄積を防ぐ
+  {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'error',
+    },
+  },
+
   // Ignore patterns
   globalIgnores([
     '.next/**',

--- a/apps/product/src/features/auth/components/LoginForm.tsx
+++ b/apps/product/src/features/auth/components/LoginForm.tsx
@@ -167,9 +167,7 @@ export function LoginForm({ className, ...props }: React.ComponentProps<'div'>) 
     <div className={cn('flex flex-col gap-6', className)} {...props}>
       <Card className="overflow-hidden p-0">
         <CardContent className="grid p-0 md:grid-cols-2">
-          {/* onSubmit は event handler として submit 時にのみ turnstileRef.current を読む。
-              react-hooks/refs が handleSubmit(onSubmit) の closure 解析で誤検知するため disable */}
-          {/* eslint-disable-next-line react-hooks/refs */}
+          {/* eslint-disable-next-line react-hooks/refs -- onSubmit は submit 時のみ turnstileRef.current を読む event handler。handleSubmit(onSubmit) の closure 解析による誤検知を抑制 */}
           <form className="p-6 md:p-8" onSubmit={handleSubmit(onSubmit)}>
             <FieldGroup>
               <div className="flex flex-col items-center text-center">

--- a/apps/product/src/features/auth/components/SignupForm.tsx
+++ b/apps/product/src/features/auth/components/SignupForm.tsx
@@ -165,9 +165,7 @@ export function SignupForm({ className, ...props }: React.ComponentProps<'div'>)
     <div className={cn('flex flex-col gap-6', className)} {...props}>
       <Card className="overflow-hidden p-0">
         <CardContent className="grid p-0 md:grid-cols-2">
-          {/* onSubmit は event handler として submit 時にのみ turnstileRef.current を読む。
-              react-hooks/refs が handleSubmit(onSubmit) の closure 解析で誤検知するため disable */}
-          {/* eslint-disable-next-line react-hooks/refs */}
+          {/* eslint-disable-next-line react-hooks/refs -- onSubmit は submit 時のみ turnstileRef.current を読む event handler。handleSubmit(onSubmit) の closure 解析による誤検知を抑制 */}
           <form className="p-6 md:p-8" onSubmit={handleSubmit(onSubmit)}>
             <FieldGroup>
               <div className="flex flex-col items-center text-center">

--- a/apps/product/src/features/entry/hooks/useInspectorURLSync.ts
+++ b/apps/product/src/features/entry/hooks/useInspectorURLSync.ts
@@ -45,7 +45,7 @@ export function useInspectorURLSync() {
         isUpdatingFromURLRef.current = false;
       }, 0);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- 初回マウント時のみ URL から復元する意図的な mount-only effect
   }, []);
 
   // インスペクタ状態変更時: URLを更新

--- a/apps/product/src/features/settings/components/sections/MFASection.tsx
+++ b/apps/product/src/features/settings/components/sections/MFASection.tsx
@@ -161,7 +161,7 @@ export function MFASection({ _useMFAHook }: MFASectionProps = {}) {
                 </p>
                 {/* QRコードは白背景必須（読み取り精度のため） */}
                 <div className="flex justify-center rounded-2xl bg-white p-4">
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  {/* eslint-disable-next-line @next/next/no-img-element -- qrCode は動的生成の data URL。next/image の最適化対象外で利点がなく img で十分 */}
                   <img src={qrCode} alt="QR Code" className="h-48 w-48" />
                 </div>
                 <p className="text-muted-foreground mt-2 text-xs">

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -7,6 +7,12 @@ export default [
   {
     ignores: ['node_modules/', '.next/', 'out/', 'public/', '**/*.d.ts'],
   },
+  // 未使用の eslint-disable ディレクティブを error 扱いにする（再発防止）
+  {
+    linterOptions: {
+      reportUnusedDisableDirectives: 'error',
+    },
+  },
   {
     files: ['**/*.{ts,tsx,js,jsx}'],
     plugins: {

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -28,7 +28,7 @@ export default async function LocaleLayout({
 
   // Client Component が使わない重いネームスペースを除外（legal: ~96KB）
   // legal/ossCredits は Server Component で getTranslations() 経由で直接取得する
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- rest destructuring で除外する legal/ossCredits は意図的に未使用
   const { legal, ossCredits, ...clientMessages } = messages as Record<string, unknown>;
 
   return <NextIntlClientProvider messages={clientMessages}>{children}</NextIntlClientProvider>;

--- a/docs/projects/README.md
+++ b/docs/projects/README.md
@@ -21,6 +21,7 @@ Project 単位の完了記録アーカイブ。詳細な工程は各 project の
 | `cleanup-2026-04-26`          | 2026-04-26 | cleanup plan          | [overview](./cleanup-2026-04-26/overview.md)                       |
 | `mcp-server`                  | 2026-04-30 | design                | [overview](./mcp-server/overview.md)                               |
 | `timeline-precision-redesign` | 2026-04-28 | design                | [overview](./timeline-precision-redesign/overview.md)              |
+| `codebase-refactoring`        | 2026-06-15 | 24 issue / Phase 0-7  | [summary](./codebase-refactoring/summary.md)                       |
 
 ## 命名規則
 

--- a/docs/projects/codebase-refactoring/summary.md
+++ b/docs/projects/codebase-refactoring/summary.md
@@ -1,0 +1,108 @@
+# codebase-refactoring 完了サマリー
+
+- **期間**: 2026-06-12 〜 2026-06-15
+- **規模**: 大規模（Phase 0-7 / I-01〜I-23 の 24 issue / 1 issue = 1 PR）
+- **設計書**: [`overview.md`](./overview.md)
+- **状態**: ✅ 完了（全 issue close、CI 全 gate green）
+
+---
+
+## Project ゴール
+
+コードベース全体を段階的にリファクタリングし、「デッドコードが増え続ける構造」と「AI の精度を落とすノイズ」を解消する。挙動・UI・仕様は変えず（offline-sync の製品判断 I-23 のみ例外）、**パターン逸脱が入った瞬間に CI で落ちる**状態を作って project を閉じる。
+
+---
+
+## フェーズ別成果
+
+| Phase                       | 内容                                                                                                         | 主な issue       | 状態 |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------ | ---------------- | ---- |
+| **P0** 調査・安全網         | knip 誤検出解消 / tag-detail liveness 表 / characterization tests                                            | I-01, I-02, I-03 | ✅   |
+| **P1** 削除 + knip blocking | tag-detail dead chain 削除 / 空 package 削除 / unused exports 削減 / knip CI blocking 化 / offline-sync 削除 | I-04〜I-07, I-23 | ✅   |
+| **P2** 構成・命名・責務     | feature barrel 契約整理 + date-utils 吸収 / packages 統合                                                    | I-08, I-22       | ✅   |
+| **P3** service 層統一       | settings / auth recovery / entry の service 抽出 / 巨大 service・hook 分割                                   | I-09〜I-12       | ✅   |
+| **P4** 状態管理             | server state 保持 Zustand store を TanStack Query へ移行 / settings optimistic update                        | I-13, I-14       | ✅   |
+| **P5** DB / RLS             | 孤児 DB RPC drop / RLS snapshot 自動生成 + CI drift check / ロジック置き場方針                               | I-15, I-16       | ✅   |
+| **P6** test / docs          | RLS integration parameterized suite / auth・chronotype・contact テスト補強 / project docs summary 整備       | I-17〜I-19       | ✅   |
+| **P7** 再発防止・締め       | eslint-disable 棚卸し + 再発防止ルール / project summary                                                     | I-20, I-21       | ✅   |
+
+---
+
+## before / after metrics
+
+### デッドコード（knip）
+
+| 指標           | before（2026-06-12 Phase 0 計測）           | after（2026-06-15）                                                          |
+| -------------- | ------------------------------------------- | ---------------------------------------------------------------------------- |
+| unused exports | 219                                         | **0**                                                                        |
+| unused types   | 249                                         | **0**                                                                        |
+| unused deps    | 8（+ indirect devDeps 15 を誤検出）         | **0**                                                                        |
+| unused files   | 12                                          | 9（CI では `--exclude files` で除外、残りは barrel 等の意図的 export point） |
+| knip CI        | `--no-exit-code` で **decして fail しない** | **blocking + green**（unused export/type/dep が増えると CI fail）            |
+
+### コード削減（主なもの）
+
+- tag-detail dead chain 削除（I-04）: **約 -2,125 行**（component 6 / dead hook 3 / dead procedure 群 + stories / i18n）
+- offline-sync 削除（I-23, Q4 製品判断）: 自前同期エンジン実装 + `offline-sync.test.ts` 1,278 行 + e2e spec（TODO 42 件）を撤去。PWA installability は存続
+- 空 package 削除（I-05）: `@dayopt/utils` / `@dayopt/server`
+- 孤児 DB RPC drop（I-15）: tag-detail 系 9 関数。コード（I-04）と DB の dead chain を両面で解消
+
+### 構造的改善
+
+- server state を保持する Zustand store **3 → 0**（TanStack Query へ一本化、I-13/I-14）
+- tRPC router からの `ctx.supabase` 直呼び **解消**（settings 7 + entry 1 を service 層へ、I-09/I-12）
+- RLS snapshot を `pnpm rls:snapshot` で自動生成 + CI drift check（`apps/storybook/docs/dev/db/rls-snapshot.md`、I-16）
+- eslint-disable 46 件を機械検証（stale 0 件）、`reportUnusedDisableDirectives: error` で再発防止（I-20）
+
+---
+
+## 要確認 Q1-Q7 の最終判断
+
+| #   | 項目                                             | 決定（2026-06-12）                                                | 結果                                                                 |
+| --- | ------------------------------------------------ | ----------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Q1  | tag-detail チャート 6 件 + dead chain の削除可否 | **削除する**（liveness 表で dead 確定した export 単位）           | I-04 / I-15 で完遂                                                   |
+| Q2  | `toast.info` / `toast.warning`（@deprecated）    | **現状維持**（Inline Banner 移行は UI 変更を伴うため本計画外）    | 据え置き                                                             |
+| Q3  | migration squash（baseline 再生成）              | **見送り**（判断資料のみ作成し将来再検討）                        | [`migration-squash-assessment.md`](./migration-squash-assessment.md) |
+| Q4  | PWA offline-sync（製品判断）                     | **機能を切る**（コード・spec を削除、経緯と再導入条件を docs 化） | I-23 で完遂                                                          |
+| Q5  | `@tanstack/react-virtual` 等の依存削除可否       | **I-01 の再調査結果に従う**（使用ゼロ確定分のみ削除）             | I-01/I-06 で反映                                                     |
+| Q6  | `packages/domain` barrel の export 整備          | **現状維持**                                                      | 据え置き                                                             |
+| Q7  | packages 統合（10 → 2-3 個）                     | **統合する（低優先）**                                            | I-22 で実施                                                          |
+
+---
+
+## 見送り事項と再検討条件
+
+| 事項                                                                   | 見送り理由                                                                                      | 再検討する条件                                                                                                                                                                                                                       |
+| ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **migration squash**（active 115 / `_archive` 116 の baseline 再生成） | solo / pre-launch では churn コストに見合う情報価値が薄い。判断資料のみ作成                     | migration 数がさらに増えて新規環境セットアップ（`db:fresh`）が体感で遅くなった時、または複数開発者参加で履歴の可読性が問題化した時。手順・リスクは [`migration-squash-assessment.md`](./migration-squash-assessment.md) を起点にする |
+| **offline-sync の再導入**                                              | 自前同期エンジンが中途半端で保守コストが高い（Q4）                                              | 同期エンジンを「自作でなく購入/採用」する別 plan が立った時。installability（manifest / install prompt）は残しているので PWA 基盤は再利用可                                                                                          |
+| **`toast.info` / `toast.warning` の Inline Banner 移行**（Q2）         | UI 変更を伴いリファクタと混ぜない方針                                                           | Inline Banner の design が確定し、UI 変更を含む別 plan として切り出せる時                                                                                                                                                            |
+| **600 行超 warn lint**（I-20 任意項目）                                | 機械的検知の費用対効果が現時点で薄い（巨大 service は I-12 で分割済み、再発の実害が出ていない） | 巨大ファイルの再発が複数回観測された時に file-size lint を導入                                                                                                                                                                       |
+
+---
+
+## 残課題 / follow-up
+
+- **Supabase advisors 棚卸し**（I-16 の②）: production の security / performance advisor 確認は cloud supabase MCP の token が必要で、本 project 期間中は期限切れのため未実施。token 復旧後に別 follow-up で `get_advisors` を実行し、指摘を issue 化する。
+- `@typescript-eslint/no-unused-vars` は引き続き `off`（TS 本体 + Prettier が未使用 import を消すため低優先）。on 化は費用対効果が薄いと判断（I-20）。
+
+---
+
+## 学び
+
+- **検出器の信頼回復を最初にやる（Phase 0）**: knip の誤検出を潰してから削除に入ることで、「消してよい」根拠が機械的に得られた。
+- **削除は export 単位**: ファイル単位でなく export 単位で liveness を確定すると、live / dead が同居するファイル（`useTagDetailData.ts` の 4 hooks 中 3 つが dead 等）を安全に削れる。
+- **DB RPC drop は順序厳守**: コード側削除を production へ deploy → Sentry 静穏確認 → drop migration。単一 production project 運用では PR Preview は DB 分離の安全網にならない。
+- **生成 docs は CI drift check で守る**: RLS snapshot / openapi.json は手動運用だと陳腐化する。`pnpm rls:snapshot` のように 1 コマンド生成 + CI 差分検出にする。
+- **再発防止は「CI で落ちる」状態にして初めて完成**: knip blocking（I-07）、reportUnusedDisableDirectives（I-20）、lint:boundaries、RLS drift check が steady-state を維持する。
+
+---
+
+## 関連リンク
+
+- 全体設計: [`overview.md`](./overview.md)
+- knip 棚卸し: [`knip-audit.md`](./knip-audit.md)
+- tag-detail liveness: [`tag-detail-liveness.md`](./tag-detail-liveness.md)
+- characterization tests: [`i03-characterization.md`](./i03-characterization.md)
+- migration squash 判断資料: [`migration-squash-assessment.md`](./migration-squash-assessment.md)
+- RLS snapshot: `apps/storybook/docs/dev/db/rls-snapshot.md`（`pnpm rls:snapshot` で生成）


### PR DESCRIPTION
codebase-refactoring project の Phase 7（最終クリーンアップ・再発防止）。I-20 と I-21 で project を締める。

## I-20: eslint-disable 棚卸し + 再発防止ルール（#1316）
- eslint-disable 46 件を `--report-unused-disable-directives` で機械検証 → **stale（不要）0 件、全て load-bearing**
- inline reason が欠落していた 5 件に `-- 理由` を補記し self-documenting に統一
- `apps/product` / `apps/web` の `eslint.config.mjs` に `reportUnusedDisableDirectives: 'error'` を明示（発火しなくなった disable を CI で fail）
- `.claude/rules/code-style.md` に「eslint-disable の運用」節を追加

## I-21: project summary（#1317）
- `docs/projects/codebase-refactoring/summary.md` を作成（Phase 0-7 成果 / before-after metrics / Q1-Q7 最終判断 / 見送り事項の再検討条件 / 残課題）
- `docs/projects/README.md` の Completed projects に追記

## before/after（抜粋）
- unused exports 219→0 / types 249→0 / deps 0、knip CI blocking + green
- server state Zustand store 3→0

## Reversibility
eslint config + comment-only source 編集 + docs。全て `[minutes]`（git revert で即時）。挙動・UI 変更なし。

## Not Doing
- `@typescript-eslint/no-unused-vars` の on 化（費用対効果が薄い。TS + Prettier が未使用 import を消す）
- 600 行超 warn lint（I-20 任意項目、実害が出ていないため見送り）
- advisors 棚卸し（cloud supabase MCP token 復旧後の follow-up）

Closes #1316, Closes #1317

🤖 Generated with [Claude Code](https://claude.com/claude-code)