### PR TITLE
fix: auth api の認可境界を強化

### DIFF
--- a/apps/product/src/lib/auth/__tests__/token-expiry.test.ts
+++ b/apps/product/src/lib/auth/__tests__/token-expiry.test.ts
@@ -21,6 +21,9 @@ const authTestRouter = createTRPCRouter({
   userSettings: createTRPCRouter({
     update: protectedProcedure.mutation(() => 'updated'),
   }),
+  user: createTRPCRouter({
+    verifyRecoveryCode: protectedProcedure.mutation(() => 'recovered'),
+  }),
 });
 
 const createCaller = createCallerFactory(authTestRouter);
@@ -65,6 +68,29 @@ describe('トークン期限切れ・セッション検証', () => {
       const caller = createCaller(ctx as never);
 
       await expect(caller.whoami()).rejects.toThrow(expect.objectContaining({ code: 'FORBIDDEN' }));
+    });
+
+    it('MFA登録済みAAL1セッションでもリカバリーコード検証は通過する', async () => {
+      const ctx = createMockContext({
+        userId: 'user-1',
+        mfaAssurance: { currentLevel: 'aal1', nextLevel: 'aal2' },
+      });
+      const caller = createCaller(ctx as never);
+
+      await expect(caller.user.verifyRecoveryCode()).resolves.toBe('recovered');
+    });
+
+    it('AAL取得失敗時はfail closedでFORBIDDEN', async () => {
+      const ctx = createMockContext({
+        userId: 'user-1',
+        mfaAssurance: { currentLevel: null, nextLevel: null, lookupFailed: true },
+      });
+      const caller = createCaller(ctx as never);
+
+      await expect(caller.whoami()).rejects.toThrow(expect.objectContaining({ code: 'FORBIDDEN' }));
+      await expect(caller.user.verifyRecoveryCode()).rejects.toThrow(
+        expect.objectContaining({ code: 'FORBIDDEN' }),
+      );
     });
 
     it('AAL2セッションは通過する', async () => {

--- a/apps/product/src/lib/auth/__tests__/token-expiry.test.ts
+++ b/apps/product/src/lib/auth/__tests__/token-expiry.test.ts
@@ -15,6 +15,12 @@ import { createCallerFactory, createTRPCRouter, protectedProcedure } from '../..
 // protectedProcedure の認証ガードテスト用ルーター
 const authTestRouter = createTRPCRouter({
   whoami: protectedProcedure.query(({ ctx }) => ({ userId: ctx.userId })),
+  entries: createTRPCRouter({
+    list: protectedProcedure.query(() => 'entries'),
+  }),
+  userSettings: createTRPCRouter({
+    update: protectedProcedure.mutation(() => 'updated'),
+  }),
 });
 
 const createCaller = createCallerFactory(authTestRouter);
@@ -49,6 +55,56 @@ describe('トークン期限切れ・セッション検証', () => {
 
       const result = await caller.whoami();
       expect(result.userId).toBe('user-1');
+    });
+
+    it('MFA登録済みAAL1セッションはFORBIDDEN', async () => {
+      const ctx = createMockContext({
+        userId: 'user-1',
+        mfaAssurance: { currentLevel: 'aal1', nextLevel: 'aal2' },
+      });
+      const caller = createCaller(ctx as never);
+
+      await expect(caller.whoami()).rejects.toThrow(expect.objectContaining({ code: 'FORBIDDEN' }));
+    });
+
+    it('AAL2セッションは通過する', async () => {
+      const ctx = createMockContext({
+        userId: 'user-1',
+        mfaAssurance: { currentLevel: 'aal2', nextLevel: 'aal2' },
+      });
+      const caller = createCaller(ctx as never);
+
+      const result = await caller.whoami();
+      expect(result.userId).toBe('user-1');
+    });
+
+    it('OAuth read:entries token は明示許可された entries.list だけ通過する', async () => {
+      const ctx = createMockContext({
+        userId: 'user-1',
+        authMode: 'oauth',
+        oauthClientId: 'claude-ai',
+        oauthScopes: ['read:entries'],
+      });
+      const caller = createCaller(ctx as never);
+
+      await expect(caller.entries.list()).resolves.toBe('entries');
+      await expect(caller.userSettings.update()).rejects.toThrow(
+        expect.objectContaining({ code: 'FORBIDDEN' }),
+      );
+    });
+
+    it('OAuth token はscopeなしでentries.listを通過できない', async () => {
+      const ctx = createMockContext({
+        userId: 'user-1',
+        authMode: 'oauth',
+        oauthClientId: 'claude-ai',
+        oauthScopes: ['read:tags'],
+      });
+      const caller = createCaller(ctx as never);
+
+      await expect(caller.entries.list()).rejects.toThrow(
+        expect.objectContaining({ code: 'FORBIDDEN' }),
+      );
     });
   });
 

--- a/apps/product/src/lib/mcp/trpc-bridge.ts
+++ b/apps/product/src/lib/mcp/trpc-bridge.ts
@@ -31,6 +31,8 @@ export function createMcpTrpcCaller(input: McpTrpcContextInput) {
     req: { headers: {}, cookies: {} },
     res: {},
     userId: input.userId,
+    oauthClientId: input.clientId,
+    oauthScopes: input.scopes,
     supabase,
     authMode: 'oauth',
   });

--- a/apps/product/src/lib/safe-redirect.test.ts
+++ b/apps/product/src/lib/safe-redirect.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { getSafeRedirectPath } from './safe-redirect';
+
+describe('getSafeRedirectPath', () => {
+  it('allows same-origin relative paths', () => {
+    expect(getSafeRedirectPath('/week?date=2026-07-06&panel=review')).toBe(
+      '/week?date=2026-07-06&panel=review',
+    );
+  });
+
+  it('rejects absolute and protocol-relative URLs', () => {
+    expect(getSafeRedirectPath('https://evil.example')).toBe('/week');
+    expect(getSafeRedirectPath('//evil.example/path')).toBe('/week');
+    expect(getSafeRedirectPath('/%2F%2Fevil.example/path')).toBe('/week');
+  });
+
+  it('rejects raw and encoded backslash redirects', () => {
+    expect(getSafeRedirectPath('/\\evil.example/path')).toBe('/week');
+    expect(getSafeRedirectPath('/%5C%5Cevil.example/path')).toBe('/week');
+    expect(getSafeRedirectPath('/%5cevil.example/path')).toBe('/week');
+  });
+
+  it('rejects decoded scheme payloads', () => {
+    expect(getSafeRedirectPath('/https%3A%2F%2Fevil.example')).toBe('/week');
+  });
+});

--- a/apps/product/src/lib/safe-redirect.ts
+++ b/apps/product/src/lib/safe-redirect.ts
@@ -14,17 +14,30 @@
  * - 絶対URL (`https://evil.com`)
  * - プロトコル相対URL (`//evil.com`)
  * - エンコードされたバイパス (`%2F%2Fevil.com`)
+ * - raw / encoded backslash (`/%5C%5Cevil.com`)
  */
 export function getSafeRedirectPath(next: string | null, fallback = '/week'): string {
   if (!next) return fallback;
 
   // 相対パスでない、またはプロトコル相対URL
   if (!next.startsWith('/') || next.startsWith('//')) return fallback;
+  if (next.includes('\\')) return fallback;
 
   // エンコードされたバイパスを検出
+  let decoded: string;
   try {
-    const decoded = decodeURIComponent(next);
-    if (decoded.startsWith('//') || decoded.includes('://')) return fallback;
+    decoded = decodeURIComponent(next);
+  } catch {
+    return fallback;
+  }
+  if (decoded.startsWith('//') || decoded.includes('://') || decoded.includes('\\')) {
+    return fallback;
+  }
+
+  const appOrigin = 'https://app.dayopt.app';
+  try {
+    const parsed = new URL(decoded, appOrigin);
+    if (parsed.origin !== appOrigin) return fallback;
   } catch {
     return fallback;
   }

--- a/apps/product/src/lib/test/trpc-test-helpers.ts
+++ b/apps/product/src/lib/test/trpc-test-helpers.ts
@@ -25,6 +25,7 @@ import type { AnyRouter } from '@trpc/server';
 import { vi } from 'vitest';
 
 import type { Database } from '@/lib/database';
+import type { OAuthClientId, SupportedScope } from '@/lib/oauth-server';
 import { createCallerFactory, type Context } from '@/lib/trpc/procedures';
 
 // Re-export factories for backward compatibility
@@ -34,6 +35,10 @@ import { createCallerFactory, type Context } from '@/lib/trpc/procedures';
 interface MockContextOptions {
   userId?: string | undefined;
   sessionId?: string | undefined;
+  authMode?: Context['authMode'];
+  oauthClientId?: OAuthClientId | undefined;
+  oauthScopes?: SupportedScope[] | undefined;
+  mfaAssurance?: Context['mfaAssurance'];
   supabaseOverrides?: Partial<MockSupabaseClient>;
 }
 
@@ -86,7 +91,15 @@ export function createMockSupabase(overrides?: Partial<MockSupabaseClient>): Moc
  * モックコンテキストを作成
  */
 export function createMockContext(options: MockContextOptions = {}): Context {
-  const { userId, sessionId, supabaseOverrides } = options;
+  const {
+    userId,
+    sessionId,
+    authMode = 'session',
+    oauthClientId,
+    oauthScopes,
+    mfaAssurance,
+    supabaseOverrides,
+  } = options;
 
   const mockSupabase = createMockSupabase(supabaseOverrides);
 
@@ -102,8 +115,11 @@ export function createMockContext(options: MockContextOptions = {}): Context {
     } as unknown as Context['res'],
     userId,
     sessionId,
+    oauthClientId,
+    oauthScopes,
+    mfaAssurance,
     supabase: mockSupabase as unknown as SupabaseClient<Database>,
-    authMode: 'session' as const,
+    authMode,
   };
 }
 

--- a/apps/product/src/lib/trpc/procedures.ts
+++ b/apps/product/src/lib/trpc/procedures.ts
@@ -192,19 +192,37 @@ async function createTRPCContext(opts: {
       if (user) {
         userId = user.id;
         // セッションからアクセストークンを取得（ログ・追跡用）
-        const {
-          data: { session },
-        } = await supabase.auth.getSession();
-        sessionId = session?.access_token;
-        const { data: aalData, error: aalError } =
-          await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
-        mfaAssurance = {
-          currentLevel: normalizeMfaAssuranceLevel(aalData?.currentLevel),
-          nextLevel: normalizeMfaAssuranceLevel(aalData?.nextLevel),
-          lookupFailed: Boolean(aalError),
-        };
-        if (aalError) {
-          logger.warn('MFA assurance lookup failed', { message: aalError.message });
+        try {
+          const {
+            data: { session },
+          } = await supabase.auth.getSession();
+          sessionId = session?.access_token;
+        } catch (error) {
+          logger.warn('Session token lookup failed', {
+            message: error instanceof Error ? error.message : 'Unknown error',
+          });
+        }
+
+        try {
+          const { data: aalData, error: aalError } =
+            await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+          mfaAssurance = {
+            currentLevel: normalizeMfaAssuranceLevel(aalData?.currentLevel),
+            nextLevel: normalizeMfaAssuranceLevel(aalData?.nextLevel),
+            lookupFailed: Boolean(aalError),
+          };
+          if (aalError) {
+            logger.warn('MFA assurance lookup failed', { message: aalError.message });
+          }
+        } catch (error) {
+          mfaAssurance = {
+            currentLevel: null,
+            nextLevel: null,
+            lookupFailed: true,
+          };
+          logger.warn('MFA assurance lookup threw', {
+            message: error instanceof Error ? error.message : 'Unknown error',
+          });
         }
       }
     } catch {

--- a/apps/product/src/lib/trpc/procedures.ts
+++ b/apps/product/src/lib/trpc/procedures.ts
@@ -20,7 +20,7 @@ import { logger } from '@/lib/logger';
 // 循環依存防止: barrel `@/lib/mcp` は trpc-bridge を再 export し、それが appRouter →
 // feature router → procedures.ts と辿るため、ここでは auth.ts を直 import する。
 import { extractBearerToken, verifyAccessToken } from '@/lib/mcp/auth';
-import { OAuthServerError } from '@/lib/oauth-server';
+import { OAuthServerError, type OAuthClientId, type SupportedScope } from '@/lib/oauth-server';
 import { trpcUserRateLimit } from '@/lib/rate-limit/upstash';
 import { AuthMode, createServiceRoleClient, detectAuthMode } from '@/lib/supabase/oauth';
 import { ServiceError } from '@/lib/trpc/errors';
@@ -59,6 +59,8 @@ export interface TrpcResponseLike {
   end?: (...args: unknown[]) => void;
 }
 
+type MfaAssuranceLevel = 'aal1' | 'aal2';
+
 /** tRPCプロシージャのコンテキスト型 */
 export interface Context {
   req: TrpcRequestLike;
@@ -70,6 +72,17 @@ export interface Context {
   authMode: AuthMode;
   /** OAuth 2.1トークン（oauth modeの場合のみ） */
   accessToken?: string | undefined;
+  /** OAuth 2.1 client_id（oauth modeの場合のみ） */
+  oauthClientId?: OAuthClientId | undefined;
+  /** 検証済み OAuth scopes（oauth modeの場合のみ） */
+  oauthScopes?: SupportedScope[] | undefined;
+  /** Supabase Auth MFA assurance level（session modeの場合のみ） */
+  mfaAssurance?:
+    | {
+        currentLevel: MfaAssuranceLevel | null;
+        nextLevel: MfaAssuranceLevel | null;
+      }
+    | undefined;
   /** JWTカスタムクレームから取得したサブスクリプション状態（custom_access_token hook） */
   subscriptionStatus?: string | undefined;
 }
@@ -95,6 +108,9 @@ async function createTRPCContext(opts: {
   let userId: string | undefined;
   let sessionId: string | undefined;
   let accessToken: string | undefined;
+  let oauthClientId: OAuthClientId | undefined;
+  let oauthScopes: SupportedScope[] | undefined;
+  let mfaAssurance: Context['mfaAssurance'];
   let supabase: SupabaseClient<Database>;
 
   // 1. OAuth 2.1トークン認証（MCP用） — Dayopt 発行の opaque token を oauth_tokens 検証
@@ -107,6 +123,8 @@ async function createTRPCContext(opts: {
 
       userId = verified.userId;
       accessToken = token;
+      oauthClientId = verified.clientId;
+      oauthScopes = verified.scopes;
       // Opaque token は JWT ではないため subscription_status は proProcedure 側で
       // 必ず DB lookup する (Decision 1)。supabase は service-role client。
       supabase = createServiceRoleClient();
@@ -177,6 +195,11 @@ async function createTRPCContext(opts: {
           data: { session },
         } = await supabase.auth.getSession();
         sessionId = session?.access_token;
+        const { data: aalData } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+        mfaAssurance = {
+          currentLevel: normalizeMfaAssuranceLevel(aalData?.currentLevel),
+          nextLevel: normalizeMfaAssuranceLevel(aalData?.nextLevel),
+        };
       }
     } catch {
       // 認証エラーは無視（ゲストユーザーとして扱う）
@@ -210,6 +233,9 @@ async function createTRPCContext(opts: {
     userId,
     sessionId,
     accessToken,
+    oauthClientId,
+    oauthScopes,
+    mfaAssurance,
     supabase,
     authMode,
     subscriptionStatus,
@@ -273,6 +299,10 @@ const USER_RATE_LIMIT = 100;
 const USER_RATE_WINDOW_MS = 60 * 1000;
 const userRequestLog = new Map<string, number[]>();
 
+const OAUTH_TRPC_SCOPE_REQUIREMENTS: Partial<Record<string, SupportedScope>> = {
+  'entries.list': 'read:entries',
+};
+
 function isUserRateLimitedInMemory(userId: string): boolean {
   const now = Date.now();
   const timestamps = userRequestLog.get(userId) ?? [];
@@ -312,12 +342,35 @@ async function isUserRateLimited(userId: string): Promise<boolean> {
  */
 export const protectedProcedure = t.procedure
   .meta({ auth: 'protected' })
-  .use(async ({ ctx, next }) => {
+  .use(async ({ ctx, next, path }) => {
     if (!ctx.userId) {
       throw new TRPCError({
         code: 'UNAUTHORIZED',
         message: 'Authentication required',
         cause: new ServiceError('INVALID_TOKEN', 'Authentication required'),
+      });
+    }
+
+    if (ctx.authMode === 'oauth') {
+      const requiredScope = OAUTH_TRPC_SCOPE_REQUIREMENTS[path];
+      if (!requiredScope || !ctx.oauthScopes?.includes(requiredScope)) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'OAuth token scope does not allow this procedure',
+          cause: new ServiceError('FORBIDDEN', 'OAuth scope denied'),
+        });
+      }
+    }
+
+    if (
+      ctx.authMode === 'session' &&
+      ctx.mfaAssurance?.currentLevel === 'aal1' &&
+      ctx.mfaAssurance.nextLevel === 'aal2'
+    ) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'MFA verification required',
+        cause: new ServiceError('FORBIDDEN', 'MFA AAL2 required'),
       });
     }
 
@@ -448,4 +501,8 @@ function parseCookieHeader(cookieHeader: string | null): Record<string, string> 
   }
 
   return cookies;
+}
+
+function normalizeMfaAssuranceLevel(level: unknown): MfaAssuranceLevel | null {
+  return level === 'aal1' || level === 'aal2' ? level : null;
 }

--- a/apps/product/src/lib/trpc/procedures.ts
+++ b/apps/product/src/lib/trpc/procedures.ts
@@ -81,6 +81,7 @@ export interface Context {
     | {
         currentLevel: MfaAssuranceLevel | null;
         nextLevel: MfaAssuranceLevel | null;
+        lookupFailed?: boolean | undefined;
       }
     | undefined;
   /** JWTカスタムクレームから取得したサブスクリプション状態（custom_access_token hook） */
@@ -195,11 +196,16 @@ async function createTRPCContext(opts: {
           data: { session },
         } = await supabase.auth.getSession();
         sessionId = session?.access_token;
-        const { data: aalData } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+        const { data: aalData, error: aalError } =
+          await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
         mfaAssurance = {
           currentLevel: normalizeMfaAssuranceLevel(aalData?.currentLevel),
           nextLevel: normalizeMfaAssuranceLevel(aalData?.nextLevel),
+          lookupFailed: Boolean(aalError),
         };
+        if (aalError) {
+          logger.warn('MFA assurance lookup failed', { message: aalError.message });
+        }
       }
     } catch {
       // 認証エラーは無視（ゲストユーザーとして扱う）
@@ -303,6 +309,8 @@ const OAUTH_TRPC_SCOPE_REQUIREMENTS: Partial<Record<string, SupportedScope>> = {
   'entries.list': 'read:entries',
 };
 
+const MFA_CHALLENGE_TRPC_PATHS = new Set(['user.verifyRecoveryCode']);
+
 function isUserRateLimitedInMemory(userId: string): boolean {
   const now = Date.now();
   const timestamps = userRequestLog.get(userId) ?? [];
@@ -362,16 +370,26 @@ export const protectedProcedure = t.procedure
       }
     }
 
-    if (
-      ctx.authMode === 'session' &&
-      ctx.mfaAssurance?.currentLevel === 'aal1' &&
-      ctx.mfaAssurance.nextLevel === 'aal2'
-    ) {
-      throw new TRPCError({
-        code: 'FORBIDDEN',
-        message: 'MFA verification required',
-        cause: new ServiceError('FORBIDDEN', 'MFA AAL2 required'),
-      });
+    if (ctx.authMode === 'session') {
+      if (ctx.mfaAssurance?.lookupFailed) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'MFA verification required',
+          cause: new ServiceError('FORBIDDEN', 'MFA AAL lookup failed'),
+        });
+      }
+
+      if (
+        !MFA_CHALLENGE_TRPC_PATHS.has(path) &&
+        ctx.mfaAssurance?.currentLevel === 'aal1' &&
+        ctx.mfaAssurance.nextLevel === 'aal2'
+      ) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'MFA verification required',
+          cause: new ServiceError('FORBIDDEN', 'MFA AAL2 required'),
+        });
+      }
     }
 
     // per-userId レート制限

--- a/docs/product/specs/auth.md
+++ b/docs/product/specs/auth.md
@@ -12,7 +12,17 @@ Supabase Auth ベースの認証機能。
 
 - Supabase Auth によるセッション管理（メール/パスワード、MFA検証フローを含む）
 - `protectedProcedure` で保護された tRPC procedure が `ctx.userId` でデータアクセスを制限する
+- MFA登録済みで session assurance level が `aal1` のブラウザセッションは、画面遷移だけでなく tRPC API 側でも protected procedure を拒否する
 - RLS（Row Level Security）によるDBレベルでの認可を併用する
+
+## tRPC API auth policy
+
+`/api/trpc` は middleware/proxy を通らないため、API gate 自体で認証状態を再評価する。
+
+- Session cookie mode: Supabase Auth の `getUser()` でユーザーを検証し、MFA登録済み `aal1 -> aal2` の状態なら `FORBIDDEN` を返す
+- OAuth bearer mode: token を `oauth_tokens` で検証し、`client_id` と `scopes` を tRPC context に保持する
+- OAuth bearer mode の汎用 tRPC 呼び出しは、procedure path ごとの allowlist と scope が一致した場合だけ許可する
+- Phase 1 で OAuth bearer mode から許可する tRPC procedure は `entries.list` + `read:entries` のみ
 
 ## OAuth / MCP redirect URI policy
 

--- a/docs/product/specs/auth.md
+++ b/docs/product/specs/auth.md
@@ -20,6 +20,8 @@ Supabase Auth ベースの認証機能。
 `/api/trpc` は middleware/proxy を通らないため、API gate 自体で認証状態を再評価する。
 
 - Session cookie mode: Supabase Auth の `getUser()` でユーザーを検証し、MFA登録済み `aal1 -> aal2` の状態なら `FORBIDDEN` を返す
+- MFA AAL 取得に失敗した session cookie mode は fail closed として `FORBIDDEN` を返す
+- `user.verifyRecoveryCode` は recovery-code 検証により MFA factor を解除するため、既知の `aal1 -> aal2` 状態でも通過を許可する
 - OAuth bearer mode: token を `oauth_tokens` で検証し、`client_id` と `scopes` を tRPC context に保持する
 - OAuth bearer mode の汎用 tRPC 呼び出しは、procedure path ごとの allowlist と scope が一致した場合だけ許可する
 - Phase 1 で OAuth bearer mode から許可する tRPC procedure は `entries.list` + `read:entries` のみ


### PR DESCRIPTION
## Summary
- OAuth bearer token の tRPC 汎用呼び出しを procedure path + scope allowlist で制限
- MFA 登録済み AAL1 セッションを tRPC protectedProcedure 側でも拒否
- auth redirect の raw / encoded backslash canonicalization を拒否
- 対象仕様と回帰テストを追加

## Issues
Closes #1439
Closes #1447
Closes #1441

## Verification
- pnpm --filter @dayopt/product test:run -- src/lib/auth/__tests__/token-expiry.test.ts src/lib/safe-redirect.test.ts
- pnpm typecheck
- pnpm lint
- pnpm lint:boundaries
- pnpm docs:check
- pnpm license:check
- pnpm license:credits:check
- pnpm lint:i18n
- pnpm storybook:taxonomy
- pnpm quality:deadcode:ci
- pnpm test:run
- pnpm exec prettier --check apps/product/src/lib/trpc/procedures.ts apps/product/src/lib/mcp/trpc-bridge.ts apps/product/src/lib/test/trpc-test-helpers.ts apps/product/src/lib/safe-redirect.ts apps/product/src/lib/safe-redirect.test.ts apps/product/src/lib/auth/__tests__/token-expiry.test.ts docs/product/specs/auth.md

Note: pnpm check は unrelated untracked docs/projects/lp-launch-content/overview.md の Prettier warning で停止。変更対象ファイルの prettier check と pnpm check の構成要素は個別に通過済み。