### PR TITLE
chore(release): v0.30.0 へ version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dayopt",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "private": true,
   "packageManager": "pnpm@11.1.2",
   "scripts": {


### PR DESCRIPTION
## 概要

`v0.30.0` リリースのための version bump（`0.29.0` → `0.30.0`）。

このPRをマージ後、`main` に `v0.30.0` タグを打つことで GitHub Actions が本番デプロイ + GitHub Release を自動実行する。

## 変更

- `package.json` の `version` を `0.30.0` に更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)