### PR TITLE
refactor(entry): 更新パスの as キャストを除去し Zod↔DB 列の乖離を型で検出

### DIFF
--- a/apps/product/src/features/entry/lib/entry-normalization.ts
+++ b/apps/product/src/features/entry/lib/entry-normalization.ts
@@ -3,6 +3,7 @@
  * Helper functions for router operations
  */
 
+import type { TablesUpdate } from '@dayopt/database';
 import { formatInTimeZone, fromZonedTime } from 'date-fns-tz';
 
 import { tzIsSameDay } from '@/lib/date/timezone';
@@ -10,15 +11,37 @@ import { logger } from '@/lib/logger';
 
 /**
  * Remove undefined fields from an object (for exactOptionalPropertyTypes)
+ *
+ * 戻り値の型からも undefined を除外する（Exclude）。実体が undefined を落とすので、
+ * 結果を DB の Insert/Update 型へ as キャストなしで渡せる（issue #1288 項目2）。
  */
-export function removeUndefinedFields<T extends Record<string, unknown>>(obj: T): Partial<T> {
-  const result: Partial<T> = {};
+export function removeUndefinedFields<T extends Record<string, unknown>>(
+  obj: T,
+): { [K in keyof T]?: Exclude<T[K], undefined> } {
+  const result: Record<string, unknown> = {};
   for (const key in obj) {
     if (obj[key] !== undefined) {
       result[key] = obj[key];
     }
   }
-  return result;
+  return result as { [K in keyof T]?: Exclude<T[K], undefined> };
+}
+
+/**
+ * Zod 更新入力を entries の Update ペイロードへ変換する。
+ *
+ * - undefined を除去する（exactOptionalPropertyTypes 対応）
+ * - DB に存在しない列が Zod 側に紛れ込むと、`Record<Exclude<…>, never>` 制約で
+ *   呼び出し側がコンパイルエラーになる（列の追加漏れ・rename を検出）
+ * - 共有列の型乖離は戻り値の代入（Partial<TablesUpdate<'entries'>>）で検出する
+ *
+ * 従来は `removeUndefinedFields(input) as TablesUpdate<'entries'>` と as キャストで
+ * Zod↔DB の乖離を握り潰していた。本関数で typecheck の防壁に変える（issue #1288 項目2）。
+ */
+export function toEntryUpdatePayload<T extends Record<string, unknown>>(
+  input: T & Record<Exclude<keyof T, keyof TablesUpdate<'entries'>>, never>,
+): Partial<TablesUpdate<'entries'>> {
+  return removeUndefinedFields(input);
 }
 
 /**

--- a/apps/product/src/features/entry/server/entry-service.ts
+++ b/apps/product/src/features/entry/server/entry-service.ts
@@ -8,7 +8,11 @@ import 'server-only';
 
 import type { TablesInsert, TablesUpdate } from '@dayopt/database';
 import { determineEntryOrigin } from '../domain';
-import { normalizeDateTimeConsistency, removeUndefinedFields } from '../lib/entry-normalization';
+import {
+  normalizeDateTimeConsistency,
+  removeUndefinedFields,
+  toEntryUpdatePayload,
+} from '../lib/entry-normalization';
 
 import { EntryLifecycleService } from './entry-lifecycle-service';
 import { EntryOverlapService, type EntryOverlapOptions } from './entry-overlap-service';
@@ -257,7 +261,8 @@ export class EntryService {
       await this.ensureNoOverlaps(userId, finalEntry, entryId);
     }
 
-    const updateData = removeUndefinedFields(normalizedInput) as TablesUpdate<'entries'>;
+    // normalizeUpdateInput が既に TablesUpdate<'entries'> 型で返すため as キャスト不要。
+    const updateData = removeUndefinedFields(normalizedInput);
 
     const { data, error } = await this.supabase
       .from('entries')
@@ -548,11 +553,14 @@ export class EntryService {
     return normalized;
   }
 
+  // 戻り値を entries の Update 型に固定し、Zod 更新スキーマと DB 列の乖離（DB に無い列の
+  // 紛れ込み・列名 rename）を typecheck で検出する。Record<string, unknown> に緩めると
+  // 下流の as キャストと相まって乖離が runtime まで素通りするため戻さない（issue #1288 項目2）。
   private normalizeUpdateInput(
     input: UpdateEntryOptions['input'],
     existingData: EntryRow,
     timezone?: string,
-  ): Record<string, unknown> {
+  ): Partial<TablesUpdate<'entries'>> {
     if (input.origin !== undefined && input.origin !== existingData.origin) {
       throw new EntryServiceError(
         'INVALID_ENTRY_SHAPE',
@@ -579,7 +587,7 @@ export class EntryService {
       );
       // 自動記録モデル: 未来 planned の時間変更は plan range のみ。
       // actual へのコピーはしない（actual NULL = 未編集を維持する）。
-      return removeUndefinedFields({
+      return toEntryUpdatePayload({
         ...baseInput,
         start_time: plannedRange.start,
         end_time: plannedRange.end,
@@ -596,7 +604,7 @@ export class EntryService {
       );
     }
 
-    return removeUndefinedFields(baseInput);
+    return toEntryUpdatePayload(baseInput);
   }
 
   private resolveCreateRange(input: CreateEntryOptions['input'], timezone?: string): EntryRange {

--- a/apps/product/src/features/entry/server/router.ts
+++ b/apps/product/src/features/entry/server/router.ts
@@ -15,7 +15,7 @@ import { captureBusinessEvent } from '@/lib/sentry';
 import { getUserTimezone } from '@/lib/server/user-timezone-cache';
 import { handleServiceError } from '@/lib/trpc/errors';
 import { createTRPCRouter, protectedProcedure } from '@/lib/trpc/procedures';
-import type { TablesUpdate } from '@dayopt/database';
+import { toEntryUpdatePayload } from '../lib/entry-normalization';
 import {
   bulkDeleteEntrySchema,
   bulkUpdateEntrySchema,
@@ -26,8 +26,6 @@ import {
   updateEntrySchema,
 } from '../schemas/entry';
 import { createEntryService } from './service-index';
-
-import { removeUndefinedFields } from '../lib/entry-normalization';
 
 // =============================================================================
 // ユーザータイムゾーン取得 / レート制限の実装は lib に分離済み（P0-4 / P2-3）
@@ -267,7 +265,8 @@ export const entriesCoreRouter = createTRPCRouter({
     .input(bulkUpdateEntrySchema)
     .mutation(async ({ ctx, input }) => {
       const { supabase, userId } = ctx;
-      const updateData = removeUndefinedFields(input.data) as TablesUpdate<'entries'>;
+      // normalizeUpdateInput と同様、DB に無い列が Zod 側に紛れると型エラーになる。
+      const updateData = toEntryUpdatePayload(input.data);
 
       const { data, error } = await supabase
         .from('entries')


### PR DESCRIPTION
## 背景

issue #1288 項目2（Zod スキーマと DB 生成型の二重定義）の前倒し対応。

実測ベースで範囲を絞った（[#1288 のコメント](https://github.com/Dayopt/dayopt/issues/1288#issuecomment-4736453423)参照）:

- **項目3（集計テーブル/MV）は見送り** — Sentry 過去30日で `db.query` スパン 0 件・全スパン約370件で、再訪条件「p95 ≥ 100ms」を評価できる本番トラフィックが無い。憶測最適化を避ける。
- **項目2は更新パスの穴だけを塞ぐ** — フル codegen（生成型→Zod 自動導出）は再訪条件（実 sync 漏れバグ）未発生のため保留。

## 何が問題だったか

調査で前提が一部覆った:

- **作成パスは既に型ガード済み**。`entry-service.ts` の `normalizeCreateInput` が `NormalizedEntryInput = TablesInsert<'entries'>` 注釈付きで組むため、Zod 列が DB 列と乖離すれば作成側は typecheck で落ちる。
- **本当の穴は更新パス**。`normalizeUpdateInput` / `bulkUpdate` が `removeUndefinedFields(...) as TablesUpdate<'entries'>` の **as キャストで乖離を握り潰して**おり、DB に無い列が Zod 側に紛れても runtime（PostgREST の unknown column）まで素通りしていた。

## 変更内容

- `toEntryUpdatePayload` ヘルパーを追加。`Record<Exclude<keyof T, keyof TablesUpdate<'entries'>>, never>` 制約で、**DB に存在しない列が Zod 側にあると呼び出し側がコンパイルエラー**になる（列の追加漏れ・rename を検出）。共有列の型乖離も戻り値の代入で検出。
- 更新2パス（`normalizeUpdateInput`）+ `bulkUpdate` を同ヘルパー経由に統一し、`as TablesUpdate<'entries'>` キャストを除去。
- `removeUndefinedFields` の戻り値型を精緻化（undefined を `Exclude`）し、キャストなしで DB 型へ渡せるようにする。

作成パスの insert（`as TablesInsert<'entries'>`）は既存の `NormalizedEntryInput` 注釈で型ガード済みのため対象外。

## 検証

- `pnpm typecheck` / `pnpm lint` / `pnpm lint:boundaries` green
- unit テスト 1806 件 green（更新ロジックの挙動不変）
- **乖離検出を実証**: Zod スキーマに DB 非存在列を一時追加 → 更新3サイトで typecheck が落ちることを確認 → 撤去

## 関連

ref #1288（ウォッチリストとして open 継続。項目1 / 項目3 / 項目2のフル codegen が残る）

🤖 Generated with [Claude Code](https://claude.com/claude-code)