### PR TITLE
docs(architecture): Storybook の architecture を docs へ移設し Architecture カテゴリを廃止

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: pnpm exec prettier --check "apps/product/src/**/*.{ts,tsx,js,jsx,json,md}"
 
       - name: Workspace Prettier
-        run: pnpm exec prettier --check "package.json" "packages/*/package.json" "apps/*/package.json" "apps/storybook/docs/**/*.mdx" "docs/**/*.md"
+        run: pnpm exec prettier --check "package.json" "packages/*/package.json" "apps/*/package.json" "docs/**/*.md"
 
       - name: License check
         run: pnpm license:check

--- a/apps/product/src/components/ui/props-inventory.stories.tsx
+++ b/apps/product/src/components/ui/props-inventory.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
 const meta = {
-  title: 'Architecture/Props Inventory',
+  title: 'Components/UI/Props Inventory',
   parameters: {
     layout: 'fullscreen',
   },
@@ -286,7 +286,7 @@ export const Overview: Story = {
                 {components.map((c) => (
                   <tr
                     key={c.name}
-                    className={`border-border border-b last:border-b-0 ${c.note ? 'bg-warning/5' : ''}`}
+                    className={`border-border border-b last:border-b-0 ${c.note ? 'bg-warning-tint' : ''}`}
                   >
                     <td className="px-4 py-2 font-mono text-xs font-medium">{c.name}</td>
                     <td className="text-muted-foreground px-4 py-2 font-mono text-xs">
@@ -300,7 +300,7 @@ export const Overview: Story = {
                     <td className="px-4 py-2 text-center">{c.className ? <Check /> : <Dash />}</td>
                     <td className="px-4 py-2 text-xs">
                       {c.note && (
-                        <span className="bg-warning/10 text-warning rounded-lg px-2 py-0.5 font-mono">
+                        <span className="bg-warning-tint text-warning rounded-lg px-2 py-1 font-mono">
                           {c.note}
                         </span>
                       )}
@@ -313,7 +313,7 @@ export const Overview: Story = {
         </section>
 
         {/* ステータス */}
-        <section className="bg-primary/5 border-primary/20 rounded-lg border p-4">
+        <section className="bg-primary-state-selected border-primary rounded-lg border p-4">
           <p className="text-primary text-sm font-medium">
             &#10003; すべてのpropsが統一ルールに準拠しています
           </p>

--- a/apps/product/src/emails/EmailTemplates.stories.tsx
+++ b/apps/product/src/emails/EmailTemplates.stories.tsx
@@ -29,7 +29,7 @@ import { TrialStartEmail } from './TrialStartEmail';
 import { WelcomeEmail } from './WelcomeEmail';
 
 const meta = {
-  title: 'Architecture/Email',
+  title: 'Patterns/Email',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -16,8 +16,6 @@ const config: StorybookConfig = {
     '../../../packages/foundations/src/**/*.mdx',
     '../../../packages/foundations/src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
     '../../../packages/components/src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
-    '../docs/**/*.mdx',
-    '../docs/**/*.stories.@(js|jsx|mjs|ts|tsx)',
     './stories/**/*.stories.@(js|jsx|mjs|ts|tsx)',
   ],
   addons: [

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -41,16 +41,7 @@ const preview: Preview = {
     options: {
       storySort: {
         method: 'alphabetical',
-        order: [
-          'Welcome',
-          'Architecture',
-          'Components',
-          'Features',
-          'Design',
-          'UI',
-          'Foundations',
-          'Patterns',
-        ],
+        order: ['Welcome', 'Components', 'Features', 'Design', 'UI', 'Foundations', 'Patterns'],
       },
     },
     darkMode: {

--- a/docs/architecture/accessibility/component-guide.md
+++ b/docs/architecture/accessibility/component-guide.md
@@ -1,7 +1,3 @@
-import { Meta } from '@storybook/addon-docs/blocks';
-
-<Meta title="Architecture/Accessibility/Component Guide" />
-
 # shadcn/ui コンポーネント別ガイド
 
 shadcn/ui（Radix UI）コンポーネントのa11y対応状況

--- a/docs/architecture/accessibility/focus-and-keyboard.md
+++ b/docs/architecture/accessibility/focus-and-keyboard.md
@@ -1,7 +1,3 @@
-import { Meta } from '@storybook/addon-docs/blocks';
-
-<Meta title="Architecture/Accessibility/Focus & Keyboard" />
-
 # フォーカスとキーボード
 
 キーボード操作時のフォーカス状態を明確に表示し、キーボードのみで全機能が使えるようにする

--- a/docs/architecture/accessibility/forms-and-dialog.md
+++ b/docs/architecture/accessibility/forms-and-dialog.md
@@ -1,7 +1,3 @@
-import { Meta } from '@storybook/addon-docs/blocks';
-
-<Meta title="Architecture/Accessibility/Forms & Dialog" />
-
 # フォームとDialog
 
 フォーム要素のラベル紐付け、エラー状態、Dialog の必須ルール

--- a/docs/architecture/accessibility/overview.md
+++ b/docs/architecture/accessibility/overview.md
@@ -1,7 +1,3 @@
-import { Meta } from '@storybook/addon-docs/blocks';
-
-<Meta title="Architecture/Accessibility/Overview" />
-
 # アクセシビリティガイド
 
 Dayoptのアクセシビリティ対応に関する基準と実装パターン

--- a/docs/architecture/accessibility/prohibited-patterns.md
+++ b/docs/architecture/accessibility/prohibited-patterns.md
@@ -1,7 +1,3 @@
-import { Meta } from '@storybook/addon-docs/blocks';
-
-<Meta title="Architecture/Accessibility/Prohibited Patterns" />
-
 # 禁止事項
 
 アクセシビリティを損なう実装パターン

--- a/docs/architecture/accessibility/screen-reader.md
+++ b/docs/architecture/accessibility/screen-reader.md
@@ -1,7 +1,3 @@
-import { Meta } from '@storybook/addon-docs/blocks';
-
-<Meta title="Architecture/Accessibility/Screen Reader" />
-
 # スクリーンリーダー対応
 
 視覚的には見えないが、スクリーンリーダーには読み上げられるテキストの実装パターン

--- a/docs/architecture/domain-glossary.md
+++ b/docs/architecture/domain-glossary.md
@@ -2,7 +2,7 @@
 
 Dayopt固有のドメイン概念とコードベースで使用される用語の定義。
 
-> Storybook用語（CSF, Meta, Story 等）は [Storybook 公式用語集](../../apps/storybook/docs/dev/OfficialGlossary.mdx) を参照。
+> Storybook用語（CSF, Meta, Story 等）は [Storybook 公式用語集](./storybook-glossary.md) を参照。
 
 ---
 

--- a/docs/architecture/product-overview.md
+++ b/docs/architecture/product-overview.md
@@ -1,8 +1,3 @@
-import { Meta } from '@storybook/addon-docs/blocks';
-import { Mermaid } from '../../.storybook/decorators/Mermaid';
-
-<Meta title="Architecture/Product Overview" />
-
 # Dayopt — Product Overview
 
 タイムボクシング × 時間記録 × タスク × カレンダーを一体化した、個人向け生産性アプリ。
@@ -56,7 +51,8 @@ Dayoptの中心概念。「時間ブロック」として、計画と記録を�
 
 ## ユーザージャーニー
 
-<Mermaid chart={`graph LR
+```mermaid
+graph LR
     A["🎯 Onboarding<br/>クロノタイプ診断"]
     B["📅 Calendar<br/>時間ブロックを配置"]
     C["⏱️ Track<br/>実績を記録"]
@@ -68,8 +64,7 @@ Dayoptの中心概念。「時間ブロック」として、計画と記録を�
     C --> D
     D --> E
     E --> B
-
-`} />
+```
 
 1. **Onboarding** — クロノタイプ診断でエネルギーパターンを把握
 2. **Calendar** — Day/Week/MultiDay ビューで時間ブロックを視覚的に配置
@@ -83,11 +78,12 @@ Dayoptの中心概念。「時間ブロック」として、計画と記録を�
 
 15の機能モジュールがDAG（有向非巡回グラフ）で依存関係を構成：
 
-<Mermaid chart={`graph TD
+```mermaid
+graph TD
     subgraph "Layer 0 — Foundation"
-        tags["🏷️ Tags<br/>活動分類"]
-        chronotype["🧬 Chronotype<br/>生産性パターン"]
-    end
+tags["🏷️ Tags<br/>活動分類"]
+chronotype["🧬 Chronotype<br/>生産性パターン"]
+end
 
     subgraph "Layer 1 — Core Domain"
         entry["📦 Entry<br/>時間ブロック"]
@@ -116,8 +112,7 @@ Dayoptの中心概念。「時間ブロック」として、計画と記録を�
     entry --> stats
     entry --> history
     entry --> palette
-
-`} />
+```
 
 **Layer 0** はどの機能にも依存しない基盤。**Layer 1** は Layer 0 のみに依存。**Layer 2** は Layer 0/1 に依存。この階層は ESLint で強制される。
 
@@ -153,10 +148,10 @@ Dayoptの中心概念。「時間ブロック」として、計画と記録を�
 
 ## 次に読むべきドキュメント
 
-| ドキュメント                                                                                           | 内容                          |
-| ------------------------------------------------------------------------------------------------------ | ----------------------------- |
-| [Domain Glossary](https://github.com/Dayopt/dayopt/blob/main/docs/architecture/domain-glossary.md)     | ドメイン用語の定義            |
-| [Data Flow](https://github.com/Dayopt/dayopt/blob/main/docs/architecture/data-flow.md)                 | データの流れ（UI → API → DB） |
-| [ADR-001](https://github.com/Dayopt/dayopt/blob/main/docs/architecture/adr/001-unified-block-model.md) | Entry統合モデルの設計判断     |
-| [State Management](https://github.com/Dayopt/dayopt/blob/main/docs/architecture/state-management.md)   | 状態管理の使い分け            |
-| [Colors](?path=/story/foundations-colors--all-colors)                                                  | デザイントークン              |
+| ドキュメント                                | 内容                          |
+| ------------------------------------------- | ----------------------------- |
+| [Domain Glossary](./domain-glossary.md)     | ドメイン用語の定義            |
+| [Data Flow](./data-flow.md)                 | データの流れ（UI → API → DB） |
+| [ADR-001](./adr/001-unified-block-model.md) | Entry統合モデルの設計判断     |
+| [State Management](./state-management.md)   | 状態管理の使い分け            |
+| Colors（Storybook: Foundations/Colors）     | デザイントークン              |

--- a/docs/architecture/storybook-glossary.md
+++ b/docs/architecture/storybook-glossary.md
@@ -1,7 +1,3 @@
-import { Meta } from '@storybook/addon-docs/blocks';
-
-<Meta title="Architecture/Storybook Glossary" />
-
 # Storybook 公式用語集
 
 Storybook 8 の構成要素を公式用語に基づいて整理したリファレンス。

--- a/docs/architecture/storybook-guide.md
+++ b/docs/architecture/storybook-guide.md
@@ -1,7 +1,3 @@
-import { Meta } from '@storybook/addon-docs/blocks';
-
-<Meta title="Architecture/Introduction" />
-
 # Dayopt Storybook
 
 DayoptのUIコンポーネントとデザイントークンのカタログです。
@@ -147,14 +143,14 @@ Story作成時に確認：
 
 初めてDayoptのコードベースに触れる場合、以下の順に読むとスムーズです：
 
-| 順番 | ドキュメント                                                                                           | 内容                                           |
-| ---- | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------- |
-| 1    | [Product Overview](?path=/docs/docs-product-overview--docs)                                            | Dayoptとは何か、コアコンセプト、Feature Map    |
-| 2    | [Domain Glossary](https://github.com/Dayopt/dayopt/blob/main/docs/architecture/domain-glossary.md)     | Entry, EntryState, Chronotype 等のドメイン用語 |
-| 3    | [Developer Map](https://github.com/Dayopt/dayopt/blob/main/docs/guides/developer-map.md)               | ディレクトリ構成と「どこに何があるか」         |
-| 4    | [Packages Overview](https://github.com/Dayopt/dayopt/blob/main/docs/architecture/packages-overview.md) | monorepo packages の責務境界と token 移行方針  |
-| 5    | [Data Flow](https://github.com/Dayopt/dayopt/blob/main/docs/architecture/data-flow.md)                 | UI → tRPC → Supabase のデータの流れ            |
-| 6    | [Common Pitfalls](https://github.com/Dayopt/dayopt/blob/main/docs/guides/common-pitfalls.md)           | よくある間違いと正しいパターン                 |
-| 7    | [Colors](?path=/story/foundations-colors--all-colors)                                                  | カラートークン、Surface体系                    |
-| 8    | [Typography](?path=/docs/foundations-typography--docs)                                                 | フォントサイズ、行間、ウェイト                 |
-| 9    | [Accessibility](?path=/docs/docs-accessibility-overview--docs)                                         | a11yチェックリスト、WCAG準拠                   |
+| 順番 | ドキュメント                                    | 内容                                           |
+| ---- | ----------------------------------------------- | ---------------------------------------------- |
+| 1    | [Product Overview](./product-overview.md)       | Dayoptとは何か、コアコンセプト、Feature Map    |
+| 2    | [Domain Glossary](./domain-glossary.md)         | Entry, EntryState, Chronotype 等のドメイン用語 |
+| 3    | [Developer Map](../guides/developer-map.md)     | ディレクトリ構成と「どこに何があるか」         |
+| 4    | [Packages Overview](./packages-overview.md)     | monorepo packages の責務境界と token 移行方針  |
+| 5    | [Data Flow](./data-flow.md)                     | UI → tRPC → Supabase のデータの流れ            |
+| 6    | [Common Pitfalls](../guides/common-pitfalls.md) | よくある間違いと正しいパターン                 |
+| 7    | Colors（Storybook: Foundations/Colors）         | カラートークン、Surface体系                    |
+| 8    | Typography（Storybook: Foundations/Typography） | フォントサイズ、行間、ウェイト                 |
+| 9    | [Accessibility](./accessibility/overview.md)    | a11yチェックリスト、WCAG準拠                   |

--- a/docs/guides/developer-map.md
+++ b/docs/guides/developer-map.md
@@ -182,9 +182,9 @@ src/features/{name}/
 
 ## 関連ドキュメント
 
-| ドキュメント                                                          | 内容           |
-| --------------------------------------------------------------------- | -------------- |
-| [Product Overview](../../apps/storybook/docs/dev/ProductOverview.mdx) | Dayoptの全体像 |
-| [Data Flow](../architecture/data-flow.md)                             | データの流れ   |
-| [Commands](commands.md)                                               | 全コマンド一覧 |
-| [Common Pitfalls](common-pitfalls.md)                                 | よくある間違い |
+| ドキュメント                                            | 内容           |
+| ------------------------------------------------------- | -------------- |
+| [Product Overview](../architecture/product-overview.md) | Dayoptの全体像 |
+| [Data Flow](../architecture/data-flow.md)               | データの流れ   |
+| [Commands](commands.md)                                 | 全コマンド一覧 |
+| [Common Pitfalls](common-pitfalls.md)                   | よくある間違い |


### PR DESCRIPTION
## 概要

Storybook を責務ごとに分ける設計の第一歩。Storybook の `Architecture/` カテゴリにあった散文ドキュメントを `docs/architecture/` に集約し（workflow.md の方針）、カテゴリ自体を廃止する。

コミットは内容ごとに 2 つに分割（merge commit でそのまま main に載る運用）。

## コミット

### 1. `docs(architecture): architecture ドキュメントを Storybook から docs へ移設`
- `Architecture/` 配下の MDX 9 本（ProductOverview / OfficialGlossary / Introduction + Accessibility 6 本）を素の Markdown として `docs/architecture/` へ移動
- `<Meta>` / addon-docs import を除去、`<Mermaid>` を mermaid フェンスに変換（GitHub ネイティブ描画）
- Storybook 内部リンク `?path=` を相対リンク化、Storybook 専用の Foundations はテキスト参照に
- `domain-glossary.md` / `developer-map.md` の参照先を新パスへ更新

### 2. `refactor(storybook): カテゴリ Architecture を廃止し Story を再分類`
- **Props Inventory** → `components/ui/props-inventory.stories.tsx` へ移動、title を `Components/UI/Props Inventory` に（product 配下に入り token チェック対象になったため透過トークン・off-grid spacing 違反も是正）
- **Email** → title を `Patterns/Email` に変更
- `preview.tsx` の `storySort` から `Architecture` を削除
- `main.ts` の dead な docs glob を削除（空になった `apps/storybook/docs/` は撤去）

## 検証
- ✅ `pnpm typecheck` / `pnpm lint` / `pnpm lint:boundaries`
- ✅ `pnpm lint:tokens` — 変更ファイルはすべてクリーン（残違反は main 由来の既存ファイルのみ）

## 補足
ローカルで起きていた Storybook の 500（`packages/ui/src/*.stories.tsx` ENOENT）は本 PR と無関係で、起動中 dev サーバーが main 取り込みで削除済みファイルを掴んでいたため。**Storybook を再起動**すれば解消し、本 PR の新カテゴリ構成が反映される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
