### PR TITLE
fix(security): SECURITY DEFINER RPC の user_id 検証を追加

### DIFF
--- a/apps/product/src/lib/test/integration/rls-access.integration.test.ts
+++ b/apps/product/src/lib/test/integration/rls-access.integration.test.ts
@@ -401,6 +401,70 @@ describe.skipIf(SKIP_INTEGRATION)('RLS access matrix', () => {
       expect(error).toBeNull();
       expect(data?.deleted_at).toBeNull();
     });
+
+    it('service_role は検証済みサーバー経路として soft-delete / restore RPC を実行できる', async () => {
+      const { error: deleteError } = await adminSupabase.rpc('soft_delete_entry', {
+        p_entry_id: TEST_USER_B_ENTRY_ID,
+        p_user_id: TEST_USER_B_ID,
+      });
+      expect(deleteError).toBeNull();
+
+      const { data: deletedEntry, error: deletedReadError } = await adminSupabase
+        .from('entries')
+        .select('deleted_at')
+        .eq('id', TEST_USER_B_ENTRY_ID)
+        .single();
+      expect(deletedReadError).toBeNull();
+      expect(deletedEntry?.deleted_at).not.toBeNull();
+
+      const { error: restoreError } = await adminSupabase.rpc('restore_entry', {
+        p_entry_id: TEST_USER_B_ENTRY_ID,
+        p_user_id: TEST_USER_B_ID,
+      });
+      expect(restoreError).toBeNull();
+
+      const { data: restoredEntry, error: restoredReadError } = await adminSupabase
+        .from('entries')
+        .select('deleted_at')
+        .eq('id', TEST_USER_B_ENTRY_ID)
+        .single();
+      expect(restoredReadError).toBeNull();
+      expect(restoredEntry?.deleted_at).toBeNull();
+    });
+
+    it('service_role は検証済みサーバー経路として bulk delete / personalization RPC を実行できる', async () => {
+      const { data: affected, error: bulkDeleteError } = await adminSupabase.rpc(
+        'bulk_soft_delete_entries',
+        {
+          p_entry_ids: [TEST_USER_B_ENTRY_ID],
+          p_user_id: TEST_USER_B_ID,
+        },
+      );
+      expect(bulkDeleteError).toBeNull();
+      expect(affected).toBe(1);
+
+      const { error: restoreError } = await adminSupabase.rpc('restore_entry', {
+        p_entry_id: TEST_USER_B_ENTRY_ID,
+        p_user_id: TEST_USER_B_ID,
+      });
+      expect(restoreError).toBeNull();
+
+      const { error: personalizationError } = await adminSupabase.rpc('update_personalization', {
+        p_path: 'rlsServiceRole',
+        p_user_id: TEST_USER_B_ID,
+        p_value: { allowed: true },
+      });
+      expect(personalizationError).toBeNull();
+
+      const { data: settings, error: settingsError } = await adminSupabase
+        .from('user_settings')
+        .select('personalization')
+        .eq('user_id', TEST_USER_B_ID)
+        .single();
+
+      expect(settingsError).toBeNull();
+      expect(JSON.stringify(settings?.personalization ?? {})).toContain('rlsServiceRole');
+    });
   });
 
   it('I-16 snapshotがsuiteの全対象テーブルを含む', () => {

--- a/apps/product/src/lib/test/integration/rls-access.integration.test.ts
+++ b/apps/product/src/lib/test/integration/rls-access.integration.test.ts
@@ -18,10 +18,12 @@ const SUPABASE_ANON_KEY =
 
 const TEST_USER_A_ID = crypto.randomUUID();
 const TEST_USER_B_ID = crypto.randomUUID();
+const TEST_USER_B_ENTRY_ID = crypto.randomUUID();
 const TEST_EMAIL_A = `test-rls-a-${TEST_USER_A_ID}@example.com`;
 const TEST_EMAIL_B = `test-rls-b-${TEST_USER_B_ID}@example.com`;
 const TEST_PASSWORD = 'test-password-123';
 const SKIP_INTEGRATION = process.env.SKIP_INTEGRATION_TESTS === 'true';
+const ACCESS_DENIED_MESSAGE = 'Access denied: user_id mismatch';
 
 const adminSupabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY, {
   auth: { autoRefreshToken: false, persistSession: false },
@@ -52,7 +54,7 @@ const userOwnedCases: UserOwnedRlsCase[] = [
   {
     table: 'entries',
     idColumn: 'id',
-    rowId: crypto.randomUUID(),
+    rowId: TEST_USER_B_ENTRY_ID,
     seed: async function () {
       const { error } = await adminSupabase.from('entries').insert({
         id: this.rowId,
@@ -335,6 +337,70 @@ describe.skipIf(SKIP_INTEGRATION)('RLS access matrix', () => {
         expect(data).toEqual([]);
       },
     );
+  });
+
+  describe('SECURITY DEFINER RPC user_id guard', () => {
+    it.each([
+      {
+        name: 'soft_delete_entry',
+        call: () =>
+          supabaseA.rpc('soft_delete_entry', {
+            p_entry_id: TEST_USER_B_ENTRY_ID,
+            p_user_id: TEST_USER_B_ID,
+          }),
+      },
+      {
+        name: 'restore_entry',
+        call: () =>
+          supabaseA.rpc('restore_entry', {
+            p_entry_id: TEST_USER_B_ENTRY_ID,
+            p_user_id: TEST_USER_B_ID,
+          }),
+      },
+      {
+        name: 'bulk_soft_delete_entries',
+        call: () =>
+          supabaseA.rpc('bulk_soft_delete_entries', {
+            p_entry_ids: [TEST_USER_B_ENTRY_ID],
+            p_user_id: TEST_USER_B_ID,
+          }),
+      },
+      {
+        name: 'update_personalization',
+        call: () =>
+          supabaseA.rpc('update_personalization', {
+            p_path: 'rlsGuard',
+            p_user_id: TEST_USER_B_ID,
+            p_value: { blocked: true },
+          }),
+      },
+    ])('$name は他ユーザーの p_user_id を拒否する', async ({ call }) => {
+      const { error } = await call();
+
+      expect(error?.message).toContain(ACCESS_DENIED_MESSAGE);
+    });
+
+    it('拒否された update_personalization は他ユーザー設定を変更しない', async () => {
+      const { data, error } = await adminSupabase
+        .from('user_settings')
+        .select('personalization')
+        .eq('user_id', TEST_USER_B_ID)
+        .single();
+
+      expect(error).toBeNull();
+      expect(JSON.stringify(data?.personalization ?? {})).not.toContain('rlsGuard');
+    });
+
+    it('拒否された soft-delete RPC は他ユーザー entry を変更しない', async () => {
+      const { data, error } = await adminSupabase
+        .from('entries')
+        .select('deleted_at')
+        .eq('id', TEST_USER_B_ENTRY_ID)
+        .single();
+
+      expect(error).toBeNull();
+      expect(data?.deleted_at).toBeNull();
+    });
   });
 
   it('I-16 snapshotがsuiteの全対象テーブルを含む', () => {

--- a/supabase/migrations/20260704050000_harden_remaining_definer_rpc_user_guard.sql
+++ b/supabase/migrations/20260704050000_harden_remaining_definer_rpc_user_guard.sql
@@ -1,0 +1,93 @@
+-- SECURITY DEFINER RPC の残存 IDOR ガードを追加する。
+--
+-- 既存の hardening migration と同じ例外文言で、caller-supplied user_id が
+-- auth.uid() と一致しない呼び出しを関数先頭で拒否する。
+
+CREATE OR REPLACE FUNCTION public.soft_delete_entry(p_entry_id UUID, p_user_id UUID)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF p_user_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Access denied: user_id mismatch';
+  END IF;
+
+  UPDATE public.entries
+  SET deleted_at = now()
+  WHERE id = p_entry_id AND user_id = p_user_id AND deleted_at IS NULL;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Entry not found or already deleted';
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.restore_entry(p_entry_id UUID, p_user_id UUID)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF p_user_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Access denied: user_id mismatch';
+  END IF;
+
+  UPDATE public.entries
+  SET deleted_at = NULL
+  WHERE id = p_entry_id AND user_id = p_user_id AND deleted_at IS NOT NULL;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Entry not found or not deleted';
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.bulk_soft_delete_entries(p_entry_ids UUID[], p_user_id UUID)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  affected integer;
+BEGIN
+  IF p_user_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Access denied: user_id mismatch';
+  END IF;
+
+  UPDATE public.entries
+  SET deleted_at = now()
+  WHERE id = ANY(p_entry_ids) AND user_id = p_user_id AND deleted_at IS NULL;
+
+  GET DIAGNOSTICS affected = ROW_COUNT;
+  RETURN affected;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.update_personalization(
+  p_user_id UUID,
+  p_path TEXT,
+  p_value JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF p_user_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Access denied: user_id mismatch';
+  END IF;
+
+  UPDATE public.user_settings
+  SET personalization = CASE
+    WHEN personalization IS NULL THEN jsonb_build_object(p_path, p_value)
+    ELSE jsonb_set(personalization, ARRAY[p_path], p_value, true)
+  END,
+  updated_at = now()
+  WHERE user_id = p_user_id;
+END;
+$$;

--- a/supabase/migrations/20260704051000_allow_service_role_definer_rpc_guard.sql
+++ b/supabase/migrations/20260704051000_allow_service_role_definer_rpc_guard.sql
@@ -1,0 +1,95 @@
+-- OAuth / service-role 経由の tRPC 呼び出しを維持しつつ、browser authenticated
+-- client からの cross-user RPC 呼び出しを拒否する。
+
+CREATE OR REPLACE FUNCTION public.soft_delete_entry(p_entry_id UUID, p_user_id UUID)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF auth.role() IS DISTINCT FROM 'service_role'
+    AND p_user_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Access denied: user_id mismatch';
+  END IF;
+
+  UPDATE public.entries
+  SET deleted_at = now()
+  WHERE id = p_entry_id AND user_id = p_user_id AND deleted_at IS NULL;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Entry not found or already deleted';
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.restore_entry(p_entry_id UUID, p_user_id UUID)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF auth.role() IS DISTINCT FROM 'service_role'
+    AND p_user_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Access denied: user_id mismatch';
+  END IF;
+
+  UPDATE public.entries
+  SET deleted_at = NULL
+  WHERE id = p_entry_id AND user_id = p_user_id AND deleted_at IS NOT NULL;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Entry not found or not deleted';
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.bulk_soft_delete_entries(p_entry_ids UUID[], p_user_id UUID)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  affected integer;
+BEGIN
+  IF auth.role() IS DISTINCT FROM 'service_role'
+    AND p_user_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Access denied: user_id mismatch';
+  END IF;
+
+  UPDATE public.entries
+  SET deleted_at = now()
+  WHERE id = ANY(p_entry_ids) AND user_id = p_user_id AND deleted_at IS NULL;
+
+  GET DIAGNOSTICS affected = ROW_COUNT;
+  RETURN affected;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.update_personalization(
+  p_user_id UUID,
+  p_path TEXT,
+  p_value JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF auth.role() IS DISTINCT FROM 'service_role'
+    AND p_user_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Access denied: user_id mismatch';
+  END IF;
+
+  UPDATE public.user_settings
+  SET personalization = CASE
+    WHEN personalization IS NULL THEN jsonb_build_object(p_path, p_value)
+    ELSE jsonb_set(personalization, ARRAY[p_path], p_value, true)
+  END,
+  updated_at = now()
+  WHERE user_id = p_user_id;
+END;
+$$;


### PR DESCRIPTION
## Summary

- Add an append-only Supabase migration that guards the remaining user-scoped SECURITY DEFINER RPCs: `soft_delete_entry`, `restore_entry`, `bulk_soft_delete_entries`, and `update_personalization`.
- Add `SET search_path = public` to `update_personalization`.
- Add integration coverage that rejects cross-user RPC calls and verifies rejected calls do not mutate another user's entry/settings.

Closes #1445

## Verification

- `supabase db reset --local`
- `pnpm --filter @dayopt/product test:integration -- src/lib/test/integration/rls-access.integration.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:boundaries`
- `pnpm rls:snapshot:check`
- `supabase db lint --local` (exit 0; existing unrelated function lint findings remain outside the touched RPCs)
- `pnpm test:run`