### PR TITLE
docs(supabase): migration の GRANT 明示ルール追加 + CI checkout の SHA pin 統一

### DIFF
--- a/.agents/skills/supabase/SKILL.md
+++ b/.agents/skills/supabase/SKILL.md
@@ -145,6 +145,12 @@ CREATE TABLE IF NOT EXISTS public.new_table (
 -- RLSを有効化
 ALTER TABLE public.new_table ENABLE ROW LEVEL SECURITY;
 
+-- Data API への明示 GRANT（RLS とセットで必須）
+-- Supabase は新規 public テーブルを Data API に自動公開しなくなる方向のため、
+-- authenticated role での PostgREST アクセス権を明示的に付与する。
+-- anon は原則付与しない（公開読み取りが必要なテーブルのみ SELECT を個別付与）。
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.new_table TO authenticated;
+
 -- RLSポリシー
 CREATE POLICY "Users can view own data"
   ON public.new_table FOR SELECT
@@ -176,6 +182,8 @@ CREATE INDEX idx_new_table_user_id ON public.new_table(user_id);
 
 - [ ] RLS を有効化したか
 - [ ] 適切な RLS ポリシーを設定したか
+- [ ] `authenticated` への `GRANT` を明示したか（RLS + policy + GRANT をセットで。Data API 自動公開に依存しない）
+- [ ] `anon` に過剰な権限を付与していないか（公開読み取りが必要なテーブルのみ `SELECT` を個別付与）
 - [ ] `user_id` カラムがあるか(ユーザーデータの場合)
 - [ ] `ON DELETE CASCADE` を設定したか
 - [ ] インデックスを追加したか
@@ -209,6 +217,8 @@ INSERT INTO public.tags (id, name, color, user_id) VALUES
 1. 全テーブルで RLS を有効化
 2. auth.uid() = user_id でフィルタ
 3. tRPC側でも ctx.userId でフィルタ(二重チェック)
+4. authenticated への GRANT を明示（RLS は GRANT 済みテーブルへのアクセスを絞るもの。
+   GRANT が無いと RLS 以前に permission denied になる）
 ```
 
 ### パターン別ポリシー

--- a/.claude/skills/supabase/SKILL.md
+++ b/.claude/skills/supabase/SKILL.md
@@ -145,6 +145,12 @@ CREATE TABLE IF NOT EXISTS public.new_table (
 -- RLSを有効化
 ALTER TABLE public.new_table ENABLE ROW LEVEL SECURITY;
 
+-- Data API への明示 GRANT（RLS とセットで必須）
+-- Supabase は新規 public テーブルを Data API に自動公開しなくなる方向のため、
+-- authenticated role での PostgREST アクセス権を明示的に付与する。
+-- anon は原則付与しない（公開読み取りが必要なテーブルのみ SELECT を個別付与）。
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.new_table TO authenticated;
+
 -- RLSポリシー
 CREATE POLICY "Users can view own data"
   ON public.new_table FOR SELECT
@@ -176,6 +182,8 @@ CREATE INDEX idx_new_table_user_id ON public.new_table(user_id);
 
 - [ ] RLS を有効化したか
 - [ ] 適切な RLS ポリシーを設定したか
+- [ ] `authenticated` への `GRANT` を明示したか（RLS + policy + GRANT をセットで。Data API 自動公開に依存しない）
+- [ ] `anon` に過剰な権限を付与していないか（公開読み取りが必要なテーブルのみ `SELECT` を個別付与）
 - [ ] `user_id` カラムがあるか(ユーザーデータの場合)
 - [ ] `ON DELETE CASCADE` を設定したか
 - [ ] インデックスを追加したか
@@ -209,6 +217,8 @@ INSERT INTO public.tags (id, name, color, user_id) VALUES
 1. 全テーブルで RLS を有効化
 2. auth.uid() = user_id でフィルタ
 3. tRPC側でも ctx.userId でフィルタ(二重チェック)
+4. authenticated への GRANT を明示（RLS は GRANT 済みテーブルへのアクセスを絞るもの。
+   GRANT が無いと RLS 以前に permission denied になる）
 ```
 
 ### パターン別ポリシー

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## 概要

issue #1415（Supabase GRANT 明示ルール）と #1416（GitHub Actions checkout 安全性確認）の対応。

## #1415 — migration に GRANT 明示ルールを追加

`supabase` skill の migration テンプレ・チェックリスト・RLS 基本ルールに、`authenticated` への明示 `GRANT` を追加した。

### 背景・なぜやるか
- Supabase は新規 `public` テーブルを Data API へ自動公開しなくなる方向（[changelog](https://supabase.com/changelog)）
- Dayopt の標準クエリ経路は **anon key + cookie JWT の `authenticated` role による PostgREST アクセス**（`lib/trpc/server.ts` / `lib/trpc/procedures.ts`）。`.from('table')` がこの経路を通る
- → テーブルへの `GRANT` が無いと **RLS 以前に permission denied** になる
- 現状は Supabase 管理の暗黙 default privileges で `authenticated`/`anon`/`service_role` に自動 GRANT されて動作している（本番照合済み: `entries` / `reports` / `oauth_tokens` 等がフル GRANT、migration には GRANT 記述なし）
- この暗黙付与が将来止まると、現テンプレ（GRANT なし）で作る新テーブルが壊れる

### 変更内容
- migration テンプレに `GRANT SELECT, INSERT, UPDATE, DELETE ON public.<table> TO authenticated;` を追加
- `anon` は原則付与しない方針を明記（過剰権限の抑止。実際 `tags` は過去に anon を SELECT のみへ絞った先例あり）
- チェックリストに「`authenticated` への GRANT を明示したか」「`anon` に過剰権限を付与していないか」を追加
- RLS 基本ルールに GRANT と RLS の関係を 1 行追記

### 棚卸し結論
既存テーブルは暗黙 GRANT 依存だが現状は機能。明示移行は**新規分から**で十分（既存への一括 GRANT migration は本 PR では行わない）。

## #1416 — checkout 安全性（確認 + 軽微 follow-up）

確認の結果 `pull_request_target` は未使用・checkout は全て SHA pin・権限は最小で**問題なし**（issue は close 済み）。唯一 `create-release.yml` のみ `actions/checkout@v7`（mutable tag）だったため、他 workflow と同じ SHA pin（`9c091bb…# v7.0.0`）へ統一した。

## Reversibility
- skill md / workflow yml のみ。`[minutes]`（git revert で即戻せる）。DB 変更・schema 変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1415
