### PR TITLE
chore(storybook): story title taxonomy ガードレールを導入

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
       - name: i18n integrity
         run: pnpm lint:i18n
 
+      - name: Story taxonomy
+        run: pnpm storybook:taxonomy
+
       - name: Dead code check
         run: |
           set +e

--- a/docs/architecture/storybook-guide.md
+++ b/docs/architecture/storybook-guide.md
@@ -101,13 +101,35 @@ src/components/ui/my-component.stories.tsx     # Story（Canvas）
 src/components/ui/my-component.docs.mdx        # Docs（テーブルが必要な場合のみ）
 ```
 
-### 命名規則
+### 命名規則（所有境界 taxonomy）
+
+story の `title:` の **top-level は所有境界（どの package / app の資産か）** で分ける。第二階層以下は責務ベース。決定の経緯は [ADR-013](./adr/013-storybook-ownership-taxonomy.md)。
 
 - `Shared/Foundations/Colors` → デザイントークン
-- `Shared/Components/Actions/Button` → 単体UIコンポーネント
-- `Features/Navigation/AppHeader` → ナビゲーションコンポーネント
-- `Features/Entry/Inspector/EntryInspector` → Featureコンポーネント
-- `Docs/はじめに` → ドキュメント
+- `Shared/Components/Actions/Button` → 共有 UI コンポーネント（`packages/components`）
+- `Product/Features/Navigation/AppHeader` → product のナビゲーションコンポーネント
+- `Product/Features/Entry/Inspector/EntryInspector` → product の Feature コンポーネント
+- `Web/Sections/Pricing` → web LP のセクション（現状は構造予約のみ）
+- `Docs/はじめに` → ドキュメント（top-level doc は所有境界の外）
+
+#### title prefix は物理位置で決まる
+
+新規 story の prefix は「ファイルがどこに在るか」で機械的に決まる。下表に従う。
+
+| 物理位置                                     | title prefix                                                |
+| -------------------------------------------- | ----------------------------------------------------------- |
+| `packages/components/src/**`                 | `Shared/Components/`                                        |
+| `packages/foundations/src/**`                | `Shared/Foundations/`                                       |
+| `apps/storybook/.storybook/stories/patterns` | `Shared/Patterns/` または `Product/Patterns/`（依存ベース） |
+| `apps/product/src/components/**`             | `Product/Components/`                                       |
+| `apps/product/src/features/**`               | `Product/Features/`（一部 `Product/Components/`）           |
+| `apps/product/src/emails/**`                 | `Product/Emails`                                            |
+| `apps/web/src/**`                            | `Web/`                                                      |
+
+- **Patterns の依存ベース分離**: import が `@/`（product 内部）に依存 → `Product/Patterns/`。`@dayopt/components` だけに依存 → `Shared/Patterns/`。
+- **例外**: `apps/product/src/lib/styles/tokens/**` の token doc はサイドバー一貫性を優先し `Shared/Foundations/States` に揃える（title と物理位置の軽微な不一致を許容）。
+
+このルールは `scripts/check-story-taxonomy.ts` が CI（`pnpm storybook:taxonomy`）で機械検証する。逸脱した title は lint job で hard-fail する。
 
 ### 同期ルール
 

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "security:check": "pnpm --filter @dayopt/product security:check",
     "security:check:production": "pnpm --filter @dayopt/product security:check:production",
     "storybook:coverage": "pnpm --filter @dayopt/product storybook:coverage",
+    "storybook:taxonomy": "tsx scripts/check-story-taxonomy.ts",
     "storybook": "pnpm --filter @dayopt/storybook storybook",
     "build-storybook": "pnpm --filter @dayopt/storybook build",
     "dev:web": "pnpm --filter @dayopt/web dev",

--- a/scripts/check-story-taxonomy.ts
+++ b/scripts/check-story-taxonomy.ts
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/**
+ * Storybook Story Taxonomy チェッカー（ADR-013）
+ *
+ * story の meta title prefix が物理位置（所有境界 Shared / Product / Web）と
+ * 一致するかを検証する。一致しない story が 1 件でもあれば exit 1（hard-fail）。
+ *
+ * 設計上の肝:
+ *   meta title は CSF の `const meta` / `export default` の title のみを抽出する。
+ *   prop / fixture の `title:`（例: defaultLabels.title, CalendarEvent.title）を
+ *   誤検知しないよう、meta 宣言をアンカーにして直後の最初の title を取る。
+ *
+ * 参照: docs/architecture/adr/013-storybook-ownership-taxonomy.md
+ *
+ * Usage:
+ *   npx tsx scripts/check-story-taxonomy.ts
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '..');
+
+// ─────────────────────────────────────────────────────────
+// Config
+// ─────────────────────────────────────────────────────────
+
+/** story / mdx を走査する root ディレクトリ */
+const SCAN_DIRS = [
+  path.join(ROOT, 'packages/components/src'),
+  path.join(ROOT, 'packages/foundations/src'),
+  path.join(ROOT, 'apps/product/src'),
+  path.join(ROOT, 'apps/storybook/.storybook/stories'),
+  path.join(ROOT, 'apps/web/src'),
+];
+
+/**
+ * 物理位置 → 許容 title prefix（ADR-013 の移行ルール表に準拠）。
+ *
+ * 評価は配列の上から順。最初にマッチした rule を採用するため、
+ * より具体的な path（tokens / emails）を product/src より前に置く。
+ * どの rule にもマッチしない story は taxonomy 対象外として skip する
+ * （例: .storybook/stories/docs の Welcome / Glossary など top-level doc）。
+ */
+const TAXONOMY_RULES: { match: string; allowed: string[] }[] = [
+  // 例外: token doc は物理的には product 配下だが Shared/Foundations に揃える
+  { match: 'apps/product/src/lib/styles/tokens', allowed: ['Shared/Foundations'] },
+  { match: 'apps/product/src/emails', allowed: ['Product/Emails'] },
+  // product の component / feature / app-shell。straggler 例外で Components も許容
+  { match: 'apps/product/src', allowed: ['Product/Components', 'Product/Features'] },
+  { match: 'packages/components/src', allowed: ['Shared/Components'] },
+  { match: 'packages/foundations/src', allowed: ['Shared/Foundations'] },
+  // patterns は依存ベースで Shared / Product に分かれる（両方許容）
+  {
+    match: 'apps/storybook/.storybook/stories/patterns',
+    allowed: ['Shared/Patterns', 'Product/Patterns'],
+  },
+  { match: 'apps/web/src', allowed: ['Web'] },
+];
+
+// ─────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────
+
+interface Violation {
+  file: string;
+  actual: string;
+  expected: string[];
+}
+
+// ─────────────────────────────────────────────────────────
+// Collection
+// ─────────────────────────────────────────────────────────
+
+function findStoryFiles(dir: string): string[] {
+  const results: string[] = [];
+  if (!fs.existsSync(dir)) return results;
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory() && entry.name !== 'node_modules' && entry.name !== '.next') {
+      results.push(...findStoryFiles(fullPath));
+    } else if (entry.name.endsWith('.stories.tsx') || entry.name.endsWith('.mdx')) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+// ─────────────────────────────────────────────────────────
+// Title 抽出
+// ─────────────────────────────────────────────────────────
+
+/**
+ * meta title のみを抽出する。
+ * - .mdx: `<Meta title="...">` を取る（title を持たない doc は null）
+ * - .stories.tsx: `const meta` / `export default` をアンカーにし、その直後の
+ *   最初の `title:` を取る。これにより宣言前の fixture / 宣言後の prop を除外する。
+ */
+function extractMetaTitle(file: string, content: string): string | null {
+  if (file.endsWith('.mdx')) {
+    const m = content.match(/<Meta\b[^>]*\btitle\s*=\s*["']([^"']+)["']/);
+    return m ? m[1] : null;
+  }
+
+  const anchor = content.search(/(?:const\s+meta\b|export\s+default\b)/);
+  if (anchor === -1) return null;
+  const m = content.slice(anchor).match(/title\s*:\s*["']([^"']+)["']/);
+  return m ? m[1] : null;
+}
+
+function matchRule(relPath: string): { allowed: string[] } | null {
+  const normalized = relPath.replace(/\\/g, '/');
+  for (const rule of TAXONOMY_RULES) {
+    if (normalized.includes(rule.match)) return rule;
+  }
+  return null;
+}
+
+function isAllowed(title: string, allowed: string[]): boolean {
+  return allowed.some((prefix) => title === prefix || title.startsWith(`${prefix}/`));
+}
+
+// ─────────────────────────────────────────────────────────
+// Main
+// ─────────────────────────────────────────────────────────
+
+function main(): void {
+  const files = SCAN_DIRS.flatMap((dir) => findStoryFiles(dir));
+
+  const violations: Violation[] = [];
+  const noTitle: string[] = [];
+  let checked = 0;
+
+  for (const file of files) {
+    const relPath = path.relative(ROOT, file).replace(/\\/g, '/');
+    const rule = matchRule(relPath);
+    if (!rule) continue; // taxonomy 対象外（top-level doc 等）
+
+    const content = fs.readFileSync(file, 'utf-8');
+    const title = extractMetaTitle(file, content);
+
+    // title を持たない mdx（純 doc）は対象外。stories は meta title 必須なので warn
+    if (title === null) {
+      if (file.endsWith('.stories.tsx')) noTitle.push(relPath);
+      continue;
+    }
+
+    checked++;
+    if (!isAllowed(title, rule.allowed)) {
+      violations.push({ file: relPath, actual: title, expected: rule.allowed });
+    }
+  }
+
+  console.log('\n━━━ Story Taxonomy (ADR-013) ━━━\n');
+  console.log(`Checked: ${checked} stories across ${SCAN_DIRS.length} roots\n`);
+
+  if (noTitle.length > 0) {
+    console.log(`⚠ meta title が抽出できない story (${noTitle.length}):`);
+    for (const f of noTitle) console.log(`  ${f}`);
+    console.log('');
+  }
+
+  if (violations.length === 0) {
+    console.log('✓ All story titles match their ownership boundary.\n');
+    return;
+  }
+
+  console.log(`✗ Taxonomy violations (${violations.length}):\n`);
+  for (const { file, actual, expected } of violations) {
+    console.log(`  ${file}`);
+    console.log(`    actual:   ${actual}`);
+    console.log(`    expected: ${expected.map((e) => `${e}/...`).join(' or ')}`);
+  }
+  console.log('');
+  console.error(
+    `ERROR: ${violations.length} story title(s) violate the ownership taxonomy (ADR-013).`,
+  );
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## 背景

ADR-013（所有境界 top-level: Shared / Product / Web）の実体移行は [#1408](https://github.com/Dayopt/dayopt/pull/1408) で完了済み。一方で title 逸脱を検出する仕組みが無く、新規 story が旧 prefix（`Components/` 等）で復活しても気づけない状態だった。本 PR はそのガードレールと命名ルールの明文化を追加する。

## 変更

- **`scripts/check-story-taxonomy.ts`（新規）**: story の meta title prefix が物理位置（所有境界）と一致するかを検証。違反 1 件で exit 1。
  - meta（`const meta` / `export default`）の title のみ抽出し、prop / fixture の `title:` を誤検知しない（`"Contact Us"` / `"Focus block"` が誤検知されないことを確認済み）
- **CI**: lint job に `pnpm storybook:taxonomy` ステップを追加（PR で hard-fail）
- **docs**: `storybook-guide.md` の命名規則を所有境界 taxonomy に更新（物理位置→prefix 表 / Patterns 依存ベース分離 / States 例外 / ADR-013 参照）。旧 prefix の古い例も修正

## 検証

- `pnpm storybook:taxonomy` → 174 stories / 違反0 / exit 0
- title を一時破壊 → exit 1 + 該当ファイル列挙を確認
- `pnpm typecheck` / `lint` / `lint:boundaries` / prettier すべて pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)