### PR TITLE
docs: supabase migration drift調査を記録

### DIFF
--- a/docs/engineering/infra.md
+++ b/docs/engineering/infra.md
@@ -996,11 +996,22 @@ PR を作成すると Supabase GitHub integration が Preview Branch を作成�
 
 通常運用では手動 `supabase db push` を使わない。Supabase integration 障害などで緊急対応が必要な場合だけ、Production の 1Password secret を使い、作業ログに理由を残して実行する。
 
+`main` branch が `MIGRATIONS_FAILED` を示している場合は、先に失敗状態が production migration path の実体か、Preview Branch 側の古い状態かを確認する。production schema に未適用 migration があるまま launch-blocker の security migration を merge すると、Git 上では修正済みでも本番 DB へ反映されない。
+
+確認すること:
+
+- Supabase dashboard の production deployment / branch log に失敗した migration 名と SQL error が残っている
+- production DB の `supabase_migrations.schema_migrations` 最新 version が repo の `supabase/migrations/` と一致している
+- 不一致がある場合、未適用 migration を列挙して作業ログに残している
+- 手動適用が必要な場合、`--dry-run` 結果と backup / PITR の状態を確認している
+
 ```bash
 supabase link --project-ref yvglwblxrnrenfifsnje
 supabase db push --dry-run
 supabase db push
 ```
+
+手動適用後は migration history を再確認し、Supabase branch status が解消されたか、または production path に影響しない非 authoritative な preview 状態だったことを作業ログに残す。
 
 ### マイグレーション統合時の注意
 

--- a/docs/engineering/infra.md
+++ b/docs/engineering/infra.md
@@ -1003,7 +1003,7 @@ PR を作成すると Supabase GitHub integration が Preview Branch を作成�
 - Supabase dashboard の production deployment / branch log に失敗した migration 名と SQL error が残っている
 - production DB の `supabase_migrations.schema_migrations` 最新 version が repo の `supabase/migrations/` と一致している
 - 不一致がある場合、未適用 migration を列挙して作業ログに残している
-- 手動適用が必要な場合、`--dry-run` 結果と backup / PITR の状態を確認している
+- 手動適用が必要な場合、`--dry-run` で適用対象 migration を確認し、対象 SQL の destructive change / backfill / lock risk と backup / PITR の状態を確認している
 
 ```bash
 supabase link --project-ref yvglwblxrnrenfifsnje

--- a/docs/operations/log/2026-07-08-supabase-migration-drift.md
+++ b/docs/operations/log/2026-07-08-supabase-migration-drift.md
@@ -40,7 +40,7 @@ GitHub integration が production migration の通常経路である前提は維
 - Supabase dashboard の production deployment / branch log で失敗箇所を特定する。
 - production DB の backup / PITR 状態を確認する。
 - `supabase db push --dry-run` で未適用 migration と SQL plan を確認する。
-- 手動 `supabase db push` が必要な場合は、作業理由と dry-run 結果をこの log または後続 log に残してから実行する。
+- 手動 `supabase db push` が必要な場合は、作業理由と dry-run 結果を後続 log に残してから実行する。
 - 適用後に `supabase_migrations.schema_migrations` の最新 version と branch status を再確認する。
 
 ## 検証

--- a/docs/operations/log/2026-07-08-supabase-migration-drift.md
+++ b/docs/operations/log/2026-07-08-supabase-migration-drift.md
@@ -39,7 +39,7 @@ GitHub integration が production migration の通常経路である前提は維
 
 - Supabase dashboard の production deployment / branch log で失敗箇所を特定する。
 - production DB の backup / PITR 状態を確認する。
-- `supabase db push --dry-run` で未適用 migration と SQL plan を確認する。
+- `supabase db push --dry-run` で未適用 migration を確認し、対象 migration ファイルの destructive change / backfill / lock risk をレビューする。
 - 手動 `supabase db push` が必要な場合は、作業理由と dry-run 結果を後続 log に残してから実行する。
 - 適用後に `supabase_migrations.schema_migrations` の最新 version と branch status を再確認する。
 

--- a/docs/operations/log/2026-07-08-supabase-migration-drift.md
+++ b/docs/operations/log/2026-07-08-supabase-migration-drift.md
@@ -1,0 +1,50 @@
+---
+status: active
+last_verified: 2026-07-08
+issue: 1462
+code: supabase/migrations
+---
+
+# Supabase main branch MIGRATIONS_FAILED 調査
+
+Issue #1462 の初期調査として、Supabase main branch status と production migration history を非破壊で確認した。
+
+## 確認結果
+
+- Supabase project `dayopt` (`yvglwblxrnrenfifsnje`) の default branch `main` は `MIGRATIONS_FAILED` のまま。
+- Preview project status は `ACTIVE_HEALTHY`。
+- production DB の `supabase_migrations.schema_migrations` で確認できる最新 migration は `20260604232051_grant_authenticated_rpc_helpers`。
+- repo の `supabase/migrations/` には `20260604232051` より後の migration が 10 本ある。
+
+未適用候補:
+
+- `20260610000000_entry_auto_record_model.sql`
+- `20260613000000_drop_orphan_tag_detail_rpcs.sql`
+- `20260615000000_drop_unused_stats_rpcs.sql`
+- `20260616000000_rename_duration_to_planned_duration.sql`
+- `20260704050000_harden_remaining_definer_rpc_user_guard.sql`
+- `20260704051000_allow_service_role_definer_rpc_guard.sql`
+- `20260705070000_restrict_profiles_billing_column_grants.sql`
+- `20260705070100_restrict_profiles_billing_column_grants_for_anon.sql`
+- `20260706120000_enforce_entry_tag_owner.sql`
+- `20260706120100_backfill_entry_tag_owner_mismatch.sql`
+
+## 判断
+
+GitHub integration が production migration の通常経路である前提は維持する。ただし、現時点では repo の migration と production DB の migration history が一致していないため、#1462 はまだ close しない。
+
+この状態では、security migration を merge しても production DB へ反映済みとは判断できない。launch 前に Supabase dashboard の production deployment log を確認し、失敗した migration 名と SQL error を特定する必要がある。
+
+## 復旧ゲート
+
+- Supabase dashboard の production deployment / branch log で失敗箇所を特定する。
+- production DB の backup / PITR 状態を確認する。
+- `supabase db push --dry-run` で未適用 migration と SQL plan を確認する。
+- 手動 `supabase db push` が必要な場合は、作業理由と dry-run 結果をこの log または後続 log に残してから実行する。
+- 適用後に `supabase_migrations.schema_migrations` の最新 version と branch status を再確認する。
+
+## 検証
+
+- Supabase branch list: default `main` status `MIGRATIONS_FAILED`
+- production migration history read: latest `20260604232051_grant_authenticated_rpc_helpers`
+- local migration list read: `20260706120100_backfill_entry_tag_owner_mismatch.sql` まで存在


### PR DESCRIPTION
## Summary

- Refs #1462
- Supabase main branch の `MIGRATIONS_FAILED` と production migration history の現状を運用ログに記録
- repo と production DB の migration history 差分、未適用候補 10 本、復旧前の確認ゲートを明文化
- `docs/engineering/infra.md` の Emergency Runbook に failure state 確認手順を追加

## Notes

- #1462 はまだ close しません。production schema drift の解消、または failure state が production path に影響しないことの確認が残っています。
- Vercel 系 issue は別 worktree 対応のため、この PR では扱っていません。

## Verification

- `pnpm docs:check`
- `pnpm secrets:check`