### PR TITLE
fix(security): profilesの課金カラム更新権限を制限

### DIFF
--- a/apps/product/src/features/settings/server/__tests__/billing-router.test.ts
+++ b/apps/product/src/features/settings/server/__tests__/billing-router.test.ts
@@ -6,6 +6,12 @@ import { createCallerFactory } from '@/lib/trpc/procedures';
 
 import { billingRouter } from '../billing-router';
 
+const serviceRoleSupabaseMock = vi.hoisted(() => ({ from: vi.fn() }));
+
+vi.mock('@/lib/supabase/oauth', () => ({
+  createServiceRoleClient: vi.fn(() => serviceRoleSupabaseMock),
+}));
+
 // billing-service モック
 vi.mock('../billing-service', () => ({
   getBillingInfo: vi.fn(),
@@ -146,7 +152,7 @@ describe('billing-router', () => {
       );
     });
 
-    it('caller supplied priceId を service に渡さない', async () => {
+    it('caller supplied priceId を service に渡さずservice role経路でcheckoutを作成する', async () => {
       vi.mocked(billingServiceMock.createCheckoutSession).mockResolvedValue(
         'https://checkout.stripe.com/test',
       );
@@ -163,7 +169,7 @@ describe('billing-router', () => {
 
       expect(result?.url).toBe('https://checkout.stripe.com/test');
       expect(billingServiceMock.createCheckoutSession).toHaveBeenCalledWith(
-        ctx.supabase,
+        serviceRoleSupabaseMock,
         'user-1',
         'test@example.com',
       );

--- a/apps/product/src/features/settings/server/billing-router.ts
+++ b/apps/product/src/features/settings/server/billing-router.ts
@@ -8,6 +8,7 @@ import { TRPCError } from '@trpc/server';
 
 import { logger } from '@/lib/logger';
 import { captureBusinessEvent } from '@/lib/sentry';
+import { createServiceRoleClient } from '@/lib/supabase/oauth';
 import { handleServiceError } from '@/lib/trpc/errors';
 import { createTRPCRouter, protectedProcedure } from '@/lib/trpc/procedures';
 
@@ -84,7 +85,8 @@ export const billingRouter = createTRPCRouter({
           });
         }
 
-        const url = await createCheckoutSession(ctx.supabase, ctx.userId, user.email);
+        const serviceRoleSupabase = createServiceRoleClient();
+        const url = await createCheckoutSession(serviceRoleSupabase, ctx.userId, user.email);
 
         captureBusinessEvent('billing.checkout_started', { plan: 'pro' });
         return { url };

--- a/apps/product/src/lib/test/integration/rls-access.integration.test.ts
+++ b/apps/product/src/lib/test/integration/rls-access.integration.test.ts
@@ -305,6 +305,81 @@ describe.skipIf(SKIP_INTEGRATION)('RLS access matrix', () => {
     );
   });
 
+  describe('profiles billing column grants', () => {
+    it('ownerでもbilling entitlement columnsを直接更新できない', async () => {
+      const { error } = await supabaseB
+        .from('profiles')
+        .update({
+          stripe_customer_id: `cus_forbidden_${crypto.randomUUID()}`,
+          subscription_id: `sub_forbidden_${crypto.randomUUID()}`,
+          subscription_status: 'active',
+        })
+        .eq('id', TEST_USER_B_ID);
+
+      expect(error?.code).toBe('42501');
+
+      const { data, error: readError } = await adminSupabase
+        .from('profiles')
+        .select('stripe_customer_id, subscription_id, subscription_status')
+        .eq('id', TEST_USER_B_ID)
+        .single();
+
+      expect(readError).toBeNull();
+      expect(data?.stripe_customer_id).toBeNull();
+      expect(data?.subscription_id).toBeNull();
+      expect(data?.subscription_status).toBe('free');
+    });
+
+    it('ownerはprofile presentation columnsを更新できる', async () => {
+      const { error } = await supabaseB
+        .from('profiles')
+        .update({ full_name: 'RLS profile owner update', avatar_url: null })
+        .eq('id', TEST_USER_B_ID);
+
+      expect(error).toBeNull();
+    });
+
+    it('service_roleはStripe webhook経路としてbilling entitlement columnsを更新できる', async () => {
+      const stripeCustomerId = `cus_allowed_${crypto.randomUUID()}`;
+      const subscriptionId = `sub_allowed_${crypto.randomUUID()}`;
+
+      const { error } = await adminSupabase
+        .from('profiles')
+        .update({
+          stripe_customer_id: stripeCustomerId,
+          subscription_id: subscriptionId,
+          subscription_status: 'active',
+        })
+        .eq('id', TEST_USER_B_ID);
+
+      expect(error).toBeNull();
+
+      const { data, error: readError } = await adminSupabase
+        .from('profiles')
+        .select('stripe_customer_id, subscription_id, subscription_status')
+        .eq('id', TEST_USER_B_ID)
+        .single();
+
+      expect(readError).toBeNull();
+      expect(data).toMatchObject({
+        stripe_customer_id: stripeCustomerId,
+        subscription_id: subscriptionId,
+        subscription_status: 'active',
+      });
+
+      const { error: resetError } = await adminSupabase
+        .from('profiles')
+        .update({
+          stripe_customer_id: null,
+          subscription_id: null,
+          subscription_status: 'free',
+        })
+        .eq('id', TEST_USER_B_ID);
+
+      expect(resetError).toBeNull();
+    });
+  });
+
   describe.each(serviceRoleCases)('$table', (testCase) => {
     it.each(['select', 'insert', 'update', 'delete'] as const)(
       'authenticated clientの%sを拒否する',

--- a/supabase/migrations/20260705070000_restrict_profiles_billing_column_grants.sql
+++ b/supabase/migrations/20260705070000_restrict_profiles_billing_column_grants.sql
@@ -1,0 +1,22 @@
+-- Keep billing entitlement columns server-owned.
+--
+-- RLS can decide which rows a user may touch, but it cannot distinguish safe
+-- profile fields from Stripe-controlled billing fields. Use column-level grants
+-- so authenticated browser clients can edit only profile presentation fields.
+
+BEGIN;
+
+REVOKE INSERT, UPDATE ON TABLE public.profiles FROM authenticated;
+
+GRANT INSERT (id, email, full_name, avatar_url)
+  ON TABLE public.profiles
+  TO authenticated;
+
+GRANT UPDATE (full_name, avatar_url, updated_at)
+  ON TABLE public.profiles
+  TO authenticated;
+
+GRANT INSERT, UPDATE ON TABLE public.profiles
+  TO service_role;
+
+COMMIT;

--- a/supabase/migrations/20260705070100_restrict_profiles_billing_column_grants_for_anon.sql
+++ b/supabase/migrations/20260705070100_restrict_profiles_billing_column_grants_for_anon.sql
@@ -1,0 +1,9 @@
+-- Mirror the profiles write hardening for anon. RLS already denies these paths,
+-- but column privileges should not expose billing entitlement writes to browser
+-- roles in the first place.
+
+BEGIN;
+
+REVOKE INSERT, UPDATE ON TABLE public.profiles FROM anon;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- restrict `profiles` INSERT/UPDATE grants so browser roles cannot write billing entitlement columns
- keep profile presentation writes available for authenticated users
- keep service_role writes available for Stripe webhook/server-owned paths
- add RLS integration coverage for denied owner writes and allowed service_role writes

Closes #1448

## Validation
- Supabase MCP read-only grant check confirmed current production grants expose authenticated INSERT/UPDATE on `stripe_customer_id`, `subscription_id`, and `subscription_status` before this migration
- `supabase db reset --local`
- `pnpm --filter @dayopt/product test:integration -- src/lib/test/integration/rls-access.integration.test.ts`
- `pnpm rls:snapshot:check`
- local SQL check confirmed authenticated INSERT/UPDATE is limited to safe profile columns after migration
- local SQL check confirmed service_role keeps INSERT/UPDATE on billing entitlement columns
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:boundaries`
- `supabase db lint --local` exited 0; it still reports pre-existing unrelated function lint issues (`get_active_users_for_reflection`, `get_fulfillment_trend`, `merge_tags_with_hierarchy`, `get_time_by_tag`, `get_total_time`)

## Notes
- First local DB validation attempt failed because Docker was not running; Docker Desktop was started and the full local Supabase validation then passed.