### PR TITLE
feat: entriesからplan/logへのbackfillを追加

### DIFF
--- a/docs/engineering/data/db/rls-snapshot.md
+++ b/docs/engineering/data/db/rls-snapshot.md
@@ -5,7 +5,7 @@
 > **手で編集しない**。migration 変更時は CI（`pnpm rls:snapshot:check`）が drift を検出する。
 > 再生成で更新すること。
 >
-> 集計: public スキーマの policy 42 件 / RLS 対象テーブル 14 件 / GRANT 128 件 / Realtime publication 0 件。
+> 集計: public スキーマの policy 42 件 / RLS 対象テーブル 14 件 / GRANT 129 件 / Realtime publication 0 件。
 
 ## RLS 有効状態（public テーブル）
 
@@ -53,13 +53,13 @@
 
 ### logs
 
-| policy                               | cmd    | permissive | roles           | USING                                                              | WITH CHECK                              |
-| ------------------------------------ | ------ | ---------- | --------------- | ------------------------------------------------------------------ | --------------------------------------- |
-| Service role has full access to logs | ALL    | PERMISSIVE | {service_role}  | true                                                               | true                                    |
-| Users can delete own logs            | DELETE | PERMISSIVE | {authenticated} | (( SELECT auth.uid() AS uid) = user_id)                            | —                                       |
-| Users can insert own logs            | INSERT | PERMISSIVE | {authenticated} | —                                                                  | (( SELECT auth.uid() AS uid) = user_id) |
-| Users can view own logs              | SELECT | PERMISSIVE | {authenticated} | ((( SELECT auth.uid() AS uid) = user_id) AND (deleted_at IS NULL)) | —                                       |
-| Users can update own logs            | UPDATE | PERMISSIVE | {authenticated} | (( SELECT auth.uid() AS uid) = user_id)                            | (( SELECT auth.uid() AS uid) = user_id) |
+| policy                               | cmd    | permissive | roles           | USING                                                                           | WITH CHECK                                                                      |
+| ------------------------------------ | ------ | ---------- | --------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Service role has full access to logs | ALL    | PERMISSIVE | {service_role}  | true                                                                            | true                                                                            |
+| Users can delete own logs            | DELETE | PERMISSIVE | {authenticated} | ((( SELECT auth.uid() AS uid) = user_id) AND (source <> 'auto_migrated'::text)) | —                                                                               |
+| Users can insert own logs            | INSERT | PERMISSIVE | {authenticated} | —                                                                               | ((( SELECT auth.uid() AS uid) = user_id) AND (source <> 'auto_migrated'::text)) |
+| Users can view own logs              | SELECT | PERMISSIVE | {authenticated} | ((( SELECT auth.uid() AS uid) = user_id) AND (deleted_at IS NULL))              | —                                                                               |
+| Users can update own logs            | UPDATE | PERMISSIVE | {authenticated} | ((( SELECT auth.uid() AS uid) = user_id) AND (source <> 'auto_migrated'::text)) | ((( SELECT auth.uid() AS uid) = user_id) AND (source <> 'auto_migrated'::text)) |
 
 ### mfa_recovery_codes
 
@@ -151,6 +151,7 @@
 | column      | public.profiles.id                                                                                                                                                                                                                                                                      | authenticated       | INSERT                         |
 | column      | public.profiles.updated_at                                                                                                                                                                                                                                                              | authenticated       | UPDATE                         |
 | routine     | public.auto_shrink_neighbors(p_user_id uuid, p_entry_id uuid, p_actual_start timestamp with time zone, p_actual_end timestamp with time zone)                                                                                                                                           | service_role        | EXECUTE                        |
+| routine     | public.backfill_entries_to_plans_logs(p_backfill_now timestamp with time zone)                                                                                                                                                                                                          | service_role        | EXECUTE                        |
 | routine     | public.batch_rename_tags(p_user_id uuid, p_tag_ids uuid[], p_new_names text[])                                                                                                                                                                                                          | authenticated       | EXECUTE                        |
 | routine     | public.batch_rename_tags(p_user_id uuid, p_tag_ids uuid[], p_new_names text[])                                                                                                                                                                                                          | service_role        | EXECUTE                        |
 | routine     | public.batch_reorder_tags(p_user_id uuid, p_tag_ids uuid[], p_sort_orders integer[])                                                                                                                                                                                                    | service_role        | EXECUTE                        |

--- a/docs/projects/time-model-split/overview.md
+++ b/docs/projects/time-model-split/overview.md
@@ -36,14 +36,14 @@ code: apps/product/src/features/entry
 
 ### logs（Dayopt 内の記録）
 
-| カラム                                                                      | 型                   | 制約                                                                |
-| --------------------------------------------------------------------------- | -------------------- | ------------------------------------------------------------------- |
-| id / user_id / tag_id / title / note / created_at / updated_at / deleted_at |                      | plans と同形                                                        |
-| plan_id                                                                     | uuid NULL            | FK → plans。あり = 予定に対する記録（**1:N**）、なし = 予定外の記録 |
-| start_at / end_at                                                           | timestamptz NOT NULL | CHECK `end_at > start_at`                                           |
-| source                                                                      | text NOT NULL        | `manual` / `from_plan` / `external_calendar` / `api`                |
-| external_calendar_event_id                                                  | uuid NULL            | FK → external_calendar_events                                       |
-| fulfillment_score                                                           | integer NULL         | entries から移設（記録側の属性）                                    |
+| カラム                                                                      | 型                   | 制約                                                                   |
+| --------------------------------------------------------------------------- | -------------------- | ---------------------------------------------------------------------- |
+| id / user_id / tag_id / title / note / created_at / updated_at / deleted_at |                      | plans と同形                                                           |
+| plan_id                                                                     | uuid NULL            | FK → plans。あり = 予定に対する記録（**1:N**）、なし = 予定外の記録    |
+| start_at / end_at                                                           | timestamptz NOT NULL | CHECK `end_at > start_at`                                              |
+| source                                                                      | text NOT NULL        | `manual` / `from_plan` / `auto_migrated` / `external_calendar` / `api` |
+| external_calendar_event_id                                                  | uuid NULL            | FK → external_calendar_events                                          |
+| fulfillment_score                                                           | integer NULL         | entries から移設（記録側の属性）                                       |
 
 - CHECK: `source = 'from_plan'` ⇒ `plan_id IS NOT NULL`、`source = 'external_calendar'` ⇒ `external_calendar_event_id IS NOT NULL`
 - EXCLUDE: `logs_no_overlap` — plans と同型
@@ -179,7 +179,7 @@ code: apps/product/src/features/entry
 1. 別日実行の diff 帰属 — log は log の日に計上・plan は自分の日に未達、が有力 → **Step 7**
 2. plan と log の tag / title 乖離時、Review はどちらで束ねるか — log 側優先が有力 → **Step 7**
 3. plan soft delete 時の紐づき logs の見せ方（「予定に対する記録」のままか「予定外」に落とすか） → **Step 7**
-4. 移行時に実体化した logs を明示記録と区別するか — ADR-019 は自動記録を見積もり精度の分母から除外していた。区別を落とすと精度指標が汚れる → **Step 2**
+4. 移行時に実体化した logs を明示記録と区別するか — **決定: `logs.source = 'auto_migrated'` で区別する（Step 2）**
 5. iCal export（`/api/v1/calendar/[token]`）に plans / logs のどちらを出すか（両方なら 2 フィード） → **Step 8**
 6. ghost の有効期限・視覚表現（principles.md でも未確定） → **Phase 2**
 7. MCP / API が公開している entries 形の契約をどう version するか → **Step 8**

--- a/docs/projects/time-model-split/step-2-backfill-migration.md
+++ b/docs/projects/time-model-split/step-2-backfill-migration.md
@@ -14,24 +14,24 @@ code:
 
 entries の全データを plans / logs として実体化し、いつでも再実行して最新化できる backfill を作る。
 
-## 決めること（overview §8 未決 4）
+## 決定（overview §8 未決 4）
 
 auto-record 実体化 log を明示記録と区別するか。
 
-- **Option α（推奨）**: `logs.source` に `auto_migrated` を追加（Step 1 の source CHECK を拡張）。provenance は source の責務そのものであり、ADR-019 の「自動記録は見積もり精度の分母に入れない」意味論を Step 4 で継承できる
+- **採用: Option α**: `logs.source` に `auto_migrated` を追加（Step 1 の source CHECK を拡張）。provenance は source の責務そのものであり、ADR-019 の「自動記録は見積もり精度の分母に入れない」意味論を Step 4 で継承できる
 - Option β: `logs.auto_recorded boolean` 列を追加。source の意味を汚さないが、列が1つ増える
 - Option γ: 区別しない。最小だが精度指標が恒久的に汚れ、後から復元不能（[irreversible]）
 
 ## Minimum Viable Approach
 
-1. **id を決定的にマッピングする**: planned entry → `plans.id = entries.id`、unplanned entry → `logs.id = entries.id`、planned entry の実績 log → `uuid_generate_v5(entry.id 名前空間, 'log')` 等の決定的導出。再実行時の upsert と FK 安定性の両方が成立する
+1. **id を決定的にマッピングする**: planned entry → `plans.id = entries.id`、unplanned entry → `logs.id = entries.id`、planned entry の実績 log → `uuid_generate_v5(entry.id 名前空間, 'log')` 等の決定的導出。再実行前に各 entry から導出され得る全 deterministic id を管理対象として削除し、`logs -> plans` の順で掃除してから `plans -> logs` の順で再挿入する。これにより immediate EXCLUDE 制約の row-by-row update 衝突と `updated_at` trigger の上書きを避ける
 2. 変換規則（overview §7 準拠）:
    - `origin = 'planned'` → plans（`start_time`/`end_time` → `start_at`/`end_at`、`skipped_at`・`deleted_at` 移設、`source = 'manual'`）
-   - 明示 actual（両端 NOT NULL）→ logs（`plan_id` = 対応 plan、`source = 'from_plan'`、`fulfillment_score` 移設）
+   - 明示 actual（両端 NOT NULL）→ logs（`plan_id` = 対応 plan、`source = 'from_plan'`、`fulfillment_score` 移設）。soft-deleted historical row など plan range が欠ける planned entry は plan FK を作れないため log 化しない
    - `origin = 'unplanned'` → logs（`plan_id` NULL、`source = 'manual'`）
    - auto-record（planned・actual NULL・未 skip・`end_time <= now()`）→ logs（plan range を実体化、source = 未決 4 の決定値）。effective actual の判定式は `entries_effective` と同一ロジックを backfill SQL 内に一度だけ書く
-3. `INSERT ... ON CONFLICT (id) DO UPDATE` で冪等化。soft delete 行も `deleted_at` ごと移行（Step 1 の CHECK は deleted 行の歴史的 shape を許容済み）
-4. **EXCLUDE 整合の事前検証**: 明示 actual 同士は現行 DB 制約で重なりゼロが保証済み。auto-record 実体化同士・auto-record × 明示 actual はサービス層防衛だった領域なので、backfill 前に重なり検出クエリを流して 0 件を確認する（ヒットしたら ADR-018 の前例に従い新しい側を soft delete）
+3. 管理対象行を delete/reinsert して冪等化。soft delete 行も `deleted_at` ごと移行（Step 1 の CHECK は deleted 行の歴史的 shape を許容済み）。`created_at` / `updated_at` は entries の値を明示挿入し、更新 trigger による replay 時の時刻変化を避ける
+4. **EXCLUDE 整合の修復と事前検証**: 明示 actual 同士は現行 DB 制約で重なりゼロが保証済み。auto-record 実体化同士・auto-record × 明示 actual はサービス層防衛だった領域なので、期待 log 集合を作る前に重なり検出クエリを流し、ヒットしたら ADR-018 の前例に従い新しい側を soft delete する。修復後の期待 log 集合にも重なりが残る場合は migration を止める
 5. 検証クエリを migration とペアで残す: 件数突合（planned 数 = plans 数、actual/unplanned/auto 数 = logs 数）、時間合計突合、`plan_id` 参照整合
 
 ## Scope
@@ -43,7 +43,7 @@ auto-record 実体化 log を明示記録と区別するか。
 
 | Step                               | Tag            | 備考                                                                        |
 | ---------------------------------- | -------------- | --------------------------------------------------------------------------- |
-| backfill upsert                    | [hours]        | 新テーブルはまだ未参照。TRUNCATE + 再実行で何度でもやり直せる。entries 無傷 |
+| backfill delete/reinsert           | [hours]        | 新テーブルはまだ未参照。TRUNCATE + 再実行で何度でもやり直せる。entries 無傷 |
 | source CHECK 拡張（未決 4 = α 時） | [hours]        | 値の追加のみ。既存行に影響なし                                              |
 | auto-record の区別を落とす（γ 時） | [irreversible] | 実体化後に「自動だったか」を復元できない。α / β なら回避                    |
 

--- a/supabase/migrations/20260709131514_backfill_entries_to_time_model.sql
+++ b/supabase/migrations/20260709131514_backfill_entries_to_time_model.sql
@@ -1,0 +1,345 @@
+-- time-model-split Phase 1 Step 2.
+-- Backfill entries into plans/logs while keeping entries as the runtime source.
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp" SCHEMA extensions;
+
+ALTER TABLE public.logs
+  DROP CONSTRAINT IF EXISTS logs_source_check;
+
+ALTER TABLE public.logs
+  ADD CONSTRAINT logs_source_check
+  CHECK (source IN ('manual', 'from_plan', 'auto_migrated', 'external_calendar', 'api'));
+
+ALTER POLICY "Users can insert own logs"
+  ON public.logs
+  WITH CHECK (((select auth.uid()) = user_id) AND source <> 'auto_migrated');
+
+ALTER POLICY "Users can update own logs"
+  ON public.logs
+  USING (((select auth.uid()) = user_id) AND source <> 'auto_migrated')
+  WITH CHECK (((select auth.uid()) = user_id) AND source <> 'auto_migrated');
+
+ALTER POLICY "Users can delete own logs"
+  ON public.logs
+  USING (((select auth.uid()) = user_id) AND source <> 'auto_migrated');
+
+CREATE OR REPLACE FUNCTION public.backfill_entries_to_plans_logs(
+  p_backfill_now TIMESTAMPTZ DEFAULT now()
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_log_namespace CONSTANT UUID := '8f48b7ce-9362-5a4d-bf4c-65fcd4fe93e9';
+  v_overlap_count INTEGER;
+  v_expected_count INTEGER;
+  v_actual_count INTEGER;
+  v_missing_fk_count INTEGER;
+BEGIN
+  WITH projected_logs AS (
+    SELECT
+      e.id AS entry_id,
+      e.user_id,
+      e.actual_start_time AS start_at,
+      e.actual_end_time AS end_at,
+      'manual'::TEXT AS source
+    FROM public.entries e
+    WHERE e.deleted_at IS NULL
+      AND e.origin = 'unplanned'
+      AND e.actual_start_time IS NOT NULL
+      AND e.actual_end_time IS NOT NULL
+
+    UNION ALL
+
+    SELECT
+      e.id AS entry_id,
+      e.user_id,
+      e.actual_start_time AS start_at,
+      e.actual_end_time AS end_at,
+      'from_plan'::TEXT AS source
+    FROM public.entries e
+    WHERE e.deleted_at IS NULL
+      AND e.origin = 'planned'
+      AND e.start_time IS NOT NULL
+      AND e.end_time IS NOT NULL
+      AND e.actual_start_time IS NOT NULL
+      AND e.actual_end_time IS NOT NULL
+
+    UNION ALL
+
+    SELECT
+      e.id AS entry_id,
+      e.user_id,
+      e.start_time AS start_at,
+      e.end_time AS end_at,
+      'auto_migrated'::TEXT AS source
+    FROM public.entries e
+    WHERE e.deleted_at IS NULL
+      AND e.origin = 'planned'
+      AND e.actual_start_time IS NULL
+      AND e.actual_end_time IS NULL
+      AND e.skipped_at IS NULL
+      AND e.start_time IS NOT NULL
+      AND e.end_time IS NOT NULL
+      AND e.end_time <= p_backfill_now
+  ), effective_log_overlap_pairs AS (
+    SELECT l2.entry_id AS delete_id
+    FROM projected_logs l1
+    JOIN projected_logs l2
+      ON l1.user_id = l2.user_id
+     AND l1.entry_id < l2.entry_id
+     AND (l1.source = 'auto_migrated' OR l2.source = 'auto_migrated')
+     AND tstzrange(l1.start_at, l1.end_at, '[)') && tstzrange(l2.start_at, l2.end_at, '[)')
+  )
+  UPDATE public.entries e
+  SET deleted_at = now()
+  WHERE e.id IN (SELECT delete_id FROM effective_log_overlap_pairs)
+    AND e.deleted_at IS NULL;
+
+  CREATE TEMP TABLE time_model_expected_plans ON COMMIT DROP AS
+  SELECT
+    e.id,
+    e.user_id,
+    e.tag_id,
+    NULL::UUID AS external_calendar_event_id,
+    e.title,
+    e.description AS note,
+    e.start_time AS start_at,
+    e.end_time AS end_at,
+    e.skipped_at,
+    'manual'::TEXT AS source,
+    e.deleted_at,
+    e.created_at,
+    e.updated_at
+  FROM public.entries e
+  WHERE e.origin = 'planned'
+    AND e.start_time IS NOT NULL
+    AND e.end_time IS NOT NULL;
+
+  CREATE TEMP TABLE time_model_expected_logs ON COMMIT DROP AS
+  SELECT
+    e.id,
+    e.user_id,
+    e.tag_id,
+    NULL::UUID AS plan_id,
+    NULL::UUID AS external_calendar_event_id,
+    e.title,
+    e.description AS note,
+    e.actual_start_time AS start_at,
+    e.actual_end_time AS end_at,
+    'manual'::TEXT AS source,
+    e.fulfillment_score,
+    e.deleted_at,
+    e.created_at,
+    e.updated_at
+  FROM public.entries e
+  WHERE e.origin = 'unplanned'
+    AND e.actual_start_time IS NOT NULL
+    AND e.actual_end_time IS NOT NULL
+
+  UNION ALL
+
+  SELECT
+    extensions.uuid_generate_v5(v_log_namespace, e.id::TEXT || ':log') AS id,
+    e.user_id,
+    e.tag_id,
+    e.id AS plan_id,
+    NULL::UUID AS external_calendar_event_id,
+    e.title,
+    e.description AS note,
+    e.actual_start_time AS start_at,
+    e.actual_end_time AS end_at,
+    'from_plan'::TEXT AS source,
+    e.fulfillment_score,
+    e.deleted_at,
+    e.created_at,
+    e.updated_at
+  FROM public.entries e
+  WHERE e.origin = 'planned'
+    AND e.start_time IS NOT NULL
+    AND e.end_time IS NOT NULL
+    AND e.actual_start_time IS NOT NULL
+    AND e.actual_end_time IS NOT NULL
+
+  UNION ALL
+
+  SELECT
+    extensions.uuid_generate_v5(v_log_namespace, e.id::TEXT || ':log') AS id,
+    e.user_id,
+    e.tag_id,
+    e.id AS plan_id,
+    NULL::UUID AS external_calendar_event_id,
+    e.title,
+    e.description AS note,
+    e.start_time AS start_at,
+    e.end_time AS end_at,
+    'auto_migrated'::TEXT AS source,
+    e.fulfillment_score,
+    e.deleted_at,
+    e.created_at,
+    e.updated_at
+  FROM public.entries e
+  WHERE e.origin = 'planned'
+    AND e.actual_start_time IS NULL
+    AND e.actual_end_time IS NULL
+    AND e.skipped_at IS NULL
+    AND e.start_time IS NOT NULL
+    AND e.end_time IS NOT NULL
+    AND e.end_time <= p_backfill_now;
+
+  CREATE TEMP TABLE time_model_managed_plan_ids ON COMMIT DROP AS
+  SELECT e.id
+  FROM public.entries e;
+
+  CREATE TEMP TABLE time_model_managed_log_ids ON COMMIT DROP AS
+  SELECT e.id
+  FROM public.entries e
+
+  UNION
+
+  SELECT extensions.uuid_generate_v5(v_log_namespace, e.id::TEXT || ':log') AS id
+  FROM public.entries e;
+
+  SELECT count(*)::INTEGER
+  INTO v_overlap_count
+  FROM pg_temp.time_model_expected_logs l1
+  JOIN pg_temp.time_model_expected_logs l2
+    ON l1.user_id = l2.user_id
+   AND l1.id < l2.id
+   AND l1.deleted_at IS NULL
+   AND l2.deleted_at IS NULL
+   AND tstzrange(l1.start_at, l1.end_at, '[)') && tstzrange(l2.start_at, l2.end_at, '[)');
+
+  IF v_overlap_count > 0 THEN
+    RAISE EXCEPTION 'time-model backfill would create % overlapping active logs', v_overlap_count
+      USING ERRCODE = '23514';
+  END IF;
+
+  DELETE FROM public.logs l
+  USING pg_temp.time_model_managed_log_ids managed
+  WHERE l.id = managed.id;
+
+  DELETE FROM public.plans p
+  USING pg_temp.time_model_managed_plan_ids managed
+  WHERE p.id = managed.id;
+
+  INSERT INTO public.plans (
+    id,
+    user_id,
+    tag_id,
+    external_calendar_event_id,
+    title,
+    note,
+    start_at,
+    end_at,
+    skipped_at,
+    source,
+    deleted_at,
+    created_at,
+    updated_at
+  )
+  SELECT
+    id,
+    user_id,
+    tag_id,
+    external_calendar_event_id,
+    title,
+    note,
+    start_at,
+    end_at,
+    skipped_at,
+    source,
+    deleted_at,
+    created_at,
+    updated_at
+  FROM pg_temp.time_model_expected_plans;
+
+  INSERT INTO public.logs (
+    id,
+    user_id,
+    tag_id,
+    plan_id,
+    external_calendar_event_id,
+    title,
+    note,
+    start_at,
+    end_at,
+    source,
+    fulfillment_score,
+    deleted_at,
+    created_at,
+    updated_at
+  )
+  SELECT
+    id,
+    user_id,
+    tag_id,
+    plan_id,
+    external_calendar_event_id,
+    title,
+    note,
+    start_at,
+    end_at,
+    source,
+    fulfillment_score,
+    deleted_at,
+    created_at,
+    updated_at
+  FROM pg_temp.time_model_expected_logs;
+
+  SELECT count(*)::INTEGER
+  INTO v_expected_count
+  FROM pg_temp.time_model_expected_plans;
+
+  SELECT count(*)::INTEGER
+  INTO v_actual_count
+  FROM public.plans p
+  JOIN pg_temp.time_model_expected_plans expected
+    ON expected.id = p.id;
+
+  IF v_actual_count <> v_expected_count THEN
+    RAISE EXCEPTION 'time-model backfill plan count mismatch: expected %, got %', v_expected_count, v_actual_count
+      USING ERRCODE = '23514';
+  END IF;
+
+  SELECT count(*)::INTEGER
+  INTO v_expected_count
+  FROM pg_temp.time_model_expected_logs;
+
+  SELECT count(*)::INTEGER
+  INTO v_actual_count
+  FROM public.logs l
+  JOIN pg_temp.time_model_expected_logs expected
+    ON expected.id = l.id;
+
+  IF v_actual_count <> v_expected_count THEN
+    RAISE EXCEPTION 'time-model backfill log count mismatch: expected %, got %', v_expected_count, v_actual_count
+      USING ERRCODE = '23514';
+  END IF;
+
+  SELECT count(*)::INTEGER
+  INTO v_missing_fk_count
+  FROM pg_temp.time_model_expected_logs expected
+  LEFT JOIN public.plans p
+    ON p.id = expected.plan_id
+  WHERE expected.plan_id IS NOT NULL
+    AND p.id IS NULL;
+
+  IF v_missing_fk_count > 0 THEN
+    RAISE EXCEPTION 'time-model backfill missing plan references: %', v_missing_fk_count
+      USING ERRCODE = '23514';
+  END IF;
+
+  DROP TABLE pg_temp.time_model_expected_plans;
+  DROP TABLE pg_temp.time_model_expected_logs;
+  DROP TABLE pg_temp.time_model_managed_plan_ids;
+  DROP TABLE pg_temp.time_model_managed_log_ids;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.backfill_entries_to_plans_logs(TIMESTAMPTZ) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.backfill_entries_to_plans_logs(TIMESTAMPTZ) TO service_role;
+
+SELECT public.backfill_entries_to_plans_logs();

--- a/supabase/schemas/010_tables_core.sql
+++ b/supabase/schemas/010_tables_core.sql
@@ -125,7 +125,7 @@ CREATE TABLE public.logs (
   note TEXT,
   start_at TIMESTAMPTZ NOT NULL,
   end_at TIMESTAMPTZ NOT NULL,
-  source TEXT NOT NULL DEFAULT 'manual', -- manual / from_plan / external_calendar / api
+  source TEXT NOT NULL DEFAULT 'manual', -- manual / from_plan / auto_migrated / external_calendar / api
   fulfillment_score INTEGER,
   deleted_at TIMESTAMPTZ,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),

--- a/supabase/schemas/040_functions.sql
+++ b/supabase/schemas/040_functions.sql
@@ -35,6 +35,7 @@
 --   restore_entry(entry_id, user_id)          — entries.deleted_at を解除
 --   bulk_soft_delete_entries(entry_ids, user_id) — entries の一括 soft delete
 --   issue_oauth_token_pair(...)               — refresh/access token pair を service-role 経由で発行
+--   backfill_entries_to_plans_logs(now)       — entries を plans / logs へ冪等 backfill
 
 -- ■ app-facing 統計関数（authenticated に明示 GRANT）
 --   get_time_pl_data(...)                     — Time PL の集計データ


### PR DESCRIPTION
## Summary
- Add a Step 2 backfill migration that materializes legacy `entries` into dormant `plans` / `logs` tables.
- Add `logs.source = 'auto_migrated'` so migrated auto-record logs remain distinguishable from user-confirmed logs.
- Keep the backfill rerunnable through `public.backfill_entries_to_plans_logs()` and restrict execution to `service_role`.

## Notes
- Planned entries map to `plans.id = entries.id`.
- Unplanned entries map to `logs.id = entries.id`.
- Planned actual / auto-migrated logs use a deterministic v5 UUID derived from the entry id.
- The function checks projected active log overlaps, plan/log count parity, and plan FK integrity before completing.

## Verification
- `supabase db reset --local`
- `psql ... -c 'select public.backfill_entries_to_plans_logs();'` twice after seed; counts stayed stable (`entries=43`, `plans=39`, `logs=43`)
- `pnpm rls:snapshot:check`
- `pnpm docs:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:boundaries`
- `pnpm check`
