### PR TITLE
fix(contact): フィードバック起票をbest-effort化し消失を防ぐ

### DIFF
--- a/apps/product/src/features/contact/server/__tests__/contact-service.test.ts
+++ b/apps/product/src/features/contact/server/__tests__/contact-service.test.ts
@@ -8,40 +8,56 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
+const mockLoggerError = vi.fn();
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    log: vi.fn(),
+    error: (...args: unknown[]) => mockLoggerError(...args),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+const mockCaptureException = vi.fn();
+vi.mock('@sentry/nextjs', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+  addBreadcrumb: vi.fn(),
+}));
+
 async function importService(envOverrides?: Record<string, string>) {
   vi.resetModules();
 
   vi.stubEnv('GITHUB_TOKEN', envOverrides?.GITHUB_TOKEN ?? 'ghp_test_token');
   vi.stubEnv('GITHUB_CONTACT_REPO', envOverrides?.GITHUB_CONTACT_REPO ?? 'test-owner/test-repo');
 
-  const mod = await import('../contact-service');
-  return mod.createGitHubIssue;
+  return import('../contact-service');
 }
 
-describe('createGitHubIssue', () => {
-  const defaultParams = {
-    userId: 'user-123',
-    userEmail: 'test@example.com',
-    userName: 'Test User',
-    input: {
-      category: 'bug' as const,
-      message: 'Something is broken',
-      environment: {
-        appVersion: '0.19.0',
-        os: 'macOS 15.0',
-        browser: 'Chrome 120.0',
-        timezone: 'Asia/Tokyo',
-        language: 'ja',
-      },
+const defaultParams = {
+  userId: 'user-123',
+  userEmail: 'test@example.com',
+  userName: 'Test User',
+  input: {
+    category: 'bug' as const,
+    message: 'Something is broken',
+    environment: {
+      appVersion: '0.19.0',
+      os: 'macOS 15.0',
+      browser: 'Chrome 120.0',
+      timezone: 'Asia/Tokyo',
+      language: 'ja',
     },
-  };
+  },
+};
 
+describe('createGitHubIssue', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it('正常系: GitHub Issue を作成する', async () => {
-    const createGitHubIssue = await importService();
+    const { createGitHubIssue } = await importService();
 
     mockFetch.mockResolvedValueOnce({
       ok: true,
@@ -67,7 +83,7 @@ describe('createGitHubIssue', () => {
   });
 
   it('正常系: Issue 本文にユーザー情報とメッセージが含まれる', async () => {
-    const createGitHubIssue = await importService();
+    const { createGitHubIssue } = await importService();
 
     mockFetch.mockResolvedValueOnce({
       ok: true,
@@ -94,11 +110,11 @@ describe('createGitHubIssue', () => {
     expect(body.body).toContain('Browser: Chrome 120.0');
     expect(body.body).toContain('Timezone: Asia/Tokyo');
     expect(body.body).toContain('Language: ja');
-    expect(body.labels).toEqual(['contact', 'app', 'bug']);
+    expect(body.labels).toEqual(['contact', 'feedback', 'app', 'bug']);
   });
 
   it('正常系: カテゴリごとのラベルが正しい', async () => {
-    const createGitHubIssue = await importService();
+    const { createGitHubIssue } = await importService();
 
     const categories = [
       { input: 'bug' as const, label: 'Bug' },
@@ -135,7 +151,7 @@ describe('createGitHubIssue', () => {
   });
 
   it('エラー系: GitHub API がエラーを返す', async () => {
-    const createGitHubIssue = await importService();
+    const { createGitHubIssue } = await importService();
 
     mockFetch.mockResolvedValueOnce({
       ok: false,
@@ -149,15 +165,18 @@ describe('createGitHubIssue', () => {
   });
 
   it('エラー系: 環境変数が未設定', async () => {
-    const createGitHubIssue = await importService({ GITHUB_TOKEN: '', GITHUB_CONTACT_REPO: '' });
+    const { createGitHubIssue } = await importService({
+      GITHUB_TOKEN: '',
+      GITHUB_CONTACT_REPO: '',
+    });
 
     await expect(createGitHubIssue(defaultParams)).rejects.toThrow(
       'GitHub API configuration is missing',
     );
   });
 
-  it('GitHub API向けの必須headerとlabelsを送る', async () => {
-    const createGitHubIssue = await importService();
+  it('GitHub API向けの必須headerとlabelsとtimeout signalを送る', async () => {
+    const { createGitHubIssue } = await importService();
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: () => Promise.resolve({ html_url: 'https://github.com/issues/3', number: 3 }),
@@ -178,12 +197,13 @@ describe('createGitHubIssue', () => {
     );
     const request = mockFetch.mock.calls[0]![1] as RequestInit;
     expect(JSON.parse(request.body as string)).toMatchObject({
-      labels: ['contact', 'app', 'bug'],
+      labels: ['contact', 'feedback', 'app', 'bug'],
     });
+    expect(request.signal).toBeInstanceOf(AbortSignal);
   });
 
   it('複数行とUnicodeを含むmessageをそのまま保持する', async () => {
-    const createGitHubIssue = await importService();
+    const { createGitHubIssue } = await importService();
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: () => Promise.resolve({ html_url: 'https://github.com/issues/4', number: 4 }),
@@ -201,7 +221,7 @@ describe('createGitHubIssue', () => {
   });
 
   it('GITHUB_TOKENだけ未設定でもAPIを呼ばない', async () => {
-    const createGitHubIssue = await importService({
+    const { createGitHubIssue } = await importService({
       GITHUB_TOKEN: '',
       GITHUB_CONTACT_REPO: 'test-owner/test-repo',
     });
@@ -213,7 +233,7 @@ describe('createGitHubIssue', () => {
   });
 
   it('GITHUB_CONTACT_REPOだけ未設定でもAPIを呼ばない', async () => {
-    const createGitHubIssue = await importService({
+    const { createGitHubIssue } = await importService({
       GITHUB_TOKEN: 'ghp_test_token',
       GITHUB_CONTACT_REPO: '',
     });
@@ -225,11 +245,109 @@ describe('createGitHubIssue', () => {
   });
 
   it('network errorを呼び出し元へ伝播する', async () => {
-    const createGitHubIssue = await importService();
+    const { createGitHubIssue } = await importService();
     const networkError = new TypeError('fetch failed');
     mockFetch.mockRejectedValueOnce(networkError);
 
     await expect(createGitHubIssue(defaultParams)).rejects.toBe(networkError);
     expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('deliverContactFeedback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('正常系: 起票成功時は delivered: true と issue 情報を返す', async () => {
+    const { deliverContactFeedback } = await importService();
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ html_url: 'https://github.com/issues/5', number: 5 }),
+    });
+
+    const result = await deliverContactFeedback(defaultParams);
+
+    expect(result).toEqual({
+      delivered: true,
+      issueUrl: 'https://github.com/issues/5',
+      issueNumber: 5,
+    });
+    expect(mockLoggerError).not.toHaveBeenCalled();
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('best-effort: GitHub API 失敗時も throw せず delivered: false を返す', async () => {
+    const { deliverContactFeedback } = await importService();
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve('Internal Server Error'),
+    });
+
+    const result = await deliverContactFeedback(defaultParams);
+
+    expect(result).toEqual({ delivered: false });
+  });
+
+  it('best-effort: 失敗時にフィードバック内容を構造化ログへ退避する', async () => {
+    const { deliverContactFeedback } = await importService();
+
+    const networkError = new TypeError('fetch failed');
+    mockFetch.mockRejectedValueOnce(networkError);
+
+    await deliverContactFeedback(defaultParams);
+
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      'Contact feedback delivery to GitHub failed',
+      expect.objectContaining({
+        userId: 'user-123',
+        userEmail: 'test@example.com',
+        category: 'bug',
+        message: 'Something is broken',
+        environment: defaultParams.input.environment,
+        error: 'fetch failed',
+      }),
+    );
+  });
+
+  it('best-effort: 失敗時に Sentry へ内容つきで capture する', async () => {
+    const { deliverContactFeedback } = await importService();
+
+    const networkError = new TypeError('fetch failed');
+    mockFetch.mockRejectedValueOnce(networkError);
+
+    await deliverContactFeedback(defaultParams);
+
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      networkError,
+      expect.objectContaining({
+        tags: { source: 'contact', operation: 'github_issue_create' },
+        user: { id: 'user-123' },
+        extra: expect.objectContaining({
+          category: 'bug',
+          message: 'Something is broken',
+        }),
+      }),
+    );
+  });
+
+  it('best-effort: 環境変数未設定でも throw せず内容を退避する', async () => {
+    const { deliverContactFeedback } = await importService({
+      GITHUB_TOKEN: '',
+      GITHUB_CONTACT_REPO: '',
+    });
+
+    const result = await deliverContactFeedback(defaultParams);
+
+    expect(result).toEqual({ delivered: false });
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      'Contact feedback delivery to GitHub failed',
+      expect.objectContaining({ message: 'Something is broken' }),
+    );
+    expect(mockCaptureException).toHaveBeenCalled();
   });
 });

--- a/apps/product/src/features/contact/server/contact-service.ts
+++ b/apps/product/src/features/contact/server/contact-service.ts
@@ -8,7 +8,10 @@ import 'server-only';
  * App側は環境情報・プラン情報を自動付与
  */
 
+import * as Sentry from '@sentry/nextjs';
+
 import { env } from '@/env';
+import { logger } from '@/lib/logger';
 import { ServiceError } from '@/lib/trpc/errors';
 
 import type { ContactFormInput } from '../types';
@@ -16,6 +19,9 @@ import type { ContactFormInput } from '../types';
 const GITHUB_TOKEN = env.GITHUB_TOKEN;
 /** Web側と同じ変数名 (e.g. "Dayopt/dayopt") */
 const GITHUB_CONTACT_REPO = env.GITHUB_CONTACT_REPO;
+
+/** GitHub API のタイムアウト（Web側 apps/web/src/app/api/contact/route.ts と同値） */
+const GITHUB_API_TIMEOUT_MS = 10_000;
 
 /** Web側と統一したカテゴリラベル */
 const CATEGORY_LABELS: Record<string, string> = {
@@ -36,6 +42,10 @@ interface CreateIssueResult {
   issueUrl: string;
   issueNumber: number;
 }
+
+/** GitHub Issue 起票の結果。失敗してもフィードバック自体は失われない */
+export type DeliverContactFeedbackResult =
+  { delivered: true; issueUrl: string; issueNumber: number } | { delivered: false };
 
 /**
  * GitHub Issue を作成する
@@ -69,32 +79,81 @@ export async function createGitHubIssue(params: CreateIssueParams): Promise<Crea
     input.message,
   ].join('\n');
 
-  const response = await fetch(`https://api.github.com/repos/${GITHUB_CONTACT_REPO}/issues`, {
-    method: 'POST',
-    headers: {
-      Authorization: `token ${GITHUB_TOKEN}`,
-      'Content-Type': 'application/json',
-      Accept: 'application/vnd.github.v3+json',
-    },
-    body: JSON.stringify({
-      title: `[App] [${categoryLabel}] ${userName}`,
-      body: issueBody,
-      labels: ['contact', 'app', input.category],
-    }),
-  });
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), GITHUB_API_TIMEOUT_MS);
 
-  if (!response.ok) {
-    const errorBody = await response.text();
-    throw new ServiceError(
-      'GITHUB_API_FAILED',
-      `GitHub API error (${response.status}): ${errorBody}`,
-    );
+  try {
+    const response = await fetch(`https://api.github.com/repos/${GITHUB_CONTACT_REPO}/issues`, {
+      method: 'POST',
+      headers: {
+        Authorization: `token ${GITHUB_TOKEN}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/vnd.github.v3+json',
+      },
+      body: JSON.stringify({
+        title: `[App] [${categoryLabel}] ${userName}`,
+        body: issueBody,
+        labels: ['contact', 'feedback', 'app', input.category],
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new ServiceError(
+        'GITHUB_API_FAILED',
+        `GitHub API error (${response.status}): ${errorBody}`,
+      );
+    }
+
+    const data = (await response.json()) as { html_url: string; number: number };
+
+    return {
+      issueUrl: data.html_url,
+      issueNumber: data.number,
+    };
+  } finally {
+    clearTimeout(timeoutId);
   }
+}
 
-  const data = (await response.json()) as { html_url: string; number: number };
+/**
+ * フィードバックを GitHub Issue として起票する（best-effort）
+ *
+ * 初期ユーザーの声はこのプロダクトで最も回収不能な資産なので、起票に失敗しても
+ * ユーザーの送信は失敗させない。内容を構造化ログと Sentry event に退避してから
+ * `delivered: false` を返す（呼び出し元は成功として扱ってよい）。
+ */
+export async function deliverContactFeedback(
+  params: CreateIssueParams,
+): Promise<DeliverContactFeedbackResult> {
+  try {
+    const result = await createGitHubIssue(params);
+    return { delivered: true, ...result };
+  } catch (error) {
+    const { userId, userEmail, input } = params;
 
-  return {
-    issueUrl: data.html_url,
-    issueNumber: data.number,
-  };
+    logger.error('Contact feedback delivery to GitHub failed', {
+      userId,
+      userEmail,
+      category: input.category,
+      message: input.message,
+      environment: input.environment,
+      error: error instanceof Error ? error.message : String(error),
+    });
+
+    // Sentry の extra は PII scrub（scrub-pii.ts）で email が redact されるため、
+    // 送信者の特定は user.id 側で担保する
+    Sentry.captureException(error instanceof Error ? error : new Error(String(error)), {
+      tags: { source: 'contact', operation: 'github_issue_create' },
+      user: { id: userId },
+      extra: {
+        category: input.category,
+        message: input.message,
+        environment: input.environment,
+      },
+    });
+
+    return { delivered: false };
+  }
 }

--- a/apps/product/src/features/contact/server/router.ts
+++ b/apps/product/src/features/contact/server/router.ts
@@ -12,7 +12,7 @@ import { handleServiceError } from '@/lib/trpc/errors';
 import { createTRPCRouter, protectedProcedure } from '@/lib/trpc/procedures';
 
 import { contactFormSchema } from '../schemas';
-import { createGitHubIssue } from './contact-service';
+import { deliverContactFeedback } from './contact-service';
 
 /** お問い合わせフォームのtRPCルーター */
 export const contactRouter = createTRPCRouter({
@@ -45,28 +45,22 @@ export const contactRouter = createTRPCRouter({
       const userEmail = user?.email ?? 'unknown';
       const userName = user?.user_metadata?.full_name ?? 'Unknown';
 
-      try {
-        const result = await createGitHubIssue({
-          userId: ctx.userId,
-          userEmail,
-          userName,
-          input,
-        });
+      // 起票失敗時も deliverContactFeedback 内で内容がログ/Sentryに退避されるため、
+      // ユーザーへは常に成功を返す（フィードバックを失わせない）
+      const result = await deliverContactFeedback({
+        userId: ctx.userId,
+        userEmail,
+        userName,
+        input,
+      });
 
-        logger.info('Contact form submitted', {
-          userId: ctx.userId,
-          category: input.category,
-          issueNumber: result.issueNumber,
-        });
+      logger.info('Contact form submitted', {
+        userId: ctx.userId,
+        category: input.category,
+        delivered: result.delivered,
+        issueNumber: result.delivered ? result.issueNumber : undefined,
+      });
 
-        return { success: true as const };
-      } catch (error) {
-        logger.error('Contact form submission failed', {
-          userId: ctx.userId,
-          category: input.category,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        return handleServiceError(error);
-      }
+      return { success: true as const };
     }),
 });

--- a/docs/product/specs/contact.md
+++ b/docs/product/specs/contact.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_verified: 2026-07-02
+last_verified: 2026-07-06
 code: apps/product/src/features/contact
 ---
 
@@ -11,4 +11,13 @@ code: apps/product/src/features/contact
 ## 現在の振る舞い
 
 - フォーム経由でユーザーの声（感想・要望・不具合報告）を受け付ける
-- 受け取ったフィードバックは `docs/log/notes/YYYY-MM-DD-feedback-<slug>.md` に記録する運用（AGENTS.md 参照）
+- 送信内容は GitHub Issue として自動起票する（repo: `GITHUB_CONTACT_REPO`、labels: `contact` / `feedback` / `app` / カテゴリ）。Web側（dayopt.app/contact）と同一フォーマット
+- **起票は best-effort**: GitHub API の失敗・env 未設定時もユーザーの送信は成功扱いとし、内容を構造化ログと Sentry event（`source: contact`）へ退避する。フィードバックはどの経路でも失われない
+- GitHub API 呼び出しは 10 秒でタイムアウト（Web側と同値）
+- レート制限は userId ベース（Upstash）
+- 受け取ったフィードバックは `docs/product/log/YYYY-MM-DD-feedback-<slug>.md` に記録する運用（AGENTS.md 参照）。GitHub Issue 起票により一次記録は自動化されており、docs への記録は「原文の凍結」として行う
+
+## 運用前提
+
+- `GITHUB_TOKEN` / `GITHUB_CONTACT_REPO` を product アプリの本番 env に設定する（web プロジェクトには設定済み。運用は `docs/operations/secrets.md` に従う）
+- env 未設定の間も送信は成功するが、内容の回収先が Sentry / ログのみになる


### PR DESCRIPTION
## 背景

創業者監査（`docs/business/log/2026-07-05-founder-audit.md`）のフォローアップ。「Contactフォームは実装済みなのにフィードバック記録がゼロ」の根本原因を調査した結果:

- **product の Vercel 本番プロジェクトに `GITHUB_TOKEN` / `GITHUB_CONTACT_REPO` が未設定**（web プロジェクトには3環境とも設定済み）。現行実装は env 未設定時に throw するため、**本番のアプリ内Contactフォームは送信が全件エラーになる状態**だった
- さらに GitHub API 障害時はフィードバック内容がどこにも残らず完全消失する設計だった

## 変更内容

- `deliverContactFeedback` を新設し、GitHub Issue 起票を **best-effort** 化。失敗時（API障害・env未設定）は内容を構造化ログ + Sentry event（`source: contact`、`user.id` 付き、本文は extra に退避）に保全し、ユーザーへは成功を返す
- GitHub API 呼び出しに **10秒タイムアウト**を追加（Web側 `apps/web/src/app/api/contact/route.ts` と同値）
- Issue labels に `feedback` を追加（ユーザーの声のフィルタ用）
- 仕様doc `docs/product/specs/contact.md` を実態に同期（stale だった記録先パス `docs/log/notes/` → `docs/product/log/` も修正）

## PII について

Sentry の extra は `scrub-pii.ts` により email が redact されるため、送信者特定は `user.id` で担保。ログ側（Vercel runtime logs）には email を含む全文が残る（GitHub Issue に書く内容と同等）。

## 検証

- unit tests 49件 pass（`deliverContactFeedback` の成功/失敗/env未設定の3経路を追加）
- `pnpm typecheck` / `pnpm lint` / `pnpm lint:boundaries` pass
- 実配管テスト: コードと同一ペイロードで実 API 起票 → #1507 が labels 4つ（`contact`/`feedback`/`app`/`other`、未作成ラベルは自動作成）付きで作成されることを確認 → close 済み
- `contact` / `feedback` ラベルを説明付きで事前作成済み

## マージ後に必要な作業（コード外・要ユーザー対応）

- [ ] **product の Vercel プロジェクトに `GITHUB_TOKEN` / `GITHUB_CONTACT_REPO` を設定する**（web プロジェクトと同じ値。`docs/operations/secrets.md` の運用に従う）。これが本 issue の本丸で、未設定の間はフォールバック（ログ/Sentry）経由でのみ回収可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)
