### PR TITLE
docs: 並行レーン orchestration 策定と refactor 凍結判断を記録

### DIFF
--- a/.agents/skills/dispatch
+++ b/.agents/skills/dispatch
@@ -1,0 +1,1 @@
+../../.claude/skills/dispatch

--- a/.claude/commands/dispatch.md
+++ b/.claude/commands/dispatch.md
@@ -1,0 +1,70 @@
+---
+description: 並行レーン orchestration の指揮者運用 — tracking issue から worker へ issue を渡し、新規作業を issue 化し、定期棚卸しで gap を検出する
+---
+
+# /dispatch
+
+feature 開発と並行する非 feature 作業を issue ベースで回す指揮者（conductor）の定常運用。**どのモデルでも実行できる**ことを前提に、判断基準をすべて本ファイルに明文化する。個人メモリや特定モデルの記憶に依存しない。
+
+**正（source of truth）**: 現行の orchestration tracking issue（2026-07 時点は #1567）。レーン定義・凍結リスト・推奨着手順はそこを読む。本ファイルは「手順」、tracking issue は「状態」。
+
+引数で操作を指定する: `/dispatch`（渡す）/ `/dispatch intake <内容>`（起票）/ `/dispatch sweep`（棚卸し）/ `/dispatch unfreeze`（凍結解除判定）。引数なしは操作 A。
+
+## 操作 A: dispatch — issue を worker に渡す
+
+1. tracking issue を読み、「今すぐ worker 可」から候補を選ぶ（ユーザー指定があればそれを優先）
+2. **衝突チェック**: 候補 issue が触るファイル・ディレクトリを、(a) 進行中 feature の設計書（例: `docs/projects/time-model-split/` の該当 Step）の対象、(b) 他の in-progress issue（`status:in-progress` ラベル）の対象、と突合する。重なれば渡さず次の候補へ
+3. **凍結チェック**: `status:blocked` が付いていないこと、tracking issue の凍結リストに載っていないことを確認
+4. issue 本文を **handoff-quality** に補強する（下記テンプレート）。worker が repo 探索なしで着手できる密度が基準
+5. `status:in-progress` ラベルを付け、tracking issue の checklist にコメントで dispatch 先（Sonnet / Codex / その他）を記録
+6. worker への指示は issue URL + 「本文の受け入れ条件と検証コマンドに従う」だけで済む状態にする
+
+### handoff-quality テンプレート（issue 本文に含める 4 要素）
+
+```markdown
+## 背景 — なぜやるか。関連 issue / docs / 過去 PR へのリンク
+
+## やること — 番号付き手順。対象ファイル path を明記
+
+## 注意 — 既知の罠、触ってはいけない領域、関連 skill（例: supabase skill のフロー）
+
+## 検証 — pass すべきコマンド（pnpm check 等）と確認観点
+```
+
+### 規模別の渡し方
+
+- size s/xs: 直接実装でよい。plan 不要
+- size m/l: worker に plan を先に出させ、`/plan-review` を通してから実装
+- spike / 設計判断を含む issue: worker に渡さない。最上位ティア（`.claude/rules/ai-behavior.md` のティア表参照）のセッションで実施
+
+## 操作 B: intake — 新しい作業を issue 化する
+
+作業依頼・発見事項・監査結果が issue の外にある状態を作らない。
+
+1. `gh search issues` で既存 issue との重複を確認（close 済み含む）
+2. 重複なら既存 issue に本文追記 or コメントで統合。新規なら handoff-quality で起票
+3. ラベルは既存体系のみ使う: `type:*` / `priority:*` / `area:*` / `size:*` / `quality:security` / `ops` など。**新ラベルを作らない**
+4. tracking issue の該当レーンに追記し、担当区分（worker 可 / 最上位ティア / 🔒 prod 操作）を付ける
+
+## 操作 C: sweep — 定期棚卸しで gap を検出する
+
+月次（`/gardening` と同時期）または大きな節目に実施。以下の「issue の外に作業が溜まりやすい場所」を機械的に確認し、見つけたら操作 B で起票する:
+
+- [ ] Supabase advisors: `get_advisors`（security / performance）の WARN が issue 化されているか
+- [ ] Dependabot security alerts: `gh api repos/Dayopt/dayopt/dependabot/alerts?state=open` が 0 件か
+- [ ] `docs/operations/log/` の監査・incident ログ末尾の「残タスク」が issue 化されているか
+- [ ] NOT_PLANNED で close された issue の中身が、実は未完了のまま受け皿を失っていないか
+- [ ] 生成系スクリプト（`api:spec` / `types:generate` / `rls:snapshot`）が現在も exit 0 で通るか
+- [ ] open PR で 2 週間以上動きがないものの扱い（rebase / close / 引き継ぎ）
+
+## 操作 D: unfreeze — 凍結解除の判定
+
+tracking issue の凍結リストにある issue は、記載された解除条件（例: time-model-split Step 8 cutover 完了）を満たしたときのみ解除する。
+
+1. 解除条件の達成を設計書・merge 済み PR で確認する
+2. 凍結 issue の `status:blocked` を外し、**着手前に設計を現状に合わせて見直す**コメントを残す（凍結中に前提が変わっているため、本文の対象ファイル・手順は書き直し前提）
+3. tracking issue の凍結リストからレーンへ移す
+
+## tracking issue が消化されたら
+
+checklist が全て閉じたら tracking issue を close し、次の棚卸し（操作 C をフル実施）を起点に後継 tracking issue を同じ構成（レーン定義 / 凍結リスト / 着手順 / 運用ルール）で新設する。本ファイル冒頭の issue 番号を更新する。

--- a/.claude/commands/gardening.md
+++ b/.claude/commands/gardening.md
@@ -39,6 +39,10 @@ feedback / incident の note は、対応がまだ `operations/` 側の手順に
 
 `docs/engineering/log/` に `*-ai-config-audit.md` が直近 3 ヶ月存在しなければ、`audit-ai-config` skill による AI 設定棚卸しの実施をユーザーに提案する（このステップで実施はしない。提案のみ）。
 
+### 5.5. 並行レーン sweep（月次）
+
+`dispatch` skill（`.agents/skills/dispatch/SKILL.md`）の操作 C（sweep）を実施する。issue の外に溜まった作業（advisors / Dependabot alerts / 監査ログ残タスク / 生成スクリプトの故障 / 放置 PR）を検出し、見つけたら同 skill の intake で起票する。結果はステップ 6 のロールアップに件数を記録する。
+
 ### 6. 月次ロールアップへの記録
 
 このガーデニング実施の内容(蒸留したセッション件数、triageした上位10件の対応、昇格したnote、スモークテストの結果)を当月 `docs/engineering/log/YYYY-MM-01-journal.md` に追記して終了する。

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -183,6 +183,43 @@ gh pr merge <PR番号> --merge --delete-branch
 - revert は対象を見極める。マージコミット自体を戻す場合は `git revert -m 1 <merge-sha>`、個別コミットを戻す場合は通常の `git revert <sha>`
 - マージ済みブランチは GitHub が自動削除（`deleteBranchOnMerge: true`）。ローカルでは `git branch -d` がマージを検出して安全に削除できる（squash 時代の `-D` 強制は不要になる）
 
+## Worktree 運用
+
+策定日: 2026-07-10
+
+**原則: 1 worktree = 1 branch = 1 PR。役目（PR の merge / close）を終えた worktree はその場で削除する。** 放置すると worktree・ブランチ・孤児ディレクトリが積み上がり、どれが生きている作業か判別できなくなる。
+
+### 置き場と作成
+
+- Claude Code は `.claude/worktrees/<name>/` に自動作成する（gitignore 済み）。Codex は `~/.codex/worktrees/` を使う。**手動で `git worktree add` する場合も `.claude/worktrees/` 配下に置く**（repo 直下や無関係な場所に散らさない）
+- 他ツールの worktree（`~/.codex/` 配下）は各ツールの管理に任せ、手動で触らない
+
+### マージ後の掃除（AI の責務、merge と同一セッションで実施）
+
+```bash
+gh pr merge <N> --merge --delete-branch  # remote は deleteBranchOnMerge でも自動削除
+git worktree remove <worktree-path>      # branch が worktree に checkout されている場合は先に
+git branch -d <branch>                   # merge 済みなら -d が通る（-D は使わない）
+```
+
+順序に意味がある: **worktree に checkout されたブランチは削除できない**ため、`git worktree remove` が先。
+
+### 削除時の安全確認
+
+- 削除前に `git -C <worktree-path> status --porcelain` が空であることを確認する。未コミット差分が残る worktree はユーザー作業として扱い、勝手に消さない（確認を取る）
+- **`rm -rf` で worktree を直接消さない**。git の管理情報が残って孤児化する。必ず `git worktree remove` を使う
+- gitignore された生成物（`.next/` 等）だけが残って `remove` が拒否される場合は、tracked ファイルに差分がないことを確認した上で `git worktree remove --force`
+
+### 定期掃除（月次 sweep で実施）
+
+```bash
+git worktree list          # 全 worktree と branch の対応を俯瞰
+git worktree prune         # 手動削除などで孤児化した管理情報を掃除
+git branch --merged main   # merge 済みローカルブランチ → git branch -d で削除
+```
+
+`git worktree list` に出ないのに `.claude/worktrees/` 配下に残っているディレクトリは孤児（過去の削除で gitignore 生成物だけが残った残骸）。中身が生成物のみであることを確認して削除する。
+
 ## 実例の参照先
 
 各規模の実例:

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -72,6 +72,7 @@ feature 開発と並行する非 feature 作業を issue ベースで回す指�
 - [ ] NOT_PLANNED で close された issue の中身が、実は未完了のまま受け皿を失っていないか
 - [ ] 生成系スクリプト（`api:spec` / `types:generate` / `rls:snapshot`）が現在も exit 0 で通るか
 - [ ] open PR で 2 週間以上動きがないものの扱い（rebase / close / 引き継ぎ）
+- [ ] worktree・ブランチの残骸: `git worktree list` / `git worktree prune` / `git branch --merged main`（手順は `.claude/rules/workflow.md` §Worktree 運用）
 
 ## 操作 D: unfreeze — 凍結解除の判定
 

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -1,14 +1,30 @@
 ---
-description: 並行レーン orchestration の指揮者運用 — tracking issue から worker へ issue を渡し、新規作業を issue 化し、定期棚卸しで gap を検出する
+name: dispatch
+description: GitHub issue を worker（Sonnet / Codex）へ渡す準備をする時、非 feature 作業の issue を新規起票する時、orchestration tracking issue を更新する時、`status:blocked` の凍結 issue への着手が話題になった時、並行作業の定期棚卸し（sweep）や凍結解除を行う時に発動。凍結・衝突チェック、handoff-quality 補強、既存ラベル体系を適用する。issue の中身の実装作業そのものや、docs ログ作成（/decision・/note の領域）では発動しない。
 ---
 
-# /dispatch
+# Dispatch Skill
 
-feature 開発と並行する非 feature 作業を issue ベースで回す指揮者（conductor）の定常運用。**どのモデルでも実行できる**ことを前提に、判断基準をすべて本ファイルに明文化する。個人メモリや特定モデルの記憶に依存しない。
+feature 開発と並行する非 feature 作業を issue ベースで回す指揮者（conductor）の定常運用。**どのモデル（Opus / Sonnet / Codex / それ以降）でも実行できる**ことを前提に、判断基準をすべて本ファイルに明文化する。個人メモリや特定モデルの記憶に依存しない。
 
 **正（source of truth）**: 現行の orchestration tracking issue（2026-07 時点は #1567）。レーン定義・凍結リスト・推奨着手順はそこを読む。本ファイルは「手順」、tracking issue は「状態」。
 
-引数で操作を指定する: `/dispatch`（渡す）/ `/dispatch intake <内容>`（起票）/ `/dispatch sweep`（棚卸し）/ `/dispatch unfreeze`（凍結解除判定）。引数なしは操作 A。
+## When to Use
+
+以下の状況で発動:
+
+- worker に渡す issue を選定・準備する時（→ 操作 A）
+- 非 feature 作業（refactor / security / ops / content）の issue を新規起票する時（→ 操作 B）
+- orchestration tracking issue のレーン・checklist を更新する時
+- 定期棚卸し（sweep）や凍結解除（unfreeze）を明示依頼された時（→ 操作 C / D）
+- 提案・plan の中に `status:blocked` 付き issue への着手が含まれているのを検出した時（凍結違反の防止）
+- issue 化されていない作業（監査ログの残タスク、alert、会話中の口頭依頼）がセッション内に現れた時
+
+## When NOT to Use
+
+- 各 issue の中身の実装作業そのもの（issue 本文の受け入れ条件と、該当する project skill に従う）
+- 意思決定ログ・調査ログの作成（/decision・/note コマンドの領域）
+- feature 実装 plan の策定（`.claude/rules/plan-format.md` に従う。dispatch は「誰に渡すか」だけを扱う）
 
 ## 操作 A: dispatch — issue を worker に渡す
 
@@ -16,7 +32,7 @@ feature 開発と並行する非 feature 作業を issue ベースで回す指�
 2. **衝突チェック**: 候補 issue が触るファイル・ディレクトリを、(a) 進行中 feature の設計書（例: `docs/projects/time-model-split/` の該当 Step）の対象、(b) 他の in-progress issue（`status:in-progress` ラベル）の対象、と突合する。重なれば渡さず次の候補へ
 3. **凍結チェック**: `status:blocked` が付いていないこと、tracking issue の凍結リストに載っていないことを確認
 4. issue 本文を **handoff-quality** に補強する（下記テンプレート）。worker が repo 探索なしで着手できる密度が基準
-5. `status:in-progress` ラベルを付け、tracking issue の checklist にコメントで dispatch 先（Sonnet / Codex / その他）を記録
+5. `status:in-progress` ラベルを付け、tracking issue にコメントで dispatch 先（Sonnet / Codex / その他）を記録
 6. worker への指示は issue URL + 「本文の受け入れ条件と検証コマンドに従う」だけで済む状態にする
 
 ### handoff-quality テンプレート（issue 本文に含める 4 要素）

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ Claude Code は `Skill` tool、Codex は該当ファイルを直接読んで手�
 | コマンド        | 内容                                                                     |
 | --------------- | ---------------------------------------------------------------------- |
 | `/decision`     | 各ドメインの `log/` に `YYYY-MM-DD-slug.md` で意思決定ログを新規作成         |
+| `/dispatch`     | 並行レーン orchestration の指揮者運用: issue を worker へ渡す / intake 起票 / sweep 棚卸し / 凍結解除。正は tracking issue（#1567） |
 | `/plan-review`  | 直前の実装 plan を plan-fact-checker / plan-critic の 2 agent で並列レビュー |
 | `/note`         | 各ドメインの `log/YYYY-MM-DD-slug.md` を新規作成（feedback-/incident- prefix対応） |
 | `/session-end`  | 当日の作業を `docs/engineering/log/YYYY-MM-DD-session.md` に記録し `latest.md` を更新 |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ pnpm docs:check               # リンク切れ/frontmatter/命名/append-only �
   | `docs`     | ドキュメントのみの変更         |
   | `test`     | テストの追加・修正             |
   | `perf`     | パフォーマンス改善             |
-- PR を merge する時は、枝分かれを履歴に残すため `gh pr merge --merge` を標準にする
+- PR を merge する時は、枝分かれを履歴に残すため `gh pr merge --merge --delete-branch` を標準にする。**マージ後は同一セッション内でローカルブランチと作業に使った worktree も削除する**（worktree remove → branch -d の順。`.claude/rules/workflow.md` §Worktree 運用）
 
 ## Coding Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ pnpm docs:check               # リンク切れ/frontmatter/命名/append-only �
 ## Non-Negotiables
 
 - 既存コードを検索してから変更する。`rg` / `rg --files` を優先する
+- issue の起票・worker への作業依頼・`status:blocked` issue への着手判断は `dispatch` skill（`.agents/skills/dispatch/SKILL.md`）の規約に従う。凍結 issue には着手しない
 - 既存の未コミット差分はユーザー作業として扱い、勝手に revert / stage しない
 - `git add .` は避ける。必ず path-limited add で scope を固定する
 - コミット前に `git diff --cached` を確認する
@@ -102,7 +103,6 @@ Claude Code は `Skill` tool、Codex は該当ファイルを直接読んで手�
 | コマンド        | 内容                                                                     |
 | --------------- | ---------------------------------------------------------------------- |
 | `/decision`     | 各ドメインの `log/` に `YYYY-MM-DD-slug.md` で意思決定ログを新規作成         |
-| `/dispatch`     | 並行レーン orchestration の指揮者運用: issue を worker へ渡す / intake 起票 / sweep 棚卸し / 凍結解除。正は tracking issue（#1567） |
 | `/plan-review`  | 直前の実装 plan を plan-fact-checker / plan-critic の 2 agent で並列レビュー |
 | `/note`         | 各ドメインの `log/YYYY-MM-DD-slug.md` を新規作成（feedback-/incident- prefix対応） |
 | `/session-end`  | 当日の作業を `docs/engineering/log/YYYY-MM-DD-session.md` に記録し `latest.md` を更新 |
@@ -130,7 +130,7 @@ Claude Code は `Skill` tool、Codex は該当ファイルを直接読んで手�
 
 Project skills は `.agents/skills/` を参照する。該当する作業では `SKILL.md` を先に読む。実体は `.claude/skills/` が正本で、`.agents/skills/` は各 skill への symlink（二重管理しない）。
 
-error-handling / storybook / test / security / store-creating / docs-writing / trpc-router-creating / supabase / i18n / releasing / optimistic-update / eagle-dayopt / audit-ai-config
+error-handling / storybook / test / security / store-creating / docs-writing / trpc-router-creating / supabase / i18n / releasing / optimistic-update / eagle-dayopt / audit-ai-config / dispatch
 
 ## Workflow
 

--- a/docs/engineering/log/2026-07-10-parallel-lanes-orchestration.md
+++ b/docs/engineering/log/2026-07-10-parallel-lanes-orchestration.md
@@ -23,14 +23,15 @@ repo-refactor 棚卸し（#1536）のうち R-09（#1524）/ R-12（#1527）/ R-
 
 ## 決定 2: issue 化されていなかった残骸の補充
 
-検証の上 3 件を起票し、1 件を既存 issue に統合した:
+検証の上 4 件を起票し、1 件を既存 issue に統合した:
 
 - #1564 — Supabase security advisors **WARN 24 件**の棚卸し（全件 `SECURITY DEFINER` × `p_user_id` パターン。一部は 2026-07-04 の migration でガード済みだが体系的な検証がない）。I-16（#1312）close 時の持ち越し分
 - #1565 — `api:spec` ジェネレータ故障の修復（2026-06-15 から `buildErrorResponses` で TypeError、2026-07-10 再現確認。openapi.json が手作業編集運用になっている）
 - #1566 — Sentry 運用整備（alert / Vercel integration 責務 / quota・inbound filter・dashboard。#1006 が NOT_PLANNED close で受け皿がなかった）
+- #1569 — Dependabot security alerts 16 件（high 1 / moderate 13 / low 2）の解消。high は `@modelcontextprotocol/sdk` の transitive 依存 `hono` の CORS 脆弱性（MCP サーバー面）
 - #1558 に pre-deploy 監査ログ（2026-07-08）の残タスク 2 件（Preview long-lived secrets / Development encrypted secrets の見直し）を統合
 
-dependabot 放置 PR（#1033/#1034/#1035）は gap 候補だったが merged 済みと確認し、対象外とした。
+dependabot の version-bump PR（#1033/#1034/#1035）は gap 候補だったが merged 済みと確認し、対象外とした（security alerts は別枠で残っていたため #1569 に切り出し）。
 
 ## 決定 3: 運用ルール（トークン効率）
 

--- a/docs/engineering/log/2026-07-10-parallel-lanes-orchestration.md
+++ b/docs/engineering/log/2026-07-10-parallel-lanes-orchestration.md
@@ -1,0 +1,46 @@
+---
+status: frozen
+updated: 2026-07-10
+---
+
+# 並行レーン orchestration の策定と refactor 凍結判断
+
+feature 開発（time-model-split）と同時に進める非 feature 作業を 5 レーン（Feature / Refactor / Security・Ops / LP・Content / Watch）に整理し、tracking issue #1567 に固定した。指揮者（Fable セッション）が dispatch と順序を管理し、実装は worker（Sonnet / Codex）が行う体制。
+
+---
+
+## 決定 1: 衝突 refactor の凍結
+
+repo-refactor 棚卸し（#1536）のうち R-09（#1524）/ R-12（#1527）/ R-13（#1528）/ R-14（#1529）/ R-28（#1544）を **time-model-split Step 8 cutover 完了まで凍結**した（`status:blocked` 付与）。
+
+**理由**: これらは calendar / entry / review の巨大ファイル分割・cross-feature import 解消であり、time-model-split Step 5-7（calendar 2 レーン化 / 作成・編集フロー / Review 差分再定義）が書き換える領域とファイル単位で衝突する。書き換え予定のファイルを先に分割するのは二度手間で、merge conflict のコストだけが残る。refactor の目的（長期で最適であり続ける）にとっても、新しい plans/logs 構造が確定してから分割する方が正しい切り方になる。
+
+**例外・連動**:
+
+- R-27（#1543、stats サーバー所属 spike）は Step 4（statistics service）の設計入力になるため **Step 4 着手前に実施**
+- R-25（#1541、Supabase 型生成漏れ）は stats RPC 型を触るため Step 4 前に済ませる
+- R-10（#1525、日付フォーマッタ集約）は凍結対象ファイルに触れる範囲を除外した段階 PR で進行可
+
+## 決定 2: issue 化されていなかった残骸の補充
+
+検証の上 3 件を起票し、1 件を既存 issue に統合した:
+
+- #1564 — Supabase security advisors **WARN 24 件**の棚卸し（全件 `SECURITY DEFINER` × `p_user_id` パターン。一部は 2026-07-04 の migration でガード済みだが体系的な検証がない）。I-16（#1312）close 時の持ち越し分
+- #1565 — `api:spec` ジェネレータ故障の修復（2026-06-15 から `buildErrorResponses` で TypeError、2026-07-10 再現確認。openapi.json が手作業編集運用になっている）
+- #1566 — Sentry 運用整備（alert / Vercel integration 責務 / quota・inbound filter・dashboard。#1006 が NOT_PLANNED close で受け皿がなかった）
+- #1558 に pre-deploy 監査ログ（2026-07-08）の残タスク 2 件（Preview long-lived secrets / Development encrypted secrets の見直し）を統合
+
+dependabot 放置 PR（#1033/#1034/#1035）は gap 候補だったが merged 済みと確認し、対象外とした。
+
+## 決定 3: 運用ルール（トークン効率）
+
+- 1 issue = 1 PR = 1 worker セッション。同一 feature dir の並行 dispatch 禁止
+- dispatch 時に指揮者が issue 本文を handoff-quality（受け入れ条件・対象ファイル・検証コマンド完結）に補強してから worker に渡す
+- plan-review は size m/l のみ。worker の PR は別系統 agent がクロスレビュー
+- Sonnet / Codex への個別割り当ては設計しない（ユーザー側で決める）。issue には「worker 可 / Fable / 🔒 prod 操作」の 3 区分だけ付ける
+
+## 参照
+
+- Tracking: #1567（レーン定義・凍結リスト・着手順の正）
+- 凍結注記: #1536 コメント + 凍結 5 issue の `status:blocked`
+- time-model-split 設計書: `docs/projects/time-model-split/overview.md`


### PR DESCRIPTION
## 概要

feature 開発（time-model-split）と並行して進める非 feature 作業のオーケストレーション体制を策定し、意思決定ログと**モデル非依存の運用手順**を記録する。

## 実施内容（本 PR 外の GitHub 操作を含む全体）

- Tracking issue **#1567** を新設（5 レーン定義 / 凍結リスト / 推奨着手順 / worker 運用ルール）
- **凍結決定**: R-09 #1524 / R-12 #1527 / R-13 #1528 / R-14 #1529 / R-28 #1544 を time-model-split Step 8 cutover まで `status:blocked`（Step 5-7 が書き換える calendar / entry / review と衝突するため）
- **gap issue 起票**: #1564（Supabase security advisors WARN 24 件）/ #1565（api:spec ジェネレータ故障）/ #1566（Sentry 運用整備）/ #1569（Dependabot alerts 16 件）。#1558 に pre-deploy 監査残タスク 2 件を統合
- 本 PR:
  - 意思決定ログ `docs/engineering/log/2026-07-10-parallel-lanes-orchestration.md`
  - **`dispatch` skill**（`.claude/skills/dispatch/SKILL.md` + `.agents/skills/dispatch` symlink）— 指揮者運用（dispatch / intake / sweep / unfreeze）を判断基準ごと明文化。issue 起票・worker 依頼・凍結 issue 着手の場面で **description による自動発動**。Opus / Sonnet はskill 発動、Codex は symlink 経由で参照
  - AGENTS.md Non-Negotiables に dispatch 規約準拠を明記（常時コンテキストの backstop）
  - `/gardening` にステップ 5.5（月次 sweep）を追加（定期実行の導線）

## 検証

- `pnpm docs:check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)