### PR TITLE
refactor(storybook): story を所有境界 top-level（Shared/Product/Web）に再編

### DIFF
--- a/.claude/skills/storybook/SKILL.md
+++ b/.claude/skills/storybook/SKILL.md
@@ -230,7 +230,9 @@ export const Surfaces: Story = {
 ### Pattern
 
 **パス**: `apps/storybook/.storybook/stories/patterns/`
-**title**: `Shared/Patterns/`
+**title**: 依存ベースで分ける（ADR-013）。`@dayopt/components` だけで再現できる pattern は
+`Shared/Patterns/`、`@/`（product 内部: `@/components` / `@/lib` / `@/features`）に依存する
+pattern は `Product/Patterns/`
 **layout**: `fullscreen`
 **モック**: 不要
 **テキスト見出し**: 許可（パターンドキュメントのため）
@@ -238,10 +240,11 @@ export const Surfaces: Story = {
 ```tsx
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
-import { Button } from '@/components/ui/button';
+import { Button } from '@dayopt/components';
 
 const meta = {
-  title: 'Shared/Patterns/Feedback',
+  // shared 例。product 結合（@/ 依存）なら 'Product/Patterns/Feedback'
+  title: 'Shared/Patterns/Actions',
   parameters: { layout: 'fullscreen' },
 } satisfies Meta;
 

--- a/.claude/skills/storybook/SKILL.md
+++ b/.claude/skills/storybook/SKILL.md
@@ -36,8 +36,13 @@ maxTurns: 15
 
 ### UI Component
 
-**パス**: `apps/product/src/lib/components/ui/`, `apps/product/src/lib/components/common/`, `apps/product/src/lib/components/shell/`
-**title**: `Components/UI/` or `Components/Common/` or `Components/Shell/`
+top-level は所有境界で決める（ADR-013）。共有 UI は `packages/components`、product 固有は `apps/product`。
+
+| 物理位置                              | title prefix                                              |
+| ------------------------------------- | --------------------------------------------------------- |
+| `packages/components/src/<category>/` | `Shared/Components/<Category>/`（責務9category, ADR-012） |
+| `apps/product/src/components/**`      | `Product/Components/`（Shell / Display / Feedback 等）    |
+
 **layout**: `centered`
 **モック**: 不要（props only）
 
@@ -47,7 +52,8 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { MyComponent } from './my-component';
 
 const meta = {
-  title: 'Components/UI/MyComponent',
+  // 共有 UI なら 'Shared/Components/Actions/MyComponent'
+  title: 'Product/Components/MyComponent',
   component: MyComponent,
   tags: ['autodocs'],
   parameters: { layout: 'centered' },
@@ -96,7 +102,7 @@ export const Default: Story = {
 ### Feature Component
 
 **パス**: `apps/product/src/features/*/components/`
-**title**: `Features/{feature名}/`
+**title**: `Product/Features/{feature名}/`
 **layout**: `padded`
 **モック**: `parameters.trpcMocks` + `parameters.storeMocks` で宣言
 
@@ -109,7 +115,7 @@ import { StoryTRPCProvider } from '../../../.storybook/mocks/trpc';
 import { MyFeatureComponent } from './my-feature-component';
 
 const meta = {
-  title: 'Features/Settings/MyFeatureComponent',
+  title: 'Product/Features/Settings/MyFeatureComponent',
   component: MyFeatureComponent,
   tags: ['autodocs'],
   parameters: {
@@ -169,7 +175,7 @@ export const AllPatterns: Story = {
 ### Foundation
 
 **パス**: `apps/product/src/lib/styles/tokens/`
-**title**: `Foundations/`
+**title**: `Shared/Foundations/`
 **layout**: `fullscreen`
 **モック**: 不要
 **テキスト見出し**: 許可（トークン可視化のため）
@@ -178,7 +184,7 @@ export const AllPatterns: Story = {
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
 const meta = {
-  title: 'Foundations/Colors',
+  title: 'Shared/Foundations/Colors',
   parameters: { layout: 'fullscreen' },
 } satisfies Meta;
 
@@ -224,7 +230,7 @@ export const Surfaces: Story = {
 ### Pattern
 
 **パス**: `apps/storybook/.storybook/stories/patterns/`
-**title**: `Patterns/`
+**title**: `Shared/Patterns/`
 **layout**: `fullscreen`
 **モック**: 不要
 **テキスト見出し**: 許可（パターンドキュメントのため）
@@ -235,7 +241,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Button } from '@/components/ui/button';
 
 const meta = {
-  title: 'Patterns/Feedback',
+  title: 'Shared/Patterns/Feedback',
   parameters: { layout: 'fullscreen' },
 } satisfies Meta;
 

--- a/apps/product/src/app/[locale]/(app)/_shell/BottomTabBar.stories.tsx
+++ b/apps/product/src/app/[locale]/(app)/_shell/BottomTabBar.stories.tsx
@@ -73,7 +73,7 @@ function MockBottomTabBar({
 }
 
 const meta = {
-  title: 'Components/Shell/BottomTabBar',
+  title: 'Product/Components/Shell/BottomTabBar',
   component: MockBottomTabBar,
   parameters: {
     layout: 'fullscreen',

--- a/apps/product/src/components/shell/AppHeader.stories.tsx
+++ b/apps/product/src/components/shell/AppHeader.stories.tsx
@@ -77,7 +77,7 @@ function StubPageNav({ activePage = 'calendar' }: { activePage?: 'calendar' | 's
 
 /** AppHeader - アプリ共通ヘッダーシェル */
 const meta = {
-  title: 'Components/Shell/AppHeader',
+  title: 'Product/Components/Shell/AppHeader',
   parameters: {
     layout: 'padded',
   },

--- a/apps/product/src/components/shell/CookieConsentBanner.stories.tsx
+++ b/apps/product/src/components/shell/CookieConsentBanner.stories.tsx
@@ -6,7 +6,7 @@ import { CookieConsentBanner } from './CookieConsentBanner';
 const STORAGE_KEY = 'dayopt_cookie_consent';
 
 const meta = {
-  title: 'Components/Shell/CookieConsentBanner',
+  title: 'Product/Components/Shell/CookieConsentBanner',
   component: CookieConsentBanner,
   tags: ['autodocs'],
   parameters: {

--- a/apps/product/src/components/shell/IOSInstallGuide.stories.tsx
+++ b/apps/product/src/components/shell/IOSInstallGuide.stories.tsx
@@ -11,7 +11,7 @@ import { fn } from 'storybook/test';
 import { IOSInstallGuide } from './IOSInstallGuide';
 
 const meta = {
-  title: 'Components/Shell/IOSInstallGuide',
+  title: 'Product/Components/Shell/IOSInstallGuide',
   component: IOSInstallGuide,
   parameters: { layout: 'fullscreen' },
   args: {

--- a/apps/product/src/components/shell/InstallBanner.stories.tsx
+++ b/apps/product/src/components/shell/InstallBanner.stories.tsx
@@ -11,7 +11,7 @@ import { fn } from 'storybook/test';
 import { InstallBanner } from './InstallBanner';
 
 const meta = {
-  title: 'Components/Shell/InstallBanner',
+  title: 'Product/Components/Shell/InstallBanner',
   component: InstallBanner,
   parameters: { layout: 'fullscreen' },
   args: {

--- a/apps/product/src/components/shell/sidebar/BlockItem.stories.tsx
+++ b/apps/product/src/components/shell/sidebar/BlockItem.stories.tsx
@@ -14,7 +14,7 @@ import { withWrapper } from '@dayopt/storybook/decorators';
 import { BlockItem } from './BlockItem';
 
 const meta = {
-  title: 'Components/Shell/Sidebar/BlockItem',
+  title: 'Product/Components/Shell/Sidebar/BlockItem',
   component: BlockItem,
   parameters: { layout: 'padded' },
   args: {

--- a/apps/product/src/components/shell/sidebar/NavBadge.stories.tsx
+++ b/apps/product/src/components/shell/sidebar/NavBadge.stories.tsx
@@ -36,7 +36,7 @@ function MockNavBadge({
 
 /** NavBadge — icon 右上に配置する "NEW" / "β" バッジ。AI タブの stub 状態を暗示する用途。 */
 const meta = {
-  title: 'Components/Shell/Sidebar/NavBadge',
+  title: 'Product/Components/Shell/Sidebar/NavBadge',
   component: MockNavBadge,
   parameters: { layout: 'centered' },
   tags: ['autodocs'],

--- a/apps/product/src/components/shell/sidebar/PageNav.stories.tsx
+++ b/apps/product/src/components/shell/sidebar/PageNav.stories.tsx
@@ -67,7 +67,7 @@ function MockPageNav({ activePage = 'calendar' }: { activePage?: ActivePage }) {
 
 /** PageNav — ヘッダー右端のページナビゲーション。Calendar / Review のセグメントコントロール。 */
 const meta = {
-  title: 'Components/Shell/Sidebar/PageNav',
+  title: 'Product/Components/Shell/Sidebar/PageNav',
   component: MockPageNav,
   parameters: {
     layout: 'centered',

--- a/apps/product/src/components/shell/sidebar/Sidebar.docs.mdx
+++ b/apps/product/src/components/shell/sidebar/Sidebar.docs.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Components/Shell/Sidebar/Guide" />
+<Meta title="Product/Components/Shell/Sidebar/Guide" />
 
 # Sidebar
 

--- a/apps/product/src/components/shell/sidebar/Sidebar.stories.tsx
+++ b/apps/product/src/components/shell/sidebar/Sidebar.stories.tsx
@@ -37,7 +37,7 @@ function MockSidebarContent() {
 
 /** サイドバーコンテナ。Dayoptロゴ + 検索 + 閉じるボタン、children スロット、UserMenu + footerActions。 */
 const meta = {
-  title: 'Components/Shell/Sidebar/Container',
+  title: 'Product/Components/Shell/Sidebar/Container',
   component: Sidebar,
   parameters: {
     layout: 'fullscreen',

--- a/apps/product/src/components/shell/sidebar/SidebarSection.stories.tsx
+++ b/apps/product/src/components/shell/sidebar/SidebarSection.stories.tsx
@@ -147,7 +147,7 @@ function SidebarShell({ children }: { children: React.ReactNode }) {
 
 /** SidebarSection — サイドバー共通のセクション。title + 右端 action + 常時表示 children。 */
 const meta = {
-  title: 'Components/Shell/Sidebar/Section',
+  title: 'Product/Components/Shell/Sidebar/Section',
   component: SidebarSection,
   parameters: {
     layout: 'fullscreen',

--- a/apps/product/src/components/shell/sidebar/UserMenu.stories.tsx
+++ b/apps/product/src/components/shell/sidebar/UserMenu.stories.tsx
@@ -4,7 +4,7 @@ import { UserMenu } from './UserMenu';
 
 /** UserMenu - サイドバーフッターのユーザーメニュー */
 const meta = {
-  title: 'Components/Shell/Sidebar/UserMenu',
+  title: 'Product/Components/Shell/Sidebar/UserMenu',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/product/src/components/ui/display/LabeledRow.stories.tsx
+++ b/apps/product/src/components/ui/display/LabeledRow.stories.tsx
@@ -6,7 +6,7 @@ import { withWrapper } from '@dayopt/storybook/decorators';
 import { LabeledRow } from './LabeledRow';
 
 const meta = {
-  title: 'Components/Display/LabeledRow',
+  title: 'Product/Components/Display/LabeledRow',
   component: LabeledRow,
   tags: ['autodocs'],
   decorators: [withWrapper('w-[500px]')],

--- a/apps/product/src/components/ui/display/SectionCard.stories.tsx
+++ b/apps/product/src/components/ui/display/SectionCard.stories.tsx
@@ -7,7 +7,7 @@ import { LabeledRow } from './LabeledRow';
 import { SectionCard } from './SectionCard';
 
 const meta = {
-  title: 'Components/Display/SectionCard',
+  title: 'Product/Components/Display/SectionCard',
   component: SectionCard,
   tags: ['autodocs'],
   decorators: [withWrapper('w-[500px]')],

--- a/apps/product/src/components/ui/feedback/EmptyState.stories.tsx
+++ b/apps/product/src/components/ui/feedback/EmptyState.stories.tsx
@@ -7,7 +7,7 @@ import { withWrapper } from '@dayopt/storybook/decorators';
 import { EmptyState } from './EmptyState';
 
 const meta = {
-  title: 'Components/Feedback/EmptyState',
+  title: 'Product/Components/Feedback/EmptyState',
   component: EmptyState,
   tags: ['autodocs'],
   parameters: {

--- a/apps/product/src/components/ui/feedback/ErrorState.stories.tsx
+++ b/apps/product/src/components/ui/feedback/ErrorState.stories.tsx
@@ -6,7 +6,7 @@ import { Button } from '@dayopt/components';
 import { ErrorState } from './ErrorState';
 
 const meta = {
-  title: 'Components/Feedback/ErrorState',
+  title: 'Product/Components/Feedback/ErrorState',
   component: ErrorState,
   tags: ['autodocs'],
   parameters: {

--- a/apps/product/src/components/ui/feedback/error-boundary.stories.tsx
+++ b/apps/product/src/components/ui/feedback/error-boundary.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { DefaultErrorFallback, DevErrorFallback, FeatureErrorFallback } from './error-boundary';
 
 const meta = {
-  title: 'Components/Feedback/ErrorBoundary',
+  title: 'Product/Components/Feedback/ErrorBoundary',
   tags: ['autodocs'],
   parameters: {
     layout: 'centered',

--- a/apps/product/src/components/ui/feedback/toast.stories.tsx
+++ b/apps/product/src/components/ui/feedback/toast.stories.tsx
@@ -5,7 +5,7 @@ import { Button } from '@dayopt/components';
 import { Toaster } from './toast';
 
 const meta = {
-  title: 'Components/Feedback/Toast',
+  title: 'Product/Components/Feedback/Toast',
   component: Toaster,
   tags: ['autodocs'],
   parameters: {

--- a/apps/product/src/components/ui/inputs/avatar-upload.stories.tsx
+++ b/apps/product/src/components/ui/inputs/avatar-upload.stories.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { AvatarUpload } from './avatar-upload';
 
 const meta = {
-  title: 'Components/Inputs/AvatarUpload',
+  title: 'Product/Components/Inputs/AvatarUpload',
   component: AvatarUpload,
   tags: ['autodocs'],
   parameters: { layout: 'centered' },

--- a/apps/product/src/components/ui/inputs/mini-calendar.stories.tsx
+++ b/apps/product/src/components/ui/inputs/mini-calendar.stories.tsx
@@ -8,7 +8,7 @@ import { Button } from '@dayopt/components';
 import { withWrapper } from '@dayopt/storybook/decorators';
 
 const meta = {
-  title: 'Components/Inputs/MiniCalendar',
+  title: 'Product/Components/Inputs/MiniCalendar',
   component: MiniCalendar,
   tags: ['autodocs'],
   parameters: {

--- a/apps/product/src/components/ui/navigation/DateNavigator.stories.tsx
+++ b/apps/product/src/components/ui/navigation/DateNavigator.stories.tsx
@@ -4,7 +4,7 @@ import { expect, fn, userEvent, within } from 'storybook/test';
 import { CompactDateNavigator, DateNavigator } from './DateNavigator';
 
 const meta = {
-  title: 'Components/Navigation/DateNavigator',
+  title: 'Product/Components/Navigation/DateNavigator',
   component: DateNavigator,
   tags: ['autodocs'],
 } satisfies Meta<typeof DateNavigator>;

--- a/apps/product/src/components/ui/overlays/confirm-dialog.stories.tsx
+++ b/apps/product/src/components/ui/overlays/confirm-dialog.stories.tsx
@@ -6,7 +6,7 @@ import { Button } from '@dayopt/components';
 import { ConfirmDialog } from './confirm-dialog';
 
 const meta = {
-  title: 'Components/Overlays/ConfirmDialog',
+  title: 'Product/Components/Overlays/ConfirmDialog',
   component: ConfirmDialog,
   tags: ['autodocs'],
   parameters: {

--- a/apps/product/src/components/ui/overlays/destructive-form-dialog.stories.tsx
+++ b/apps/product/src/components/ui/overlays/destructive-form-dialog.stories.tsx
@@ -6,7 +6,7 @@ import { Button, RadioGroup, RadioGroupItem } from '@dayopt/components';
 import { DestructiveFormDialog } from './destructive-form-dialog';
 
 const meta = {
-  title: 'Components/Overlays/DestructiveFormDialog',
+  title: 'Product/Components/Overlays/DestructiveFormDialog',
   component: DestructiveFormDialog,
   tags: ['autodocs'],
   parameters: {

--- a/apps/product/src/components/ui/props-inventory.stories.tsx
+++ b/apps/product/src/components/ui/props-inventory.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
 const meta = {
-  title: 'Components/Props Inventory',
+  title: 'Product/Components/Props Inventory',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/product/src/emails/EmailTemplates.stories.tsx
+++ b/apps/product/src/emails/EmailTemplates.stories.tsx
@@ -29,7 +29,7 @@ import { TrialStartEmail } from './TrialStartEmail';
 import { WelcomeEmail } from './WelcomeEmail';
 
 const meta = {
-  title: 'Patterns/Email',
+  title: 'Product/Emails',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/product/src/features/auth/components/Auth.docs.mdx
+++ b/apps/product/src/features/auth/components/Auth.docs.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Features/Auth/Guide" />
+<Meta title="Product/Features/Auth/Guide" />
 
 # Auth
 

--- a/apps/product/src/features/auth/components/AuthLayout.stories.tsx
+++ b/apps/product/src/features/auth/components/AuthLayout.stories.tsx
@@ -13,7 +13,7 @@ import { AuthLayout } from './AuthLayout';
  * メール確認完了・リンク期限切れ等のシンプルなページ向け。
  */
 const meta = {
-  title: 'Features/Auth/AuthLayout',
+  title: 'Product/Features/Auth/AuthLayout',
   parameters: {
     layout: 'fullscreen',
     nextjs: {

--- a/apps/product/src/features/auth/components/LoginForm.stories.tsx
+++ b/apps/product/src/features/auth/components/LoginForm.stories.tsx
@@ -7,7 +7,7 @@ import { LoginForm } from './LoginForm';
 
 /** LoginForm - ログインフォーム */
 const meta = {
-  title: 'Features/Auth/LoginForm',
+  title: 'Product/Features/Auth/LoginForm',
   component: LoginForm,
   parameters: {
     layout: 'padded',

--- a/apps/product/src/features/auth/components/MFAVerifyForm.stories.tsx
+++ b/apps/product/src/features/auth/components/MFAVerifyForm.stories.tsx
@@ -7,7 +7,7 @@ import { MFAVerifyForm } from './MFAVerifyForm';
 
 /** MFAVerifyForm - 2段階認証フォーム（TOTP / リカバリーコード） */
 const meta = {
-  title: 'Features/Auth/MFAVerifyForm',
+  title: 'Product/Features/Auth/MFAVerifyForm',
   component: MFAVerifyForm,
   parameters: {
     layout: 'padded',

--- a/apps/product/src/features/auth/components/PasswordResetForm.stories.tsx
+++ b/apps/product/src/features/auth/components/PasswordResetForm.stories.tsx
@@ -7,7 +7,7 @@ import { PasswordResetForm } from './PasswordResetForm';
 
 /** PasswordResetForm - パスワードリセット依頼フォーム */
 const meta = {
-  title: 'Features/Auth/PasswordResetForm',
+  title: 'Product/Features/Auth/PasswordResetForm',
   component: PasswordResetForm,
   parameters: {
     layout: 'padded',

--- a/apps/product/src/features/auth/components/ResetPasswordForm.stories.tsx
+++ b/apps/product/src/features/auth/components/ResetPasswordForm.stories.tsx
@@ -8,7 +8,7 @@ import { ResetPasswordForm } from './ResetPasswordForm';
 
 /** ResetPasswordForm - パスワードリセットフォーム（メールリンク経由） */
 const meta = {
-  title: 'Features/Auth/ResetPasswordForm',
+  title: 'Product/Features/Auth/ResetPasswordForm',
   component: ResetPasswordForm,
   parameters: {
     layout: 'padded',

--- a/apps/product/src/features/auth/components/SessionTimeoutDialog.stories.tsx
+++ b/apps/product/src/features/auth/components/SessionTimeoutDialog.stories.tsx
@@ -9,7 +9,7 @@ import { SessionTimeoutDialog } from './SessionTimeoutDialog';
 
 /** SessionTimeoutDialog - セッションタイムアウト警告 */
 const meta = {
-  title: 'Features/Auth/SessionTimeoutDialog',
+  title: 'Product/Features/Auth/SessionTimeoutDialog',
   component: SessionTimeoutDialog,
   parameters: {
     layout: 'centered',

--- a/apps/product/src/features/auth/components/SignupForm.stories.tsx
+++ b/apps/product/src/features/auth/components/SignupForm.stories.tsx
@@ -7,7 +7,7 @@ import { SignupForm } from './SignupForm';
 
 /** SignupForm - サインアップフォーム */
 const meta = {
-  title: 'Features/Auth/SignupForm',
+  title: 'Product/Features/Auth/SignupForm',
   component: SignupForm,
   parameters: {
     layout: 'padded',

--- a/apps/product/src/features/calendar/components/Calendar.docs.mdx
+++ b/apps/product/src/features/calendar/components/Calendar.docs.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Features/Calendar/Guide" />
+<Meta title="Product/Features/Calendar/Guide" />
 
 # Calendar
 

--- a/apps/product/src/features/calendar/components/analytics/CalendarAnalyticsPanel.stories.tsx
+++ b/apps/product/src/features/calendar/components/analytics/CalendarAnalyticsPanel.stories.tsx
@@ -31,7 +31,7 @@ const tags = [
 ];
 
 const meta = {
-  title: 'Features/Calendar/Analytics/CalendarAnalyticsPanel',
+  title: 'Product/Features/Calendar/Analytics/CalendarAnalyticsPanel',
   component: CalendarAnalyticsPanel,
   tags: ['autodocs'],
   parameters: {

--- a/apps/product/src/features/calendar/components/controller/components/CalendarViewSkeleton.stories.tsx
+++ b/apps/product/src/features/calendar/components/controller/components/CalendarViewSkeleton.stories.tsx
@@ -8,7 +8,7 @@ import { CalendarViewSkeleton } from './CalendarViewSkeleton';
  * 時間ラベル列 + グリッド本体 + ダミーイベントスロット。
  */
 const meta = {
-  title: 'Features/Calendar/ViewSkeleton',
+  title: 'Product/Features/Calendar/ViewSkeleton',
   component: CalendarViewSkeleton,
   tags: ['autodocs'],
   parameters: {

--- a/apps/product/src/features/calendar/components/day-diff/CalendarDayDiffRail.stories.tsx
+++ b/apps/product/src/features/calendar/components/day-diff/CalendarDayDiffRail.stories.tsx
@@ -109,7 +109,7 @@ const tags = [
 ];
 
 const meta = {
-  title: 'Features/Calendar/DayDiff/CalendarDayDiffRail',
+  title: 'Product/Features/Calendar/DayDiff/CalendarDayDiffRail',
   component: CalendarDayDiffRail,
   tags: ['autodocs'],
   parameters: {

--- a/apps/product/src/features/calendar/components/layout/Header/DateRangeDisplay.stories.tsx
+++ b/apps/product/src/features/calendar/components/layout/Header/DateRangeDisplay.stories.tsx
@@ -5,7 +5,7 @@ import { CompactDateDisplay, DateRangeDisplay } from './DateRangeDisplay';
 
 /** 日付範囲表示。単一日付または期間をヘッダーに表示するコンポーネント。 */
 const meta = {
-  title: 'Features/Calendar/DateRangeDisplay',
+  title: 'Product/Features/Calendar/DateRangeDisplay',
   component: DateRangeDisplay,
   parameters: {
     layout: 'padded',

--- a/apps/product/src/features/calendar/components/layout/Header/Header.stories.tsx
+++ b/apps/product/src/features/calendar/components/layout/Header/Header.stories.tsx
@@ -8,7 +8,7 @@ import { ViewSwitcher } from './ViewSwitcher';
 
 /** カレンダーヘッダーのサブコンポーネント（ViewSwitcher, DateNavigator）。 */
 const meta = {
-  title: 'Features/Calendar/Header',
+  title: 'Product/Features/Calendar/Header',
   parameters: {
     layout: 'padded',
   },

--- a/apps/product/src/features/calendar/components/layout/Header/MobileCalendarHeader.stories.tsx
+++ b/apps/product/src/features/calendar/components/layout/Header/MobileCalendarHeader.stories.tsx
@@ -8,7 +8,7 @@ import { MobileCalendarHeader } from './MobileCalendarHeader';
 
 /** モバイル専用カレンダーヘッダー。日付タップでインライン展開月グリッドを表示し、タイムラインを押し下げる。 */
 const meta = {
-  title: 'Features/Calendar/Header/MobileCalendarHeader',
+  title: 'Product/Features/Calendar/Header/MobileCalendarHeader',
   component: MobileCalendarHeader,
   parameters: {
     layout: 'fullscreen',

--- a/apps/product/src/features/calendar/components/layout/Header/ViewSwitcher.stories.tsx
+++ b/apps/product/src/features/calendar/components/layout/Header/ViewSwitcher.stories.tsx
@@ -11,7 +11,7 @@ import { ViewSwitcher } from './ViewSwitcher';
  * キーボードショートカット対応（D, W, 1-9, 0）。
  */
 const meta = {
-  title: 'Features/Calendar/Header/ViewSwitcher',
+  title: 'Product/Features/Calendar/Header/ViewSwitcher',
   component: ViewSwitcher,
   tags: ['autodocs'],
   parameters: {

--- a/apps/product/src/features/calendar/components/tag-filter/CalendarFilterList.stories.tsx
+++ b/apps/product/src/features/calendar/components/tag-filter/CalendarFilterList.stories.tsx
@@ -99,7 +99,7 @@ const MOCK_TRPC = {
 
 /** CalendarFilterList — カレンダーフィルターサイドバー（タグ表示切替） */
 const meta = {
-  title: 'Features/Calendar/FilterList',
+  title: 'Product/Features/Calendar/FilterList',
   component: CalendarFilterList,
   parameters: {
     layout: 'padded',

--- a/apps/product/src/features/calendar/components/tag-filter/components/FilterItem/FilterItem.stories.tsx
+++ b/apps/product/src/features/calendar/components/tag-filter/components/FilterItem/FilterItem.stories.tsx
@@ -11,7 +11,7 @@ import { FilterItem } from './FilterItem';
  * チェック/未チェック・各カラーバリアント・無効状態に対応。
  */
 const meta = {
-  title: 'Features/Calendar/Sidebar/TagFilter/FilterItem',
+  title: 'Product/Features/Calendar/Sidebar/TagFilter/FilterItem',
   component: FilterItem,
   tags: ['autodocs'],
   parameters: {

--- a/apps/product/src/features/calendar/components/tag-filter/components/FilterItem/FilterItemMenu.stories.tsx
+++ b/apps/product/src/features/calendar/components/tag-filter/components/FilterItem/FilterItemMenu.stories.tsx
@@ -19,7 +19,7 @@ import { FilterItemMenu, UntaggedItemMenu } from './FilterItemMenu';
  * 色変更はグループ単位で統一するため、グループ内タグでは非表示。
  */
 const meta = {
-  title: 'Features/Tags/FilterItemMenu',
+  title: 'Product/Features/Tags/FilterItemMenu',
   component: FilterItemMenu,
   tags: ['autodocs'],
   parameters: {

--- a/apps/product/src/features/calendar/components/tag-filter/components/GroupHeader.stories.tsx
+++ b/apps/product/src/features/calendar/components/tag-filter/components/GroupHeader.stories.tsx
@@ -24,7 +24,7 @@ import { GroupHeader } from './GroupHeader';
  * 子タグ（グループ内タグ）のメニューは `FilterItemMenu` 参照。
  */
 const meta = {
-  title: 'Features/Tags/GroupHeader',
+  title: 'Product/Features/Tags/GroupHeader',
   component: GroupHeader,
   tags: ['autodocs'],
   parameters: {

--- a/apps/product/src/features/calendar/components/tag-filter/components/TagChipRow/TagChipRow.stories.tsx
+++ b/apps/product/src/features/calendar/components/tag-filter/components/TagChipRow/TagChipRow.stories.tsx
@@ -115,7 +115,7 @@ const MANY_TAGS: Tag[] = Array.from({ length: 30 }, (_, i) => ({
  * - タップで bottom sheet popover（既存 TagEntryCreatePopover を isMobile=true で再利用）
  */
 const meta = {
-  title: 'Features/Calendar/Sidebar/TagFilter/TagChipRow',
+  title: 'Product/Features/Calendar/Sidebar/TagFilter/TagChipRow',
   component: TagChipRow,
   parameters: {
     layout: 'fullscreen',

--- a/apps/product/src/features/calendar/components/tag-filter/components/TagEntryCreatePopover/TagEntryCreatePopover.stories.tsx
+++ b/apps/product/src/features/calendar/components/tag-filter/components/TagEntryCreatePopover/TagEntryCreatePopover.stories.tsx
@@ -35,7 +35,7 @@ function mockTrpc(entries: unknown[] = []) {
  * - 実機 / dev での dogfooding を前提に、Storybook variants は配置確認用の最小セット
  */
 const meta = {
-  title: 'Features/Calendar/Sidebar/TagFilter/TagEntryCreatePopover',
+  title: 'Product/Features/Calendar/Sidebar/TagFilter/TagEntryCreatePopover',
   component: TagEntryCreatePopover,
   parameters: {
     layout: 'centered',

--- a/apps/product/src/features/calendar/components/views/DayView/DayView.stories.tsx
+++ b/apps/product/src/features/calendar/components/views/DayView/DayView.stories.tsx
@@ -8,7 +8,7 @@ import { DayView } from './DayView';
 
 /** DayView - 日表示ビュー */
 const meta = {
-  title: 'Features/Calendar/Views/DayView',
+  title: 'Product/Features/Calendar/Views/DayView',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/product/src/features/calendar/components/views/WeekView/WeekView.stories.tsx
+++ b/apps/product/src/features/calendar/components/views/WeekView/WeekView.stories.tsx
@@ -7,7 +7,7 @@ import { WeekView } from './WeekView';
 
 /** WeekView - 週表示ビュー */
 const meta = {
-  title: 'Features/Calendar/Views/WeekView',
+  title: 'Product/Features/Calendar/Views/WeekView',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/product/src/features/calendar/components/views/shared/DateDisplay/DateDisplay.stories.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/DateDisplay/DateDisplay.stories.tsx
@@ -5,7 +5,7 @@ import { DateDisplay } from './DateDisplay';
 
 /** カレンダーの日付表示コンポーネント（DateDisplay）。 */
 const meta = {
-  title: 'Features/Calendar/DateDisplay',
+  title: 'Product/Features/Calendar/DateDisplay',
   parameters: {
     layout: 'padded',
   },

--- a/apps/product/src/features/calendar/components/views/shared/components/CalendarDragSelection/MobileTouchHint.stories.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/CalendarDragSelection/MobileTouchHint.stories.tsx
@@ -20,7 +20,7 @@ import { MobileTouchHint } from './MobileTouchHint';
  * 各ストーリーのデコレーターで `window.matchMedia` をモックし、モバイル判定を強制する。
  */
 const meta = {
-  title: 'Features/Calendar/MobileTouchHint',
+  title: 'Product/Features/Calendar/MobileTouchHint',
   component: MobileTouchHint,
   parameters: {
     layout: 'fullscreen',

--- a/apps/product/src/features/calendar/components/views/shared/components/ConflictOverlay.stories.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/ConflictOverlay.stories.tsx
@@ -7,7 +7,7 @@ import { ConflictOverlay } from './ConflictOverlay';
  * タグ下書きの 5 面で共有する「この時間帯には既に予定があります」表示。
  */
 const meta = {
-  title: 'Features/Calendar/ConflictOverlay',
+  title: 'Product/Features/Calendar/ConflictOverlay',
   // color-contrast: text-destructive on bg-destructive-tint（設計上可読）
   parameters: { layout: 'padded', a11y: { test: 'todo' } },
   tags: ['autodocs'],

--- a/apps/product/src/features/calendar/components/views/shared/components/DayColumn/DayColumn.stories.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/DayColumn/DayColumn.stories.tsx
@@ -11,7 +11,7 @@ import { DayColumn } from './DayColumn';
  * useEntryInspectorStore / useTagsMap はグローバルプロバイダーで解決済み。
  */
 const meta = {
-  title: 'Features/Calendar/Views/DayColumn',
+  title: 'Product/Features/Calendar/Views/DayColumn',
   component: DayColumn,
   tags: ['autodocs'],
   parameters: {

--- a/apps/product/src/features/calendar/components/views/shared/components/DragAndDrop.stories.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/DragAndDrop.stories.tsx
@@ -19,7 +19,7 @@ import { DragSelectionPreview } from './CalendarDragSelection/DragSelectionPrevi
  * パレット→カレンダーはクリックで現在時刻に配置（DnD不使用）。
  */
 const meta = {
-  title: 'Features/Calendar/DragAndDrop',
+  title: 'Product/Features/Calendar/DragAndDrop',
   parameters: {
     layout: 'padded',
   },

--- a/apps/product/src/features/calendar/components/views/shared/components/DragSelectionPreview.stories.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/DragSelectionPreview.stories.tsx
@@ -4,7 +4,7 @@ import { DragSelectionPreview } from './CalendarDragSelection/DragSelectionPrevi
 
 /** ドラッグ選択プレビュー。グリッド上の時間範囲選択UI。 */
 const meta = {
-  title: 'Features/Calendar/DragSelectionPreview',
+  title: 'Product/Features/Calendar/DragSelectionPreview',
   parameters: {
     layout: 'padded',
   },

--- a/apps/product/src/features/calendar/components/views/shared/components/EntryContextMenu.stories.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/EntryContextMenu.stories.tsx
@@ -8,7 +8,7 @@ import { EventContextMenu } from './EntryContextMenu';
 
 /** エントリコンテキストメニュー。右クリックメニューとして使用する。 */
 const meta = {
-  title: 'Features/Calendar/EntryContextMenu',
+  title: 'Product/Features/Calendar/EntryContextMenu',
   parameters: {
     layout: 'padded',
   },

--- a/apps/product/src/features/calendar/components/views/shared/components/InlineTagPalette/InlineTagPalette.stories.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/InlineTagPalette/InlineTagPalette.stories.tsx
@@ -42,7 +42,7 @@ const PAST_DAY = new Date('2020-01-01T00:00:00.000Z');
  * fullscreen レイアウトで相対コンテナ内に配置して確認する。
  */
 const meta = {
-  title: 'Features/Calendar/InlineTagPalette',
+  title: 'Product/Features/Calendar/InlineTagPalette',
   component: InlineTagPalette,
   parameters: {
     layout: 'fullscreen',

--- a/apps/product/src/features/calendar/components/views/shared/components/TimezoneOffset/TimezoneOffset.stories.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/TimezoneOffset/TimezoneOffset.stories.tsx
@@ -7,7 +7,7 @@ import { TimezoneOffset } from './TimezoneOffset';
 
 /** タイムゾーン選択セレクト。カレンダーグリッドの時刻列に表示するUTCオフセット表示。 */
 const meta = {
-  title: 'Features/Calendar/TimezoneOffset',
+  title: 'Product/Features/Calendar/TimezoneOffset',
   component: TimezoneOffset,
   parameters: {
     layout: 'padded',

--- a/apps/product/src/features/calendar/components/views/shared/grid/CurrentTimeLine/CurrentTimeLine.stories.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/grid/CurrentTimeLine/CurrentTimeLine.stories.tsx
@@ -6,7 +6,7 @@ import { CurrentTimeLine, CurrentTimeLineForColumn } from './CurrentTimeLine';
  * 現在時刻インジケーター線。dot(6px) + bar(2px) 構造、bg-now-indicator 色。日ビュー用（全幅）とカラム用（列内）の2バリアント。startHour/endHour で範囲外非表示。
  */
 const meta = {
-  title: 'Features/Calendar/Views/Grid/CurrentTimeLine',
+  title: 'Product/Features/Calendar/Views/Grid/CurrentTimeLine',
   component: CurrentTimeLine,
   tags: ['autodocs'],
   parameters: {

--- a/apps/product/src/features/calendar/components/views/shared/grid/TimeColumn/TimeColumn.stories.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/grid/TimeColumn/TimeColumn.stories.tsx
@@ -7,7 +7,7 @@ import { TimeColumn } from './TimeColumn';
  * 24時間/12時間表示切替、時間範囲指定、密度調整に対応。
  */
 const meta = {
-  title: 'Features/Calendar/Views/Grid/TimeColumn',
+  title: 'Product/Features/Calendar/Views/Grid/TimeColumn',
   component: TimeColumn,
   tags: ['autodocs'],
   parameters: {

--- a/apps/product/src/features/contact/components/Contact.docs.mdx
+++ b/apps/product/src/features/contact/components/Contact.docs.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Features/Contact/Guide" />
+<Meta title="Product/Features/Contact/Guide" />
 
 # Contact
 

--- a/apps/product/src/features/contact/components/ContactDialogContent.stories.tsx
+++ b/apps/product/src/features/contact/components/ContactDialogContent.stories.tsx
@@ -29,7 +29,7 @@ const defaultLabels = {
 
 /** ContactDialogContent - お問い合わせフォームUI */
 const meta = {
-  title: 'Features/Contact/ContactDialogContent',
+  title: 'Product/Features/Contact/ContactDialogContent',
   component: ContactDialogContent,
   parameters: { layout: 'centered' },
   tags: ['autodocs'],

--- a/apps/product/src/features/entry/components/Entries.docs.mdx
+++ b/apps/product/src/features/entry/components/Entries.docs.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Features/Entry/Guide" />
+<Meta title="Product/Features/Entry/Guide" />
 
 # Entries
 

--- a/apps/product/src/features/entry/components/card/EntryCard.stories.tsx
+++ b/apps/product/src/features/entry/components/card/EntryCard.stories.tsx
@@ -6,7 +6,7 @@ import { EntryCard } from './EntryCard';
 
 /** エントリーカード。カレンダーグリッド上の表示ブロック。タグカラー・レイアウト・インタラクション状態によるバリエーション。 */
 const meta = {
-  title: 'Features/Entry/Card',
+  title: 'Product/Features/Entry/Card',
   parameters: {
     layout: 'padded',
   },

--- a/apps/product/src/features/entry/components/card/EntryCardContent.stories.tsx
+++ b/apps/product/src/features/entry/components/card/EntryCardContent.stories.tsx
@@ -11,7 +11,7 @@ import { EntryCardContent } from './EntryCardContent';
  * EntryCard の内側で使われるが、独立してテスト可能な純粋コンポーネント。
  */
 const meta = {
-  title: 'Features/Entry/CardContent',
+  title: 'Product/Features/Entry/CardContent',
   parameters: {
     layout: 'padded',
   },

--- a/apps/product/src/features/entry/components/inspector/EntryInspector.stories.tsx
+++ b/apps/product/src/features/entry/components/inspector/EntryInspector.stories.tsx
@@ -21,7 +21,7 @@ import { InspectorFrame, MockTagRow } from './story-helpers';
  * TimeDiffBlock の差分バーは記録入力時のみ表示。
  */
 const meta = {
-  title: 'Features/Entry/Inspector/EntryInspector',
+  title: 'Product/Features/Entry/Inspector/EntryInspector',
   parameters: {
     layout: 'centered',
     a11y: { test: 'todo' },

--- a/apps/product/src/features/entry/components/inspector/fields/DateRow.stories.tsx
+++ b/apps/product/src/features/entry/components/inspector/fields/DateRow.stories.tsx
@@ -13,7 +13,7 @@ import { DateRow } from './DateRow';
  * 予定・記録インスペクター両方で使用される。
  */
 const meta = {
-  title: 'Features/Entry/Inspector/DateRow',
+  title: 'Product/Features/Entry/Inspector/DateRow',
   tags: ['autodocs'],
   parameters: {
     layout: 'centered',

--- a/apps/product/src/features/entry/components/inspector/fields/NoteSection.stories.tsx
+++ b/apps/product/src/features/entry/components/inspector/fields/NoteSection.stories.tsx
@@ -14,7 +14,7 @@ import { NoteSection } from './NoteSection';
  * HTML文字列が入力された場合は自動的にタグを除去してプレーンテキスト表示する。
  */
 const meta = {
-  title: 'Features/Entry/Inspector/NoteSection',
+  title: 'Product/Features/Entry/Inspector/NoteSection',
   tags: ['autodocs'],
   parameters: {
     layout: 'centered',

--- a/apps/product/src/features/entry/components/inspector/fields/TagRow.stories.tsx
+++ b/apps/product/src/features/entry/components/inspector/fields/TagRow.stories.tsx
@@ -14,7 +14,7 @@ import { TagRow } from './TagRow';
  * 右側に「…」メニュー（getEntryMenuItems で生成された項目）を配置。
  */
 const meta = {
-  title: 'Features/Entry/Inspector/TagRow',
+  title: 'Product/Features/Entry/Inspector/TagRow',
   tags: ['autodocs'],
   parameters: {
     layout: 'centered',

--- a/apps/product/src/features/entry/components/inspector/fields/TimeConflictAlert.stories.tsx
+++ b/apps/product/src/features/entry/components/inspector/fields/TimeConflictAlert.stories.tsx
@@ -10,7 +10,7 @@ import { TimeConflictAlert } from './TimeConflictAlert';
  * `aria-live="assertive"` によりスクリーンリーダーに即時通知される。
  */
 const meta = {
-  title: 'Features/Entry/Inspector/TimeConflictAlert',
+  title: 'Product/Features/Entry/Inspector/TimeConflictAlert',
   tags: ['autodocs'],
   parameters: {
     layout: 'centered',

--- a/apps/product/src/features/entry/components/inspector/fields/TimeDiffBlock.stories.tsx
+++ b/apps/product/src/features/entry/components/inspector/fields/TimeDiffBlock.stories.tsx
@@ -12,7 +12,7 @@ import { TimeDiffBlock } from './TimeDiffBlock';
  * - タグ色塗り = 計画と実績が重なる実行区間
  */
 const meta = {
-  title: 'Features/Entry/Inspector/TimeDiffBlock',
+  title: 'Product/Features/Entry/Inspector/TimeDiffBlock',
   tags: ['autodocs'],
   parameters: {
     layout: 'centered',

--- a/apps/product/src/features/entry/components/inspector/fields/TimeRow.stories.tsx
+++ b/apps/product/src/features/entry/components/inspector/fields/TimeRow.stories.tsx
@@ -13,7 +13,7 @@ import { TimeRow, TimeRowPlaceholder } from './TimeRow';
  * `isPrimary` が true のときは記録行として視覚的に強調される。
  */
 const meta = {
-  title: 'Features/Entry/Inspector/TimeRow',
+  title: 'Product/Features/Entry/Inspector/TimeRow',
   tags: ['autodocs'],
   parameters: {
     layout: 'centered',

--- a/apps/product/src/features/review/components/Review.docs.mdx
+++ b/apps/product/src/features/review/components/Review.docs.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Features/Stats/Guide/Overview" />
+<Meta title="Product/Features/Stats/Guide/Overview" />
 
 # Review
 

--- a/apps/product/src/features/review/components/docs/DataFlow.docs.mdx
+++ b/apps/product/src/features/review/components/docs/DataFlow.docs.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Features/Stats/Guide/Data Flow" />
+<Meta title="Product/Features/Stats/Guide/Data Flow" />
 
 # Data Flow
 

--- a/apps/product/src/features/review/components/docs/LayerArchitecture.docs.mdx
+++ b/apps/product/src/features/review/components/docs/LayerArchitecture.docs.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Features/Stats/Guide/Layer Architecture" />
+<Meta title="Product/Features/Stats/Guide/Layer Architecture" />
 
 # Layer Architecture
 

--- a/apps/product/src/features/review/components/insights/ReviewMetricsGrid.stories.tsx
+++ b/apps/product/src/features/review/components/insights/ReviewMetricsGrid.stories.tsx
@@ -65,7 +65,7 @@ const MOCK_PAGE_DATA: StatsPageData = {
 
 /** ReviewMetricsGrid — KPIメトリクスをグリッド表示 */
 const meta = {
-  title: 'Features/Stats/Review/MetricsGrid',
+  title: 'Product/Features/Stats/Review/MetricsGrid',
   component: ReviewMetricsGrid,
   parameters: {
     layout: 'padded',

--- a/apps/product/src/features/review/components/metrics/MetricCard.stories.tsx
+++ b/apps/product/src/features/review/components/metrics/MetricCard.stories.tsx
@@ -5,7 +5,7 @@ import { MetricCard } from './MetricCard';
 
 /** MetricCard — KPI数値を表示するカード（weather.com風の数値/単位分離デザイン） */
 const meta = {
-  title: 'Features/Stats/Review/MetricCard',
+  title: 'Product/Features/Stats/Review/MetricCard',
   component: MetricCard,
   parameters: {
     layout: 'padded',

--- a/apps/product/src/features/review/components/review/EstimationAccuracyList.stories.tsx
+++ b/apps/product/src/features/review/components/review/EstimationAccuracyList.stories.tsx
@@ -34,7 +34,7 @@ const ESTIMATION_ROWS = [
 
 /** EstimationAccuracyList — タグ別の見積もり精度リスト（週次ビューのセクション） */
 const meta = {
-  title: 'Features/Stats/Review/EstimationAccuracyList',
+  title: 'Product/Features/Stats/Review/EstimationAccuracyList',
   component: EstimationAccuracyList,
   parameters: {
     layout: 'padded',

--- a/apps/product/src/features/review/components/review/RhythmCharts.stories.tsx
+++ b/apps/product/src/features/review/components/review/RhythmCharts.stories.tsx
@@ -25,7 +25,7 @@ const HOURLY_DATA = [
 
 /** RhythmCharts — 期間全体の曜日別・時間帯別バー（週次ビューの「週のリズム」） */
 const meta = {
-  title: 'Features/Stats/Review/RhythmCharts',
+  title: 'Product/Features/Stats/Review/RhythmCharts',
   component: DowRhythmChart,
   parameters: {
     layout: 'padded',

--- a/apps/product/src/features/review/components/review/RuleInsightList.stories.tsx
+++ b/apps/product/src/features/review/components/review/RuleInsightList.stories.tsx
@@ -6,7 +6,7 @@ import { RuleInsightList } from './RuleInsightList';
 
 /** RuleInsightList — 閾値ベースの気づきリスト（Review タブ KPI グリッド下） */
 const meta = {
-  title: 'Features/Stats/Review/RuleInsightList',
+  title: 'Product/Features/Stats/Review/RuleInsightList',
   component: RuleInsightList,
   parameters: { layout: 'padded' },
   tags: ['autodocs'],

--- a/apps/product/src/features/review/components/review/TagBalancePanel.stories.tsx
+++ b/apps/product/src/features/review/components/review/TagBalancePanel.stories.tsx
@@ -40,7 +40,7 @@ const ROWS: TagBalanceRow[] = [
 
 /** TagBalancePanel — タグ別時間配分（週次 / 月次 / 年次ビューで共用） */
 const meta = {
-  title: 'Features/Stats/Review/TagBalancePanel',
+  title: 'Product/Features/Stats/Review/TagBalancePanel',
   component: TagBalancePanel,
   parameters: {
     layout: 'padded',

--- a/apps/product/src/features/review/components/review/TagBreakdownBar.stories.tsx
+++ b/apps/product/src/features/review/components/review/TagBreakdownBar.stories.tsx
@@ -4,7 +4,7 @@ import { TagBreakdownBar } from './TagBreakdownBar';
 
 /** TagBreakdownBar — タグ別時間配分の積み上げバー + 凡例 */
 const meta = {
-  title: 'Features/Stats/Review/TagBreakdownBar',
+  title: 'Product/Features/Stats/Review/TagBreakdownBar',
   component: TagBreakdownBar,
   parameters: { layout: 'padded' },
   tags: ['autodocs'],

--- a/apps/product/src/features/review/components/shared/EntryMicroInsight.stories.tsx
+++ b/apps/product/src/features/review/components/shared/EntryMicroInsight.stories.tsx
@@ -12,7 +12,7 @@ import { EntryMicroInsight } from './EntryMicroInsight';
  * - 優先度2: ピーク時間帯通知
  */
 const meta = {
-  title: 'Features/Stats/Shared/EntryMicroInsight',
+  title: 'Product/Features/Stats/Shared/EntryMicroInsight',
   component: EntryMicroInsight,
   parameters: { layout: 'padded' },
   tags: ['autodocs'],

--- a/apps/product/src/features/review/components/shared/InsightSlot.stories.tsx
+++ b/apps/product/src/features/review/components/shared/InsightSlot.stories.tsx
@@ -4,7 +4,7 @@ import { InsightSlot } from './InsightSlot';
 
 /** InsightSlot — 研究者の所見スロット（各粒度ビューの冒頭に 1-2 文だけ表示） */
 const meta = {
-  title: 'Features/Stats/Shared/InsightSlot',
+  title: 'Product/Features/Stats/Shared/InsightSlot',
   component: InsightSlot,
   parameters: {
     layout: 'padded',

--- a/apps/product/src/features/review/components/shared/NextActionLink.stories.tsx
+++ b/apps/product/src/features/review/components/shared/NextActionLink.stories.tsx
@@ -4,7 +4,7 @@ import { NextActionLink } from './NextActionLink';
 
 /** NextActionLink — Review から次の計画（Calendar）への還流導線（Tier 2 CTA） */
 const meta = {
-  title: 'Features/Stats/Shared/NextActionLink',
+  title: 'Product/Features/Stats/Shared/NextActionLink',
   component: NextActionLink,
   parameters: {
     layout: 'padded',

--- a/apps/product/src/features/review/components/shared/SummaryCard.stories.tsx
+++ b/apps/product/src/features/review/components/shared/SummaryCard.stories.tsx
@@ -5,7 +5,7 @@ import { SummaryCard } from './SummaryCard';
 
 /** SummaryCard — 粒度ビュー共通の KPI カード（前期間比トレンド付き） */
 const meta = {
-  title: 'Features/Stats/Shared/SummaryCard',
+  title: 'Product/Features/Stats/Shared/SummaryCard',
   component: SummaryCard,
   parameters: {
     layout: 'padded',

--- a/apps/product/src/features/review/components/shared/TrendBadge.stories.tsx
+++ b/apps/product/src/features/review/components/shared/TrendBadge.stories.tsx
@@ -4,7 +4,7 @@ import { TrendBadge } from './TrendBadge';
 
 /** TrendBadge — 前期間比のトレンド方向と変化率を表示するバッジ */
 const meta = {
-  title: 'Features/Stats/Shared/TrendBadge',
+  title: 'Product/Features/Stats/Shared/TrendBadge',
   component: TrendBadge,
   parameters: { layout: 'padded' },
   tags: ['autodocs'],

--- a/apps/product/src/features/review/components/time-pl/TimePL.stories.tsx
+++ b/apps/product/src/features/review/components/time-pl/TimePL.stories.tsx
@@ -10,7 +10,7 @@ import {
 
 /** Time P/L — 予実比較ビューを1つの入力データから描画 */
 const meta = {
-  title: 'Features/Stats/TimePL',
+  title: 'Product/Features/Stats/TimePL',
   component: TimePLContainer,
   parameters: { layout: 'padded' },
   tags: ['autodocs'],

--- a/apps/product/src/features/settings/components/AccountSettings.stories.tsx
+++ b/apps/product/src/features/settings/components/AccountSettings.stories.tsx
@@ -66,7 +66,7 @@ function createMockMFA(overrides: Partial<UseMFAReturn> = {}): UseMFAReturn {
  * `satisfies Meta`（型引数なし）を使い、render 関数内で直接 prop を渡す。
  */
 const meta = {
-  title: 'Features/Settings/AccountSettings',
+  title: 'Product/Features/Settings/AccountSettings',
   component: AccountSettings,
   parameters: {
     layout: 'padded',

--- a/apps/product/src/features/settings/components/BillingSettings.stories.tsx
+++ b/apps/product/src/features/settings/components/BillingSettings.stories.tsx
@@ -115,7 +115,7 @@ function makeBillingMocks(
 // ─────────────────────────────────────────────────────────
 
 const meta = {
-  title: 'Features/Settings/BillingSettings',
+  title: 'Product/Features/Settings/BillingSettings',
   component: BillingSettings,
   parameters: {
     layout: 'padded',

--- a/apps/product/src/features/settings/components/DataSettings.stories.tsx
+++ b/apps/product/src/features/settings/components/DataSettings.stories.tsx
@@ -16,7 +16,7 @@ import { DataSettings } from './data-settings';
 // ─────────────────────────────────────────────────────────
 
 const meta = {
-  title: 'Features/Settings/DataSettings',
+  title: 'Product/Features/Settings/DataSettings',
   component: DataSettings,
   parameters: {
     layout: 'padded',

--- a/apps/product/src/features/settings/components/DisplaySettings.stories.tsx
+++ b/apps/product/src/features/settings/components/DisplaySettings.stories.tsx
@@ -19,7 +19,7 @@ import { DisplaySettings } from './display-settings';
 // ─────────────────────────────────────────────────────────
 
 const meta = {
-  title: 'Features/Settings/DisplaySettings',
+  title: 'Product/Features/Settings/DisplaySettings',
   component: DisplaySettings,
   parameters: {
     layout: 'padded',

--- a/apps/product/src/features/settings/components/DisplaySettingsPatterns.stories.tsx
+++ b/apps/product/src/features/settings/components/DisplaySettingsPatterns.stories.tsx
@@ -210,7 +210,7 @@ function TimezoneListReference() {
 // ─────────────────────────────────────────────────────────
 
 const meta = {
-  title: 'Features/Settings/DisplaySettingsPatterns',
+  title: 'Product/Features/Settings/DisplaySettingsPatterns',
   parameters: {
     layout: 'padded',
     // button-name: SelectTrigger inside LabeledRow without explicit aria-label

--- a/apps/product/src/features/settings/components/InfoBox.stories.tsx
+++ b/apps/product/src/features/settings/components/InfoBox.stories.tsx
@@ -7,7 +7,7 @@ import { Button } from '@dayopt/components';
 import { InfoBox } from './InfoBox';
 
 const meta = {
-  title: 'Features/Settings/InfoBox',
+  title: 'Product/Features/Settings/InfoBox',
   component: InfoBox,
   tags: ['autodocs'],
   decorators: [

--- a/apps/product/src/features/settings/components/PaymentErrorDialog.stories.tsx
+++ b/apps/product/src/features/settings/components/PaymentErrorDialog.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { PaymentErrorDialog } from './PaymentErrorDialog';
 
 const meta = {
-  title: 'Components/Overlays/PaymentErrorDialog',
+  title: 'Product/Components/Overlays/PaymentErrorDialog',
   component: PaymentErrorDialog,
   tags: ['autodocs'],
   parameters: {

--- a/apps/product/src/features/settings/components/ProfileSettings.stories.tsx
+++ b/apps/product/src/features/settings/components/ProfileSettings.stories.tsx
@@ -15,7 +15,7 @@ import { ProfileSettings } from './profile-settings';
 // ─────────────────────────────────────────────────────────
 
 const meta = {
-  title: 'Features/Settings/ProfileSettings',
+  title: 'Product/Features/Settings/ProfileSettings',
   component: ProfileSettings,
   parameters: {
     layout: 'padded',

--- a/apps/product/src/features/settings/components/Settings.docs.mdx
+++ b/apps/product/src/features/settings/components/Settings.docs.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Features/Settings/Guide" />
+<Meta title="Product/Features/Settings/Guide" />
 
 # Settings
 

--- a/apps/product/src/features/settings/components/SettingsDialog.stories.tsx
+++ b/apps/product/src/features/settings/components/SettingsDialog.stories.tsx
@@ -79,7 +79,7 @@ function InteractiveSettingsDialog({
  * URL は変更せず、モーダル内でサイドバーのカテゴリ切替のみ行う。
  */
 const meta = {
-  title: 'Features/Settings/SettingsDialog',
+  title: 'Product/Features/Settings/SettingsDialog',
   component: SettingsDialog,
   parameters: {
     layout: 'fullscreen',

--- a/apps/product/src/features/settings/components/SettingsSidebar.stories.tsx
+++ b/apps/product/src/features/settings/components/SettingsSidebar.stories.tsx
@@ -27,7 +27,7 @@ import { SettingsSidebar } from './SettingsSidebar';
  * 5カテゴリ（プロフィール・表示・データ・課金・アカウント）を表示。
  */
 const meta = {
-  title: 'Features/Settings/SettingsSidebar',
+  title: 'Product/Features/Settings/SettingsSidebar',
   component: SettingsSidebar,
   parameters: {
     layout: 'padded',

--- a/apps/product/src/features/settings/components/TrialEndedDialog.stories.tsx
+++ b/apps/product/src/features/settings/components/TrialEndedDialog.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { TrialEndedDialog } from './TrialEndedDialog';
 
 const meta = {
-  title: 'Components/Overlays/TrialEndedDialog',
+  title: 'Product/Components/Overlays/TrialEndedDialog',
   component: TrialEndedDialog,
   tags: ['autodocs'],
   parameters: {

--- a/apps/product/src/features/settings/components/account-deletion-dialog.stories.tsx
+++ b/apps/product/src/features/settings/components/account-deletion-dialog.stories.tsx
@@ -11,7 +11,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { AccountDeletionDialog } from './account-deletion-dialog';
 
 const meta = {
-  title: 'Features/Settings/AccountDeletionDialog',
+  title: 'Product/Features/Settings/AccountDeletionDialog',
   component: AccountDeletionDialog,
   parameters: {
     layout: 'padded',

--- a/apps/product/src/features/settings/components/avatar-change-dialog.stories.tsx
+++ b/apps/product/src/features/settings/components/avatar-change-dialog.stories.tsx
@@ -37,7 +37,7 @@ const AUTH_WITH_AVATAR = {
 // ─────────────────────────────────────────────────────────
 
 const meta = {
-  title: 'Features/Settings/AvatarChangeDialog',
+  title: 'Product/Features/Settings/AvatarChangeDialog',
   component: AvatarChangeDialog,
   parameters: {
     layout: 'centered',

--- a/apps/product/src/features/settings/components/display-name-dialog.stories.tsx
+++ b/apps/product/src/features/settings/components/display-name-dialog.stories.tsx
@@ -14,7 +14,7 @@ import { PRESET_AUTH } from '@dayopt/storybook/mocks/presets';
 import { DisplayNameDialog } from './display-name-dialog';
 
 const meta = {
-  title: 'Features/Settings/DisplayNameDialog',
+  title: 'Product/Features/Settings/DisplayNameDialog',
   component: DisplayNameDialog,
   parameters: {
     layout: 'centered',

--- a/apps/product/src/features/settings/components/email-change-dialog.stories.tsx
+++ b/apps/product/src/features/settings/components/email-change-dialog.stories.tsx
@@ -15,7 +15,7 @@ import { Button } from '@dayopt/components';
 import { EmailChangeDialog } from './email-change-dialog';
 
 const meta = {
-  title: 'Features/Settings/EmailChangeDialog',
+  title: 'Product/Features/Settings/EmailChangeDialog',
   component: EmailChangeDialog,
   parameters: {
     layout: 'centered',

--- a/apps/product/src/features/settings/components/password-change-dialog.stories.tsx
+++ b/apps/product/src/features/settings/components/password-change-dialog.stories.tsx
@@ -18,7 +18,7 @@ import { PRESET_AUTH } from '@dayopt/storybook/mocks/presets';
 import { PasswordChangeDialog } from './password-change-dialog';
 
 const meta = {
-  title: 'Features/Settings/PasswordChangeDialog',
+  title: 'Product/Features/Settings/PasswordChangeDialog',
   component: PasswordChangeDialog,
   parameters: {
     layout: 'centered',

--- a/apps/product/src/features/settings/components/sections/MFASection.stories.tsx
+++ b/apps/product/src/features/settings/components/sections/MFASection.stories.tsx
@@ -56,7 +56,7 @@ function createMockMFA(overrides: Partial<UseMFAReturn> = {}): UseMFAReturn {
  * render 関数内で直接 prop を渡す。
  */
 const meta = {
-  title: 'Features/Settings/MFASection',
+  title: 'Product/Features/Settings/MFASection',
   component: MFASection,
   parameters: { layout: 'padded' },
   tags: ['autodocs'],

--- a/apps/product/src/features/tags/components/IconPicker.stories.tsx
+++ b/apps/product/src/features/tags/components/IconPicker.stories.tsx
@@ -14,7 +14,7 @@ import { TagIcon } from './TagIcon';
  * 「アイコンなし」を選択すると従来の色ドットにフォールバック。
  */
 const meta = {
-  title: 'Features/Tags/IconPicker',
+  title: 'Product/Features/Tags/IconPicker',
   parameters: {
     layout: 'padded',
   },

--- a/apps/product/src/features/tags/components/TagDeleteStrategyDialog.stories.tsx
+++ b/apps/product/src/features/tags/components/TagDeleteStrategyDialog.stories.tsx
@@ -95,7 +95,7 @@ const mockTags: Tag[] = [
 ];
 
 const meta = {
-  title: 'Features/Tags/DeleteStrategyDialog',
+  title: 'Product/Features/Tags/DeleteStrategyDialog',
   parameters: {
     layout: 'centered',
   },

--- a/apps/product/src/features/tags/components/TagGridSelector.stories.tsx
+++ b/apps/product/src/features/tags/components/TagGridSelector.stories.tsx
@@ -456,7 +456,7 @@ function SelectorFrame({
  * 子タグはドリルダウンで2画面目に遷移。
  */
 const meta = {
-  title: 'Features/Tags/GridSelector',
+  title: 'Product/Features/Tags/GridSelector',
   parameters: {
     layout: 'centered',
   },

--- a/apps/product/src/features/tags/components/TagIcon.stories.tsx
+++ b/apps/product/src/features/tags/components/TagIcon.stories.tsx
@@ -11,7 +11,7 @@ import { TagIcon } from './TagIcon';
  * 未設定（null）なら従来の色ドットにフォールバック。
  */
 const meta = {
-  title: 'Features/Tags/TagIcon',
+  title: 'Product/Features/Tags/TagIcon',
   parameters: {
     layout: 'padded',
   },

--- a/apps/product/src/features/tags/components/Tags.docs.mdx
+++ b/apps/product/src/features/tags/components/Tags.docs.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Features/Tags/Guide" />
+<Meta title="Product/Features/Tags/Guide" />
 
 # Tags
 

--- a/apps/product/src/features/tags/components/color-palette-picker.stories.tsx
+++ b/apps/product/src/features/tags/components/color-palette-picker.stories.tsx
@@ -11,7 +11,7 @@ import { Button, DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '
 import { ColorPaletteMenuItems, getColorDisplayName } from './color-palette-picker';
 
 const meta = {
-  title: 'Components/ColorPaletteMenuItems',
+  title: 'Product/Components/ColorPaletteMenuItems',
   component: ColorPaletteMenuItems,
   tags: ['autodocs'],
   parameters: {

--- a/apps/product/src/features/tags/components/tag-merge-modal.stories.tsx
+++ b/apps/product/src/features/tags/components/tag-merge-modal.stories.tsx
@@ -126,7 +126,7 @@ function InteractiveTagMerge({ tags = MOCK_TAGS }: { tags?: typeof MOCK_TAGS }) 
  * @see GlobalTagMergeModal — useModalStore と接続するラッパー
  */
 const meta = {
-  title: 'Features/Tags/MergeModal',
+  title: 'Product/Features/Tags/MergeModal',
   parameters: {
     layout: 'fullscreen',
     trpcMocks: { 'tags.list': { data: MOCK_TAGS } },

--- a/apps/product/src/features/tags/components/tag-rename-modal.stories.tsx
+++ b/apps/product/src/features/tags/components/tag-rename-modal.stories.tsx
@@ -67,7 +67,7 @@ const TARGET = { id: 'tag-1', name: '仕事', parent_id: null };
  * @see GlobalTagRenameModal — useShellStore に接続するラッパー
  */
 const meta = {
-  title: 'Features/Tags/RenameModal',
+  title: 'Product/Features/Tags/RenameModal',
   parameters: {
     layout: 'fullscreen',
     trpcMocks: { 'tags.list': { data: MOCK_TAGS } },

--- a/apps/product/src/lib/styles/tokens/states.stories.tsx
+++ b/apps/product/src/lib/styles/tokens/states.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Button, Input } from '@dayopt/components';
 
 const meta = {
-  title: 'Foundations/States',
+  title: 'Shared/Foundations/States',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -13,6 +13,9 @@ const config: StorybookConfig = {
   stories: [
     '../../product/src/**/*.mdx',
     '../../product/src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
+    // Web layer（apps/web）— 現状は Web/Overview のみ。今後 component/section/page story を追加する受け皿
+    '../../web/src/**/*.mdx',
+    '../../web/src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
     '../../../packages/foundations/src/**/*.mdx',
     '../../../packages/foundations/src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
     '../../../packages/components/src/**/*.mdx',

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -41,26 +41,34 @@ const preview: Preview = {
     options: {
       storySort: {
         method: 'alphabetical',
+        // top-level は所有境界（package / app）で分ける
         order: [
           'Welcome',
-          'Components',
-          // Components 直下は責務ベース taxonomy（ADR-012）の流れで並べる
+          // Shared = packages（再利用資産）
+          'Shared',
           [
-            'Identity',
-            'Actions',
-            'Inputs',
-            'Navigation',
-            'Feedback',
-            'Overlays',
-            'Display',
-            'Layout',
-            'Utilities',
+            'Foundations',
+            'Components',
+            // Shared/Components 直下は責務ベース taxonomy（ADR-012）の流れで並べる
+            [
+              'Identity',
+              'Actions',
+              'Inputs',
+              'Navigation',
+              'Feedback',
+              'Overlays',
+              'Display',
+              'Layout',
+              'Utilities',
+            ],
+            'Patterns',
           ],
-          'Features',
-          'Design',
-          'UI',
-          'Foundations',
-          'Patterns',
+          // Product = apps/product
+          'Product',
+          ['Components', 'Features', 'Emails'],
+          // Web = apps/web（現状は構造のみ予約）
+          'Web',
+          ['Components', 'Sections', 'Pages'],
         ],
       },
     },

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -65,7 +65,7 @@ const preview: Preview = {
           ],
           // Product = apps/product
           'Product',
-          ['Components', 'Features', 'Emails'],
+          ['Components', 'Features', 'Patterns', 'Emails'],
           // Web = apps/web（現状は構造のみ予約）
           'Web',
           ['Components', 'Sections', 'Pages'],

--- a/apps/storybook/.storybook/stories/patterns/Actions.stories.tsx
+++ b/apps/storybook/.storybook/stories/patterns/Actions.stories.tsx
@@ -20,7 +20,7 @@ import {
 } from '@dayopt/components';
 
 const meta = {
-  title: 'Patterns/Actions',
+  title: 'Shared/Patterns/Actions',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/storybook/.storybook/stories/patterns/Cards.stories.tsx
+++ b/apps/storybook/.storybook/stories/patterns/Cards.stories.tsx
@@ -18,7 +18,7 @@ import {
 } from '@dayopt/components';
 
 const meta = {
-  title: 'Patterns/Cards',
+  title: 'Shared/Patterns/Cards',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/storybook/.storybook/stories/patterns/Confirmation.stories.tsx
+++ b/apps/storybook/.storybook/stories/patterns/Confirmation.stories.tsx
@@ -6,7 +6,7 @@ import { ConfirmDialog } from '@/components/ui/overlays/confirm-dialog';
 import { Button } from '@dayopt/components';
 
 const meta = {
-  title: 'Patterns/Confirmation',
+  title: 'Shared/Patterns/Confirmation',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/storybook/.storybook/stories/patterns/Confirmation.stories.tsx
+++ b/apps/storybook/.storybook/stories/patterns/Confirmation.stories.tsx
@@ -6,7 +6,7 @@ import { ConfirmDialog } from '@/components/ui/overlays/confirm-dialog';
 import { Button } from '@dayopt/components';
 
 const meta = {
-  title: 'Shared/Patterns/Confirmation',
+  title: 'Product/Patterns/Confirmation',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/storybook/.storybook/stories/patterns/Copywriting.stories.tsx
+++ b/apps/storybook/.storybook/stories/patterns/Copywriting.stories.tsx
@@ -19,7 +19,7 @@ import {
 } from './_data/copywriting-audit';
 
 const meta = {
-  title: 'Shared/Patterns/Copywriting',
+  title: 'Product/Patterns/Copywriting',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/storybook/.storybook/stories/patterns/Copywriting.stories.tsx
+++ b/apps/storybook/.storybook/stories/patterns/Copywriting.stories.tsx
@@ -19,7 +19,7 @@ import {
 } from './_data/copywriting-audit';
 
 const meta = {
-  title: 'Patterns/Copywriting',
+  title: 'Shared/Patterns/Copywriting',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/storybook/.storybook/stories/patterns/EmptyStates.stories.tsx
+++ b/apps/storybook/.storybook/stories/patterns/EmptyStates.stories.tsx
@@ -5,7 +5,7 @@ import { EmptyState } from '@/components/ui/feedback/EmptyState';
 import { Button } from '@dayopt/components';
 
 const meta = {
-  title: 'Shared/Patterns/EmptyStates',
+  title: 'Product/Patterns/EmptyStates',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/storybook/.storybook/stories/patterns/EmptyStates.stories.tsx
+++ b/apps/storybook/.storybook/stories/patterns/EmptyStates.stories.tsx
@@ -5,7 +5,7 @@ import { EmptyState } from '@/components/ui/feedback/EmptyState';
 import { Button } from '@dayopt/components';
 
 const meta = {
-  title: 'Patterns/EmptyStates',
+  title: 'Shared/Patterns/EmptyStates',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/storybook/.storybook/stories/patterns/ErrorPages.stories.tsx
+++ b/apps/storybook/.storybook/stories/patterns/ErrorPages.stories.tsx
@@ -17,7 +17,7 @@ import type { ReactNode } from 'react';
  * - maintenance/route.ts: メンテナンス（静的 HTML）
  */
 const meta = {
-  title: 'Patterns/ErrorPages',
+  title: 'Shared/Patterns/ErrorPages',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/storybook/.storybook/stories/patterns/ErrorStates.stories.tsx
+++ b/apps/storybook/.storybook/stories/patterns/ErrorStates.stories.tsx
@@ -20,7 +20,7 @@ import { Button } from '@dayopt/components';
  * | Mutation 失敗 | Toast (sonner) | `onError` callback |
  */
 const meta = {
-  title: 'Patterns/ErrorStates',
+  title: 'Shared/Patterns/ErrorStates',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/storybook/.storybook/stories/patterns/ErrorStates.stories.tsx
+++ b/apps/storybook/.storybook/stories/patterns/ErrorStates.stories.tsx
@@ -20,7 +20,7 @@ import { Button } from '@dayopt/components';
  * | Mutation 失敗 | Toast (sonner) | `onError` callback |
  */
 const meta = {
-  title: 'Shared/Patterns/ErrorStates',
+  title: 'Product/Patterns/ErrorStates',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/storybook/.storybook/stories/patterns/Feedback.stories.tsx
+++ b/apps/storybook/.storybook/stories/patterns/Feedback.stories.tsx
@@ -6,7 +6,7 @@ import { toast } from '@/lib/toast';
 import { Button } from '@dayopt/components';
 
 const meta = {
-  title: 'Patterns/Feedback',
+  title: 'Shared/Patterns/Feedback',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/storybook/.storybook/stories/patterns/Feedback.stories.tsx
+++ b/apps/storybook/.storybook/stories/patterns/Feedback.stories.tsx
@@ -6,7 +6,7 @@ import { toast } from '@/lib/toast';
 import { Button } from '@dayopt/components';
 
 const meta = {
-  title: 'Shared/Patterns/Feedback',
+  title: 'Product/Patterns/Feedback',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/storybook/.storybook/stories/patterns/Forms.stories.tsx
+++ b/apps/storybook/.storybook/stories/patterns/Forms.stories.tsx
@@ -4,7 +4,7 @@ import { AlertCircle, CheckCircle2 } from 'lucide-react';
 import { Button, Field, FieldError, FieldLabel, FieldSupportText, Input } from '@dayopt/components';
 
 const meta = {
-  title: 'Patterns/Forms',
+  title: 'Shared/Patterns/Forms',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/storybook/.storybook/stories/patterns/Loading.stories.tsx
+++ b/apps/storybook/.storybook/stories/patterns/Loading.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Spinner } from '@dayopt/components';
 
 const meta = {
-  title: 'Patterns/Loading',
+  title: 'Shared/Patterns/Loading',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/storybook/.storybook/stories/patterns/Security.stories.tsx
+++ b/apps/storybook/.storybook/stories/patterns/Security.stories.tsx
@@ -34,7 +34,7 @@ import { Button } from '@dayopt/components';
  * | UI | エラーサニタイズ + 確認ダイアログ | OWASP準拠メッセージ + 破壊操作ガード |
  */
 const meta = {
-  title: 'Patterns/Security',
+  title: 'Shared/Patterns/Security',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/storybook/.storybook/stories/patterns/Security.stories.tsx
+++ b/apps/storybook/.storybook/stories/patterns/Security.stories.tsx
@@ -34,7 +34,7 @@ import { Button } from '@dayopt/components';
  * | UI | エラーサニタイズ + 確認ダイアログ | OWASP準拠メッセージ + 破壊操作ガード |
  */
 const meta = {
-  title: 'Shared/Patterns/Security',
+  title: 'Product/Patterns/Security',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/storybook/.storybook/stories/patterns/Selection.stories.tsx
+++ b/apps/storybook/.storybook/stories/patterns/Selection.stories.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { Badge, Button, Checkbox, Label, RadioGroup, RadioGroupItem } from '@dayopt/components';
 
 const meta = {
-  title: 'Patterns/Selection',
+  title: 'Shared/Patterns/Selection',
   parameters: {
     layout: 'fullscreen',
   },

--- a/apps/web/src/Web.docs.mdx
+++ b/apps/web/src/Web.docs.mdx
@@ -1,0 +1,27 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Web/Overview" />
+
+# Web
+
+`apps/web`（マーケティングサイト・docs・blog・releases）の Storybook レイヤー。
+
+現状このレイヤーには個別 story がまだ無く、**構造（命名規約）だけを予約**している。
+`apps/web` の component に story を追加する際は、以下の第二階層に沿って `title` を付ける。
+
+| 第二階層         | 置き場                                | 用途                                                        |
+| ---------------- | ------------------------------------- | ----------------------------------------------------------- |
+| `Web/Components` | `apps/web/src/components/**`          | 単体 UI（ボタン、カード等の web 固有 primitive / 表示部品） |
+| `Web/Sections`   | `apps/web/src/features/**` の section | ページを構成するまとまった区画（Hero、料金表、FAQ 等）      |
+| `Web/Pages`      | ページ全体の組み上げ                  | 1 ルート分の合成（LP、docs ページ等）                       |
+
+## taxonomy 上の位置づけ
+
+Storybook の top-level は**所有境界（package / app）**で分ける（ADR-012 の続き、cosmetic 再整列）。
+
+- `Shared/*` — `packages/*`（foundations / components / patterns）。再利用資産
+- `Product/*` — `apps/product`（components / features / emails）
+- `Web/*` — `apps/web`（components / sections / pages）← 本レイヤー
+
+共有 UI は `@dayopt/components`（`Shared/Components`）から取得する。web 固有のものだけを
+`Web/Components` に置く。

--- a/apps/web/src/Web.docs.mdx
+++ b/apps/web/src/Web.docs.mdx
@@ -9,19 +9,109 @@ import { Meta } from '@storybook/addon-docs/blocks';
 現状このレイヤーには個別 story がまだ無く、**構造（命名規約）だけを予約**している。
 `apps/web` の component に story を追加する際は、以下の第二階層に沿って `title` を付ける。
 
-| 第二階層         | 置き場                                | 用途                                                        |
-| ---------------- | ------------------------------------- | ----------------------------------------------------------- |
-| `Web/Components` | `apps/web/src/components/**`          | 単体 UI（ボタン、カード等の web 固有 primitive / 表示部品） |
-| `Web/Sections`   | `apps/web/src/features/**` の section | ページを構成するまとまった区画（Hero、料金表、FAQ 等）      |
-| `Web/Pages`      | ページ全体の組み上げ                  | 1 ルート分の合成（LP、docs ページ等）                       |
+| 第二階層         | 意図                                        |
+| ---------------- | ------------------------------------------- |
+| `Web/Components` | web 全体で使うが product とは共有しない部品 |
+| `Web/Sections`   | ページを構成する意味のある区画              |
+| `Web/Pages`      | ページ全体の構成確認                        |
 
 ## taxonomy 上の位置づけ
 
-Storybook の top-level は**所有境界（package / app）**で分ける（ADR-012 の続き、cosmetic 再整列）。
+Storybook の top-level は**所有境界（package / app）**で分ける（ADR-013）。
 
 - `Shared/*` — `packages/*`（foundations / components / patterns）。再利用資産
-- `Product/*` — `apps/product`（components / features / emails）
+- `Product/*` — `apps/product`（components / features / patterns / emails）
 - `Web/*` — `apps/web`（components / sections / pages）← 本レイヤー
 
-共有 UI は `@dayopt/components`（`Shared/Components`）から取得する。web 固有のものだけを
-`Web/Components` に置く。
+共有 UI は `@dayopt/components`（`Shared/Components`）から取得する。web 固有のものだけを `Web/*` に置く。
+
+---
+
+## Web/Components
+
+web 全体で使うが、**product とは共有しない** component。`Shared/Components`（product と共有）でも
+`Web/Sections`（ページの区画）でもない、web サイト共通の部品。
+
+```
+Web/Components
+  Shell
+    Header
+    Footer
+    PublicLayout
+
+  Navigation
+    HeaderNav
+    FooterNav
+    MobileMenu
+
+  Content
+    MarkdownContent
+    Prose
+    LinkCard
+
+  SEO
+    SeoMeta
+    OgPreview
+```
+
+ここに入るのは「LP だけ」のものではなく、**web サイト全体で使う**もの。たとえば `Header` /
+`Footer` / `SeoMeta` / `Prose` など。
+
+## Web/Sections
+
+ページを構成する**意味のある区画**。Web の UI は Product のような「機能単位」よりも、
+**セクション単位**で見る方が自然。
+
+```
+Web/Sections
+  Landing
+    Hero
+    Problem
+    HowItWorks
+    Features
+    CTA
+
+  Pricing
+    PricingHero
+    PricingTable
+    PlanComparison
+    FAQ
+
+  Help
+    HelpHero
+    HelpCategoryList
+    HelpArticleList
+
+  Legal
+    LegalLayout
+    LegalSection
+```
+
+たとえば `Hero` は feature ではない。でも LP の伝達構造としては重要。なので
+`Web/Sections/Landing/Hero` が自然な置き場になる。
+
+## Web/Pages
+
+**ページ全体の構成確認**。page story を持つ意味は、個別 section ではなく、
+**ページとして並べたときにどう見えるか**を確認するため。
+
+```
+Web/Pages
+  Home
+  Pricing
+  Help
+  Legal
+```
+
+### Section 単体 vs Page 全体
+
+```
+Web/Sections/Landing/Hero
+  = Hero 単体
+
+Web/Pages/Home
+  = Hero + Problem + Features + CTA を並べたページ全体
+```
+
+LP は section 単体よりも、**順番・流れ・情報設計**が大事。section の並びとページとしての見え方を
+確認するために Page story を持つ。

--- a/docs/architecture/adr/013-storybook-ownership-taxonomy.md
+++ b/docs/architecture/adr/013-storybook-ownership-taxonomy.md
@@ -43,14 +43,14 @@ Storybook の **top-level を所有境界（package / app）**で分ける。第
 
 ### 物理位置と title の対応（移行ルール）
 
-| 物理位置                                     | 旧 title prefix             | 新 title prefix                             |
-| -------------------------------------------- | --------------------------- | ------------------------------------------- |
-| `packages/components/src/**`                 | `Components/`               | `Shared/Components/`                        |
-| `packages/foundations/src/**`                | `Foundations`               | `Shared/Foundations`                        |
-| `apps/storybook/.storybook/stories/patterns` | `Patterns/`                 | `Shared/Patterns/`                          |
-| `apps/product/src/components/**`             | `Components/`               | `Product/Components/`                       |
-| `apps/product/src/features/**`               | `Features/` / `Components/` | `Product/Features/` / `Product/Components/` |
-| `apps/product/src/emails`                    | `Patterns/Email`            | `Product/Emails`                            |
+| 物理位置                                     | 旧 title prefix             | 新 title prefix                                                   |
+| -------------------------------------------- | --------------------------- | ----------------------------------------------------------------- |
+| `packages/components/src/**`                 | `Components/`               | `Shared/Components/`                                              |
+| `packages/foundations/src/**`                | `Foundations`               | `Shared/Foundations`                                              |
+| `apps/storybook/.storybook/stories/patterns` | `Patterns/`                 | `Shared/Patterns/` または `Product/Patterns/`（依存ベース、下記） |
+| `apps/product/src/components/**`             | `Components/`               | `Product/Components/`                                             |
+| `apps/product/src/features/**`               | `Features/` / `Components/` | `Product/Features/` / `Product/Components/`                       |
+| `apps/product/src/emails`                    | `Patterns/Email`            | `Product/Emails`                                                  |
 
 ### 例外
 
@@ -59,6 +59,21 @@ Storybook の **top-level を所有境界（package / app）**で分ける。第
   不一致を許容。将来 `packages/foundations` へ移設する余地あり）。
 - `apps/product` 内で `Components/` を名乗っていた straggler（`ColorPaletteMenuItems` /
   `Props Inventory` / app-shell の `BottomTabBar`）は `Product/Components/` に寄せた。
+
+### Patterns は依存ベースで Shared / Product に分割
+
+`patterns/` 配下は物理的に 1 ディレクトリに同居するため、物理位置では分けられない。代わりに
+**story の import 依存**で判定する。「shared pattern は `@dayopt/components` だけで再現できるもの」
+という所有境界の原則に従い、`@/`（product 内部: `@/components` / `@/lib` / `@/features`）に
+依存する pattern は `Product/Patterns/` に置く。
+
+| 分類                | pattern                                                                 |
+| ------------------- | ----------------------------------------------------------------------- |
+| `Shared/Patterns/`  | Actions, Cards, ErrorPages, Forms, Loading, Selection                   |
+| `Product/Patterns/` | Confirmation, Copywriting, EmptyStates, ErrorStates, Feedback, Security |
+
+ファイルは `apps/storybook/.storybook/stories/patterns/` に据え置き、title だけ付け替える
+（`Foundations/States` と同じ title↔位置 decouple）。
 
 ## 結果
 

--- a/docs/architecture/adr/013-storybook-ownership-taxonomy.md
+++ b/docs/architecture/adr/013-storybook-ownership-taxonomy.md
@@ -1,0 +1,83 @@
+# ADR-013: Storybook story-title の所有境界 top-level（Shared / Product / Web）
+
+> accepted（2026-06-24）
+
+> ADR-012 が「別途の cosmetic 作業」として残した Storybook story `title:` の再整列を確定する。
+> 物理配置・barrel・公開 API は不変。サイドバーの **top-level 階層のみ**を変える。
+
+---
+
+## コンテキスト
+
+ADR-011 / ADR-012 で共有 UI を `packages/components` に canonical 集約し、第二階層を
+責務ベース 9 category に切り直した。その際 story の `title:` は物理 path と decouple している
+ため再整列は保留された（ADR-012「結果／トレードオフ」）。
+
+保留の結果、サイドバー top-level は `Components / Features / Foundations / Patterns` のままで、
+**所有境界が読めない**状態になっていた。とくに第二階層 category の精緻化により、共有資産と
+app 固有 component が同じ `Components/<Category>/` に混在した：
+
+- `Components/Inputs/Input`（`packages/components`）と `Components/Inputs/MiniCalendar`（`apps/product`）が同居
+- `Components/Display/Avatar`（shared）と `Components/Display/LabeledRow`（product）が同居
+
+サイドバー上で「どの package / app の資産か」が判別できない。
+
+## 決定
+
+Storybook の **top-level を所有境界（package / app）**で分ける。第二階層以下は現状維持。
+
+| top-level   | 実体           | 第二階層                                                  |
+| ----------- | -------------- | --------------------------------------------------------- |
+| `Shared/*`  | `packages/*`   | `Foundations` / `Components`（責務9category）/ `Patterns` |
+| `Product/*` | `apps/product` | `Components` / `Features` / `Emails`                      |
+| `Web/*`     | `apps/web`     | `Components` / `Sections` / `Pages`（予約のみ）           |
+
+- `title:` の再整列は **物理ディレクトリ基準**で機械適用する（shared と product が同じ
+  `Components/` prefix を共有するため、prefix 一致では分離できない）。
+- `apps/storybook/.storybook/preview.tsx` の `storySort.order` を新 top-level に更新。
+  `Shared/Components` 直下は ADR-012 の責務 9 category 順を維持する。
+- `apps/web` は story 未作成のため、`main.ts` の glob 追加 + `Web/Overview`（`apps/web/src/Web.docs.mdx`）
+  placeholder + storySort 枠で**構造だけ予約**する。
+
+## 詳細
+
+### 物理位置と title の対応（移行ルール）
+
+| 物理位置                                     | 旧 title prefix             | 新 title prefix                             |
+| -------------------------------------------- | --------------------------- | ------------------------------------------- |
+| `packages/components/src/**`                 | `Components/`               | `Shared/Components/`                        |
+| `packages/foundations/src/**`                | `Foundations`               | `Shared/Foundations`                        |
+| `apps/storybook/.storybook/stories/patterns` | `Patterns/`                 | `Shared/Patterns/`                          |
+| `apps/product/src/components/**`             | `Components/`               | `Product/Components/`                       |
+| `apps/product/src/features/**`               | `Features/` / `Components/` | `Product/Features/` / `Product/Components/` |
+| `apps/product/src/emails`                    | `Patterns/Email`            | `Product/Emails`                            |
+
+### 例外
+
+- `Foundations/States` は token doc だが物理的には `apps/product/src/lib/styles/tokens/` に在る。
+  サイドバーの一貫性を優先し `Shared/Foundations/States` に揃える（title と物理位置の軽微な
+  不一致を許容。将来 `packages/foundations` へ移設する余地あり）。
+- `apps/product` 内で `Components/` を名乗っていた straggler（`ColorPaletteMenuItems` /
+  `Props Inventory` / app-shell の `BottomTabBar`）は `Product/Components/` に寄せた。
+
+## 結果
+
+### メリット
+
+- サイドバー top-level から所有境界（package = `Shared` / app = `Product`・`Web`）が一目で読める
+- `Shared = packages` がツリー上で自明になり、混在していた共有 / app 固有 component が分離された
+- 1 つの Storybook で全レイヤを横断しつつ責務が分かれる
+
+### トレードオフ
+
+- title は依然 ADR-012 同様に物理 path と decouple（位置を動かさず top-level だけ付け替える方式）。
+  `Foundations/States` のような軽微な title↔位置の不一致が残る
+- `Web/*` は当面 `Web/Overview` 1 枚のみ（個別 story は今後追加）
+
+## 関連
+
+- ADR-011 — 共有レイヤー（packages canonical / app 直接 import）
+- ADR-012 — 共有 component の責務ベース 9 category（第二階層）。本 ADR はその保留事項
+  （story title 再整列）を top-level の所有境界軸で確定する
+- `apps/storybook/.storybook/preview.tsx` — `storySort.order`
+- `apps/web/src/Web.docs.mdx` — Web レイヤーの予約と命名規約

--- a/docs/architecture/adr/index.md
+++ b/docs/architecture/adr/index.md
@@ -20,6 +20,7 @@ Dayoptプロジェクトの主要な設計判断を文書化した記録。
 | [ADR-010](010-soft-delete-model.md)                       | entries の論理削除（soft delete）                                        | 2026-03-18 | accepted   |
 | [ADR-011](011-shared-packages-canonical-and-app-shims.md) | デザインシステム共有レイヤー（packages を canonical、app は直接 import） | 2026-06-22 | accepted   |
 | [ADR-012](012-component-taxonomy.md)                      | 共有 component の責務ベース taxonomy（第二階層）                         | 2026-06-23 | accepted   |
+| [ADR-013](013-storybook-ownership-taxonomy.md)            | Storybook story-title の所有境界 top-level（Shared / Product / Web）     | 2026-06-24 | accepted   |
 
 ---
 

--- a/docs/architecture/product-overview.md
+++ b/docs/architecture/product-overview.md
@@ -148,10 +148,10 @@ end
 
 ## 次に読むべきドキュメント
 
-| ドキュメント                                | 内容                          |
-| ------------------------------------------- | ----------------------------- |
-| [Domain Glossary](./domain-glossary.md)     | ドメイン用語の定義            |
-| [Data Flow](./data-flow.md)                 | データの流れ（UI → API → DB） |
-| [ADR-001](./adr/001-unified-block-model.md) | Entry統合モデルの設計判断     |
-| [State Management](./state-management.md)   | 状態管理の使い分け            |
-| Colors（Storybook: Foundations/Colors）     | デザイントークン              |
+| ドキュメント                                   | 内容                          |
+| ---------------------------------------------- | ----------------------------- |
+| [Domain Glossary](./domain-glossary.md)        | ドメイン用語の定義            |
+| [Data Flow](./data-flow.md)                    | データの流れ（UI → API → DB） |
+| [ADR-001](./adr/001-unified-block-model.md)    | Entry統合モデルの設計判断     |
+| [State Management](./state-management.md)      | 状態管理の使い分け            |
+| Colors（Storybook: Shared/Foundations/Colors） | デザイントークン              |

--- a/docs/architecture/storybook-glossary.md
+++ b/docs/architecture/storybook-glossary.md
@@ -23,7 +23,7 @@ Storybook 8 の構成要素を公式用語に基づいて整理したリファ�
 
 ```tsx
 const meta = {
-  title: 'Components/UI/Button', // Sidebar上のパス
+  title: 'Shared/Components/Actions/Button', // Sidebar上のパス
   component: Button, // 対象コンポーネント
   tags: ['autodocs'], // 自動ドキュメント生成
   argTypes: {
@@ -90,15 +90,15 @@ export const Destructive: Story = {
 └──────────┴──────────────────────────────────────┘
 ```
 
-| パーツ             | 説明                                                                                                                                                                               |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Sidebar**        | 左側の Story ツリー。Meta の `title` 階層（例: `Components/UI/Button`）で構成される。Dayopt では `storySort` で `Docs > Foundations > UI > Features > Patterns` の順に並べている。 |
-| **Canvas**         | Story を描画するメインエリア。1 つの Story を単独で表示する。                                                                                                                      |
-| **Docs page**      | `tags: ['autodocs']` で自動生成されるドキュメントページ。コンポーネントの全 Story と props テーブルを一覧表示する。Dayopt では `DocsTemplate` でページレイアウトをカスタム。       |
-| **Controls panel** | ArgTypes に基づくインタラクティブな props 操作パネル。Story の Args をリアルタイムに変更できる。                                                                                   |
-| **Actions panel**  | イベントハンドラ（`onClick`, `onChange` 等）の呼び出しログを表示するパネル。                                                                                                       |
-| **Toolbar**        | 上部バー。GlobalTypes で定義したツールを配置する。Dayopt ではテーマ切替（Light / Dark）を設定。                                                                                    |
-| **Addons panel**   | 下部のタブ切替パネル。Controls, Actions, A11y などの addon が表示される。                                                                                                          |
+| パーツ             | 説明                                                                                                                                                                                                                                                                   |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Sidebar**        | 左側の Story ツリー。Meta の `title` 階層（例: `Shared/Components/Actions/Button`）で構成される。Dayopt では top-level を所有境界で分け（ADR-013）、`Welcome > Shared(Foundations/Components/Patterns) > Product(Components/Features/Emails) > Web` の順に並べている。 |
+| **Canvas**         | Story を描画するメインエリア。1 つの Story を単独で表示する。                                                                                                                                                                                                          |
+| **Docs page**      | `tags: ['autodocs']` で自動生成されるドキュメントページ。コンポーネントの全 Story と props テーブルを一覧表示する。Dayopt では `DocsTemplate` でページレイアウトをカスタム。                                                                                           |
+| **Controls panel** | ArgTypes に基づくインタラクティブな props 操作パネル。Story の Args をリアルタイムに変更できる。                                                                                                                                                                       |
+| **Actions panel**  | イベントハンドラ（`onClick`, `onChange` 等）の呼び出しログを表示するパネル。                                                                                                                                                                                           |
+| **Toolbar**        | 上部バー。GlobalTypes で定義したツールを配置する。Dayopt ではテーマ切替（Light / Dark）を設定。                                                                                                                                                                        |
+| **Addons panel**   | 下部のタブ切替パネル。Controls, Actions, A11y などの addon が表示される。                                                                                                                                                                                              |
 
 ---
 

--- a/docs/architecture/storybook-guide.md
+++ b/docs/architecture/storybook-guide.md
@@ -84,7 +84,7 @@ AllPatterns も同様に、コンポーネントを `flex-col gap-6` で並べ�
 
 **Docs** — テーブルが必要なら MDX（`.docs.mdx`）で作成。不要なら `tags: ['autodocs']` + JSDoc で十分。
 
-公式テンプレート: `Components/UI/AlertDialog`
+公式テンプレート: `Shared/Components/Overlays/AlertDialog`
 
 ## 🛠️ 開発者向け
 
@@ -103,8 +103,8 @@ src/components/ui/my-component.docs.mdx        # Docs（テーブルが必要な
 
 ### 命名規則
 
-- `Foundations/Colors` → デザイントークン
-- `Components/UI/Button` → 単体UIコンポーネント
+- `Shared/Foundations/Colors` → デザイントークン
+- `Shared/Components/Actions/Button` → 単体UIコンポーネント
 - `Features/Navigation/AppHeader` → ナビゲーションコンポーネント
 - `Features/Entry/Inspector/EntryInspector` → Featureコンポーネント
 - `Docs/はじめに` → ドキュメント
@@ -151,6 +151,6 @@ Story作成時に確認：
 | 4    | [Packages Overview](./packages-overview.md)     | monorepo packages の責務境界と token 移行方針  |
 | 5    | [Data Flow](./data-flow.md)                     | UI → tRPC → Supabase のデータの流れ            |
 | 6    | [Common Pitfalls](../guides/common-pitfalls.md) | よくある間違いと正しいパターン                 |
-| 7    | Colors（Storybook: Foundations/Colors）         | カラートークン、Surface体系                    |
+| 7    | Colors（Storybook: Shared/Foundations/Colors）  | カラートークン、Surface体系                    |
 | 8    | Typography（Storybook: Foundations/Typography） | フォントサイズ、行間、ウェイト                 |
 | 9    | [Accessibility](./accessibility/overview.md)    | a11yチェックリスト、WCAG準拠                   |

--- a/docs/guides/eagle-asset-management.md
+++ b/docs/guides/eagle-asset-management.md
@@ -96,7 +96,7 @@ Dayopt Design/
 #### パスセグメント（自動付与）
 
 Storybook タイトルの階層がそのままタグになる。
-例: `Components/UI/Button` → `components`, `ui`, `button`
+例: `Shared/Components/Actions/Button` → `components`, `ui`, `button`
 
 #### デザイン要素（任意・手動）
 
@@ -121,7 +121,7 @@ Storybook タイトルの階層がそのままタグになる。
 Storybook タイトル階層とバリアント名からタグを自動生成する。
 
 ```
-Storybook title: Components/UI/Button
+Storybook title: Shared/Components/Actions/Button
 Story name: AllPatterns
 ファイル名: Components_UI_Button--AllPatterns_dark_mobile.png
 
@@ -257,19 +257,19 @@ Eagle MCP → `get_item_info` → メモからパスを抽出して応答でき�
 
 ### 5.2 ルール（Storybook カテゴリ準拠）
 
-| カテゴリ                        | mobile | desktop | 理由                             |
-| ------------------------------- | ------ | ------- | -------------------------------- |
-| Features/Calendar/Views/        | ✓      | ✓       | Day/Week/Grid のページレイアウト |
-| Features/Settings/              | ✓      | ✓       | 設定画面各種                     |
-| Features/Stats/                 | ✓      | ✓       | 統計タブ各種                     |
-| Features/Auth/                  | ✓      | ✓       | 認証画面                         |
-| Features/Onboarding/            | ✓      | ✓       | オンボーディング                 |
-| Components/Shell/Sidebar/       | ✓      | ✓       | デスクトップでレイアウト変化     |
-| Components/UI/                  | ✓      | -       | プリミティブ（差分小）           |
-| Components/Common/              | ✓      | -       | ユーティリティ                   |
-| Components/Shell/ (Sidebar以外) | ✓      | -       | BottomTabBar, AppHeader          |
-| Foundations/                    | ✓      | -       | デザイントークン                 |
-| その他 Feature コンポーネント   | ✓      | -       | 個別UIパーツ                     |
+| カテゴリ                                | mobile | desktop | 理由                             |
+| --------------------------------------- | ------ | ------- | -------------------------------- |
+| Features/Calendar/Views/                | ✓      | ✓       | Day/Week/Grid のページレイアウト |
+| Features/Settings/                      | ✓      | ✓       | 設定画面各種                     |
+| Features/Stats/                         | ✓      | ✓       | 統計タブ各種                     |
+| Features/Auth/                          | ✓      | ✓       | 認証画面                         |
+| Features/Onboarding/                    | ✓      | ✓       | オンボーディング                 |
+| Product/Components/Shell/Sidebar/       | ✓      | ✓       | デスクトップでレイアウト変化     |
+| Shared/Components/                      | ✓      | -       | プリミティブ（差分小）           |
+| Product/Components/                     | ✓      | -       | ユーティリティ                   |
+| Product/Components/Shell/ (Sidebar以外) | ✓      | -       | BottomTabBar, AppHeader          |
+| Foundations/                            | ✓      | -       | デザイントークン                 |
+| その他 Feature コンポーネント           | ✓      | -       | 個別UIパーツ                     |
 
 フォルダは分けず、タグ（`mobile` / `desktop`）で管理。
 

--- a/packages/components/src/actions/action-footer.stories.tsx
+++ b/packages/components/src/actions/action-footer.stories.tsx
@@ -20,7 +20,7 @@ import { ActionFooter } from '@dayopt/components';
  * | Sheet / Drawer | `ActionFooter`（このコンポーネント） |
  */
 const meta = {
-  title: 'Components/Actions/ActionFooter',
+  title: 'Shared/Components/Actions/ActionFooter',
   component: ActionFooter,
   tags: ['autodocs'],
   parameters: {

--- a/packages/components/src/actions/button.stories.tsx
+++ b/packages/components/src/actions/button.stories.tsx
@@ -4,7 +4,7 @@ import { ChevronLeft, ChevronRight, Plus, Settings, Trash2, X } from 'lucide-rea
 import { Button } from '@dayopt/components';
 
 const meta = {
-  title: 'Components/Actions/Button',
+  title: 'Shared/Components/Actions/Button',
   component: Button,
   parameters: { layout: 'fullscreen' },
   tags: ['autodocs'],

--- a/packages/components/src/actions/dropdown-menu.stories.tsx
+++ b/packages/components/src/actions/dropdown-menu.stories.tsx
@@ -32,7 +32,7 @@ import {
 
 /** DropdownMenu - ドロップダウンメニュー。ラベル使用ルールはGAFA準拠（Material Design 3, Apple HIG）。 */
 const meta = {
-  title: 'Components/Actions/DropdownMenu',
+  title: 'Shared/Components/Actions/DropdownMenu',
   component: DropdownMenu,
   tags: ['autodocs'],
   parameters: { layout: 'fullscreen' },

--- a/packages/components/src/display/avatar.stories.tsx
+++ b/packages/components/src/display/avatar.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Avatar, AvatarFallback, AvatarImage } from '@dayopt/components';
 
 const meta = {
-  title: 'Components/Display/Avatar',
+  title: 'Shared/Components/Display/Avatar',
   component: Avatar,
   tags: ['autodocs'],
   parameters: { layout: 'centered' },

--- a/packages/components/src/display/badge.stories.tsx
+++ b/packages/components/src/display/badge.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Badge } from '@dayopt/components';
 
 const meta = {
-  title: 'Components/Display/Badge',
+  title: 'Shared/Components/Display/Badge',
   component: Badge,
   parameters: { layout: 'fullscreen' },
   tags: ['autodocs'],

--- a/packages/components/src/display/card.stories.tsx
+++ b/packages/components/src/display/card.stories.tsx
@@ -16,7 +16,7 @@ import {
 } from '@dayopt/components';
 
 const meta = {
-  title: 'Components/Display/Card',
+  title: 'Shared/Components/Display/Card',
   component: Card,
   tags: ['autodocs'],
   parameters: {

--- a/packages/components/src/feedback/inline-banner.stories.tsx
+++ b/packages/components/src/feedback/inline-banner.stories.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { Button, InlineBanner } from '@dayopt/components';
 
 const meta = {
-  title: 'Components/Feedback/InlineBanner',
+  title: 'Shared/Components/Feedback/InlineBanner',
   component: InlineBanner,
   tags: ['autodocs'],
   parameters: {

--- a/packages/components/src/feedback/skeleton.stories.tsx
+++ b/packages/components/src/feedback/skeleton.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Card, CardContent, CardHeader, Skeleton } from '@dayopt/components';
 
 const meta = {
-  title: 'Components/Feedback/Skeleton',
+  title: 'Shared/Components/Feedback/Skeleton',
   component: Skeleton,
   tags: ['autodocs'],
   parameters: {

--- a/packages/components/src/feedback/spinner.stories.tsx
+++ b/packages/components/src/feedback/spinner.stories.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { Button, Spinner } from '@dayopt/components';
 
 const meta = {
-  title: 'Components/Feedback/Spinner',
+  title: 'Shared/Components/Feedback/Spinner',
   component: Spinner,
   tags: ['autodocs'],
   parameters: {

--- a/packages/components/src/inputs/checkbox.stories.tsx
+++ b/packages/components/src/inputs/checkbox.stories.tsx
@@ -8,7 +8,7 @@ import { Checkbox, Label } from '@dayopt/components';
 const greenCssVar = 'var(--tag-green)';
 
 const meta = {
-  title: 'Components/Inputs/Checkbox',
+  title: 'Shared/Components/Inputs/Checkbox',
   component: Checkbox,
   tags: ['autodocs'],
   parameters: { layout: 'fullscreen' },

--- a/packages/components/src/inputs/field.stories.tsx
+++ b/packages/components/src/inputs/field.stories.tsx
@@ -12,7 +12,7 @@ import {
 } from '@dayopt/components';
 
 const meta = {
-  title: 'Components/Inputs/Field',
+  title: 'Shared/Components/Inputs/Field',
   component: FieldLabel,
   tags: ['autodocs'],
   parameters: {

--- a/packages/components/src/inputs/input-otp.stories.tsx
+++ b/packages/components/src/inputs/input-otp.stories.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { InputOTP, InputOTPGroup, InputOTPSlot } from '@dayopt/components';
 
 const meta = {
-  title: 'Components/Inputs/InputOTP',
+  title: 'Shared/Components/Inputs/InputOTP',
   tags: ['autodocs'],
   parameters: {
     layout: 'fullscreen',

--- a/packages/components/src/inputs/input.stories.tsx
+++ b/packages/components/src/inputs/input.stories.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { Field, FieldError, FieldLabel, Input } from '@dayopt/components';
 
 const meta = {
-  title: 'Components/Inputs/Input',
+  title: 'Shared/Components/Inputs/Input',
   component: Input,
   tags: ['autodocs'],
   parameters: {

--- a/packages/components/src/inputs/label.stories.tsx
+++ b/packages/components/src/inputs/label.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Checkbox, Input, Label } from '@dayopt/components';
 
 const meta = {
-  title: 'Components/Inputs/Label',
+  title: 'Shared/Components/Inputs/Label',
   component: Label,
   tags: ['autodocs'],
   parameters: { layout: 'fullscreen' },

--- a/packages/components/src/inputs/radio-group.stories.tsx
+++ b/packages/components/src/inputs/radio-group.stories.tsx
@@ -5,7 +5,7 @@ import { Label, RadioGroup, RadioGroupItem } from '@dayopt/components';
 
 /** RadioGroup - ラジオボタングループ（単一選択）。2-4個の選択肢に適切、5個以上はSelectを使用。 */
 const meta = {
-  title: 'Components/Inputs/RadioGroup',
+  title: 'Shared/Components/Inputs/RadioGroup',
   component: RadioGroup,
   tags: ['autodocs'],
   parameters: {

--- a/packages/components/src/inputs/select.stories.tsx
+++ b/packages/components/src/inputs/select.stories.tsx
@@ -6,7 +6,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 
 /** Select - ドロップダウン選択。5個以上の選択肢に適切、2-4個はRadioGroupを使用。 */
 const meta = {
-  title: 'Components/Inputs/Select',
+  title: 'Shared/Components/Inputs/Select',
   component: Select,
   tags: ['autodocs'],
   parameters: { layout: 'fullscreen' },

--- a/packages/components/src/inputs/switch.stories.tsx
+++ b/packages/components/src/inputs/switch.stories.tsx
@@ -6,7 +6,7 @@ import { Label, Switch } from '@dayopt/components';
 
 /** Switch - トグルスイッチ（ON/OFF切替）。即座に反映される設定に使用、フォーム送信後に反映する場合はCheckboxを使用。 */
 const meta = {
-  title: 'Components/Inputs/Switch',
+  title: 'Shared/Components/Inputs/Switch',
   component: Switch,
   tags: ['autodocs'],
   parameters: { layout: 'fullscreen' },

--- a/packages/components/src/inputs/textarea.stories.tsx
+++ b/packages/components/src/inputs/textarea.stories.tsx
@@ -5,7 +5,7 @@ import { Textarea } from '@dayopt/components';
 
 /** Textarea - 複数行テキスト入力。改行や長文が必要な場面で使用、単一行はInputを使用。 */
 const meta = {
-  title: 'Components/Inputs/Textarea',
+  title: 'Shared/Components/Inputs/Textarea',
   component: Textarea,
   tags: ['autodocs'],
   parameters: { layout: 'fullscreen' },

--- a/packages/components/src/layout/collapsible.stories.tsx
+++ b/packages/components/src/layout/collapsible.stories.tsx
@@ -4,7 +4,7 @@ import { ChevronDown, ChevronRight, Clock } from 'lucide-react';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@dayopt/components';
 
 const meta = {
-  title: 'Components/Layout/Collapsible',
+  title: 'Shared/Components/Layout/Collapsible',
   component: Collapsible,
   tags: ['autodocs'],
   parameters: {

--- a/packages/components/src/layout/scroll-area.stories.tsx
+++ b/packages/components/src/layout/scroll-area.stories.tsx
@@ -4,7 +4,7 @@ import { ScrollArea, ScrollBar, Separator } from '@dayopt/components';
 
 /** ScrollArea - カスタムスクロールエリア */
 const meta = {
-  title: 'Components/Layout/ScrollArea',
+  title: 'Shared/Components/Layout/ScrollArea',
   component: ScrollArea,
   tags: ['autodocs'],
   parameters: {

--- a/packages/components/src/layout/separator.stories.tsx
+++ b/packages/components/src/layout/separator.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Separator } from '@dayopt/components';
 
 const meta = {
-  title: 'Components/Layout/Separator',
+  title: 'Shared/Components/Layout/Separator',
   component: Separator,
   tags: ['autodocs'],
   parameters: {

--- a/packages/components/src/navigation/tabs.stories.tsx
+++ b/packages/components/src/navigation/tabs.stories.tsx
@@ -4,7 +4,7 @@ import { expect, userEvent, within } from 'storybook/test';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@dayopt/components';
 
 const meta = {
-  title: 'Components/Navigation/Tabs',
+  title: 'Shared/Components/Navigation/Tabs',
   component: Tabs,
   tags: ['autodocs'],
   parameters: {

--- a/packages/components/src/overlays/alert-dialog.stories.tsx
+++ b/packages/components/src/overlays/alert-dialog.stories.tsx
@@ -18,7 +18,7 @@ import {
 } from '@dayopt/components';
 
 const meta = {
-  title: 'Components/Overlays/AlertDialog',
+  title: 'Shared/Components/Overlays/AlertDialog',
   component: AlertDialog,
   tags: [],
   parameters: {

--- a/packages/components/src/overlays/dialog.stories.tsx
+++ b/packages/components/src/overlays/dialog.stories.tsx
@@ -29,7 +29,7 @@ import {
  * **原則**: スクロールが発生しうるモーダル → 閉じるボタンあり、小さい確認ダイアログ → なし
  */
 const meta = {
-  title: 'Components/Overlays/Dialog',
+  title: 'Shared/Components/Overlays/Dialog',
   component: Dialog,
   tags: ['autodocs'],
   parameters: {

--- a/packages/components/src/overlays/drawer.stories.tsx
+++ b/packages/components/src/overlays/drawer.stories.tsx
@@ -16,7 +16,7 @@ import {
 } from '@dayopt/components';
 
 const meta = {
-  title: 'Components/Overlays/Drawer',
+  title: 'Shared/Components/Overlays/Drawer',
   component: Drawer,
   tags: ['autodocs'],
   parameters: {

--- a/packages/components/src/overlays/popover.stories.tsx
+++ b/packages/components/src/overlays/popover.stories.tsx
@@ -14,7 +14,7 @@ import {
 
 /** Popover - ポップオーバー。PopoverTrigger（ボタン開閉）とPopoverAnchor（Input開閉）の2パターンを提供。 */
 const meta = {
-  title: 'Components/Overlays/Popover',
+  title: 'Shared/Components/Overlays/Popover',
   component: Popover,
   tags: ['autodocs'],
   parameters: { layout: 'fullscreen' },

--- a/packages/components/src/overlays/sheet.stories.tsx
+++ b/packages/components/src/overlays/sheet.stories.tsx
@@ -19,7 +19,7 @@ import { Button, Sheet, SheetContent, SheetHeader, SheetTitle } from '@dayopt/co
  * フルスクリーン Sheet は `showCloseButton={false}` にして、ヘッダー内にカスタム閉じるボタンを配置する。
  */
 const meta = {
-  title: 'Components/Overlays/Sheet',
+  title: 'Shared/Components/Overlays/Sheet',
   component: Sheet,
   tags: ['autodocs'],
   parameters: {

--- a/packages/components/src/overlays/tooltip.stories.tsx
+++ b/packages/components/src/overlays/tooltip.stories.tsx
@@ -5,7 +5,7 @@ import { expect, within } from 'storybook/test';
 import { Button, HoverTooltip } from '@dayopt/components';
 
 const meta = {
-  title: 'Components/Overlays/Tooltip',
+  title: 'Shared/Components/Overlays/Tooltip',
   component: HoverTooltip,
   tags: ['autodocs'],
   parameters: {

--- a/packages/foundations/src/tokens/Colors.mdx
+++ b/packages/foundations/src/tokens/Colors.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Foundations/Colors" />
+<Meta title="Shared/Foundations/Colors" />
 
 # カラートークン
 

--- a/packages/foundations/src/tokens/Colors.stories.tsx
+++ b/packages/foundations/src/tokens/Colors.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
 const meta = {
-  title: 'Foundations/Colors',
+  title: 'Shared/Foundations/Colors',
   parameters: {
     layout: 'fullscreen',
   },

--- a/packages/foundations/src/tokens/Elevation.mdx
+++ b/packages/foundations/src/tokens/Elevation.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Foundations/Elevation" />
+<Meta title="Shared/Foundations/Elevation" />
 
 # Elevation（高さ）
 

--- a/packages/foundations/src/tokens/Elevation.stories.tsx
+++ b/packages/foundations/src/tokens/Elevation.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
 const meta = {
-  title: 'Foundations/Elevation',
+  title: 'Shared/Foundations/Elevation',
   parameters: {
     layout: 'fullscreen',
   },

--- a/packages/foundations/src/tokens/IconConventions.mdx
+++ b/packages/foundations/src/tokens/IconConventions.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Foundations/Icons/Docs" />
+<Meta title="Shared/Foundations/Icons/Docs" />
 
 # Icon Conventions
 

--- a/packages/foundations/src/tokens/Icons.stories.tsx
+++ b/packages/foundations/src/tokens/Icons.stories.tsx
@@ -71,7 +71,7 @@ import {
 } from 'lucide-react';
 
 const meta = {
-  title: 'Foundations/Icons',
+  title: 'Shared/Foundations/Icons',
   parameters: {
     layout: 'fullscreen',
   },

--- a/packages/foundations/src/tokens/Motion.stories.tsx
+++ b/packages/foundations/src/tokens/Motion.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { useCallback, useState } from 'react';
 
 const meta = {
-  title: 'Foundations/Motion',
+  title: 'Shared/Foundations/Motion',
   parameters: {
     layout: 'fullscreen',
   },

--- a/packages/foundations/src/tokens/Overview.stories.tsx
+++ b/packages/foundations/src/tokens/Overview.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
 const meta = {
-  title: 'Foundations',
+  title: 'Shared/Foundations',
   parameters: {
     layout: 'fullscreen',
   },

--- a/packages/foundations/src/tokens/Radius.mdx
+++ b/packages/foundations/src/tokens/Radius.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Foundations/Radius" />
+<Meta title="Shared/Foundations/Radius" />
 
 # Border Radius（角丸）
 

--- a/packages/foundations/src/tokens/Radius.stories.tsx
+++ b/packages/foundations/src/tokens/Radius.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
 const meta = {
-  title: 'Foundations/Radius',
+  title: 'Shared/Foundations/Radius',
   parameters: {
     layout: 'fullscreen',
   },

--- a/packages/foundations/src/tokens/Responsive.mdx
+++ b/packages/foundations/src/tokens/Responsive.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Foundations/Responsive" />
+<Meta title="Shared/Foundations/Responsive" />
 
 # Responsive
 

--- a/packages/foundations/src/tokens/Responsive.stories.tsx
+++ b/packages/foundations/src/tokens/Responsive.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { CheckCircle, XCircle } from 'lucide-react';
 
 const meta = {
-  title: 'Foundations/Responsive',
+  title: 'Shared/Foundations/Responsive',
   parameters: {
     layout: 'fullscreen',
   },

--- a/packages/foundations/src/tokens/Spacing.mdx
+++ b/packages/foundations/src/tokens/Spacing.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Foundations/Spacing" />
+<Meta title="Shared/Foundations/Spacing" />
 
 # Spacing（余白）
 

--- a/packages/foundations/src/tokens/Spacing.stories.tsx
+++ b/packages/foundations/src/tokens/Spacing.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
 const meta = {
-  title: 'Foundations/Spacing',
+  title: 'Shared/Foundations/Spacing',
   parameters: {
     layout: 'fullscreen',
   },

--- a/packages/foundations/src/tokens/Typography.mdx
+++ b/packages/foundations/src/tokens/Typography.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Foundations/Typography" />
+<Meta title="Shared/Foundations/Typography" />
 
 # Typography
 

--- a/packages/foundations/src/tokens/Typography.stories.tsx
+++ b/packages/foundations/src/tokens/Typography.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
 const meta = {
-  title: 'Foundations/Typography',
+  title: 'Shared/Foundations/Typography',
   parameters: {
     layout: 'fullscreen',
   },

--- a/packages/foundations/src/tokens/ZIndex.mdx
+++ b/packages/foundations/src/tokens/ZIndex.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Foundations/ZIndex" />
+<Meta title="Shared/Foundations/ZIndex" />
 
 # Z-Index レイヤー
 

--- a/packages/foundations/src/tokens/ZIndex.stories.tsx
+++ b/packages/foundations/src/tokens/ZIndex.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
 const meta = {
-  title: 'Foundations/ZIndex',
+  title: 'Shared/Foundations/ZIndex',
   parameters: {
     layout: 'fullscreen',
   },


### PR DESCRIPTION
## 背景

ADR-011 / ADR-012 で共有 UI を `packages/components` に canonical 集約し責務ベース 9 category に
切り直したが、**story title の再整列は ADR-012 が「別途の cosmetic 作業」として保留**していた。
その結果サイドバー top-level は `Components / Features / Foundations / Patterns` のままで、
**共有資産（packages）と app 固有 component が同じ `Components/<Category>/` に混在**し、所有境界が
読めない状態だった（例: `Components/Inputs/Input`〔package〕と `Components/Inputs/MiniCalendar`〔product〕）。

本 PR はその保留事項を **所有境界（package / app）の top-level** で確定する（ADR-013）。

## 変更内容

サイドバー top-level を所有境界で再編:

| top-level   | 第二階層                                              | 実体           |
| ----------- | ----------------------------------------------------- | -------------- |
| `Shared/*`  | Foundations / Components（責務9cat）/ Patterns        | `packages/*`   |
| `Product/*` | Components / Features / Patterns / Emails              | `apps/product` |
| `Web/*`     | Overview（Components / Sections / Pages を予約）       | `apps/web`     |

- **story title 再整列**: 物理ディレクトリ基準で `Shared / Product / Web` に振り分け（title 文字列のみ、描画は不変）。mock-data の `title` プロパティは prefix 非該当で無傷
- **Patterns の依存ベース分割**: `@/`（product 内部）に依存する 6 件（Confirmation / Copywriting / EmptyStates / ErrorStates / Feedback / Security）を `Product/Patterns` へ、`@dayopt/components` だけで再現できる 6 件（Actions / Cards / ErrorPages / Forms / Loading / Selection）を `Shared/Patterns` に
- **storySort 更新**: `Shared/Components` 直下は ADR-012 の責務 9 category 順を維持
- **Web レイヤー予約**: `main.ts` に `apps/web` glob 追加 + `Web/Overview`（命名規約・構造意図を記載、個別 story は今後）
- **ADR-013 追加** + storybook skill / reference docs の旧 prefix 追従

## コミット

1. `refactor(storybook): story title を所有境界 top-level（Shared/Product/Web）に再整列`
2. `chore(storybook): storySort を所有境界階層に更新し Web レイヤーを予約`
3. `docs(storybook): 所有境界 taxonomy を ADR-013 に記録し参照を追従`
4. `refactor(storybook): product 結合 pattern を Product/Patterns に分離`
5. `docs(storybook): web レイヤーの構造意図を Web/Overview に記載`

## 検証

- ✅ `pnpm typecheck`
- ✅ `pnpm lint`
- ✅ `pnpm lint:boundaries`（`packages → product` 逆流なし・0 violation）
- ⬜ Storybook 視覚確認（tree が Shared / Product / Web の 3 top-level になること）— レビュー時に確認

## 補足

- `Foundations/States`（物理は product の token doc）は一貫性優先で `Shared/Foundations/States` に揃えた（title↔位置の軽微な decouple、ADR-013 に明記）
- 物理ファイルは移動せず title のみ付け替え（ADR-011/012 の移動済み構造を尊重）

🤖 Generated with [Claude Code](https://claude.com/claude-code)