### PR TITLE
feat: storybookのshared componentカタログとi18nを修正

### DIFF
--- a/apps/storybook/.storybook/decorators/index.tsx
+++ b/apps/storybook/.storybook/decorators/index.tsx
@@ -33,9 +33,12 @@ export const withWrapper = (className: string): Decorator => {
 };
 
 // メッセージファイルを自動収集（namespace追加時に変更不要）
-const messageModules = import.meta.glob<Record<string, string>>('../../messages/ja/*.json', {
-  eager: true,
-});
+const messageModules = import.meta.glob<Record<string, string>>(
+  '../../../product/messages/ja/*.json',
+  {
+    eager: true,
+  },
+);
 const messages = Object.entries(messageModules).reduce<Record<string, unknown>>(
   (acc, [, mod]) => ({ ...acc, ...(mod as Record<string, unknown>) }),
   {},

--- a/packages/components/src/identity/logo.stories.tsx
+++ b/packages/components/src/identity/logo.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Logo } from '@dayopt/components';
+
+const meta = {
+  title: 'Shared/Components/Identity/Logo',
+  component: Logo,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+  argTypes: {
+    label: {
+      control: 'text',
+      description: 'ロゴに付与するアクセシブル名と wordmark の表示文言',
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'ロゴのサイズ',
+    },
+    variant: {
+      control: 'select',
+      options: ['lockup', 'mark', 'wordmark'],
+      description: 'ロゴの表示形式',
+    },
+  },
+} satisfies Meta<typeof Logo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** 基本的な lockup ロゴ。 */
+export const Default: Story = {
+  args: {
+    label: 'Dayopt',
+    size: 'md',
+    variant: 'lockup',
+  },
+};
+
+/** 全パターン一覧。 */
+export const AllPatterns: Story = {
+  render: () => (
+    <div className="flex flex-col items-start gap-6">
+      <div className="flex items-center gap-4">
+        <Logo size="sm" />
+        <Logo size="md" />
+        <Logo size="lg" />
+      </div>
+      <div className="flex items-center gap-4">
+        <Logo variant="mark" size="sm" />
+        <Logo variant="mark" size="md" />
+        <Logo variant="mark" size="lg" />
+      </div>
+      <div className="flex items-center gap-4">
+        <Logo variant="wordmark" size="sm" />
+        <Logo variant="wordmark" size="md" />
+        <Logo variant="wordmark" size="lg" />
+      </div>
+    </div>
+  ),
+};

--- a/packages/components/src/utilities/visually-hidden.stories.tsx
+++ b/packages/components/src/utilities/visually-hidden.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { Bell, Search, Settings } from 'lucide-react';
+
+import { Button, VisuallyHidden } from '@dayopt/components';
+
+const meta = {
+  title: 'Shared/Components/Utilities/VisuallyHidden',
+  component: VisuallyHidden,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+  argTypes: {
+    children: {
+      control: 'text',
+      description: 'スクリーンリーダーだけに伝える文言',
+    },
+  },
+} satisfies Meta<typeof VisuallyHidden>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** アイコンボタンへ視覚非表示のラベルを付与する例。 */
+export const Default: Story = {
+  args: {
+    children: '検索',
+  },
+  render: (args) => (
+    <Button variant="ghost" icon>
+      <Search className="size-4" />
+      <VisuallyHidden {...args} />
+    </Button>
+  ),
+};
+
+/** 全パターン一覧。 */
+export const AllPatterns: Story = {
+  render: () => (
+    <div className="flex items-center gap-3">
+      <Button variant="ghost" icon>
+        <Search className="size-4" />
+        <VisuallyHidden>検索</VisuallyHidden>
+      </Button>
+      <Button variant="ghost" icon>
+        <Bell className="size-4" />
+        <VisuallyHidden>通知</VisuallyHidden>
+      </Button>
+      <Button variant="ghost" icon>
+        <Settings className="size-4" />
+        <VisuallyHidden>設定</VisuallyHidden>
+      </Button>
+    </div>
+  ),
+};


### PR DESCRIPTION
## Summary
- add Shared/Components/Identity/Logo and Shared/Components/Utilities/VisuallyHidden stories with AllPatterns
- load product ja messages from the shared Storybook i18n decorator

Closes #1497
Closes #1498

## Verification
- pnpm storybook:taxonomy
- pnpm typecheck
- pnpm lint
- pnpm lint:boundaries
- pnpm build-storybook