### PR TITLE
docs: vercel pre-deploy/security readiness の監査結果を反映

### DIFF
--- a/docs/operations/log/2026-07-08-vercel-predeploy-security-audit.md
+++ b/docs/operations/log/2026-07-08-vercel-predeploy-security-audit.md
@@ -1,0 +1,36 @@
+---
+status: frozen
+last_verified: 2026-07-08
+---
+
+# Vercel pre-deploy / security readiness audit
+
+Issues #1502, #1461, #1459 を同じ作業単位として確認した。
+値は確認せず、Vercel project metadata、env metadata、未認証 HTTP response だけを見た。
+
+## 対象
+
+- Vercel team: `Dayopt`
+- Projects: `product`, `web`
+- Branch: `codex/vercel-predeploy-security`
+
+## 確認結果
+
+- `product` と `web` の preview URL は未認証で `302` to `https://vercel.com/sso-api`。
+- `dayopt.app` と `app.dayopt.app` は production として `200`。
+- `mcp.dayopt.app` は未認証で `401`。
+- `product` Preview に production Supabase credentials は見えない。
+- `product` の Automation Bypass は存在し、Vercel env var として管理されている。
+- local Vercel CLI `50.32.5` の `vercel deploy --help` に `--dry` は出ていない。
+- Vercel CLI API で production / preview の server-only secret 12 件を `sensitive` に更新した。
+
+## 残タスク
+
+- Preview に置かれている long-lived secrets の必要性を見直す。
+- Development scope に残した `encrypted` secrets の必要性を見直す。
+- `vercel deploy --dry` は CLI / docs の両方で確認できるまで pre-deploy check に入れない。
+
+## 関連
+
+- Stock: `docs/operations/security/environment-secrets.md`
+- Issue: #1502, #1461, #1459

--- a/docs/operations/security/environment-secrets.md
+++ b/docs/operations/security/environment-secrets.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_verified: 2026-06-17
+last_verified: 2026-07-08
 ---
 
 # Environment Secrets
@@ -40,6 +40,60 @@ GitHub branch protection では、通常の CI check に加えて Supabase integ
 
 Preview scope に production Supabase credentials を手動設定しない。
 既に入っている場合は削除するか、Preview から外して Supabase integration 管理に寄せる。
+
+### Vercel readiness audit (2026-07-08)
+
+対象 project は Vercel team `Dayopt` の `product` と `web`。
+確認は secret 値ではなく metadata と未認証レスポンスだけを見る。
+
+#### Preview protection
+
+| URL                                | 期待                                               | 2026-07-08 確認結果                   |
+| ---------------------------------- | -------------------------------------------------- | ------------------------------------- |
+| `*.vercel.app` preview (`product`) | 未認証は Vercel SSO / Deployment Protection に送る | `302` to `https://vercel.com/sso-api` |
+| `*.vercel.app` preview (`web`)     | 未認証は Vercel SSO / Deployment Protection に送る | `302` to `https://vercel.com/sso-api` |
+| `app.dayopt.app`                   | production app として通常到達できる                | `200`                                 |
+| `dayopt.app`                       | production marketing site として通常到達できる     | `200`                                 |
+| `mcp.dayopt.app`                   | OAuth / token validation で保護される              | `401`                                 |
+
+`product` には Automation Bypass が存在し、Vercel env var として管理されている。
+値は docs / issue / PR / terminal に出さない。漏えいが疑われる場合は Vercel Dashboard で rotate し、
+新しい値は 1Password か Vercel-managed secret storage だけに置く。
+
+#### Env scope / Sensitive flag
+
+`product` Preview に production Supabase credentials は見えない。
+Supabase integration 由来の production DB / key も `production` target のみ。
+
+次の server-only secret は Vercel CLI API で `sensitive` に更新済み。
+値は読まず、`vercel api` で env type だけを変更した。
+
+| Project   | Env                         | Production / Preview | Development |
+| --------- | --------------------------- | -------------------- | ----------- |
+| `product` | `SUPABASE_SERVICE_ROLE_KEY` | `sensitive`          | n/a         |
+| `product` | `RECOVERY_CODE_PEPPER`      | `sensitive`          | `encrypted` |
+| `product` | `RESEND_API_KEY`            | `sensitive`          | `encrypted` |
+| `product` | `RESEND_WEBHOOK_SECRET`     | `sensitive`          | n/a         |
+| `product` | `SENTRY_AUTH_TOKEN`         | `sensitive`          | `encrypted` |
+| `product` | `GITHUB_TOKEN`              | `sensitive`          | `encrypted` |
+| `web`     | `GITHUB_TOKEN`              | `sensitive`          | `encrypted` |
+
+Development scope の secret は Vercel Sensitive Env の対象外として `encrypted` のまま残す。
+今後の棚卸しでは、development / preview に long-lived secret が必要かを用途ごとに確認する。
+
+`NEXT_PUBLIC_*` と repository 名などの公開 metadata は secret 扱いにしない。
+`NEXT_PUBLIC_TURNSTILE_SITE_KEY` は public key なので、`sensitive` のままでも事故ではないが必須ではない。
+
+#### Pre-deploy dry run
+
+2026-07-08 時点の local Vercel CLI は `50.32.5`。
+`vercel deploy --help` に `--dry` は出ていないため、`vercel deploy --dry` を pre-deploy check / CI に入れない。
+CLI と公式 docs の両方で dry run が確認できた時点で、次の順で再評価する。
+
+1. `vercel deploy --help` で `--dry` が表示されることを確認する
+2. `product` と `web` で deploy されないことを確認する
+3. 出力が secret 値を含まないことを確認する
+4. 有用なら `pnpm` script か CI の warning-only step に入れる
 
 ## Supabase
 


### PR DESCRIPTION
## Summary

- Vercel `product` / `web` の pre-deploy / security readiness 監査結果を `environment-secrets.md` に反映
- 監査ログとして `2026-07-08-vercel-predeploy-security-audit.md` を追加
- Vercel CLI API で production / preview の server-only secrets 12 件を `sensitive` 化

## Details

- Preview URL は未認証で Vercel SSO に `302` されることを確認
- Production の `dayopt.app` / `app.dayopt.app` は `200`、`mcp.dayopt.app` は未認証 `401` を確認
- `product` Preview に production Supabase credentials が出ていないことを確認
- local Vercel CLI `50.32.5` では `vercel deploy --dry` が `vercel deploy --help` に出ないため、現時点では pre-deploy check / CI へ組み込まない判断を記録

## Validation

- `pnpm docs:check`
- `pnpm exec prettier --check docs/operations/security/environment-secrets.md docs/operations/log/2026-07-08-vercel-predeploy-security-audit.md`

Closes #1502
Closes #1461
Closes #1459
