### PR TITLE
feat: plan/log基盤テーブルを追加

### DIFF
--- a/docs/engineering/data/db/rls-snapshot.md
+++ b/docs/engineering/data/db/rls-snapshot.md
@@ -5,7 +5,7 @@
 > **手で編集しない**。migration 変更時は CI（`pnpm rls:snapshot:check`）が drift を検出する。
 > 再生成で更新すること。
 >
-> 集計: public スキーマの policy 29 件 / RLS 対象テーブル 11 件 / GRANT 115 件 / Realtime publication 0 件。
+> 集計: public スキーマの policy 42 件 / RLS 対象テーブル 14 件 / GRANT 128 件 / Realtime publication 0 件。
 
 ## RLS 有効状態（public テーブル）
 
@@ -13,10 +13,13 @@
 | ------------------------- | ----------- | ------ |
 | email_suppressions        | ✅          | —      |
 | entries                   | ✅          | —      |
+| external_calendar_events  | ✅          | —      |
+| logs                      | ✅          | —      |
 | mfa_recovery_codes        | ✅          | —      |
 | oauth_audit_log           | ✅          | —      |
 | oauth_authorization_codes | ✅          | —      |
 | oauth_tokens              | ✅          | —      |
+| plans                     | ✅          | —      |
 | profiles                  | ✅          | —      |
 | reports                   | ✅          | —      |
 | stripe_webhook_events     | ✅          | —      |
@@ -39,6 +42,24 @@
 | Users can insert own plans | INSERT | PERMISSIVE | {public} | —                                                                  | (( SELECT auth.uid() AS uid) = user_id) |
 | Users can view own plans   | SELECT | PERMISSIVE | {public} | ((( SELECT auth.uid() AS uid) = user_id) AND (deleted_at IS NULL)) | —                                       |
 | Users can update own plans | UPDATE | PERMISSIVE | {public} | (( SELECT auth.uid() AS uid) = user_id)                            | (( SELECT auth.uid() AS uid) = user_id) |
+
+### external_calendar_events
+
+| policy                                                   | cmd    | permissive | roles           | USING                                   | WITH CHECK                              |
+| -------------------------------------------------------- | ------ | ---------- | --------------- | --------------------------------------- | --------------------------------------- |
+| Service role has full access to external calendar events | ALL    | PERMISSIVE | {service_role}  | true                                    | true                                    |
+| Users can view own external calendar events              | SELECT | PERMISSIVE | {authenticated} | (( SELECT auth.uid() AS uid) = user_id) | —                                       |
+| Users can dismiss own external calendar events           | UPDATE | PERMISSIVE | {authenticated} | (( SELECT auth.uid() AS uid) = user_id) | (( SELECT auth.uid() AS uid) = user_id) |
+
+### logs
+
+| policy                               | cmd    | permissive | roles           | USING                                                              | WITH CHECK                              |
+| ------------------------------------ | ------ | ---------- | --------------- | ------------------------------------------------------------------ | --------------------------------------- |
+| Service role has full access to logs | ALL    | PERMISSIVE | {service_role}  | true                                                               | true                                    |
+| Users can delete own logs            | DELETE | PERMISSIVE | {authenticated} | (( SELECT auth.uid() AS uid) = user_id)                            | —                                       |
+| Users can insert own logs            | INSERT | PERMISSIVE | {authenticated} | —                                                                  | (( SELECT auth.uid() AS uid) = user_id) |
+| Users can view own logs              | SELECT | PERMISSIVE | {authenticated} | ((( SELECT auth.uid() AS uid) = user_id) AND (deleted_at IS NULL)) | —                                       |
+| Users can update own logs            | UPDATE | PERMISSIVE | {authenticated} | (( SELECT auth.uid() AS uid) = user_id)                            | (( SELECT auth.uid() AS uid) = user_id) |
 
 ### mfa_recovery_codes
 
@@ -65,6 +86,16 @@
 | policy                          | cmd    | permissive | roles    | USING                                   | WITH CHECK |
 | ------------------------------- | ------ | ---------- | -------- | --------------------------------------- | ---------- |
 | Users can view own oauth_tokens | SELECT | PERMISSIVE | {public} | (( SELECT auth.uid() AS uid) = user_id) | —          |
+
+### plans
+
+| policy                                | cmd    | permissive | roles           | USING                                                              | WITH CHECK                              |
+| ------------------------------------- | ------ | ---------- | --------------- | ------------------------------------------------------------------ | --------------------------------------- |
+| Service role has full access to plans | ALL    | PERMISSIVE | {service_role}  | true                                                               | true                                    |
+| Users can delete own plans            | DELETE | PERMISSIVE | {authenticated} | (( SELECT auth.uid() AS uid) = user_id)                            | —                                       |
+| Users can insert own plans            | INSERT | PERMISSIVE | {authenticated} | —                                                                  | (( SELECT auth.uid() AS uid) = user_id) |
+| Users can view own plans              | SELECT | PERMISSIVE | {authenticated} | ((( SELECT auth.uid() AS uid) = user_id) AND (deleted_at IS NULL)) | —                                       |
+| Users can update own plans            | UPDATE | PERMISSIVE | {authenticated} | (( SELECT auth.uid() AS uid) = user_id)                            | (( SELECT auth.uid() AS uid) = user_id) |
 
 ### profiles
 
@@ -113,6 +144,7 @@
 
 | object type | object                                                                                                                                                                                                                                                                                  | grantee             | privileges                     |
 | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- | ------------------------------ |
+| column      | public.external_calendar_events.dismissed_at                                                                                                                                                                                                                                            | authenticated       | UPDATE                         |
 | column      | public.profiles.avatar_url                                                                                                                                                                                                                                                              | authenticated       | INSERT, UPDATE                 |
 | column      | public.profiles.email                                                                                                                                                                                                                                                                   | authenticated       | INSERT                         |
 | column      | public.profiles.full_name                                                                                                                                                                                                                                                               | authenticated       | INSERT, UPDATE                 |
@@ -135,6 +167,11 @@
 | routine     | public.enforce_entry_tag_owner()                                                                                                                                                                                                                                                        | PUBLIC              | EXECUTE                        |
 | routine     | public.enforce_entry_tag_owner()                                                                                                                                                                                                                                                        | authenticated       | EXECUTE                        |
 | routine     | public.enforce_entry_tag_owner()                                                                                                                                                                                                                                                        | service_role        | EXECUTE                        |
+| routine     | public.enforce_log_external_event_owner()                                                                                                                                                                                                                                               | service_role        | EXECUTE                        |
+| routine     | public.enforce_log_plan_owner()                                                                                                                                                                                                                                                         | service_role        | EXECUTE                        |
+| routine     | public.enforce_log_tag_owner()                                                                                                                                                                                                                                                          | service_role        | EXECUTE                        |
+| routine     | public.enforce_plan_external_event_owner()                                                                                                                                                                                                                                              | service_role        | EXECUTE                        |
+| routine     | public.enforce_plan_tag_owner()                                                                                                                                                                                                                                                         | service_role        | EXECUTE                        |
 | routine     | public.get_active_dates(p_user_id uuid, p_start_date date, p_end_date date)                                                                                                                                                                                                             | authenticated       | EXECUTE                        |
 | routine     | public.get_active_dates(p_user_id uuid, p_start_date date, p_end_date date)                                                                                                                                                                                                             | service_role        | EXECUTE                        |
 | routine     | public.get_active_users_for_reflection(p_week_start date, p_threshold_days integer, p_limit integer)                                                                                                                                                                                    | service_role        | EXECUTE                        |
@@ -179,6 +216,7 @@
 | routine     | public.merge_tags(p_user_id uuid, p_source_tag_id uuid, p_target_tag_id uuid)                                                                                                                                                                                                           | service_role        | EXECUTE                        |
 | routine     | public.merge_tags_with_hierarchy(p_user_id uuid, p_source_tag_id uuid, p_target_tag_id uuid)                                                                                                                                                                                            | authenticated       | EXECUTE                        |
 | routine     | public.merge_tags_with_hierarchy(p_user_id uuid, p_source_tag_id uuid, p_target_tag_id uuid)                                                                                                                                                                                            | service_role        | EXECUTE                        |
+| routine     | public.prevent_time_model_source_change()                                                                                                                                                                                                                                               | service_role        | EXECUTE                        |
 | routine     | public.rename_tag_group(p_user_id uuid, p_old_prefix text, p_new_prefix text)                                                                                                                                                                                                           | authenticated       | EXECUTE                        |
 | routine     | public.rename_tag_group(p_user_id uuid, p_old_prefix text, p_new_prefix text)                                                                                                                                                                                                           | service_role        | EXECUTE                        |
 | routine     | public.restore_entry(p_entry_id uuid, p_user_id uuid)                                                                                                                                                                                                                                   | authenticated       | EXECUTE                        |
@@ -199,6 +237,10 @@
 | table       | public.entries                                                                                                                                                                                                                                                                          | anon                | DELETE, INSERT, SELECT, UPDATE |
 | table       | public.entries                                                                                                                                                                                                                                                                          | authenticated       | DELETE, INSERT, SELECT, UPDATE |
 | table       | public.entries                                                                                                                                                                                                                                                                          | service_role        | DELETE, INSERT, SELECT, UPDATE |
+| table       | public.external_calendar_events                                                                                                                                                                                                                                                         | authenticated       | SELECT                         |
+| table       | public.external_calendar_events                                                                                                                                                                                                                                                         | service_role        | DELETE, INSERT, SELECT, UPDATE |
+| table       | public.logs                                                                                                                                                                                                                                                                             | authenticated       | DELETE, INSERT, SELECT, UPDATE |
+| table       | public.logs                                                                                                                                                                                                                                                                             | service_role        | DELETE, INSERT, SELECT, UPDATE |
 | table       | public.mfa_recovery_codes                                                                                                                                                                                                                                                               | anon                | DELETE, INSERT, SELECT, UPDATE |
 | table       | public.mfa_recovery_codes                                                                                                                                                                                                                                                               | authenticated       | DELETE, INSERT, SELECT, UPDATE |
 | table       | public.mfa_recovery_codes                                                                                                                                                                                                                                                               | service_role        | DELETE, INSERT, SELECT, UPDATE |
@@ -211,6 +253,8 @@
 | table       | public.oauth_tokens                                                                                                                                                                                                                                                                     | anon                | DELETE, INSERT, SELECT, UPDATE |
 | table       | public.oauth_tokens                                                                                                                                                                                                                                                                     | authenticated       | DELETE, INSERT, SELECT, UPDATE |
 | table       | public.oauth_tokens                                                                                                                                                                                                                                                                     | service_role        | DELETE, INSERT, SELECT, UPDATE |
+| table       | public.plans                                                                                                                                                                                                                                                                            | authenticated       | DELETE, INSERT, SELECT, UPDATE |
+| table       | public.plans                                                                                                                                                                                                                                                                            | service_role        | DELETE, INSERT, SELECT, UPDATE |
 | table       | public.profiles                                                                                                                                                                                                                                                                         | anon                | DELETE, SELECT                 |
 | table       | public.profiles                                                                                                                                                                                                                                                                         | authenticated       | DELETE, SELECT                 |
 | table       | public.profiles                                                                                                                                                                                                                                                                         | service_role        | DELETE, INSERT, SELECT, UPDATE |

--- a/docs/projects/time-model-split/overview.md
+++ b/docs/projects/time-model-split/overview.md
@@ -52,18 +52,20 @@ code: apps/product/src/features/entry
 
 ### external_calendar_events（同期ミラー）
 
-| カラム                                 | 型                   | 制約                                                      |
-| -------------------------------------- | -------------------- | --------------------------------------------------------- |
-| id / user_id / created_at / updated_at |                      |                                                           |
-| provider                               | text NOT NULL        | `google` 等                                               |
-| provider_event_id                      | text NOT NULL        | UNIQUE `(user_id, provider, provider_event_id)` で upsert |
-| title / description / calendar_name    |                      | provider 値のミラー                                       |
-| start_at / end_at                      | timestamptz NOT NULL |                                                           |
-| status                                 | text NOT NULL        | provider 側状態（`confirmed` / `cancelled`）              |
-| dismissed_at                           | timestamptz NULL     | ユーザーの「何もしない」。再同期で復活させない            |
-| last_synced_at                         | timestamptz NOT NULL |                                                           |
+| カラム                                 | 型                   | 制約                                                                            |
+| -------------------------------------- | -------------------- | ------------------------------------------------------------------------------- |
+| id / user_id / created_at / updated_at |                      |                                                                                 |
+| provider                               | text NOT NULL        | `google` 等                                                                     |
+| provider_calendar_id                   | text NOT NULL        | provider 側の stable calendar id                                                |
+| provider_event_id                      | text NOT NULL        | UNIQUE `(user_id, provider, provider_calendar_id, provider_event_id)` で upsert |
+| title / description / calendar_name    |                      | provider 値のミラー。`cancelled` tombstone では title 欠落を許可                |
+| start_at / end_at                      | timestamptz NULL     | `cancelled` tombstone 以外は NOT NULL 相当                                      |
+| status                                 | text NOT NULL        | provider 側状態（`confirmed` / `cancelled`）                                    |
+| dismissed_at                           | timestamptz NULL     | ユーザーの「何もしない」。再同期で復活させない                                  |
+| last_synced_at                         | timestamptz NOT NULL |                                                                                 |
 
 - **provider 状態の純粋なミラー**。ユーザー編集不可・EXCLUDE 対象外・Review 集計対象外
+- `status = 'cancelled'` は provider tombstone として sparse row を許可する。通常 row は `title` / `start_at` / `end_at` を CHECK で必須化する。
 - **ghost は導出概念**: ミラー − (plans/logs から参照済み) − (dismissed) − (cancelled)。Calendar にゴースト表示し、ワンタップで Plan / Log に変換
 - 変換後に provider 側でイベントが変わってもミラーだけ更新し、変換済み plan/log は触らない
 - 同期 window（目安 -90日/+90日、iCal export と同じ）で prune
@@ -131,7 +133,7 @@ code: apps/product/src/features/entry
 **Phase 1 — plans / logs 分割 + 明示記録化**（external なしで完結する）
 
 1. Step 0: 統計 RPC 書き換え方針を決定済み — [step-0-statistics-rpc-policy.md](./step-0-statistics-rpc-policy.md)。結論: Plan / Log 分割後の統計ロジックは TS service 層へ移し、PL/pgSQL 統計 RPC と `entries_effective` は呼び出し元を消してから drop する
-2. schema: plans / logs 作成、EXCLUDE・CHECK・trigger・RLS・index
+2. schema: plans / logs 作成、EXCLUDE・CHECK・trigger・RLS・index — [step-1-schema-detail.md](./step-1-schema-detail.md)
 3. migration: entries → plans / logs のデータ移行（下記 §7）
 4. server: entry-service / router の分割（plans CRUD / logs CRUD / ワンタップ記録 / 一括確定）
 5. domain / UI: CalendarEvent 射影、Plan layer + Log layer の描画、Inspector、Review 差分の再定義

--- a/docs/projects/time-model-split/step-1-schema-detail.md
+++ b/docs/projects/time-model-split/step-1-schema-detail.md
@@ -1,0 +1,61 @@
+---
+status: current
+last_verified: 2026-07-09
+code:
+  - supabase/migrations/20260708232500_add_time_model_tables.sql
+---
+
+# Step 1: Plan / Log schema detail
+
+Phase 1 の最初の実装 PR として、`entries` をまだ温存したまま `plans` / `logs` / `external_calendar_events` の器だけを追加する。データ移行、router 差し替え、`entries` / `entries_effective` の削除は後続 Step に分ける。
+
+## Goal
+
+既存 runtime を壊さずに、Plan / Log 分割後の書き込み先になる新テーブルと DB 側の所有者整合を先に固定する。
+
+## Minimum Viable Approach
+
+1. `external_calendar_events` を最小ミラー table として作る。同期ジョブや ghost UI はまだ作らないが、`plans` / `logs` の FK を最初から正しく張るため table は先に置く。
+2. `plans` と `logs` を追加し、時間順序 CHECK、source CHECK、source と external FK の shape CHECK、`plans_no_overlap` / `logs_no_overlap` EXCLUDE を設定する。時間順序 CHECK は後続 backfill で soft delete 済み歴史行を保持できるよう、`deleted_at IS NOT NULL` の行を許可する。
+3. `source` は provenance なので `BEFORE UPDATE OF source` trigger で不変にする。
+4. `tag_id` / `plan_id` / `external_calendar_event_id` は constraint trigger で同一 `user_id` の所有物だけを許可する。
+5. RLS は `auth.uid() = user_id` を基本にする。soft delete 済み `plans` / `logs` は SELECT から隠す。
+
+## Scope
+
+この Step で追加するもの:
+
+- `public.external_calendar_events`
+- `public.plans`
+- `public.logs`
+- EXCLUDE / CHECK / FK / index / updated_at trigger
+- owner consistency trigger
+- RLS policies / GRANT
+
+この Step で追加しないもの:
+
+- `entries` からの backfill
+- `entries` / `entries_effective` の drop
+- `plans` / `logs` tRPC router
+- Calendar / Inspector / Review UI
+- 外部カレンダー OAuth / sync cursor / prune job / ghost UI
+
+## Reversibility Table
+
+| Step                                               | Tag     | 備考                                                                              |
+| -------------------------------------------------- | ------- | --------------------------------------------------------------------------------- |
+| `external_calendar_events` / `plans` / `logs` 追加 | [hours] | table 追加だけで既存 runtime から未参照。drop migration で戻せる                  |
+| EXCLUDE / CHECK / FK / owner trigger               | [hours] | schema rollback が必要。既存 `entries` には触れない                               |
+| RLS / GRANT 追加                                   | [hours] | policy / grant rollback が必要。Data API 公開範囲が変わるため snapshot で確認する |
+
+## Security Notes
+
+- `plans` / `logs` は authenticated user が自分の rows のみ CRUD できる。
+- `external_calendar_events` は provider mirror なので authenticated user には `SELECT` と `dismissed_at` の `UPDATE` だけを許可する。同期用の `INSERT` / `DELETE` は service role の責務に残す。
+- `external_calendar_events` の provider event uniqueness は `provider_calendar_id` まで含め、Google Calendar の event id が calendar 単位で一意な前提に合わせる。
+- `external_calendar_events` は `status = 'cancelled'` の tombstone だけ `title` / `start_at` / `end_at` 欠落を許可し、通常 event は CHECK で必須化する。
+- owner consistency trigger は RLS だけに頼らず、service role / 将来 RPC 経路から foreign tag / plan / external event を保持できないようにする。
+
+## Follow-up
+
+次の PR は `entries` → `plans` / `logs` の migration 詳細設計に進む。特に `overview.md` §8 未決 4（auto-record backfill を明示記録と区別するか）は、データ移行 SQL を書く前に決める。

--- a/supabase/migrations/20260708232500_add_time_model_tables.sql
+++ b/supabase/migrations/20260708232500_add_time_model_tables.sql
@@ -1,0 +1,448 @@
+-- time-model-split Phase 1 schema foundation.
+-- Adds the new Plan / Log tables without migrating or dropping entries.
+
+CREATE EXTENSION IF NOT EXISTS btree_gist SCHEMA extensions;
+
+-- =============================================================================
+-- 1. Tables
+-- =============================================================================
+
+CREATE TABLE public.external_calendar_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  provider TEXT NOT NULL,
+  provider_calendar_id TEXT NOT NULL,
+  provider_event_id TEXT NOT NULL,
+  title TEXT,
+  description TEXT,
+  calendar_name TEXT,
+  start_at TIMESTAMPTZ,
+  end_at TIMESTAMPTZ,
+  status TEXT NOT NULL,
+  dismissed_at TIMESTAMPTZ,
+  last_synced_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT external_calendar_events_time_order CHECK (status = 'cancelled' OR end_at > start_at),
+  CONSTRAINT external_calendar_events_active_shape CHECK (
+    status = 'cancelled' OR (title IS NOT NULL AND start_at IS NOT NULL AND end_at IS NOT NULL)
+  ),
+  CONSTRAINT external_calendar_events_provider_not_blank CHECK (length(btrim(provider)) > 0),
+  CONSTRAINT external_calendar_events_provider_calendar_id_not_blank CHECK (length(btrim(provider_calendar_id)) > 0),
+  CONSTRAINT external_calendar_events_provider_event_id_not_blank CHECK (length(btrim(provider_event_id)) > 0),
+  CONSTRAINT external_calendar_events_status_not_blank CHECK (length(btrim(status)) > 0)
+);
+
+CREATE TABLE public.plans (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  tag_id UUID REFERENCES public.tags(id) ON DELETE SET NULL,
+  external_calendar_event_id UUID REFERENCES public.external_calendar_events(id),
+  title TEXT NOT NULL,
+  note TEXT,
+  start_at TIMESTAMPTZ NOT NULL,
+  end_at TIMESTAMPTZ NOT NULL,
+  skipped_at TIMESTAMPTZ,
+  source TEXT NOT NULL DEFAULT 'manual',
+  deleted_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT plans_time_order CHECK (deleted_at IS NOT NULL OR end_at > start_at),
+  CONSTRAINT plans_source_check CHECK (source IN ('manual', 'external_calendar', 'api')),
+  CONSTRAINT plans_external_source_shape CHECK (
+    (source = 'external_calendar') = (external_calendar_event_id IS NOT NULL)
+  )
+);
+
+CREATE TABLE public.logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  tag_id UUID REFERENCES public.tags(id) ON DELETE SET NULL,
+  plan_id UUID REFERENCES public.plans(id),
+  external_calendar_event_id UUID REFERENCES public.external_calendar_events(id),
+  title TEXT NOT NULL,
+  note TEXT,
+  start_at TIMESTAMPTZ NOT NULL,
+  end_at TIMESTAMPTZ NOT NULL,
+  source TEXT NOT NULL DEFAULT 'manual',
+  fulfillment_score INTEGER,
+  deleted_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT logs_time_order CHECK (deleted_at IS NOT NULL OR end_at > start_at),
+  CONSTRAINT logs_source_check CHECK (source IN ('manual', 'from_plan', 'external_calendar', 'api')),
+  CONSTRAINT logs_from_plan_source_shape CHECK (source <> 'from_plan' OR plan_id IS NOT NULL),
+  CONSTRAINT logs_external_source_shape CHECK (
+    (source = 'external_calendar') = (external_calendar_event_id IS NOT NULL)
+  ),
+  CONSTRAINT logs_fulfillment_score_check CHECK (
+    fulfillment_score IS NULL OR fulfillment_score BETWEEN 1 AND 3
+  )
+);
+
+-- =============================================================================
+-- 2. Constraints / indexes
+-- =============================================================================
+
+ALTER TABLE public.plans
+  ADD CONSTRAINT plans_no_overlap
+  EXCLUDE USING gist (
+    user_id WITH =,
+    tstzrange(start_at, end_at, '[)') WITH &&
+  )
+  WHERE (deleted_at IS NULL);
+
+ALTER TABLE public.logs
+  ADD CONSTRAINT logs_no_overlap
+  EXCLUDE USING gist (
+    user_id WITH =,
+    tstzrange(start_at, end_at, '[)') WITH &&
+  )
+  WHERE (deleted_at IS NULL);
+
+CREATE UNIQUE INDEX external_calendar_events_provider_event_unique
+  ON public.external_calendar_events(user_id, provider, provider_calendar_id, provider_event_id);
+
+CREATE INDEX external_calendar_events_user_time_idx
+  ON public.external_calendar_events(user_id, start_at, end_at);
+
+CREATE INDEX external_calendar_events_user_dismissed_idx
+  ON public.external_calendar_events(user_id, dismissed_at)
+  WHERE dismissed_at IS NULL;
+
+CREATE INDEX plans_user_time_idx
+  ON public.plans(user_id, start_at, end_at)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX plans_user_tag_idx
+  ON public.plans(user_id, tag_id)
+  WHERE deleted_at IS NULL AND tag_id IS NOT NULL;
+
+CREATE INDEX plans_external_calendar_event_idx
+  ON public.plans(external_calendar_event_id)
+  WHERE external_calendar_event_id IS NOT NULL;
+
+CREATE INDEX logs_user_time_idx
+  ON public.logs(user_id, start_at, end_at)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX logs_user_tag_idx
+  ON public.logs(user_id, tag_id)
+  WHERE deleted_at IS NULL AND tag_id IS NOT NULL;
+
+CREATE INDEX logs_plan_id_idx
+  ON public.logs(plan_id)
+  WHERE deleted_at IS NULL AND plan_id IS NOT NULL;
+
+CREATE INDEX logs_external_calendar_event_idx
+  ON public.logs(external_calendar_event_id)
+  WHERE external_calendar_event_id IS NOT NULL;
+
+CREATE INDEX logs_fulfillment_score_idx
+  ON public.logs(fulfillment_score)
+  WHERE fulfillment_score IS NOT NULL;
+
+-- =============================================================================
+-- 3. Owner / provenance triggers
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.prevent_time_model_source_change()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.source IS DISTINCT FROM OLD.source THEN
+    RAISE EXCEPTION '%.source is immutable', TG_TABLE_NAME
+      USING ERRCODE = '23514';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.enforce_plan_tag_owner()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.tag_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.tags
+    WHERE tags.id = NEW.tag_id
+      AND tags.user_id = NEW.user_id
+  ) THEN
+    RAISE EXCEPTION 'plans.tag_id must reference a tag owned by the plan user'
+      USING ERRCODE = '23514';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.enforce_log_tag_owner()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.tag_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.tags
+    WHERE tags.id = NEW.tag_id
+      AND tags.user_id = NEW.user_id
+  ) THEN
+    RAISE EXCEPTION 'logs.tag_id must reference a tag owned by the log user'
+      USING ERRCODE = '23514';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.enforce_log_plan_owner()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.plan_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.plans
+    WHERE plans.id = NEW.plan_id
+      AND plans.user_id = NEW.user_id
+  ) THEN
+    RAISE EXCEPTION 'logs.plan_id must reference a plan owned by the log user'
+      USING ERRCODE = '23514';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.enforce_plan_external_event_owner()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.external_calendar_event_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.external_calendar_events
+    WHERE external_calendar_events.id = NEW.external_calendar_event_id
+      AND external_calendar_events.user_id = NEW.user_id
+  ) THEN
+    RAISE EXCEPTION 'plans.external_calendar_event_id must reference an event owned by the plan user'
+      USING ERRCODE = '23514';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.enforce_log_external_event_owner()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.external_calendar_event_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.external_calendar_events
+    WHERE external_calendar_events.id = NEW.external_calendar_event_id
+      AND external_calendar_events.user_id = NEW.user_id
+  ) THEN
+    RAISE EXCEPTION 'logs.external_calendar_event_id must reference an event owned by the log user'
+      USING ERRCODE = '23514';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.prevent_time_model_source_change() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.enforce_plan_tag_owner() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.enforce_log_tag_owner() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.enforce_log_plan_owner() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.enforce_plan_external_event_owner() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.enforce_log_external_event_owner() FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.prevent_time_model_source_change() TO service_role;
+GRANT EXECUTE ON FUNCTION public.enforce_plan_tag_owner() TO service_role;
+GRANT EXECUTE ON FUNCTION public.enforce_log_tag_owner() TO service_role;
+GRANT EXECUTE ON FUNCTION public.enforce_log_plan_owner() TO service_role;
+GRANT EXECUTE ON FUNCTION public.enforce_plan_external_event_owner() TO service_role;
+GRANT EXECUTE ON FUNCTION public.enforce_log_external_event_owner() TO service_role;
+
+
+CREATE TRIGGER trigger_update_external_calendar_events_updated_at
+  BEFORE UPDATE ON public.external_calendar_events
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at();
+
+CREATE TRIGGER trigger_update_plans_updated_at
+  BEFORE UPDATE ON public.plans
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at();
+
+CREATE TRIGGER trigger_update_logs_updated_at
+  BEFORE UPDATE ON public.logs
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at();
+
+CREATE TRIGGER prevent_plans_source_change
+  BEFORE UPDATE OF source ON public.plans
+  FOR EACH ROW
+  EXECUTE FUNCTION public.prevent_time_model_source_change();
+
+CREATE TRIGGER prevent_logs_source_change
+  BEFORE UPDATE OF source ON public.logs
+  FOR EACH ROW
+  EXECUTE FUNCTION public.prevent_time_model_source_change();
+
+CREATE CONSTRAINT TRIGGER enforce_plan_tag_owner
+AFTER INSERT OR UPDATE OF user_id, tag_id ON public.plans
+DEFERRABLE INITIALLY IMMEDIATE
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_plan_tag_owner();
+
+CREATE CONSTRAINT TRIGGER enforce_log_tag_owner
+AFTER INSERT OR UPDATE OF user_id, tag_id ON public.logs
+DEFERRABLE INITIALLY IMMEDIATE
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_log_tag_owner();
+
+CREATE CONSTRAINT TRIGGER enforce_log_plan_owner
+AFTER INSERT OR UPDATE OF user_id, plan_id ON public.logs
+DEFERRABLE INITIALLY IMMEDIATE
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_log_plan_owner();
+
+CREATE CONSTRAINT TRIGGER enforce_plan_external_event_owner
+AFTER INSERT OR UPDATE OF user_id, external_calendar_event_id ON public.plans
+DEFERRABLE INITIALLY IMMEDIATE
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_plan_external_event_owner();
+
+CREATE CONSTRAINT TRIGGER enforce_log_external_event_owner
+AFTER INSERT OR UPDATE OF user_id, external_calendar_event_id ON public.logs
+DEFERRABLE INITIALLY IMMEDIATE
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_log_external_event_owner();
+
+-- =============================================================================
+-- 4. RLS / GRANT
+-- =============================================================================
+
+ALTER TABLE public.external_calendar_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.plans ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.logs ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON public.external_calendar_events FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON public.plans FROM PUBLIC, anon;
+REVOKE ALL ON public.logs FROM PUBLIC, anon;
+
+GRANT SELECT ON public.external_calendar_events TO authenticated;
+GRANT UPDATE(dismissed_at) ON public.external_calendar_events TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.external_calendar_events TO service_role;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.plans TO authenticated, service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.logs TO authenticated, service_role;
+
+CREATE POLICY "Users can view own external calendar events"
+  ON public.external_calendar_events
+  FOR SELECT TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+CREATE POLICY "Users can dismiss own external calendar events"
+  ON public.external_calendar_events
+  FOR UPDATE TO authenticated
+  USING ((select auth.uid()) = user_id)
+  WITH CHECK ((select auth.uid()) = user_id);
+
+CREATE POLICY "Service role has full access to external calendar events"
+  ON public.external_calendar_events
+  FOR ALL TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY "Users can view own plans"
+  ON public.plans
+  FOR SELECT TO authenticated
+  USING (((select auth.uid()) = user_id) AND deleted_at IS NULL);
+
+CREATE POLICY "Users can insert own plans"
+  ON public.plans
+  FOR INSERT TO authenticated
+  WITH CHECK ((select auth.uid()) = user_id);
+
+CREATE POLICY "Users can update own plans"
+  ON public.plans
+  FOR UPDATE TO authenticated
+  USING ((select auth.uid()) = user_id)
+  WITH CHECK ((select auth.uid()) = user_id);
+
+CREATE POLICY "Users can delete own plans"
+  ON public.plans
+  FOR DELETE TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+CREATE POLICY "Service role has full access to plans"
+  ON public.plans
+  FOR ALL TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY "Users can view own logs"
+  ON public.logs
+  FOR SELECT TO authenticated
+  USING (((select auth.uid()) = user_id) AND deleted_at IS NULL);
+
+CREATE POLICY "Users can insert own logs"
+  ON public.logs
+  FOR INSERT TO authenticated
+  WITH CHECK ((select auth.uid()) = user_id);
+
+CREATE POLICY "Users can update own logs"
+  ON public.logs
+  FOR UPDATE TO authenticated
+  USING ((select auth.uid()) = user_id)
+  WITH CHECK ((select auth.uid()) = user_id);
+
+CREATE POLICY "Users can delete own logs"
+  ON public.logs
+  FOR DELETE TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+CREATE POLICY "Service role has full access to logs"
+  ON public.logs
+  FOR ALL TO service_role
+  USING (true)
+  WITH CHECK (true);

--- a/supabase/schemas/010_tables_core.sql
+++ b/supabase/schemas/010_tables_core.sql
@@ -3,13 +3,14 @@
 -- ============================================================
 -- Dayopt のドメインモデルの中核テーブル
 -- 実際のマイグレーションは migrations/ を参照
--- 最終同期日: 2026-06-17
+-- 最終同期日: 2026-07-09
 -- 同期対象 migration:
 --   - 20260415000000_inline_entry_tag_id.sql
 --   - 20260424000000_restore_tag_parent_hierarchy.sql
 --   - 20260425110000_fix_tag_children_trigger_active_only.sql
 --   - 20260610000000_entry_auto_record_model.sql
 --   - 20260616000000_rename_duration_to_planned_duration.sql
+--   - 20260708232500_add_time_model_tables.sql
 --
 -- カラム順序の規則:
 --   1. id (PK)
@@ -69,6 +70,74 @@ CREATE TABLE public.entries (
 
 -- entries.tag_id は nullable FK に加えて、trigger で tags.user_id = entries.user_id を強制する。
 --   enforce_entry_tag_owner -> enforce_entry_tag_owner()
+
+-- external_calendar_events: 外部カレンダー同期ミラー
+-- Phase 1 では FK の受け皿だけを追加し、OAuth / sync / ghost UI は Phase 2 で実装する
+CREATE TABLE public.external_calendar_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  provider TEXT NOT NULL,
+  provider_calendar_id TEXT NOT NULL,
+  provider_event_id TEXT NOT NULL,
+  title TEXT,
+  description TEXT,
+  calendar_name TEXT,
+  start_at TIMESTAMPTZ,
+  end_at TIMESTAMPTZ,
+  status TEXT NOT NULL,
+  dismissed_at TIMESTAMPTZ,
+  last_synced_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- plans: Dayopt 内の予定
+CREATE TABLE public.plans (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  tag_id UUID REFERENCES public.tags(id) ON DELETE SET NULL,
+  external_calendar_event_id UUID REFERENCES public.external_calendar_events(id),
+  title TEXT NOT NULL,
+  note TEXT,
+  start_at TIMESTAMPTZ NOT NULL,
+  end_at TIMESTAMPTZ NOT NULL,
+  skipped_at TIMESTAMPTZ,
+  source TEXT NOT NULL DEFAULT 'manual', -- manual / external_calendar / api
+  deleted_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- plans 関連 constraint / trigger:
+--   plans_no_overlap                    -> user_id + tstzrange(start_at, end_at, '[)') EXCLUDE
+--   prevent_plans_source_change         -> prevent_time_model_source_change()
+--   enforce_plan_tag_owner              -> enforce_plan_tag_owner()
+--   enforce_plan_external_event_owner   -> enforce_plan_external_event_owner()
+
+-- logs: Dayopt 内の記録
+CREATE TABLE public.logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  tag_id UUID REFERENCES public.tags(id) ON DELETE SET NULL,
+  plan_id UUID REFERENCES public.plans(id),
+  external_calendar_event_id UUID REFERENCES public.external_calendar_events(id),
+  title TEXT NOT NULL,
+  note TEXT,
+  start_at TIMESTAMPTZ NOT NULL,
+  end_at TIMESTAMPTZ NOT NULL,
+  source TEXT NOT NULL DEFAULT 'manual', -- manual / from_plan / external_calendar / api
+  fulfillment_score INTEGER,
+  deleted_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- logs 関連 constraint / trigger:
+--   logs_no_overlap                    -> user_id + tstzrange(start_at, end_at, '[)') EXCLUDE
+--   prevent_logs_source_change         -> prevent_time_model_source_change()
+--   enforce_log_tag_owner              -> enforce_log_tag_owner()
+--   enforce_log_plan_owner             -> enforce_log_plan_owner()
+--   enforce_log_external_event_owner   -> enforce_log_external_event_owner()
 
 -- tags: タグ（root -> child の最大2階層）
 -- 20260424000000 でコロン記法 "dev:api" から parent_id 階層へ移行済み


### PR DESCRIPTION
## 概要

- `external_calendar_events` / `plans` / `logs` の基盤テーブルを追加
- Plan / Log の時間順序、source shape、EXCLUDE overlap、owner consistency trigger、RLS / GRANT を定義
- `docs/projects/time-model-split/step-1-schema-detail.md` と schema map / RLS snapshot を更新

## スコープ

- 既存 `entries` は温存
- データ移行、router 差し替え、Calendar / Review UI、外部カレンダー同期ジョブは未実装
- `external_calendar_events` は FK の受け皿として先に追加し、authenticated user には `SELECT` と `dismissed_at` update のみ許可

## 確認

- `supabase db reset --local`
- authenticated role smoke: `plans` / `logs` insert、external mirror の privilege 確認
- `pnpm rls:snapshot:check`
- `pnpm docs:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:boundaries`

## メモ

- `supabase db lint --local` は実行しましたが、既存の古い関数に起因するエラー（例: dropped `reflections` / `duration_minutes` 参照など）で失敗しています。このPRで追加した table / policy の fresh migration 適用は `supabase db reset --local` で確認済みです。