### PR TITLE
[codex] 1Password 経由 MCP の起動範囲を整理

### DIFF
--- a/.claude/rules/mcp-usage.md
+++ b/.claude/rules/mcp-usage.md
@@ -9,7 +9,7 @@ Opus 4.7 はツール呼び出しが控えめになる傾向がある。以下�
 1. **OAuth 承認方式**（`/mcp` で承認、トークン管理不要）: `sentry` / `vercel`。`sentry` は `https://mcp.sentry.dev/mcp` を直叩きする hosted MCP。
 2. **`.mcp.json` 内 `op run` 自己解決方式**: `supabase`(cloud) / `github`。MCP プロセスの起動コマンド自体を `op run -- <bin>` でラップし、spawn 時に 1Password が `op://` 参照を解決する。**Claude 本体の起動経路に依存しない**（desktop アプリ起動でも動く）。token 系 MCP はこの方式を標準とする。
 
-**トークンを平文でハードコードしない**。env 注入を要する MCP はもう無いため、**Claude 起動に zsh の `op run` ラッパーは不要**（過去の `.op-env.mcp` / wrapper 方式は廃止）。前提は `op` CLI + 1Password desktop 統合が使えること。
+**トークンを平文でハードコードしない**。env 注入を要する MCP はもう無いため、**Claude 起動に zsh の `op run` ラッパーは不要**（過去の `.op-env.mcp` / wrapper 方式は廃止）。前提は `op` CLI + 1Password desktop 統合が使えること。`op run` は stdout / stderr の secret masking が既定で有効なので、MCP server へ env token を渡す用途では `--no-masking` を付けない。
 
 ## 運用方針
 

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -19,6 +19,48 @@ env_vars = ["SENTRY_ACCESS_TOKEN"]
 [mcp_servers.supabase-local]
 url = "http://127.0.0.1:54321/mcp"
 
+[mcp_servers.github]
+command = "op"
+args = [
+    "run",
+    "--no-masking",
+    "--",
+    "github-mcp-server",
+    "stdio",
+]
+
+[mcp_servers.github.env]
+GITHUB_PERSONAL_ACCESS_TOKEN = "op://Dayopt-Shared/github-mcp-pat/credential"
+
+[mcp_servers.playwright]
+command = "npx"
+args = [
+    "-y",
+    "@playwright/mcp@latest",
+]
+
+[mcp_servers.storybook]
+url = "http://localhost:6006/mcp"
+
+[mcp_servers.supabase]
+command = "op"
+args = [
+    "run",
+    "--no-masking",
+    "--",
+    "npx",
+    "-y",
+    "@supabase/mcp-server-supabase@latest",
+    "--read-only",
+    "--project-ref=yvglwblxrnrenfifsnje",
+]
+
+[mcp_servers.supabase.env]
+SUPABASE_ACCESS_TOKEN = "op://Dayopt-Staging/supabase/SUPABASE_ACCESS_TOKEN"
+
+[mcp_servers.vercel]
+url = "https://mcp.vercel.com"
+
 [shell_environment_policy]
 inherit = "core"
 

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -23,7 +23,6 @@ url = "http://127.0.0.1:54321/mcp"
 command = "op"
 args = [
     "run",
-    "--no-masking",
     "--",
     "github-mcp-server",
     "stdio",
@@ -41,22 +40,6 @@ args = [
 
 [mcp_servers.storybook]
 url = "http://localhost:6006/mcp"
-
-[mcp_servers.supabase]
-command = "op"
-args = [
-    "run",
-    "--no-masking",
-    "--",
-    "npx",
-    "-y",
-    "@supabase/mcp-server-supabase@latest",
-    "--read-only",
-    "--project-ref=yvglwblxrnrenfifsnje",
-]
-
-[mcp_servers.supabase.env]
-SUPABASE_ACCESS_TOKEN = "op://Dayopt-Staging/supabase/SUPABASE_ACCESS_TOKEN"
 
 [mcp_servers.vercel]
 url = "https://mcp.vercel.com"

--- a/.codex/rules/README.md
+++ b/.codex/rules/README.md
@@ -12,6 +12,7 @@ Dayopt の詳細ルールは `.claude/rules/` を canonical source とする。`
 ## Files
 
 - `git-workflow.md` — Codex での branch / commit / PR / merge 運用
+- `mcp.md` — Codex 固有の MCP 起動範囲と 1Password masking 運用
 
 ## Canonical References
 

--- a/.codex/rules/mcp.md
+++ b/.codex/rules/mcp.md
@@ -1,0 +1,16 @@
+# Codex MCP 運用
+
+Codex 固有の MCP 起動範囲だけをここに置く。Claude 共通の MCP 方針は `.claude/rules/mcp-usage.md` を canonical source とする。
+
+## 常時起動
+
+- `github`: issue / PR / branch 状態確認で頻繁に使うため `.codex/config.toml` に置く。`op run -- github-mcp-server stdio` で `op://Dayopt-Shared/github-mcp-pat/credential` を自己解決する。
+
+## オンデマンド
+
+- `supabase` cloud: production schema / RLS / advisors の確認時だけ使う。Codex 起動時の 1Password unlock を増やさないため、`.codex/config.toml` には置かない。
+- `supabase-local`: 1Password と無関係な local HTTP MCP なので `.codex/config.toml` に残す。ローカル DB が落ちている時の接続失敗は異常扱いしない。
+
+## 1Password masking
+
+`op run` は stdout / stderr の secret masking が既定で有効。MCP server へ env token を渡すだけなら `--no-masking` は使わない。

--- a/.mcp.json
+++ b/.mcp.json
@@ -27,7 +27,6 @@
       "command": "op",
       "args": [
         "run",
-        "--no-masking",
         "--",
         "npx",
         "-y",
@@ -48,7 +47,7 @@
     "github": {
       "type": "stdio",
       "command": "op",
-      "args": ["run", "--no-masking", "--", "github-mcp-server", "stdio"],
+      "args": ["run", "--", "github-mcp-server", "stdio"],
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "op://Dayopt-Shared/github-mcp-pat/credential"
       }


### PR DESCRIPTION
## Summary

- Codex 側の `.codex/config.toml` から Supabase cloud MCP を外し、起動時の 1Password unlock 対象を減らしました
- GitHub / Supabase cloud の `op run --no-masking` を削除し、既定の stdout / stderr masking を維持しました
- Codex 固有 overlay docs に GitHub 常時 / Supabase cloud オンデマンド運用を明記しました
- 既存の Codex MCP 設定追加差分もこのブランチに含めています

## Why

Codex 起動時に GitHub と Supabase cloud MCP がそれぞれ 1Password unlock を要求する構成になっていました。GitHub は issue / PR 作業で常時使う一方、Supabase cloud は production schema / RLS 確認時だけ必要なので、Codex の常時起動対象から外します。

Closes #1382

## Verification

Clean worktree at `bd556d55`:

- `pnpm lint`
- `pnpm lint:boundaries`
- `pnpm typecheck`
- `codex mcp list`

Manual checks:

- `op run -- env GITHUB_PERSONAL_ACCESS_TOKEN=op://Dayopt-Shared/github-mcp-pat/credential ...` resolves without `--no-masking` and only prints length
- `op run -- env SUPABASE_ACCESS_TOKEN=op://Dayopt-Staging/supabase/SUPABASE_ACCESS_TOKEN ...` resolves without `--no-masking` and only prints length
- `codex mcp list` no longer lists Supabase cloud from `.codex/config.toml`; GitHub env remains masked