### PR TITLE
chore(release): v0.31.0 へ version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dayopt",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "private": true,
   "packageManager": "pnpm@11.1.2",
   "scripts": {


### PR DESCRIPTION
## 概要

v0.31.0 リリースに向けた version bump。`package.json` を `0.30.0` → `0.31.0` に更新する。

このPRをマージ後、main に `v0.31.0` タグを打って GitHub Release を作成する。

## 含まれるリリース内容（v0.30.0 以降の主な変更）

- refactor(packages): 共有 package レイヤー再編（foundations / components / assets / config / database / billing）(#1402)
- refactor(routing): calendar URL を workspace 直下 day/week に平坦化 (#1414)
- feat: Calendar Day Compare Mode (#1387)
- feat(entry): 自動記録モデルのフォローアップ（未来記録ロック / skip 導線）(#1386)
- chore(i18n): Copy System + next-intl adapter として再設計 (#1400)
- refactor(db): duration_minutes → planned_duration_minutes rename (#1373)
- chore(boundaries): lint:boundaries を monorepo 全体に拡張 (#1405)
- refactor(storybook): 所有境界ベースの story taxonomy 再編 (#1407, #1408, #1409)

## 品質チェック

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm lint:boundaries`
- [x] `pnpm test:run`（1816 passed）
- [x] `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
