### PR TITLE
fix: oauth redirect uri を完全一致に制限

### DIFF
--- a/apps/product/src/env.ts
+++ b/apps/product/src/env.ts
@@ -9,6 +9,23 @@ import 'server-only';
 
 import { z } from 'zod';
 
+function isRedirectUriList(value: string | undefined): boolean {
+  if (!value) return true;
+  return value
+    .split(',')
+    .map((uri) => uri.trim())
+    .filter(Boolean)
+    .every((uri) => {
+      if (uri.includes('*')) return false;
+      try {
+        new URL(uri);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+}
+
 const serverSchema = z
   .object({
     // Supabase
@@ -34,6 +51,15 @@ const serverSchema = z
 
     // Auth
     RECOVERY_CODE_PEPPER: z.string().optional(),
+    OAUTH_CLAUDE_REDIRECT_URIS: z.string().optional().refine(isRedirectUriList, {
+      message: 'OAUTH_CLAUDE_REDIRECT_URIS は完全な redirect URI のカンマ区切りで指定してください',
+    }),
+    OAUTH_CHATGPT_REDIRECT_URIS: z.string().optional().refine(isRedirectUriList, {
+      message: 'OAUTH_CHATGPT_REDIRECT_URIS は完全な redirect URI のカンマ区切りで指定してください',
+    }),
+    OAUTH_CURSOR_REDIRECT_URIS: z.string().optional().refine(isRedirectUriList, {
+      message: 'OAUTH_CURSOR_REDIRECT_URIS は完全な redirect URI のカンマ区切りで指定してください',
+    }),
 
     // Google
     GOOGLE_SITE_VERIFICATION: z.string().optional(),

--- a/apps/product/src/lib/oauth-server/authorize-validation.test.ts
+++ b/apps/product/src/lib/oauth-server/authorize-validation.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { validateAuthorizeInput } from './authorize-validation';
+
+const baseAuthorizeInput = {
+  response_type: 'code',
+  client_id: 'claude-ai',
+  redirect_uri: 'https://claude.ai/api/mcp/auth_callback',
+  code_challenge: 'challenge',
+  code_challenge_method: 'S256',
+  scope: 'read:entries',
+};
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('validateAuthorizeInput redirect_uri allowlist', () => {
+  it('accepts exact registered redirect URIs', () => {
+    const result = validateAuthorizeInput(baseAuthorizeInput);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.redirectUri).toBe('https://claude.ai/api/mcp/auth_callback');
+    }
+  });
+
+  it('rejects sibling HTTPS paths for ChatGPT', () => {
+    const allowed = validateAuthorizeInput({
+      ...baseAuthorizeInput,
+      client_id: 'chatgpt',
+      redirect_uri: 'https://chatgpt.com/connector_platform_oauth_redirect',
+    });
+    const siblingPath = validateAuthorizeInput({
+      ...baseAuthorizeInput,
+      client_id: 'chatgpt',
+      redirect_uri: 'https://chatgpt.com/connector_platform_oauth_redirect/extra',
+    });
+    const arbitraryPath = validateAuthorizeInput({
+      ...baseAuthorizeInput,
+      client_id: 'chatgpt',
+      redirect_uri: 'https://chatgpt.com/anything',
+    });
+
+    expect(allowed.ok).toBe(true);
+    expect(siblingPath).toEqual({ ok: false, error: 'invalid_redirect_uri' });
+    expect(arbitraryPath).toEqual({ ok: false, error: 'invalid_redirect_uri' });
+  });
+
+  it('rejects arbitrary Cursor custom-scheme callbacks', () => {
+    const allowed = validateAuthorizeInput({
+      ...baseAuthorizeInput,
+      client_id: 'cursor',
+      redirect_uri: 'cursor://anysphere.cursor-mcp/oauth/callback',
+    });
+    const siblingPath = validateAuthorizeInput({
+      ...baseAuthorizeInput,
+      client_id: 'cursor',
+      redirect_uri: 'cursor://anysphere.cursor-mcp/oauth/callback/extra',
+    });
+    const arbitraryCallback = validateAuthorizeInput({
+      ...baseAuthorizeInput,
+      client_id: 'cursor',
+      redirect_uri: 'cursor://attacker.example/oauth/callback',
+    });
+
+    expect(allowed.ok).toBe(true);
+    expect(siblingPath).toEqual({ ok: false, error: 'invalid_redirect_uri' });
+    expect(arbitraryCallback).toEqual({ ok: false, error: 'invalid_redirect_uri' });
+  });
+
+  it('accepts configured ChatGPT redirect URIs by exact string only', () => {
+    vi.stubEnv('OAUTH_CHATGPT_REDIRECT_URIS', 'https://chatgpt.com/connector/oauth/dayopt-prod');
+
+    const configured = validateAuthorizeInput({
+      ...baseAuthorizeInput,
+      client_id: 'chatgpt',
+      redirect_uri: 'https://chatgpt.com/connector/oauth/dayopt-prod',
+    });
+    const configuredSibling = validateAuthorizeInput({
+      ...baseAuthorizeInput,
+      client_id: 'chatgpt',
+      redirect_uri: 'https://chatgpt.com/connector/oauth/dayopt-prod/extra',
+    });
+
+    expect(configured.ok).toBe(true);
+    expect(configuredSibling).toEqual({ ok: false, error: 'invalid_redirect_uri' });
+  });
+});

--- a/apps/product/src/lib/oauth-server/clients.ts
+++ b/apps/product/src/lib/oauth-server/clients.ts
@@ -1,5 +1,7 @@
 import 'server-only';
 
+import { env } from '@/env';
+
 /**
  * Phase 1 static client allowlist。
  * Phase 2 で DCR (Dynamic Client Registration) に置換し、`oauth_clients` テーブル管理に移行する。
@@ -13,35 +15,59 @@ export type OAuthClientId = 'claude-ai' | 'chatgpt' | 'cursor';
 export interface OAuthClient {
   id: OAuthClientId;
   displayName: string;
-  redirectUriPatterns: RegExp[];
+  redirectUris: readonly string[];
 }
 
-const CLIENTS: Record<OAuthClientId, OAuthClient> = {
+const DEFAULT_REDIRECT_URIS: Record<OAuthClientId, readonly string[]> = {
+  'claude-ai': ['https://claude.ai/api/mcp/auth_callback'],
+  chatgpt: ['https://chatgpt.com/connector_platform_oauth_redirect'],
+  cursor: ['cursor://anysphere.cursor-mcp/oauth/callback'],
+};
+
+const EXTRA_REDIRECT_URI_ENV: Record<OAuthClientId, keyof typeof env> = {
+  'claude-ai': 'OAUTH_CLAUDE_REDIRECT_URIS',
+  chatgpt: 'OAUTH_CHATGPT_REDIRECT_URIS',
+  cursor: 'OAUTH_CURSOR_REDIRECT_URIS',
+};
+
+const CLIENTS: Record<OAuthClientId, Omit<OAuthClient, 'redirectUris'>> = {
   'claude-ai': {
     id: 'claude-ai',
     displayName: 'Claude',
-    redirectUriPatterns: [/^https:\/\/claude\.ai\/api\/mcp\/auth_callback$/],
   },
   chatgpt: {
     id: 'chatgpt',
     displayName: 'ChatGPT',
-    redirectUriPatterns: [/^https:\/\/chatgpt\.com\/.*$/, /^https:\/\/chat\.openai\.com\/.*$/],
   },
   cursor: {
     id: 'cursor',
     displayName: 'Cursor',
-    redirectUriPatterns: [/^https:\/\/cursor\.com\/.*$/, /^cursor:\/\/.*$/],
   },
 };
+
+function parseExtraRedirectUris(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(',')
+    .map((uri) => uri.trim())
+    .filter(Boolean);
+}
 
 export function resolveClient(clientId: string | null | undefined): OAuthClient | null {
   if (!clientId) return null;
   if (clientId in CLIENTS) {
-    return CLIENTS[clientId as OAuthClientId];
+    const id = clientId as OAuthClientId;
+    return {
+      ...CLIENTS[id],
+      redirectUris: [
+        ...DEFAULT_REDIRECT_URIS[id],
+        ...parseExtraRedirectUris(env[EXTRA_REDIRECT_URI_ENV[id]]),
+      ],
+    };
   }
   return null;
 }
 
 export function isAllowedRedirectUri(client: OAuthClient, redirectUri: string): boolean {
-  return client.redirectUriPatterns.some((p) => p.test(redirectUri));
+  return client.redirectUris.includes(redirectUri);
 }

--- a/docs/product/specs/auth.md
+++ b/docs/product/specs/auth.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_verified: 2026-07-02
+last_verified: 2026-07-06
 code: apps/product/src/features/auth
 ---
 
@@ -13,6 +13,20 @@ Supabase Auth ベースの認証機能。
 - Supabase Auth によるセッション管理（メール/パスワード、MFA検証フローを含む）
 - `protectedProcedure` で保護された tRPC procedure が `ctx.userId` でデータアクセスを制限する
 - RLS（Row Level Security）によるDBレベルでの認可を併用する
+
+## OAuth / MCP redirect URI policy
+
+Dayopt の OAuth server は Phase 1 では static client allowlist を使う。`redirect_uri` は client ごとの登録済み URI と完全一致した場合だけ許可し、domain / scheme / path prefix の wildcard は使わない。
+
+既定で許可する callback は、公開 client が固定している最小セットだけにする:
+
+- `claude-ai`: `https://claude.ai/api/mcp/auth_callback`
+- `chatgpt`: `https://chatgpt.com/connector_platform_oauth_redirect`
+- `cursor`: `cursor://anysphere.cursor-mcp/oauth/callback`
+
+ChatGPT の現在の Apps SDK / MCP app flow は app 管理画面で callback ID 付きの production redirect URL を発行する。Dayopt 側で追加許可が必要な場合は、`OAUTH_CHATGPT_REDIRECT_URIS` に完全な URI 文字列をカンマ区切りで追加する。同じ形式で Claude / Cursor も `OAUTH_CLAUDE_REDIRECT_URIS` / `OAUTH_CURSOR_REDIRECT_URIS` に追加できる。
+
+これらの env は secret ではないが、誤って広い URI を許可すると authorization code delivery の境界が崩れる。値には `*` を含めず、client が実際に送る完全な URI だけを登録する。
 
 ## 関連する意思決定
 


### PR DESCRIPTION
## Summary
- OAuth static client redirect allowlist を正規表現 wildcard から完全一致の URI リストへ変更
- ChatGPT / Claude / Cursor の追加 redirect URI は env で完全な URI だけをカンマ区切り登録できるように追加
- ChatGPT sibling HTTPS path と Cursor arbitrary custom-scheme callback の拒否テストを追加
- redirect URI 登録ポリシーを docs/product/specs/auth.md に追記

Closes #1449

## Validation
- pnpm --filter @dayopt/product test:run -- src/lib/oauth-server/authorize-validation.test.ts
- pnpm typecheck
- pnpm lint
- pnpm lint:boundaries
- pnpm docs:check
- pnpm check
