### PR TITLE
docs: time-model-splitのStep 2-9設計書とPhase 1完了状態を追加

### DIFF
--- a/docs/projects/time-model-split/overview.md
+++ b/docs/projects/time-model-split/overview.md
@@ -130,14 +130,22 @@ code: apps/product/src/features/entry
 
 ## 5. Phase 構成
 
-**Phase 1 — plans / logs 分割 + 明示記録化**（external なしで完結する）
+**Phase 1 — plans / logs 分割 + 明示記録化**（external なしで完結する）。1 Step = 1 PR。Step 2-7 は既存 runtime に接続しない dormant 実装として積み、Step 8 で一括切り替える。
 
-1. Step 0: 統計 RPC 書き換え方針を決定済み — [step-0-statistics-rpc-policy.md](./step-0-statistics-rpc-policy.md)。結論: Plan / Log 分割後の統計ロジックは TS service 層へ移し、PL/pgSQL 統計 RPC と `entries_effective` は呼び出し元を消してから drop する
-2. schema: plans / logs 作成、EXCLUDE・CHECK・trigger・RLS・index — [step-1-schema-detail.md](./step-1-schema-detail.md)
-3. migration: entries → plans / logs のデータ移行（下記 §7）
-4. server: entry-service / router の分割（plans CRUD / logs CRUD / ワンタップ記録 / 一括確定）
-5. domain / UI: CalendarEvent 射影、Plan layer + Log layer の描画、Inspector、Review 差分の再定義
-6. 後始末: `entries_effective` view・entries テーブルの廃止、iCal export の対象決定（§8 未決 5）
+| Step | 内容                                                                              | 設計書                                      | 状態 |
+| ---- | --------------------------------------------------------------------------------- | ------------------------------------------- | ---- |
+| 0    | 統計 RPC 書き換え方針（TS service 化を決定）                                      | [step-0](./step-0-statistics-rpc-policy.md) | 完了 |
+| 1    | plans / logs / external の schema 追加                                            | [step-1](./step-1-schema-detail.md)         | 完了 |
+| 2    | entries → plans / logs の冪等 backfill migration（未決 4 をここで決定）           | [step-2](./step-2-backfill-migration.md)    |      |
+| 3    | plans / logs server 層（CRUD・ワンタップ記録・一括確定。未決 8 をここで決定）     | [step-3](./step-3-server-layer.md)          |      |
+| 4    | 統計 TS service（Step 0 方針の実装、未接続）                                      | [step-4](./step-4-statistics-service.md)    |      |
+| 5    | Calendar 2レーン表示（read 側、未接続）                                           | [step-5](./step-5-calendar-two-lane.md)     |      |
+| 6    | 作成・編集フロー（保存先ルール・記録導線、未接続）                                | [step-6](./step-6-create-edit-flows.md)     |      |
+| 7    | Review 差分の 1:N 再定義（未決 1・2・3 をここで決定）                             | [step-7](./step-7-review-diff.md)           |      |
+| 8    | カットオーバー（backfill 再実行 + 配線切替 + iCal / MCP。未決 5・7 をここで決定） | [step-8](./step-8-cutover.md)               |      |
+| 9    | 後始末（entries / RPC / 旧コード drop、specs・glossary 更新、summary.md）         | [step-9](./step-9-cleanup.md)               |      |
+
+依存関係: 2 → 3 → 4 は直列。5・6・7 は 3 以降なら並行可（6 は 5 の後推奨）。8 は 2-7 全完了が前提。9 は 8 の安定確認（1 週間目安）後。
 
 **Phase 2 — 外部カレンダー取り込み**（Phase 1 リリース後に着手）
 
@@ -166,16 +174,16 @@ code: apps/product/src/features/entry
 4. **auto-record の凍結**: actual NULL・過去・未 skip の planned entries は、移行時点の effective actual（= plan range）を一度だけ実体化して logs 化する。やらないと過去の Review が遡って「未記録」に変わる。`getEffectiveActualRange()` / `entries_effective` はこの backfill を最後の用途として廃止
 5. soft delete 済み entries も対応テーブルへ `deleted_at` ごと移行（復元可能性を維持）
 
-## 8. 未決事項（実装 Step 着手前に決める）
+## 8. 未決事項（担当 Step の着手時に決める。各 step 設計書に Option + 推奨を記載済み）
 
-1. 別日実行の diff 帰属 — 火曜の予定を水曜にやって紐づけた時、log は log の日に計上・plan は自分の日に未達、が有力
-2. plan と log の tag / title 乖離時、Review はどちらで束ねるか — log 側優先が有力
-3. plan soft delete 時の紐づき logs の見せ方（「予定に対する記録」のままか「予定外」に落とすか）
-4. 移行時に実体化した logs を明示記録と区別するか — ADR-019 は自動記録を見積もり精度の分母から除外していた。区別を落とすと精度指標が汚れる
-5. iCal export（`/api/v1/calendar/[token]`）に plans / logs のどちらを出すか（両方なら 2 フィード）
-6. ghost の有効期限・視覚表現（principles.md でも未確定）
-7. MCP / API が公開している entries 形の契約をどう version するか
-8. feature / ディレクトリ命名 — `features/log` は `@/lib/logger`（アプリログ）と紛らわしい。`features/logs` 等、衝突しない名前にする
+1. 別日実行の diff 帰属 — log は log の日に計上・plan は自分の日に未達、が有力 → **Step 7**
+2. plan と log の tag / title 乖離時、Review はどちらで束ねるか — log 側優先が有力 → **Step 7**
+3. plan soft delete 時の紐づき logs の見せ方（「予定に対する記録」のままか「予定外」に落とすか） → **Step 7**
+4. 移行時に実体化した logs を明示記録と区別するか — ADR-019 は自動記録を見積もり精度の分母から除外していた。区別を落とすと精度指標が汚れる → **Step 2**
+5. iCal export（`/api/v1/calendar/[token]`）に plans / logs のどちらを出すか（両方なら 2 フィード） → **Step 8**
+6. ghost の有効期限・視覚表現（principles.md でも未確定） → **Phase 2**
+7. MCP / API が公開している entries 形の契約をどう version するか → **Step 8**
+8. feature / ディレクトリ命名 — `features/log` は `@/lib/logger`（アプリログ）と紛らわしい。衝突しない配置にする → **Step 3**
 
 ## 9. Existing Code to Reuse
 

--- a/docs/projects/time-model-split/overview.md
+++ b/docs/projects/time-model-split/overview.md
@@ -12,7 +12,7 @@ code: apps/product/src/features/entry
 
 ## 1. Goal
 
-予定（Plan）と記録（Log）を独立エンティティに分離し、「予定を立てる → 記録する → 差分を見る → 次を改善する」のループを、1予定:N記録・予定外記録・外部カレンダー取り込みまで含めて破綻なく表現できるデータモデルにする。
+予定（Plan）と記録（Log）を独立エンティティに分離し、「予定を立てる → 記録する → 差分を見る → 次を改善する」のループを、1予定:N記録・予定外記録・外部カレンダー取り込みまで含めて破綻なく表現できるデータモデルにする。Phase 1（Step 9）完了時点の具体的な状態は §11 に定義する。
 
 ## 2. 決定済みモデル
 
@@ -202,3 +202,30 @@ code: apps/product/src/features/entry
 - 繰り返し予定の独自展開 — provider が展開した instance をそのまま保存する
 - Phase 1 / Phase 2 の同時リリース — 1 リリースに詰めない
 - 「ついで」の統計リファクタ — RPC の書き換えは分割に必要な範囲に限定（方針は Phase 1 Step 0 で確定）
+
+## 11. Phase 1 完了時の状態（Step 9 完了 = この project のゴール）
+
+Step 0-9 がすべて完了した時点で、以下がすべて真になっている。これが本 project の Definition of Done。
+
+### ユーザーから見える状態
+
+- Calendar は **Plan レーン（アウトライン・淡色）+ Log レーン（塗り・主役）の 2 レーン**。Day は 2 レーン横並び、Week「予定+記録」は Plan が細レーン、モバイル Week は表示切替
+- ブロック作成時に保存先を選ぶ UI は存在しない。**end が未来なら予定、end が今以前なら記録**として保存され、チップの表示が編集中に自動で切り替わる
+- 過去の予定は記録するまで「未記録」。**ワンタップ「そのまま記録」/ Log レーンへのドラッグ / 一括「この日を確定」**の 3 導線で記録する。自動で実績になるものは何もない
+- 表示される実績はすべてユーザーが明示した記録。1 つの予定に複数の記録を紐づけられ、差分は数字で表示（±0 は非表示）、予定外の記録は静かなマーカーのみ。判定ラベル・赤マークは無い
+- 過去の予定は時間凍結・内容（title / tag / note）訂正可。過去日付への予定追加は不可。skip で「やらなかった」と「未記録」が区別される
+- Review は **未記録 / やらなかった / 予定に対する記録 / 予定外** の 4 分類 + 差分で成立している
+
+### データ・コードの状態
+
+- 時間データは `plans` / `logs` のみが正。**`entries` / `entries_effective` / PL/pgSQL 統計 RPC は drop 済み**で、アプリからの参照ゼロ
+- 統計はすべて TS service（実績 = logs、予定 = plans、予実比較 = join）。migration で実体化した auto-record 由来の log は provenance で区別され、見積もり精度の分母に入らない
+- 重なり制約は二層 EXCLUDE で継続（plans 同士 / logs 同士は禁止、plan × log は許可、半開区間 `[)`）
+- iCal export は plans を配信（URL 不変）。MCP は `plans-list` / `logs-list` を公開し、`entries-list` は合成互換として残存
+- `external_calendar_events` はテーブルだけ存在し（Step 1 で作成済み）、中身は空。同期・ghost 表示はまだ無い
+- docs が現実と一致: `specs/entry.md` は Plan / Log 仕様に改稿済み、glossary に新用語、rls-snapshot 再生成済み、本ディレクトリに `summary.md` が追加され project は完了状態
+
+### まだ無いもの（= Phase 2 の出発点）
+
+- Google Calendar の取り込み・ghost 表示・`calendar_connections`（OAuth / カレンダー選択 / sync cursor）
+- 自動記録モデルは存在しない。将来必要になったら `logs.source` の拡張と Review の解釈追加で再導入できる（ADR-025 は扉を閉じていない）

--- a/docs/projects/time-model-split/step-2-backfill-migration.md
+++ b/docs/projects/time-model-split/step-2-backfill-migration.md
@@ -1,0 +1,63 @@
+---
+status: current
+last_verified: 2026-07-09
+code:
+  - supabase/migrations/20260708232500_add_time_model_tables.sql
+  - apps/product/src/features/entry/domain/entry-time-model.ts
+---
+
+# Step 2: entries → plans / logs backfill migration
+
+`entries` の全歴史（soft delete 込み）を Step 1 の新テーブルへ**冪等に**実体化する。entries は温存し、runtime は一切切り替えない。cutover（Step 8）でこの backfill を再実行して delta を吸収するため、再実行可能であることが最重要要件。
+
+## Goal
+
+entries の全データを plans / logs として実体化し、いつでも再実行して最新化できる backfill を作る。
+
+## 決めること（overview §8 未決 4）
+
+auto-record 実体化 log を明示記録と区別するか。
+
+- **Option α（推奨）**: `logs.source` に `auto_migrated` を追加（Step 1 の source CHECK を拡張）。provenance は source の責務そのものであり、ADR-019 の「自動記録は見積もり精度の分母に入れない」意味論を Step 4 で継承できる
+- Option β: `logs.auto_recorded boolean` 列を追加。source の意味を汚さないが、列が1つ増える
+- Option γ: 区別しない。最小だが精度指標が恒久的に汚れ、後から復元不能（[irreversible]）
+
+## Minimum Viable Approach
+
+1. **id を決定的にマッピングする**: planned entry → `plans.id = entries.id`、unplanned entry → `logs.id = entries.id`、planned entry の実績 log → `uuid_generate_v5(entry.id 名前空間, 'log')` 等の決定的導出。再実行時の upsert と FK 安定性の両方が成立する
+2. 変換規則（overview §7 準拠）:
+   - `origin = 'planned'` → plans（`start_time`/`end_time` → `start_at`/`end_at`、`skipped_at`・`deleted_at` 移設、`source = 'manual'`）
+   - 明示 actual（両端 NOT NULL）→ logs（`plan_id` = 対応 plan、`source = 'from_plan'`、`fulfillment_score` 移設）
+   - `origin = 'unplanned'` → logs（`plan_id` NULL、`source = 'manual'`）
+   - auto-record（planned・actual NULL・未 skip・`end_time <= now()`）→ logs（plan range を実体化、source = 未決 4 の決定値）。effective actual の判定式は `entries_effective` と同一ロジックを backfill SQL 内に一度だけ書く
+3. `INSERT ... ON CONFLICT (id) DO UPDATE` で冪等化。soft delete 行も `deleted_at` ごと移行（Step 1 の CHECK は deleted 行の歴史的 shape を許容済み）
+4. **EXCLUDE 整合の事前検証**: 明示 actual 同士は現行 DB 制約で重なりゼロが保証済み。auto-record 実体化同士・auto-record × 明示 actual はサービス層防衛だった領域なので、backfill 前に重なり検出クエリを流して 0 件を確認する（ヒットしたら ADR-018 の前例に従い新しい側を soft delete）
+5. 検証クエリを migration とペアで残す: 件数突合（planned 数 = plans 数、actual/unplanned/auto 数 = logs 数）、時間合計突合、`plan_id` 参照整合
+
+## Scope
+
+追加する: backfill migration（+ 未決 4 が α なら source CHECK 拡張）、検証クエリ。
+追加しない: entries / entries_effective への変更、router、UI、cutover 時の delta 処理（= 本 migration の再実行、Step 8）。
+
+## Reversibility Table
+
+| Step                               | Tag            | 備考                                                                        |
+| ---------------------------------- | -------------- | --------------------------------------------------------------------------- |
+| backfill upsert                    | [hours]        | 新テーブルはまだ未参照。TRUNCATE + 再実行で何度でもやり直せる。entries 無傷 |
+| source CHECK 拡張（未決 4 = α 時） | [hours]        | 値の追加のみ。既存行に影響なし                                              |
+| auto-record の区別を落とす（γ 時） | [irreversible] | 実体化後に「自動だったか」を復元できない。α / β なら回避                    |
+
+## Existing Code to Reuse
+
+- `apps/product/src/features/entry/domain/entry-time-model.ts` `getEffectiveActualRange()` — effective actual 判定の正（SQL へ転写する際の仕様書として。この backfill が最後の用途）
+- `supabase/migrations/20260610000000_entry_auto_record_model.sql` — `entries_effective` の判定式（SQL 表現の参照元）
+- `supabase/migrations/20260513000000_entry_two_layer_time_ranges.sql` L40-72 — 重なり検出 + 新しい側を soft delete する前例
+
+## What I'm Not Doing
+
+- entries の書き込み停止・freeze はしない。backfill 後も entries が正であり続け、新テーブルは cutover まで stale で構わない（再実行で追いつく）
+- 変換した plans / logs への手修正はしない。修正が要るバグは backfill SQL を直して再実行する（冪等性を守る）
+
+## Follow-up
+
+次は Step 3（plans / logs server 層）。backfill 済みデータがあるので、service / router の動作確認が実データで可能になる。

--- a/docs/projects/time-model-split/step-3-server-layer.md
+++ b/docs/projects/time-model-split/step-3-server-layer.md
@@ -1,0 +1,68 @@
+---
+status: current
+last_verified: 2026-07-09
+code:
+  - apps/product/src/features/entry/server
+  - apps/product/src/features/entry/schemas
+  - apps/product/src/features/entry/types
+---
+
+# Step 3: plans / logs server 層
+
+Plan / Log の型・Zod schema・service・tRPC router を追加する。root router に登録はするが **UI からは未接続（dormant）**。entries router は一切触らない。
+
+## Goal
+
+Plan / Log の CRUD + ワンタップ記録 + 一括確定を、時間ガード・重なりチェック込みで server 層として完成させる。
+
+## 決めること（overview §8 未決 8）
+
+feature 配置。
+
+- **Option α（推奨）**: 既存 `features/entry/` をコンテナとして維持し、その中に `plan-service.ts` / `log-service.ts` / `plans-router.ts` / `logs-router.ts` を追加する。calendar（191ファイル）が entry barrel に依存しており、ディレクトリ改名は Phase 1 の blast radius を無意味に広げる。`features/log/` を作らないので `@/lib/logger` との衝突も発生しない
+- Option β: `features/plans/` / `features/logs/` を新設。概念的には綺麗だが、共有エディタ・共有 domain の置き場が第3の場所に必要になり、feature DAG の組み替えが Phase 1 に混入する
+
+## Minimum Viable Approach
+
+1. types / schemas: `Plan` / `Log` 型と Zod schema（`@dayopt/domain` の enum 追加を含む）。エディタ共有（overview §4）を見据え、共通フィールドは共有 shape から合成する
+2. `plan-service.ts`: CRUD + ガード
+   - **時間ルール**: create / update とも `end_at > now()` を強制（過去 Plan は作れない）。past plan（end ≤ now）は時間フィールド変更を拒否、title / tag / note は許可（ADR-015、overview §4 マトリクス）
+   - skip / unskip（過去 plan のみ skip 可、現行 `SKIP_IN_FUTURE` と同じ向き）
+   - 重なり: EXCLUDE 違反 `23P01` → `TIME_OVERLAP` へのマッピング（現行 entry-service と同じパターン）+ 事前チェック
+3. `log-service.ts`: CRUD + ガード
+   - **時間ルール**: `end_at <= now()` を強制（未来の記録は作れない。現行 `RECORD_IN_FUTURE` / `UNPLANNED_IN_FUTURE` の後継）
+   - `plan_id` の付け替え（後から予定に紐づける）を許可。owner 整合は Step 1 の trigger が DB 側で防衛
+4. 複合 procedure:
+   - `plans.record`（ワンタップ「そのまま記録」）: plan range をコピーした log を作成（`source = 'from_plan'`）。past plan のみ
+   - `plans.confirmDay`（一括「この日を確定」）: 指定日の未記録・未 skip past plans をまとめて log 化。部分失敗が残らないよう単一トランザクションにする。RLS で表現できない原子的バッチに該当するなら Step 0 方針の例外として RPC 化を許可（`bulk_soft_delete_entries` の前例）
+5. soft delete / restore: SELECT RLS が deleted を隠すため、entries と同様に restore 経路（RPC or service role）を plans / logs にも用意する
+6. root router へ `plans` / `logs` namespace を登録（dormant）。楽観ロック（`expectedUpdatedAt`）は現行 entries.update と同じ規約を踏襲
+
+## Scope
+
+追加する: 型・schema・service・router・複合 procedure・soft delete/restore 経路・unit / integration test。
+追加しない: UI、統計（Step 4）、entries router の変更、MCP tools（Step 8）。
+
+## Reversibility Table
+
+| Step                             | Tag       | 備考                           |
+| -------------------------------- | --------- | ------------------------------ |
+| service / router 追加            | [minutes] | dormant なので revert で消せる |
+| confirmDay の RPC 化（採る場合） | [hours]   | migration rollback が必要      |
+
+## Existing Code to Reuse
+
+- `apps/product/src/features/entry/server/entry-service.ts` — 時間ガード（`RECORD_IN_FUTURE` 等）・楽観ロック・`normalize*Input` のパターン
+- `apps/product/src/features/entry/server/entry-overlap-service.ts` — 半開区間の重なり判定と `23P01` マッピング
+- `apps/product/src/features/entry/server/entry-service-error.ts` — エラー正規化
+- `supabase/migrations/20260323000001_add_soft_delete_rpc.sql` — soft delete / restore RPC の前例
+- project skills: `trpc-router-creating` / `error-handling` / `test`
+
+## What I'm Not Doing
+
+- Plan ⇄ Log の相互変換 procedure は作らない（現行 `convertPlannedToUnplanned` 系の後継は不要。保存先は end で一意に決まり、間違いは削除 + 再作成で足りる）
+- entries router の deprecation 表示や書き込み制限はしない（Step 8）
+
+## Follow-up
+
+次は Step 4（統計 TS service）。本 Step の service が読み書きの正になるため、統計はここで固まった型を読む。

--- a/docs/projects/time-model-split/step-4-statistics-service.md
+++ b/docs/projects/time-model-split/step-4-statistics-service.md
@@ -1,0 +1,57 @@
+---
+status: current
+last_verified: 2026-07-09
+code:
+  - apps/product/src/features/entry/server/statistics.ts
+  - apps/product/src/features/entry/server/tag-statistics.ts
+  - apps/product/src/features/tags/server/tag-statistics-service.ts
+---
+
+# Step 4: 統計 TS service
+
+Step 0 の Aggregation Source Contract を実装する。`plans` / `logs` を読む `statistics-service.ts` を新設し、既存 router の内部と**差し替え可能な状態**まで作る。router への接続（public 挙動の切り替え）は Step 8 のフリップで行う。
+
+## Goal
+
+現行 PL/pgSQL 統計 RPC の生存呼び出し面すべてに対応する TS 実装を、互換レスポンス形のまま用意する。
+
+## Minimum Viable Approach
+
+1. `apps/product/src/features/entry/server/statistics-service.ts` を追加。Step 0 の contract に従い、実績系は `logs`、予定系は `plans`、予実比較は `plans LEFT JOIN logs (plan_id)` を読む
+2. 対応する procedure 面（Step 0 Current Inventory の全行）:
+   - general: tag stats / time-by-tag / daily hours / hourly / dow / monthly
+   - kpi: estimation accuracy / blank rate
+   - summary: active dates / kpi summary / Time P/L / stats page data（統合 JSON を TS で同形に組み立てる）
+   - `entriesTagStatisticsRouter` / `TagStatisticsService` の logs / plans 読み替え
+3. **見積もり精度の分母**: `source = 'auto_migrated'`（Step 2 未決 4 の決定値）の logs を除外する。ワンタップ記録（`from_plan`）はユーザーが確定した実績なので分母に入れる
+4. **並走比較で検証する**: Step 2 の backfill 済みデータに対し、旧 RPC の結果と新 service の結果を突き合わせる比較テストを書く。auto-record の意味論差（旧: read 時導出 / 新: 実体化済み）による既知の差分は明示的に許容リストにする
+5. router 内部の差し替えは feature flag や分岐を入れず、**Step 8 で procedure 実装を丸ごと入れ替える**前提でシグネチャを揃えておく
+
+## Scope
+
+追加する: statistics-service.ts、domain aggregator の 1:N 対応、並走比較テスト。
+追加しない: router public 挙動の変更、RPC / `entries_effective` の drop（Step 9）、Review UI（Step 7）。
+
+## Reversibility Table
+
+| Step                     | Tag       | 備考                               |
+| ------------------------ | --------- | ---------------------------------- |
+| statistics-service 追加  | [minutes] | 未接続。revert で消せる            |
+| domain aggregator の変更 | [minutes] | 既存テストが regression を検出する |
+
+## Existing Code to Reuse
+
+- `apps/product/src/features/entry/server/statistics-shared.ts` — input schema / error handling / response 型
+- `apps/product/src/features/entry/server/statistics-overview-transform.ts` / `statistics-time-by-tag-transform.ts` / `statistics-kpi-unpackers.ts` — 互換レスポンスの契約
+- `apps/product/src/features/entry/domain/` の distribution / monthly-trend / tag-stats / estimation-accuracy — TS aggregation 部品（1:N 対応の改修ベース）
+- `apps/product/src/features/entry/server/tag-statistics.ts` — direct select + domain build の既存パターン
+
+## What I'm Not Doing
+
+- PL/pgSQL 統計 RPC の新設・改修はしない（Step 0 Decision 2）
+- `entries_effective` 互換 view を plans / logs 上に作らない（Step 0 What I'm Not Doing）
+- Stats / Review の UI 変更はしない（Step 7）
+
+## Follow-up
+
+次は Step 5(Calendar 2レーン表示)。UI 系 Step（5-7）と本 Step は依存が薄いので、並行に進めてもよい。

--- a/docs/projects/time-model-split/step-5-calendar-two-lane.md
+++ b/docs/projects/time-model-split/step-5-calendar-two-lane.md
@@ -1,0 +1,54 @@
+---
+status: current
+last_verified: 2026-07-09
+code:
+  - apps/product/src/features/calendar/components/views
+  - apps/product/src/features/entry/types/calendar-event.ts
+  - apps/product/src/features/entry/components/card
+---
+
+# Step 5: Calendar 2レーン表示（read 側）
+
+overview §4 の 2レーン構成（Log 主役・Plan 控えめ）を、既存 entries 表示を壊さず**新レンダリング系として**実装する。既存ビューへの接続は Step 8 のフリップで行い、それまで Storybook と開発用確認で検証する。
+
+## Goal
+
+plans / logs を Plan レーン + Log レーンとして描画し、差分を数字で見せる Calendar の read 側を完成させる。
+
+## Minimum Viable Approach
+
+1. 射影型: 現行 `CalendarEvent`（`features/entry/types/calendar-event.ts`）を `PlanEvent` / `LogEvent` に分割する。plan 側は `skipped_at` / 記録済みか（logs の有無）、log 側は `plan_id` / 差分分を持つ
+2. レーン描画: 日カラムを Plan レーンと Log レーンに分割。**Log = 塗りカード（主役）、Plan = アウトライン・淡色**。現行 `EntryRenderer` の配置ロジック（時間 → 座標）は流用し、レーンごとの幅計算だけ追加する
+3. 差分の数字表示: `plan_id` ありの log に差分バッジ（±0 は非表示）。`plan_id` なしは「予定外」の静かなマーカーのみ。二値ラベルは使わない（copywriting「判定せず数字で示す」）
+4. 密度対応: Day = 2レーン、Week「予定+記録」= Plan を細レーン、モバイル Week = 表示切替（予定だけ / 記録だけ）。表示モードは `useCalendarSettingsStore` 系の既存 client state 置き場に追加する
+5. 過去 Plan の見え方: 未記録（end 過去・logs なし・未 skip）は静かなプロンプト付き、skip 済みは減衰表示。実績集計との整合は overview §3 の分類に従う
+6. Storybook: PlanCard / LogCard / 2レーン day column の全 variant（AllPatterns 必須）。タグごとのスクリーンショットは eagle-dayopt 運用に従う
+
+## Scope
+
+追加する: 射影型、レーン描画コンポーネント、差分バッジ、表示モード state、stories。
+追加しない: 既存ビューへの接続（Step 8）、作成・編集フロー（Step 6）、DnD の保存先判定（Step 6）、Review パネル（Step 7）。
+
+## Reversibility Table
+
+| Step                    | Tag       | 備考                     |
+| ----------------------- | --------- | ------------------------ |
+| 新レンダリング系の追加  | [minutes] | 未接続。revert で消せる  |
+| 表示モード state の追加 | [minutes] | persist キーを増やすだけ |
+
+## Existing Code to Reuse
+
+- `apps/product/src/features/calendar/components/views/shared/components/EntryRenderer.tsx` — 時間 → 座標の配置ロジック
+- `apps/product/src/features/entry/components/card/EntryCard.tsx` / `EntryCardContent.tsx` — カードの構造・token 使用の踏襲元
+- `apps/product/src/features/entry/lib/actual-time-overlay.ts` — 旧・差分オーバーレイ（置き換え対象の仕様参照。数字バッジ移行で廃止予定）
+- `apps/product/src/features/calendar/stores/useCalendarFilterStore.ts` — タグ表示切替（レーンとは直交に維持）
+- project skills: `storybook` / `i18n`
+
+## What I'm Not Doing
+
+- 既存の単一レーン + compare rail（Diff Rail）の削除はしない（Step 8 で接続を切り替え、Step 9 で削除）
+- ghost（外部イベント）レーンは描画しない（Phase 2）
+
+## Follow-up
+
+次は Step 6（作成・編集フロー）。本 Step のレーンが DnD の保存先判定の受け皿になる。

--- a/docs/projects/time-model-split/step-6-create-edit-flows.md
+++ b/docs/projects/time-model-split/step-6-create-edit-flows.md
@@ -1,0 +1,59 @@
+---
+status: current
+last_verified: 2026-07-09
+code:
+  - apps/product/src/features/calendar/stores/useInlineCreateStore.ts
+  - apps/product/src/features/calendar/stores/useCalendarDragStore.ts
+  - apps/product/src/features/entry/components
+---
+
+# Step 6: 作成・編集フロー（保存先ルール・記録導線）
+
+overview §4 の「保存先は end で一意に決まる」ルールと Plan → Log の 3 導線を実装する。Step 3 の plans / logs router を消費する最初の UI。既存ビューへの接続は Step 8。
+
+## Goal
+
+作成・編集・記録のすべての操作が、保存先の選択を要求せず、時間ルール（ADR-015 / 未来記録禁止）と一貫して動く状態にする。
+
+## Minimum Viable Approach
+
+1. **共有エディタ**: Plan / Log でフォームを共有し、destination チップ（「予定として保存 / 記録として保存」）を常時表示する。チップはセレクタではなく**表示**: `end_at > now` → Plan、`end_at <= now` → Log。時間編集で境界をまたいだ瞬間に色・ラベルが切り替わる
+2. 作成導線:
+   - ドラッグ作成: レーンが保存先を決める（Plan レーンでドラッグ = Plan、Log レーンでドラッグ = Log）。ただし end ルールと矛盾する操作（Log レーンで未来をドラッグ等）は end ルールが勝ち、チップで可視化する
+   - タグクリック作成: 今の時刻から始まるドラフト（end 未来 = Plan 表示）。時間を過去に編集すると Log に自動切替
+3. 記録導線（3つ）:
+   - ワンタップ「そのまま記録」（`plans.record`）: past plan のカード / Inspector から 1 タップ
+   - Plan カードを Log レーンへドラッグ = そのまま記録、ドロップ後リサイズ = ずれ込みで記録
+   - 一括「この日を確定」（`plans.confirmDay`）: 日ヘッダー等に配置。未記録 past plans をまとめて log 化
+4. **過去 Plan の操作制約**（ADR-015 マトリクス）: 時間変更・移動・リサイズは disabled、title / tag / note 編集・記録・skip・削除は許可。UI disabled + service ガード（Step 3）の二重防御（temporal-constraints ルール踏襲）。end が未来の Plan は自由編集可、ただし end を過去へ縮める操作は不可
+5. mutation は `optimistic-update` skill に従い onMutate / onError / onSettled を実装。EXCLUDE 衝突（TIME_OVERLAP）はロールバック + トースト
+6. 文言: ボタンは体言止め、トーストは「記録しました ✓」等 copywriting ルール準拠。i18n キーを en / ja 両方に追加
+
+## Scope
+
+追加する: 共有エディタ + チップ、作成・記録導線、過去 Plan 制約 UI、optimistic update、i18n、stories / tests。
+追加しない: 既存ビューへの接続（Step 8）、Review（Step 7）、Plan ⇄ Log 相互変換 UI（Step 3 で procedure ごと不採用）。
+
+## Reversibility Table
+
+| Step                 | Tag       | 備考                    |
+| -------------------- | --------- | ----------------------- |
+| エディタ・導線の追加 | [minutes] | 未接続。revert で消せる |
+| i18n キー追加        | [minutes] | 追加のみ                |
+
+## Existing Code to Reuse
+
+- `apps/product/src/features/calendar/stores/useInlineCreateStore.ts` / `useCalendarDragStore.ts` — インライン作成・ドラッグの既存 state（レーン概念の追加ベース）
+- `apps/product/src/features/entry/stores/`（Inspector store）— 開閉・対象参照のパターン
+- `apps/product/src/features/calendar/stores/useEntryClipboardStore.ts` — コピー / ペースト（保存先ルールを適用して流用）
+- `.claude/rules/temporal-constraints.md` — 過去ブロック操作制約の UI + ロジック二重防御パターン
+- project skills: `optimistic-update` / `i18n` / `storybook` / `test`
+
+## What I'm Not Doing
+
+- タイマー（開始 / 停止）UI は作らない。「さっきまでやっていた」は end = 今 の Log 作成で表現でき、Toggl 型の能動ボタンは ADR-019 のコンテキストで否定済みの体験
+- skip の高度な UI（理由入力等）はしない。skip / unskip の 1 アクションのみ
+
+## Follow-up
+
+次は Step 7（Review 差分の再定義）。並行可能だが、差分バッジ（Step 5）と分類ロジックを共有するため先に Step 5 をマージしておく。

--- a/docs/projects/time-model-split/step-7-review-diff.md
+++ b/docs/projects/time-model-split/step-7-review-diff.md
@@ -1,0 +1,58 @@
+---
+status: current
+last_verified: 2026-07-09
+code:
+  - apps/product/src/features/calendar/lib/day-diff.ts
+  - apps/product/src/features/review/components/diff/ReviewDiffPanel.tsx
+  - apps/product/src/features/review/hooks/useReviewPageData.ts
+---
+
+# Step 7: Review 差分の再定義（1:N 対応）
+
+`computeCalendarDayDiffs` を plans + logs の 1:N 前提で再定義し、Review パネル / Time P/L を新統計 service（Step 4）に載せ替える。接続フリップは Step 8。
+
+## Goal
+
+overview §3 の 4 分類（未記録 / やらなかった / 予定に対する記録 / 予定外）+ 差分数字で、日次・週次の Review が成立する状態にする。
+
+## 決めること（overview §8 未決 1・2・3）
+
+- **未決 1 — 別日実行の帰属（推奨: log は log の日、plan は自分の日）**: 火曜の予定に紐づく水曜の log は、水曜の実績に計上し、火曜側は「未達（記録は水曜）」として出す。日をまたいで実績を移動させると日次サマリーの合計が崩れるため
+- **未決 2 — tag / title 乖離時の束ね（推奨: log 側優先）**: 実績集計・Time P/L は log の tag で束ねる。予定系集計（blank rate / budget）だけ plan の tag を読む。「実際に何が起きたか」が主役という製品方針と一致
+- **未決 3 — plan soft delete 時の紐づき logs（推奨: 予定外に落とす）**: log は残し `plan_id` も保持するが、Review 上は生きている plan への join が取れないため「予定外の記録」として表示する。復元すれば自動的に「予定に対する記録」へ戻る
+
+## Minimum Viable Approach
+
+1. `day-diff.ts` を再定義: 入力を (plans[], logs[]) に変更。分類は overview §3 の 4 分類。現行の shifted / resized は「plan と Σlogs の開始ずれ・長さ差」として plan 単位で再定義する（1:N では log 単位の shifted は定義しない）
+2. summary の再定義: `plannedMinutes` = Σplans（skip 除外の扱いは現行踏襲: 計画履歴には残す・実績には混ぜない）、`actualMinutes` = Σlogs、`diffMinutes`、`unplannedMinutes`、`unrecordedMinutes`（新設: 未記録 plan の合計）
+3. `ReviewDiffPanel` / compare rail: 新 shape に追随。差分は数字（±0 非表示）、判定ラベル・赤マークなし（review spec「判定しない」）
+4. `useReviewPageData` / Time P/L: Step 4 の statistics-service が返す新 shape に載せ替え（接続自体は Step 8 まで分岐せず、旧実装と並存）
+5. 比較テスト: backfill 済みデータで旧 day-diff と新 day-diff のサマリーを突合し、意味論差（auto-record 実体化・未記録の新設）を許容リスト化する
+
+## Scope
+
+追加する: day-diff 再定義、Review コンポーネントの新 shape 対応、unrecorded 分類、tests。
+追加しない: 接続フリップ（Step 8）、旧 day-diff の削除（Step 9）、Review の情報設計変更（2タブ構成などの未決は本 project のスコープ外）。
+
+## Reversibility Table
+
+| Step            | Tag       | 備考                                                                                                   |
+| --------------- | --------- | ------------------------------------------------------------------------------------------------------ |
+| day-diff 再定義 | [minutes] | 旧実装と並存。revert で消せる                                                                          |
+| 未決 1-3 の決定 | [hours]   | 表示解釈のみでデータ非破壊。後から変えられるが、ユーザーが見る数字の意味が変わるため変更時は告知が要る |
+
+## Existing Code to Reuse
+
+- `apps/product/src/features/calendar/lib/day-diff.ts` — 分類・summary の再定義ベース
+- `apps/product/src/features/review/components/diff/ReviewDiffPanel.tsx` + stories — パネルの shape 契約
+- `apps/product/src/features/review/domain/`（timePL / variance）— 予実比較の既存 domain
+- `apps/product/src/features/entry/domain/estimation-accuracy.ts` — 1:N 化の改修ベース（Step 4 と共有）
+
+## What I'm Not Doing
+
+- スコア・ストリーク・判定表示の追加はしない（review spec「判定しない」）
+- 月次・年次集計の復活はしない（core-slim 方針）
+
+## Follow-up
+
+次は Step 8（カットオーバー）。Step 4-7 の dormant 実装が揃っていることが前提。

--- a/docs/projects/time-model-split/step-8-cutover.md
+++ b/docs/projects/time-model-split/step-8-cutover.md
@@ -1,0 +1,60 @@
+---
+status: current
+last_verified: 2026-07-09
+code:
+  - apps/product/src/features/entry/server/router-index.ts
+  - apps/product/src/app/api/v1/calendar
+  - apps/product/src/app/api/mcp/_tools/entries-list.ts
+---
+
+# Step 8: カットオーバー（plans / logs への切り替え）
+
+runtime の正を entries から plans / logs に切り替える。Step 2-7 の dormant 実装が揃っていることが前提。このステップの PR は**配線とデータ再同期に限定**し、新機能は足さない。
+
+## Goal
+
+書き込み・表示・統計・外部公開面のすべてが plans / logs を読む状態にし、entries への新規書き込みを止める。
+
+## 決めること（overview §8 未決 5・7）
+
+- **未決 5 — iCal export の対象（推奨: plans のみ）**: 外部カレンダー購読の用途は「Dayopt の予定を Google 等に出す」なので plans を出す。logs のフィードが欲しくなったら別トークン・別パスで追加できる（既存 URL の意味を変えないので非破壊）。既存購読者にとっては「entries の予定レイヤー」→「plans」で実質同じ内容
+- **未決 7 — MCP contract（推奨: 追加 + 当面併存）**: `plans-list` / `logs-list` tools を追加し、既存 `entries-list` は plans + logs から旧 shape を合成して当面維持する（MCP クライアント設定はユーザー環境にあり、即時破壊を避ける）。deprecation は docs に明記し、削除は Step 9 以降の別判断
+
+## Minimum Viable Approach
+
+1. **切り替え順序**（1 リリース内）:
+   1. Step 2 の backfill migration を再実行して delta を吸収（デプロイ直前）
+   2. デプロイ: UI（Calendar / Inspector / Review）を Step 5-7 の新実装へ接続、統計 router 内部を Step 4 の service へ差し替え、entries router の mutation を閉じる（read は Step 9 まで残す）
+   3. デプロイ直後にもう一度 backfill を再実行し、migration〜デプロイ間の書き込みギャップを吸収（冪等なので安全）
+2. iCal export（`app/api/v1/calendar/[token]/route.ts`）を未決 5 の決定に従って plans 読みへ切り替え
+3. MCP: `plans-list` / `logs-list` 追加、`entries-list` は合成互換
+4. 旧 UI（単一レーン + compare rail）へのルーティングを新 UI に差し替える。旧コードは残置（削除は Step 9）
+5. **デプロイ後監視**: Sentry でエラー増加、Vercel runtime logs、EXCLUDE 違反（TIME_OVERLAP）の頻度を能動的に確認（mcp-usage ルール）。Playwright スクリーンショットで Calendar / Review の視覚確認まで完了条件に含める
+
+## Scope
+
+やる: 配線切り替え、backfill 再実行、iCal / MCP の切り替え、監視。
+やらない: entries / RPC の drop（Step 9）、新機能、Phase 2 要素。
+
+## Reversibility Table
+
+| Step                           | Tag            | 備考                                                                                                                                                                                                    |
+| ------------------------------ | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| UI / 統計 / router の配線      | [minutes]      | デプロイ直後なら revert 一発。**ただし新テーブルへ書き込みが入った後は entries 側が stale になり、巻き戻しにデータ修復判断が要る（[days] に劣化）**。切り替え後 24-48h は revert 判断を最優先で監視する |
+| iCal export 切り替え           | [irreversible] | 外部購読者が見る URL の内容契約。未決 5 を確定してから実施                                                                                                                                              |
+| MCP tools 追加（合成互換込み） | [minutes]      | 追加のみ。entries-list の挙動は維持                                                                                                                                                                     |
+
+## Existing Code to Reuse
+
+- `apps/product/src/features/entry/lib/entry-to-ical.ts` — plans 読みへの改修ベース
+- `apps/product/src/app/api/mcp/_tools/entries-list.ts` — tool 定義・auth の踏襲元
+- Step 2 の backfill migration（再実行）と検証クエリ
+
+## What I'm Not Doing
+
+- feature flag による段階公開はしない。dormant 実装 + 1 リリース切り替え + 冪等 backfill の方が、フラグ分岐の二重実装より安全域が広い
+- entries の read 経路の削除はしない（Step 9 で呼び出しゼロを確認してから）
+
+## Follow-up
+
+切り替え後 1 週間程度、Sentry / 統計数値の異常がないことを確認してから Step 9（後始末）に進む。

--- a/docs/projects/time-model-split/step-9-cleanup.md
+++ b/docs/projects/time-model-split/step-9-cleanup.md
@@ -1,0 +1,65 @@
+---
+status: current
+last_verified: 2026-07-09
+code:
+  - apps/product/src/features/entry
+  - supabase/migrations
+  - docs/product/specs/entry.md
+---
+
+# Step 9: 後始末（entries 系資産の削除と docs 反映）
+
+cutover（Step 8）が安定した後、entries 系の DB 資産・旧コードを削除し、docs を新モデルへ更新して project を完了する。
+
+## Goal
+
+entries / `entries_effective` / 統計 RPC / 旧 UI コードをゼロ参照確認のうえ削除し、docs（specs / glossary / snapshot）を plans / logs の現実に揃える。
+
+## Minimum Viable Approach
+
+1. **ゼロ参照確認**（削除より先、機械的に）:
+   - `rg "rpc\('get_" apps/product/src` — 統計 RPC 呼び出しゼロ
+   - `rg "entries_effective|from\('entries'\)" apps/product/src` — entries 読みゼロ
+   - entries router / `entriesRouter` の参照ゼロ（MCP の `entries-list` 合成互換を残す場合はそこだけ例外として明記）
+2. drop migration: 統計 RPC 群 → `entries_effective` → entries 本体（trigger / index / RLS / EXCLUDE 込み）。**実施前に production バックアップの取得を確認**（Reversibility が [days] 級のため）
+3. 旧コード削除: entry-service の entries 経路、`entry-time-model.ts`（`getEffectiveActualRange` — Step 2 で用途終了）、旧 `day-diff.ts` 実装、`actual-time-overlay.ts`、旧単一レーン描画、convert 系 procedure、`soft_delete_entry` 等の entries 用 RPC
+4. `pnpm types:generate` で生成型から entries を消し、typecheck で残存参照を炙り出す
+5. docs 反映:
+   - `docs/product/specs/entry.md` を plan / log 仕様に改稿（または `plan-log.md` へ改名。specs は stock なので書き換え可）
+   - `docs/product/glossary.md` — Plan / Log / 未記録 / 予定外の用語追加
+   - `docs/engineering/data/db/rls-snapshot.md` 再生成
+   - `docs/projects/time-model-split/summary.md` を追加（workflow.md: project 完了時）
+   - ユーザー向け docs / リリースノートは `docs-writing` skill（`draft: true`）
+6. **GitHub issue の棚卸し**: 旧モデル（entries / 自動記録 / superseded ADR）を前提にした open issue を検索し、新しい状態と関係ないものを閉じる
+   - 検索軸: `entries` / `actual_start_time` / `entries_effective` / `auto-record`（自動記録） / 統計 RPC 名（`get_stats_page_data` 等） / ADR-011・018・019 への言及
+   - 判定: (a) 前提が消滅した issue → ADR-025 と本 project へのリンクを添えて close（`not planned`） (b) 課題自体は生きているが記述が旧モデルの issue → plans / logs の用語で本文を書き直すか、コメントで読み替えを明記して残す。無言 close はしない
+   - DB 系（entries の制約・index・RPC 改善）と docs 系（旧モデル前提のドキュメント修正）の issue が主な対象になるはず
+7. `pnpm quality:deadcode` で削除漏れを検出
+
+## Scope
+
+やる: DB drop、コード削除、型再生成、docs 更新、issue 棚卸し、summary.md。
+やらない: Phase 2（external 同期・ghost UI・calendar_connections）— 着手時に別途 step docs を切る。
+
+## Reversibility Table
+
+| Step                  | Tag       | 備考                                                                                         |
+| --------------------- | --------- | -------------------------------------------------------------------------------------------- |
+| 旧コード削除          | [minutes] | git revert で戻る                                                                            |
+| RPC / view drop       | [hours]   | migration rollback で戻る（定義は migration 履歴にある）                                     |
+| entries テーブル drop | [days]    | バックアップからの復元になる。cutover 後 1 週間の安定確認 + バックアップ確認を前提条件にする |
+
+## Existing Code to Reuse
+
+- Step 2 の検証クエリ — drop 前の最終突合に再利用
+- `docs/engineering/data/db/rls-snapshot.md` の生成手順
+- project skills: `docs-writing` / `supabase`
+
+## What I'm Not Doing
+
+- entries の「念のため」アーカイブテーブル化はしない。バックアップが担う責務で、アーカイブテーブルは第二の真実になる
+- MCP `entries-list` 合成互換の削除はここでは判断しない（利用状況を見て別 decision）
+
+## Follow-up
+
+project 完了。Phase 2（external_calendar_events 同期・ghost・calendar_connections）は overview §5 を起点に、着手時に step-10 以降として詳細化する。


### PR DESCRIPTION
## Summary
- Phase 1（entries → plans/logs 分割）の残り Step（backfill migration〜後始末）を、Step 0/1 と同じ 1 Step = 1 PR 形式で設計書化（step-2〜step-9）
- overview.md の Phase 構成をリンク表に再構成し、未決事項をどの Step で決定するか紐付け
- Step 0-9 完了時にユーザー・データ・コードがどうなっているかを §11 Definition of Done として明記

## Test plan
- [x] `pnpm docs:check` pass（frontmatter / naming / append-only / stock-side link check）
- [x] 各 step 設計書内の相互参照リンクを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)