### PR TITLE
fix(security): checkout priceをサーバー設定に固定

### DIFF
--- a/apps/product/src/env.ts
+++ b/apps/product/src/env.ts
@@ -41,6 +41,7 @@ const serverSchema = z
     // Stripe
     STRIPE_SECRET_KEY: z.string().optional(),
     STRIPE_WEBHOOK_SECRET: z.string().optional(),
+    NEXT_PUBLIC_STRIPE_PRO_PRICE_ID: z.string().optional(),
 
     // Slack
     SLACK_BILLING_WEBHOOK_URL: z.string().url().optional(),

--- a/apps/product/src/features/settings/components/billing-settings.tsx
+++ b/apps/product/src/features/settings/components/billing-settings.tsx
@@ -130,7 +130,7 @@ export function BillingSettings() {
       toast.error(t('settings.subscription.stripeNotConfigured'));
       return;
     }
-    createCheckout.mutate({ priceId: STRIPE_PRICE_ID });
+    createCheckout.mutate();
   }, [createCheckout, t]);
 
   const handleManageSubscription = useCallback(() => {

--- a/apps/product/src/features/settings/server/__tests__/billing-router.test.ts
+++ b/apps/product/src/features/settings/server/__tests__/billing-router.test.ts
@@ -64,7 +64,7 @@ describe('billing-router', () => {
       const ctx = createMockContext({ userId: undefined });
       const caller = createCaller(ctx);
 
-      await expect(caller.createCheckoutSession({ priceId: 'price_test' })).rejects.toThrow(
+      await expect(caller.createCheckoutSession()).rejects.toThrow(
         expect.objectContaining({ code: 'UNAUTHORIZED' }),
       );
     });
@@ -113,14 +113,6 @@ describe('billing-router', () => {
   });
 
   describe('createCheckoutSession', () => {
-    it('無効な priceId は Zod バリデーションエラー', async () => {
-      const ctx = createMockContext({ userId: 'user-1' });
-      const caller = createCaller(ctx);
-
-      // "price_" で始まらない priceId
-      await expect(caller.createCheckoutSession({ priceId: 'invalid_id' })).rejects.toThrow();
-    });
-
     it('メールなしで BAD_REQUEST', async () => {
       const ctx = createMockContext({ userId: 'user-1' });
 
@@ -133,7 +125,7 @@ describe('billing-router', () => {
 
       const caller = createCaller(ctx);
 
-      await expect(caller.createCheckoutSession({ priceId: 'price_test123' })).rejects.toThrow(
+      await expect(caller.createCheckoutSession()).rejects.toThrow(
         expect.objectContaining({ code: 'BAD_REQUEST' }),
       );
     });
@@ -149,8 +141,31 @@ describe('billing-router', () => {
 
       const caller = createCaller(ctx);
 
-      await expect(caller.createCheckoutSession({ priceId: 'price_test123' })).rejects.toThrow(
+      await expect(caller.createCheckoutSession()).rejects.toThrow(
         expect.objectContaining({ code: 'INTERNAL_SERVER_ERROR' }),
+      );
+    });
+
+    it('caller supplied priceId を service に渡さない', async () => {
+      vi.mocked(billingServiceMock.createCheckoutSession).mockResolvedValue(
+        'https://checkout.stripe.com/test',
+      );
+
+      const ctx = createMockContext({ userId: 'user-1' });
+      const mockSupabase = ctx.supabase as unknown as Record<string, unknown>;
+      (mockSupabase.auth as Record<string, unknown>).getUser = vi.fn().mockResolvedValue({
+        data: { user: { id: 'user-1', email: 'test@example.com' } },
+        error: null,
+      });
+
+      const caller = createCaller(ctx);
+      const result = await caller.createCheckoutSession({ priceId: 'price_attacker' } as never);
+
+      expect(result?.url).toBe('https://checkout.stripe.com/test');
+      expect(billingServiceMock.createCheckoutSession).toHaveBeenCalledWith(
+        ctx.supabase,
+        'user-1',
+        'test@example.com',
       );
     });
 
@@ -168,7 +183,7 @@ describe('billing-router', () => {
       });
 
       const caller = createCaller(ctx);
-      const result = await caller.createCheckoutSession({ priceId: 'price_test123' });
+      const result = await caller.createCheckoutSession();
 
       expect(result?.url).toBe('https://checkout.stripe.com/test');
     });

--- a/apps/product/src/features/settings/server/__tests__/billing-service.test.ts
+++ b/apps/product/src/features/settings/server/__tests__/billing-service.test.ts
@@ -1,21 +1,29 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createChainableMock } from '@/lib/test/trpc-test-helpers';
 
-import { BillingServiceError, getBillingInfo, syncSubscriptionStatus } from '../billing-service';
+import {
+  BillingServiceError,
+  createCheckoutSession,
+  getBillingInfo,
+  syncSubscriptionStatus,
+} from '../billing-service';
+
+const stripeMock = vi.hoisted(() => ({
+  customers: {
+    create: vi.fn(),
+    retrieve: vi.fn(),
+  },
+  checkout: { sessions: { create: vi.fn() } },
+  subscriptions: { list: vi.fn() },
+  billingPortal: { sessions: { create: vi.fn() } },
+  paymentMethods: { retrieve: vi.fn() },
+  invoices: { list: vi.fn() },
+}));
 
 // Stripe SDK モック
 vi.mock('@/lib/stripe/client', () => ({
-  requireStripe: vi.fn(() => ({
-    customers: {
-      create: vi.fn(),
-      retrieve: vi.fn(),
-    },
-    checkout: { sessions: { create: vi.fn() } },
-    billingPortal: { sessions: { create: vi.fn() } },
-    paymentMethods: { retrieve: vi.fn() },
-    invoices: { list: vi.fn() },
-  })),
+  requireStripe: vi.fn(() => stripeMock),
   getStripe: vi.fn(),
 }));
 
@@ -37,6 +45,11 @@ function createProfileSupabase(
 }
 
 describe('billing-service', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
   describe('getBillingInfo', () => {
     it('正常系: active ユーザーの課金情報を返す', async () => {
       const supabase = createProfileSupabase({
@@ -91,6 +104,43 @@ describe('billing-service', () => {
       await expect(getBillingInfo(supabase, 'user-1')).rejects.toThrow(
         'Failed to fetch billing info',
       );
+    });
+  });
+
+  describe('createCheckoutSession', () => {
+    it('サーバー設定の Pro price だけを Stripe Checkout に渡す', async () => {
+      vi.stubEnv('NEXT_PUBLIC_STRIPE_PRO_PRICE_ID', 'price_server_pro');
+      stripeMock.subscriptions.list.mockResolvedValue({ data: [] });
+      stripeMock.checkout.sessions.create.mockResolvedValue({
+        url: 'https://checkout.stripe.com/test',
+      });
+
+      const supabase = createProfileSupabase({
+        id: 'user-1',
+        stripe_customer_id: 'cus_existing',
+      });
+
+      const url = await createCheckoutSession(supabase, 'user-1', 'test@example.com');
+
+      expect(url).toBe('https://checkout.stripe.com/test');
+      expect(stripeMock.checkout.sessions.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          line_items: [{ price: 'price_server_pro', quantity: 1 }],
+        }),
+      );
+    });
+
+    it('Pro price 未設定では Stripe Checkout を作成しない', async () => {
+      vi.stubEnv('NEXT_PUBLIC_STRIPE_PRO_PRICE_ID', '');
+      const supabase = createProfileSupabase({
+        id: 'user-1',
+        stripe_customer_id: 'cus_existing',
+      });
+
+      await expect(createCheckoutSession(supabase, 'user-1', 'test@example.com')).rejects.toThrow(
+        BillingServiceError,
+      );
+      expect(stripeMock.checkout.sessions.create).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/product/src/features/settings/server/billing-router.ts
+++ b/apps/product/src/features/settings/server/billing-router.ts
@@ -5,7 +5,6 @@
 
 import * as Sentry from '@sentry/nextjs';
 import { TRPCError } from '@trpc/server';
-import { z } from 'zod';
 
 import { logger } from '@/lib/logger';
 import { captureBusinessEvent } from '@/lib/sentry';
@@ -55,12 +54,7 @@ export const billingRouter = createTRPCRouter({
    */
   createCheckoutSession: protectedProcedure
     .meta({ description: 'Stripe Checkoutセッション作成' })
-    .input(
-      z.object({
-        priceId: z.string().startsWith('price_'),
-      }),
-    )
-    .mutation(async ({ ctx, input }) => {
+    .mutation(async ({ ctx }) => {
       try {
         // ユーザーのメールを取得
         const {
@@ -90,14 +84,9 @@ export const billingRouter = createTRPCRouter({
           });
         }
 
-        const url = await createCheckoutSession(
-          ctx.supabase,
-          ctx.userId,
-          user.email,
-          input.priceId,
-        );
+        const url = await createCheckoutSession(ctx.supabase, ctx.userId, user.email);
 
-        captureBusinessEvent('billing.checkout_started', { priceId: input.priceId });
+        captureBusinessEvent('billing.checkout_started', { plan: 'pro' });
         return { url };
       } catch (error) {
         handleServiceError(error);

--- a/apps/product/src/features/settings/server/billing-service.ts
+++ b/apps/product/src/features/settings/server/billing-service.ts
@@ -10,6 +10,7 @@ import 'server-only';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type Stripe from 'stripe';
 
+import { env } from '@/env';
 import { getAppUrl } from '@/lib/app-url';
 import type { Database } from '@/lib/database';
 import { logger } from '@/lib/logger';
@@ -52,6 +53,19 @@ export class BillingServiceError extends ServiceError {
     super(code, message);
     this.name = 'BillingServiceError';
   }
+}
+
+function getConfiguredProPriceId(): string {
+  const priceId = env.NEXT_PUBLIC_STRIPE_PRO_PRICE_ID?.trim();
+
+  if (!priceId?.startsWith('price_')) {
+    throw new BillingServiceError(
+      'STRIPE_PRICE_NOT_CONFIGURED',
+      'Stripe Pro price is not configured',
+    );
+  }
+
+  return priceId;
 }
 
 // ===== Service =====
@@ -128,9 +142,9 @@ export async function createCheckoutSession(
   supabase: SupabaseClient<Database>,
   userId: string,
   email: string,
-  priceId: string,
 ): Promise<string> {
   const stripe = requireStripe();
+  const priceId = getConfiguredProPriceId();
   const customerId = await getOrCreateCustomer(stripe, supabase, userId, email);
 
   // 過去にサブスクリプション履歴がある場合はトライアルを付与しない

--- a/docs/product/specs/billing.md
+++ b/docs/product/specs/billing.md
@@ -117,7 +117,7 @@ Webhook で受け取る Stripe の `Subscription.Status` を Dayopt のステー
 ```
 ユーザー "Pro にアップグレード" クリック
   → BillingSettings.handleUpgrade()
-  → api.billing.createCheckoutSession.mutate({ priceId })
+  → api.billing.createCheckoutSession.mutate()
   → billing-service.createCheckoutSession()
     → getOrCreateCustomer(): Stripe Customer 取得/作成 → profiles に保存
     → stripe.checkout.sessions.create({
@@ -211,11 +211,11 @@ publicProcedure          ← 認証不要
 
 ## 環境変数
 
-| 変数名                            | 用途                         | 設定場所                          |
-| --------------------------------- | ---------------------------- | --------------------------------- |
-| `STRIPE_SECRET_KEY`               | Stripe API シークレットキー  | サーバーサイドのみ (`src/env.ts`) |
-| `STRIPE_WEBHOOK_SECRET`           | Webhook 署名検証シークレット | サーバーサイドのみ                |
-| `NEXT_PUBLIC_STRIPE_PRO_PRICE_ID` | Pro プランの Price ID        | クライアント公開                  |
+| 変数名                            | 用途                         | 設定場所                                        |
+| --------------------------------- | ---------------------------- | ----------------------------------------------- |
+| `STRIPE_SECRET_KEY`               | Stripe API シークレットキー  | サーバーサイドのみ (`src/env.ts`)               |
+| `STRIPE_WEBHOOK_SECRET`           | Webhook 署名検証シークレット | サーバーサイドのみ                              |
+| `NEXT_PUBLIC_STRIPE_PRO_PRICE_ID` | Pro プランの Price ID        | サーバー側 Checkout 設定値。UI 表示制御にも使用 |
 
 **注意**: `STRIPE_SECRET_KEY` が未設定の場合、`getStripe()` は `null` を返す（graceful degradation）。課金が必須の処理では `requireStripe()` を使用し、未設定時にエラーをスローする。
 


### PR DESCRIPTION
## Summary
- remove caller-controlled `priceId` from `billing.createCheckoutSession`
- resolve the Stripe Pro price from server-side env before creating Checkout
- add regression coverage that forged `priceId` input is not forwarded to the billing service
- update billing spec to reflect the no-arg checkout mutation

Closes #1446

## Verification
- `pnpm --filter @dayopt/product test:run -- src/features/settings/server/__tests__/billing-router.test.ts src/features/settings/server/__tests__/billing-service.test.ts`
- `pnpm exec prettier --check apps/product/src/env.ts apps/product/src/features/settings/server/billing-service.ts apps/product/src/features/settings/server/billing-router.ts apps/product/src/features/settings/components/billing-settings.tsx apps/product/src/features/settings/server/__tests__/billing-router.test.ts apps/product/src/features/settings/server/__tests__/billing-service.test.ts docs/product/specs/billing.md`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:boundaries`
- `pnpm docs:check`