### PR TITLE
feat: Step 4 統計TS service新設（plans/logs集計、router未接続）

### DIFF
--- a/apps/product/src/features/entry/domain/__tests__/estimation-accuracy.test.ts
+++ b/apps/product/src/features/entry/domain/__tests__/estimation-accuracy.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import { type EstimationAccuracyDbRow, transformEstimationAccuracy } from '../estimation-accuracy';
+import {
+  aggregatePlanLogEstimationAccuracy,
+  type EstimationAccuracyDbRow,
+  type EstimationAccuracyLogRow,
+  type EstimationAccuracyPlanRow,
+  type EstimationAccuracyTagLookup,
+  transformEstimationAccuracy,
+} from '../estimation-accuracy';
 
 function makeRow(overrides: Partial<EstimationAccuracyDbRow> = {}): EstimationAccuracyDbRow {
   return {
@@ -68,5 +75,96 @@ describe('transformEstimationAccuracy', () => {
       avgDeviationMinutes: -30,
       entryCount: 0,
     });
+  });
+});
+
+function makePlan(overrides: Partial<EstimationAccuracyPlanRow> = {}): EstimationAccuracyPlanRow {
+  return { id: 'plan-1', tag_id: 'tag-1', planned_minutes: 60, ...overrides };
+}
+
+function makeLog(overrides: Partial<EstimationAccuracyLogRow> = {}): EstimationAccuracyLogRow {
+  return { plan_id: 'plan-1', source: 'from_plan', minutes: 60, ...overrides };
+}
+
+const TAGS = new Map<string, EstimationAccuracyTagLookup>([
+  ['tag-1', { name: 'Deep Work', color: 'blue' }],
+]);
+
+describe('aggregatePlanLogEstimationAccuracy', () => {
+  it('plan と紐づく非 auto_migrated log を実績として集計する（entry_count>=2 のタグのみ）', () => {
+    const plans = [makePlan({ id: 'p1' }), makePlan({ id: 'p2', planned_minutes: 30 })];
+    const logs = [makeLog({ plan_id: 'p1', minutes: 90 }), makeLog({ plan_id: 'p2', minutes: 20 })];
+
+    const result = aggregatePlanLogEstimationAccuracy(plans, logs, TAGS);
+
+    expect(result).toEqual([
+      {
+        tag_id: 'tag-1',
+        tag_name: 'Deep Work',
+        tag_color: 'blue',
+        avg_planned_minutes: 45,
+        avg_actual_minutes: 55,
+        avg_deviation_minutes: 20,
+        entry_count: 2,
+      },
+    ]);
+  });
+
+  it('entry_count が 1 件のタグは分母から除外する（旧 RPC の HAVING COUNT(*)>=2 を踏襲）', () => {
+    const plans = [makePlan({ id: 'p1' })];
+    const logs = [makeLog({ plan_id: 'p1' })];
+
+    expect(aggregatePlanLogEstimationAccuracy(plans, logs, TAGS)).toEqual([]);
+  });
+
+  it('source=auto_migrated の log は分母から除外する（Step 2 決定 4）', () => {
+    const plans = [makePlan({ id: 'p1' }), makePlan({ id: 'p2' })];
+    const logs = [
+      makeLog({ plan_id: 'p1', source: 'auto_migrated' }),
+      makeLog({ plan_id: 'p2', source: 'manual' }),
+    ];
+
+    // p1 に紐づく非 auto_migrated log が無いので実績なし扱い → entry_count は p2 のみで 1 件 → 除外
+    expect(aggregatePlanLogEstimationAccuracy(plans, logs, TAGS)).toEqual([]);
+  });
+
+  it('1 plan に複数 log（分割記録）は合算して 1 件の実績として扱う（1:N）', () => {
+    const plans = [makePlan({ id: 'p1', planned_minutes: 60 }), makePlan({ id: 'p2' })];
+    const logs = [
+      makeLog({ plan_id: 'p1', minutes: 20 }),
+      makeLog({ plan_id: 'p1', minutes: 25, source: 'manual' }),
+      makeLog({ plan_id: 'p2', minutes: 60 }),
+    ];
+
+    const result = aggregatePlanLogEstimationAccuracy(plans, logs, TAGS);
+
+    expect(result[0]?.entry_count).toBe(2);
+    expect(result[0]?.avg_actual_minutes).toBe((45 + 60) / 2);
+  });
+
+  it('紐づく log が無い plan は分母から除外する', () => {
+    const plans = [makePlan({ id: 'p1' }), makePlan({ id: 'p2' })];
+    const logs = [makeLog({ plan_id: 'p1' })];
+
+    expect(aggregatePlanLogEstimationAccuracy(plans, logs, TAGS)).toEqual([]);
+  });
+
+  it('tag_id が null の plan は無視する', () => {
+    const plans = [makePlan({ id: 'p1', tag_id: null }), makePlan({ id: 'p2' })];
+    const logs = [makeLog({ plan_id: 'p1' }), makeLog({ plan_id: 'p2' })];
+
+    // tag_id null の p1 を除くと tag-1 は 1 件のみ → HAVING で除外
+    expect(aggregatePlanLogEstimationAccuracy(plans, logs, TAGS)).toEqual([]);
+  });
+
+  it('未知の tagId は空文字にフォールバックする', () => {
+    const plans = [
+      makePlan({ id: 'p1', tag_id: 'unknown' }),
+      makePlan({ id: 'p2', tag_id: 'unknown' }),
+    ];
+    const logs = [makeLog({ plan_id: 'p1' }), makeLog({ plan_id: 'p2' })];
+
+    const result = aggregatePlanLogEstimationAccuracy(plans, logs, TAGS);
+    expect(result[0]).toMatchObject({ tag_id: 'unknown', tag_name: '', tag_color: '' });
   });
 });

--- a/apps/product/src/features/entry/domain/estimation-accuracy.ts
+++ b/apps/product/src/features/entry/domain/estimation-accuracy.ts
@@ -49,3 +49,95 @@ export function transformEstimationAccuracy(
     entryCount: row.entry_count,
   }));
 }
+
+/**
+ * Step 4: `plans` LEFT JOIN `logs` (`plan_id` 経由) の 1:N 見積もり精度集計。
+ *
+ * 1 plan に複数 log が紐づく場合（分割記録）は log 時間を合算して 1 件の
+ * 「実績」として扱う。`source = 'auto_migrated'` の log はユーザーが確定した記録
+ * ではないため合算から除外する（overview.md §8 未決 4、Step 2 決定）。
+ * 除外した結果、紐づく実績が 1 件も無い plan は estimation accuracy の分母から外れる
+ * （旧 RPC の `actual_start_time/end_time IS NOT NULL` 条件と同じ効果）。
+ *
+ * 出力は `transformEstimationAccuracy` にそのまま渡せる DB-row 互換 shape。
+ */
+
+export interface EstimationAccuracyPlanRow {
+  id: string;
+  tag_id: string | null;
+  planned_minutes: number;
+}
+
+export interface EstimationAccuracyLogRow {
+  plan_id: string | null;
+  source: string;
+  minutes: number;
+}
+
+export interface EstimationAccuracyTagLookup {
+  name: string;
+  color: string | null;
+}
+
+const AUTO_MIGRATED_SOURCE = 'auto_migrated';
+/** 旧 `get_estimation_accuracy` RPC の `HAVING COUNT(*) >= 2` を踏襲。 */
+const MIN_ENTRY_COUNT = 2;
+
+export function aggregatePlanLogEstimationAccuracy(
+  plans: ReadonlyArray<EstimationAccuracyPlanRow>,
+  logs: ReadonlyArray<EstimationAccuracyLogRow>,
+  tagsById: ReadonlyMap<string, EstimationAccuracyTagLookup>,
+): EstimationAccuracyDbRow[] {
+  const actualMinutesByPlanId = new Map<string, number>();
+  for (const log of logs) {
+    if (log.plan_id == null || log.source === AUTO_MIGRATED_SOURCE) continue;
+    actualMinutesByPlanId.set(
+      log.plan_id,
+      (actualMinutesByPlanId.get(log.plan_id) ?? 0) + log.minutes,
+    );
+  }
+
+  interface TagAccumulator {
+    tagId: string;
+    plannedSum: number;
+    actualSum: number;
+    deviationSum: number;
+    count: number;
+  }
+  const byTag = new Map<string, TagAccumulator>();
+
+  for (const plan of plans) {
+    if (plan.tag_id == null || plan.planned_minutes <= 0) continue;
+    const actualMinutes = actualMinutesByPlanId.get(plan.id);
+    if (actualMinutes == null) continue;
+
+    const acc = byTag.get(plan.tag_id) ?? {
+      tagId: plan.tag_id,
+      plannedSum: 0,
+      actualSum: 0,
+      deviationSum: 0,
+      count: 0,
+    };
+    acc.plannedSum += plan.planned_minutes;
+    acc.actualSum += actualMinutes;
+    acc.deviationSum += Math.abs(actualMinutes - plan.planned_minutes);
+    acc.count += 1;
+    byTag.set(plan.tag_id, acc);
+  }
+
+  return Array.from(byTag.values())
+    .filter((acc) => acc.count >= MIN_ENTRY_COUNT)
+    .sort((a, b) => b.count - a.count)
+    .map((acc) => {
+      const tag = tagsById.get(acc.tagId);
+      return {
+        tag_id: acc.tagId,
+        tag_name: tag?.name ?? '',
+        tag_color: tag?.color ?? '',
+        avg_planned_minutes: acc.plannedSum / acc.count,
+        avg_actual_minutes: acc.actualSum / acc.count,
+        avg_deviation_minutes: acc.deviationSum / acc.count,
+        entry_count: acc.count,
+      };
+    });
+}

--- a/apps/product/src/features/entry/domain/index.ts
+++ b/apps/product/src/features/entry/domain/index.ts
@@ -4,8 +4,16 @@ export { findSkippableAutoRecords } from './skippable-auto-records';
 
 export { aggregateDayOfWeekDistribution } from './day-of-week-distribution';
 export { buildTimeUpdateData, buildUndoTimeUpdateData } from './entry-time-update';
-export { transformEstimationAccuracy } from './estimation-accuracy';
-export type { EstimationAccuracyDbRow } from './estimation-accuracy';
+export {
+  aggregatePlanLogEstimationAccuracy,
+  transformEstimationAccuracy,
+} from './estimation-accuracy';
+export type {
+  EstimationAccuracyDbRow,
+  EstimationAccuracyLogRow,
+  EstimationAccuracyPlanRow,
+  EstimationAccuracyTagLookup,
+} from './estimation-accuracy';
 export { aggregateHourlyDistribution } from './hourly-distribution';
 export { aggregateMonthlyTrend, getMonthlyStartDate } from './monthly-trend';
 export { calculateStreak } from './streak-calculator';

--- a/apps/product/src/features/entry/domain/index.ts
+++ b/apps/product/src/features/entry/domain/index.ts
@@ -8,12 +8,7 @@ export {
   aggregatePlanLogEstimationAccuracy,
   transformEstimationAccuracy,
 } from './estimation-accuracy';
-export type {
-  EstimationAccuracyDbRow,
-  EstimationAccuracyLogRow,
-  EstimationAccuracyPlanRow,
-  EstimationAccuracyTagLookup,
-} from './estimation-accuracy';
+export type { EstimationAccuracyDbRow, EstimationAccuracyTagLookup } from './estimation-accuracy';
 export { aggregateHourlyDistribution } from './hourly-distribution';
 export { aggregateMonthlyTrend, getMonthlyStartDate } from './monthly-trend';
 export { calculateStreak } from './streak-calculator';

--- a/apps/product/src/features/entry/server/__tests__/statistics-service-grouping.test.ts
+++ b/apps/product/src/features/entry/server/__tests__/statistics-service-grouping.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeAvailableMinutesInclusive,
+  computeBlankRate,
+  computeContextSwitches,
+  groupEnergyMap,
+  groupHoursByDay,
+  groupHoursByMonth,
+  groupMinutesByDow,
+  groupMinutesByHour,
+  minutesBetween,
+} from '../statistics-service-grouping';
+
+const TZ = 'Asia/Tokyo';
+
+describe('minutesBetween', () => {
+  it('分単位の差分を返す', () => {
+    expect(minutesBetween('2026-07-01T00:00:00Z', '2026-07-01T01:30:00Z')).toBe(90);
+  });
+});
+
+describe('groupMinutesByHour', () => {
+  it('JST の時刻で hour バケットに集計する', () => {
+    // 2026-07-01T00:00:00Z = 2026-07-01T09:00:00+09:00
+    const rows = [
+      { start_at: '2026-07-01T00:00:00Z', end_at: '2026-07-01T00:30:00Z' },
+      { start_at: '2026-07-01T00:15:00Z', end_at: '2026-07-01T00:45:00Z' },
+    ];
+    const result = groupMinutesByHour(rows, TZ);
+    expect(result).toEqual([{ hour: 9, total_minutes: 60 }]);
+  });
+});
+
+describe('groupMinutesByDow', () => {
+  it('JST の曜日で dow バケットに集計する（0=日,...,6=土）', () => {
+    // 2026-07-01 は水曜日 → dow=3
+    const rows = [{ start_at: '2026-07-01T00:00:00Z', end_at: '2026-07-01T01:00:00Z' }];
+    expect(groupMinutesByDow(rows, TZ)).toEqual([{ dow: 3, total_minutes: 60 }]);
+  });
+
+  it('日曜は dow=0 になる', () => {
+    // 2026-07-05 は日曜日
+    const rows = [{ start_at: '2026-07-05T00:00:00Z', end_at: '2026-07-05T01:00:00Z' }];
+    expect(groupMinutesByDow(rows, TZ)).toEqual([{ dow: 0, total_minutes: 60 }]);
+  });
+});
+
+describe('groupHoursByDay', () => {
+  it('日別に時間を集計し 2 桁で丸める', () => {
+    const rows = [
+      { start_at: '2026-07-01T00:00:00Z', end_at: '2026-07-01T00:20:00Z' },
+      { start_at: '2026-07-01T01:00:00Z', end_at: '2026-07-01T01:10:00Z' },
+    ];
+    const result = groupHoursByDay(rows, TZ);
+    expect(result).toEqual([{ day: '2026-07-01', hours: 0.5 }]);
+  });
+
+  it('day 昇順でソートする', () => {
+    const rows = [
+      { start_at: '2026-07-02T00:00:00Z', end_at: '2026-07-02T01:00:00Z' },
+      { start_at: '2026-07-01T00:00:00Z', end_at: '2026-07-01T01:00:00Z' },
+    ];
+    expect(groupHoursByDay(rows, TZ).map((r) => r.day)).toEqual(['2026-07-01', '2026-07-02']);
+  });
+});
+
+describe('groupHoursByMonth', () => {
+  it('月別に時間を集計する', () => {
+    const rows = [
+      { start_at: '2026-07-01T00:00:00Z', end_at: '2026-07-01T02:00:00Z' },
+      { start_at: '2026-08-01T00:00:00Z', end_at: '2026-08-01T01:00:00Z' },
+    ];
+    expect(groupHoursByMonth(rows, TZ)).toEqual([
+      { month: '2026-07', hours: 2 },
+      { month: '2026-08', hours: 1 },
+    ]);
+  });
+});
+
+describe('groupEnergyMap', () => {
+  it('(hour, dow) ごとに平均充足度・合計分・件数を集計する', () => {
+    const rows = [
+      { start_at: '2026-07-01T00:00:00Z', end_at: '2026-07-01T00:30:00Z', fulfillment_score: 2 },
+      { start_at: '2026-07-01T00:10:00Z', end_at: '2026-07-01T00:40:00Z', fulfillment_score: 3 },
+    ];
+    const result = groupEnergyMap(rows, TZ);
+    expect(result).toEqual([
+      { hour: 9, dow: 3, totalMinutes: 60, entryCount: 2, avgFulfillment: 2.5 },
+    ]);
+  });
+
+  it('fulfillment_score が全て null なら avgFulfillment は null', () => {
+    const rows = [
+      { start_at: '2026-07-01T00:00:00Z', end_at: '2026-07-01T00:30:00Z', fulfillment_score: null },
+    ];
+    expect(groupEnergyMap(rows, TZ)[0]?.avgFulfillment).toBeNull();
+  });
+});
+
+describe('computeContextSwitches', () => {
+  it('同一日内でタグが変わるたびに switch を数える', () => {
+    const rows = [
+      { tag_id: 'a', start_at: '2026-07-01T00:00:00Z', end_at: '2026-07-01T00:30:00Z' },
+      { tag_id: 'b', start_at: '2026-07-01T01:00:00Z', end_at: '2026-07-01T01:30:00Z' },
+      { tag_id: 'b', start_at: '2026-07-01T02:00:00Z', end_at: '2026-07-01T02:30:00Z' },
+      { tag_id: 'a', start_at: '2026-07-01T03:00:00Z', end_at: '2026-07-01T03:30:00Z' },
+    ];
+    // a→b(switch) b→b(no) b→a(switch) = 2 switches, 1 active day
+    expect(computeContextSwitches(rows, TZ)).toEqual({ totalSwitches: 2, avgPerDay: 2 });
+  });
+
+  it('null tag から値 tag への遷移も switch として数える', () => {
+    const rows = [
+      { tag_id: null, start_at: '2026-07-01T00:00:00Z', end_at: '2026-07-01T00:30:00Z' },
+      { tag_id: 'a', start_at: '2026-07-01T01:00:00Z', end_at: '2026-07-01T01:30:00Z' },
+    ];
+    expect(computeContextSwitches(rows, TZ).totalSwitches).toBe(1);
+  });
+
+  it('行が無い場合は 0 件・avgPerDay も 0（0 除算しない）', () => {
+    expect(computeContextSwitches([], TZ)).toEqual({ totalSwitches: 0, avgPerDay: 0 });
+  });
+});
+
+describe('computeBlankRate', () => {
+  it('start/end 指定時は日数で available minutes を計算する', () => {
+    const result = computeBlankRate(60, {
+      startDate: '2026-07-01T00:00:00Z',
+      endDate: '2026-07-02T00:00:00Z',
+      wakeHour: 7,
+      sleepHour: 23,
+    });
+    // 1日 * (23-7)*60 = 960分
+    expect(result).toEqual({
+      availableMinutes: 960,
+      scheduledMinutes: 60,
+      blankMinutes: 900,
+      blankRate: 900 / 960,
+    });
+  });
+
+  it('start/end 未指定時は 7 日として計算する', () => {
+    const result = computeBlankRate(0, { wakeHour: 7, sleepHour: 23 });
+    expect(result.availableMinutes).toBe((23 - 7) * 60 * 7);
+  });
+
+  it('sleepHour <= wakeHour の日跨ぎケースを計算する', () => {
+    const result = computeBlankRate(0, { wakeHour: 22, sleepHour: 6 });
+    // (24-22+6)*60 = 480分/日 * 7日
+    expect(result.availableMinutes).toBe(480 * 7);
+  });
+
+  it('scheduledMinutes が available を超えても blankMinutes は 0 未満にならない', () => {
+    const result = computeBlankRate(100_000, {
+      startDate: '2026-07-01T00:00:00Z',
+      endDate: '2026-07-02T00:00:00Z',
+      wakeHour: 7,
+      sleepHour: 23,
+    });
+    expect(result.blankMinutes).toBe(0);
+  });
+});
+
+describe('computeAvailableMinutesInclusive', () => {
+  it('start/end が同日なら 1 日分を返す', () => {
+    const result = computeAvailableMinutesInclusive({
+      startDate: '2026-07-01T00:00:00Z',
+      endDate: '2026-07-01T12:00:00Z',
+      wakeHour: 7,
+      sleepHour: 23,
+      timezone: 'UTC',
+    });
+    expect(result).toBe((23 - 7) * 60);
+  });
+
+  it('start/end が 3 日分なら inclusive に 3 日分を返す', () => {
+    const result = computeAvailableMinutesInclusive({
+      startDate: '2026-07-01T00:00:00Z',
+      endDate: '2026-07-03T23:00:00Z',
+      wakeHour: 7,
+      sleepHour: 23,
+      timezone: 'UTC',
+    });
+    expect(result).toBe((23 - 7) * 60 * 3);
+  });
+});

--- a/apps/product/src/features/entry/server/__tests__/statistics-service.test.ts
+++ b/apps/product/src/features/entry/server/__tests__/statistics-service.test.ts
@@ -1,0 +1,299 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { invalidateUserTimezoneCache } from '@/lib/server/user-timezone-cache';
+import { createChainableMock, createMockSupabase } from '@/lib/test/trpc-test-helpers';
+import { StatisticsService } from '../statistics-service';
+import type { ServiceSupabaseClient } from '../types';
+
+const USER_ID = 'user-stats-1';
+
+function createService(tableData: Record<string, ReturnType<typeof createChainableMock>>) {
+  const mockSupabase = createMockSupabase();
+  mockSupabase.from.mockImplementation((table: string) => {
+    const mock = tableData[table];
+    if (!mock) throw new Error(`Unexpected table access in test: ${table}`);
+    return mock;
+  });
+  return {
+    mockSupabase,
+    service: new StatisticsService(mockSupabase as unknown as ServiceSupabaseClient),
+  };
+}
+
+beforeEach(() => {
+  invalidateUserTimezoneCache(USER_ID);
+});
+
+describe('StatisticsService.getTagStats', () => {
+  it('logs をタグ別に集計し counts/lastUsed を返す（deleted は除外済み前提）', async () => {
+    const { service } = createService({
+      logs: createChainableMock([
+        {
+          id: 'l1',
+          tag_id: 'tag-1',
+          plan_id: null,
+          source: 'manual',
+          start_at: '2026-07-01T00:00:00Z',
+          end_at: '2026-07-01T01:00:00Z',
+          fulfillment_score: null,
+        },
+        {
+          id: 'l2',
+          tag_id: 'tag-1',
+          plan_id: null,
+          source: 'manual',
+          start_at: '2026-07-02T00:00:00Z',
+          end_at: '2026-07-02T01:00:00Z',
+          fulfillment_score: null,
+        },
+        {
+          id: 'l3',
+          tag_id: 'tag-2',
+          plan_id: null,
+          source: 'manual',
+          start_at: '2026-07-01T00:00:00Z',
+          end_at: '2026-07-01T01:00:00Z',
+          fulfillment_score: null,
+        },
+      ]),
+    });
+
+    const result = await service.getTagStats(USER_ID);
+
+    expect(result.counts).toEqual({ 'tag-1': 2, 'tag-2': 1 });
+    expect(result.lastUsed).toEqual({
+      'tag-1': '2026-07-02T00:00:00Z',
+      'tag-2': '2026-07-01T00:00:00Z',
+    });
+  });
+
+  it('log が無い場合は空の counts/lastUsed を返す', async () => {
+    const { service } = createService({ logs: createChainableMock([]) });
+    expect(await service.getTagStats(USER_ID)).toEqual({ counts: {}, lastUsed: {} });
+  });
+});
+
+describe('StatisticsService.getTimeByTag', () => {
+  it('logs をタグ別合計時間に変換し hours 降順で返す', async () => {
+    const { service } = createService({
+      logs: createChainableMock([
+        {
+          id: 'l1',
+          tag_id: 'tag-1',
+          plan_id: null,
+          source: 'manual',
+          start_at: '2026-07-01T00:00:00Z',
+          end_at: '2026-07-01T01:00:00Z',
+          fulfillment_score: null,
+        },
+        {
+          id: 'l2',
+          tag_id: 'tag-2',
+          plan_id: null,
+          source: 'manual',
+          start_at: '2026-07-01T00:00:00Z',
+          end_at: '2026-07-01T03:00:00Z',
+          fulfillment_score: null,
+        },
+      ]),
+      tags: createChainableMock([
+        { id: 'tag-1', name: 'Deep Work', color: 'blue', icon: null },
+        { id: 'tag-2', name: 'Meeting', color: 'red', icon: null },
+      ]),
+    });
+
+    const result = await service.getTimeByTag(USER_ID);
+
+    expect(result).toEqual([
+      { tagId: 'tag-2', name: 'Meeting', color: 'red', hours: 3 },
+      { tagId: 'tag-1', name: 'Deep Work', color: 'blue', hours: 1 },
+    ]);
+  });
+});
+
+describe('StatisticsService.getEstimationAccuracy', () => {
+  it('plan に紐づく非 auto_migrated log を実績として 1:N 集計する', async () => {
+    const { service, mockSupabase } = createService({
+      plans: createChainableMock([
+        {
+          id: 'p1',
+          tag_id: 'tag-1',
+          start_at: '2026-07-01T00:00:00Z',
+          end_at: '2026-07-01T01:00:00Z',
+        },
+        {
+          id: 'p2',
+          tag_id: 'tag-1',
+          start_at: '2026-07-02T00:00:00Z',
+          end_at: '2026-07-02T00:30:00Z',
+        },
+      ]),
+      tags: createChainableMock([{ id: 'tag-1', name: 'Deep Work', color: 'blue', icon: null }]),
+      logs: createChainableMock([
+        {
+          id: 'l1',
+          tag_id: 'tag-1',
+          plan_id: 'p1',
+          source: 'from_plan',
+          start_at: '2026-07-01T00:00:00Z',
+          end_at: '2026-07-01T01:30:00Z',
+          fulfillment_score: null,
+        },
+        {
+          id: 'l2',
+          tag_id: 'tag-1',
+          plan_id: 'p2',
+          source: 'auto_migrated',
+          start_at: '2026-07-02T00:00:00Z',
+          end_at: '2026-07-02T00:30:00Z',
+          fulfillment_score: null,
+        },
+      ]),
+    });
+
+    const result = await service.getEstimationAccuracy(USER_ID);
+
+    // p2 の log は auto_migrated なので実績なし扱い → entry_count は p1 のみで 1 件 → HAVING で除外
+    expect(result).toEqual([]);
+    expect(mockSupabase.from).toHaveBeenCalledWith('plans');
+    expect(mockSupabase.from).toHaveBeenCalledWith('logs');
+  });
+});
+
+describe('StatisticsService.getBlankRate', () => {
+  it('plans の合計時間から空白率を算出する', async () => {
+    const { service } = createService({
+      plans: createChainableMock([
+        {
+          id: 'p1',
+          tag_id: 'tag-1',
+          start_at: '2026-07-01T00:00:00Z',
+          end_at: '2026-07-01T01:00:00Z',
+        },
+      ]),
+    });
+
+    const result = await service.getBlankRate(USER_ID, {
+      startDate: '2026-07-01T00:00:00Z',
+      endDate: '2026-07-02T00:00:00Z',
+      wakeHour: 7,
+      sleepHour: 23,
+    });
+
+    expect(result).toEqual({
+      availableMinutes: 960,
+      scheduledMinutes: 60,
+      blankMinutes: 900,
+      blankRate: 900 / 960,
+    });
+  });
+});
+
+describe('StatisticsService.getTagDashboard', () => {
+  it('log を主とし、紐づく plan の予定時間を代表 log にのみ割り当てる', async () => {
+    const { service } = createService({
+      user_settings: createChainableMock({ timezone: 'UTC' }),
+      tags: createChainableMock({ id: 'tag-1', name: 'Deep Work', color: 'blue', icon: 'brain' }),
+      logs: createChainableMock([
+        {
+          id: 'log-1',
+          title: 'Focus session',
+          note: null,
+          tag_id: 'tag-1',
+          plan_id: 'plan-1',
+          source: 'from_plan',
+          start_at: '2026-07-01T00:00:00Z',
+          end_at: '2026-07-01T01:00:00Z',
+          fulfillment_score: null,
+        },
+      ]),
+      plans: createChainableMock([
+        {
+          id: 'plan-1',
+          title: 'Focus session',
+          note: null,
+          tag_id: 'tag-1',
+          start_at: '2026-07-01T00:00:00Z',
+          end_at: '2026-07-01T00:45:00Z',
+          skipped_at: null,
+        },
+      ]),
+    });
+
+    const result = await service.getTagDashboard(USER_ID, {
+      tagId: 'tag-1',
+      startDate: '2026-06-30T00:00:00Z',
+      endDate: '2026-07-02T00:00:00Z',
+      limit: 50,
+    });
+
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0]).toMatchObject({
+      entryId: 'log-1',
+      plannedMinutes: 45,
+      actualMinutes: 60,
+      diffMinutes: 15,
+    });
+  });
+
+  it('未記録・未 skip の plan は予定のみの行として残す', async () => {
+    const { service } = createService({
+      user_settings: createChainableMock({ timezone: 'UTC' }),
+      tags: createChainableMock({ id: 'tag-1', name: 'Deep Work', color: 'blue', icon: null }),
+      logs: createChainableMock([]),
+      plans: createChainableMock([
+        {
+          id: 'plan-1',
+          title: 'Unrecorded plan',
+          note: null,
+          tag_id: 'tag-1',
+          start_at: '2026-07-01T00:00:00Z',
+          end_at: '2026-07-01T01:00:00Z',
+          skipped_at: null,
+        },
+      ]),
+    });
+
+    const result = await service.getTagDashboard(USER_ID, {
+      tagId: 'tag-1',
+      startDate: '2026-06-30T00:00:00Z',
+      endDate: '2026-07-02T00:00:00Z',
+      limit: 50,
+    });
+
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0]).toMatchObject({
+      entryId: 'plan-1',
+      plannedMinutes: 60,
+      actualMinutes: 0,
+    });
+  });
+
+  it('skip 済みの未記録 plan は表示しない', async () => {
+    const { service } = createService({
+      user_settings: createChainableMock({ timezone: 'UTC' }),
+      tags: createChainableMock({ id: 'tag-1', name: 'Deep Work', color: 'blue', icon: null }),
+      logs: createChainableMock([]),
+      plans: createChainableMock([
+        {
+          id: 'plan-1',
+          title: 'Skipped plan',
+          note: null,
+          tag_id: 'tag-1',
+          start_at: '2026-07-01T00:00:00Z',
+          end_at: '2026-07-01T01:00:00Z',
+          skipped_at: '2026-07-01T02:00:00Z',
+        },
+      ]),
+    });
+
+    const result = await service.getTagDashboard(USER_ID, {
+      tagId: 'tag-1',
+      startDate: '2026-06-30T00:00:00Z',
+      endDate: '2026-07-02T00:00:00Z',
+      limit: 50,
+    });
+
+    expect(result.entries).toHaveLength(0);
+  });
+});

--- a/apps/product/src/features/entry/server/statistics-service-grouping.ts
+++ b/apps/product/src/features/entry/server/statistics-service-grouping.ts
@@ -18,16 +18,16 @@
 
 import { formatInTimeZone } from 'date-fns-tz';
 
-export interface TimeRangeRow {
+interface TimeRangeRow {
   start_at: string;
   end_at: string;
 }
 
-export interface TagTimeRangeRow extends TimeRangeRow {
+interface TagTimeRangeRow extends TimeRangeRow {
   tag_id: string | null;
 }
 
-export interface FulfillmentTimeRangeRow extends TimeRangeRow {
+interface FulfillmentTimeRangeRow extends TimeRangeRow {
   fulfillment_score: number | null;
 }
 

--- a/apps/product/src/features/entry/server/statistics-service-grouping.ts
+++ b/apps/product/src/features/entry/server/statistics-service-grouping.ts
@@ -1,0 +1,243 @@
+/**
+ * Step 4 統計 TS service (`statistics-service.ts`) が使う TZ-aware なグルーピング層。
+ *
+ * `plans` / `logs` の生行（snake_case, start_at/end_at）を、既存 domain 層の
+ * `aggregate*` 関数が受け取れる RPC 互換の bucket shape（`{hour, total_minutes}` 等）
+ * に変換する。TZ 変換をここに閉じ込め、domain 層は TZ 非依存を維持する
+ * （`monthly-trend.ts` の既存コメント方針を踏襲）。
+ *
+ * PL/pgSQL 側の対応関数（比較対象）:
+ * - groupMinutesByHour   → get_hourly_distribution
+ * - groupMinutesByDow    → get_dow_distribution
+ * - groupHoursByDay      → get_daily_hours
+ * - groupHoursByMonth    → get_monthly_hours
+ * - computeBlankRate     → get_blank_rate
+ * - computeContextSwitches → get_stats_kpi_summary / get_stats_page_data の contextSwitches CTE
+ * - groupEnergyMap       → get_stats_page_data の energy_map CTE
+ */
+
+import { formatInTimeZone } from 'date-fns-tz';
+
+export interface TimeRangeRow {
+  start_at: string;
+  end_at: string;
+}
+
+export interface TagTimeRangeRow extends TimeRangeRow {
+  tag_id: string | null;
+}
+
+export interface FulfillmentTimeRangeRow extends TimeRangeRow {
+  fulfillment_score: number | null;
+}
+
+/** 分単位の所要時間（丸めなし）。 */
+export function minutesBetween(startAt: string, endAt: string): number {
+  return (new Date(endAt).getTime() - new Date(startAt).getTime()) / 60000;
+}
+
+function roundTo(value: number, decimals: number): number {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
+/** `get_hourly_distribution` 相当: 時間帯別合計分（1 桁丸め）。 */
+export function groupMinutesByHour(
+  rows: ReadonlyArray<TimeRangeRow>,
+  timezone: string,
+): Array<{ hour: number; total_minutes: number }> {
+  const totals = new Map<number, number>();
+  for (const row of rows) {
+    const hour = Number(formatInTimeZone(new Date(row.start_at), timezone, 'H'));
+    totals.set(hour, (totals.get(hour) ?? 0) + minutesBetween(row.start_at, row.end_at));
+  }
+  return Array.from(totals.entries()).map(([hour, total]) => ({
+    hour,
+    total_minutes: roundTo(total, 1),
+  }));
+}
+
+/** `get_dow_distribution` 相当: 曜日別合計分（1 桁丸め、0=日 6=土）。 */
+export function groupMinutesByDow(
+  rows: ReadonlyArray<TimeRangeRow>,
+  timezone: string,
+): Array<{ dow: number; total_minutes: number }> {
+  const totals = new Map<number, number>();
+  for (const row of rows) {
+    const dow = Number(formatInTimeZone(new Date(row.start_at), timezone, 'i')) % 7; // 'i'=1(月)-7(日) → 0(日)-6(土)
+    totals.set(dow, (totals.get(dow) ?? 0) + minutesBetween(row.start_at, row.end_at));
+  }
+  return Array.from(totals.entries()).map(([dow, total]) => ({
+    dow,
+    total_minutes: roundTo(total, 1),
+  }));
+}
+
+/** `get_daily_hours` 相当: 日別合計時間（2 桁丸め）。呼び出し側で対象年に絞り込み済みの行を渡す。 */
+export function groupHoursByDay(
+  rows: ReadonlyArray<TimeRangeRow>,
+  timezone: string,
+): Array<{ day: string; hours: number }> {
+  const totals = new Map<string, number>();
+  for (const row of rows) {
+    const day = formatInTimeZone(new Date(row.start_at), timezone, 'yyyy-MM-dd');
+    totals.set(day, (totals.get(day) ?? 0) + minutesBetween(row.start_at, row.end_at) / 60);
+  }
+  return Array.from(totals.entries())
+    .map(([day, hours]) => ({ day, hours: roundTo(hours, 2) }))
+    .sort((a, b) => a.day.localeCompare(b.day));
+}
+
+/** `get_monthly_hours` 相当: 月別合計時間（2 桁丸め）。呼び出し側で開始月以降に絞り込み済みの行を渡す。 */
+export function groupHoursByMonth(
+  rows: ReadonlyArray<TimeRangeRow>,
+  timezone: string,
+): Array<{ month: string; hours: number }> {
+  const totals = new Map<string, number>();
+  for (const row of rows) {
+    const month = formatInTimeZone(new Date(row.start_at), timezone, 'yyyy-MM');
+    totals.set(month, (totals.get(month) ?? 0) + minutesBetween(row.start_at, row.end_at) / 60);
+  }
+  return Array.from(totals.entries())
+    .map(([month, hours]) => ({ month, hours: roundTo(hours, 2) }))
+    .sort((a, b) => a.month.localeCompare(b.month));
+}
+
+/** `get_stats_page_data` の energy_map CTE 相当: (hour, dow) 別の平均充足度・合計分・件数。 */
+export function groupEnergyMap(
+  rows: ReadonlyArray<FulfillmentTimeRangeRow>,
+  timezone: string,
+): Array<{
+  hour: number;
+  dow: number;
+  totalMinutes: number;
+  entryCount: number;
+  avgFulfillment: number | null;
+}> {
+  interface Bucket {
+    hour: number;
+    dow: number;
+    totalMinutes: number;
+    entryCount: number;
+    fulfillmentSum: number;
+    fulfillmentCount: number;
+  }
+  const buckets = new Map<string, Bucket>();
+  for (const row of rows) {
+    const date = new Date(row.start_at);
+    const hour = Number(formatInTimeZone(date, timezone, 'H'));
+    const dow = Number(formatInTimeZone(date, timezone, 'i')) % 7;
+    const key = `${hour}-${dow}`;
+    const bucket = buckets.get(key) ?? {
+      hour,
+      dow,
+      totalMinutes: 0,
+      entryCount: 0,
+      fulfillmentSum: 0,
+      fulfillmentCount: 0,
+    };
+    bucket.totalMinutes += minutesBetween(row.start_at, row.end_at);
+    bucket.entryCount += 1;
+    if (row.fulfillment_score != null) {
+      bucket.fulfillmentSum += row.fulfillment_score;
+      bucket.fulfillmentCount += 1;
+    }
+    buckets.set(key, bucket);
+  }
+  return Array.from(buckets.values()).map((bucket) => ({
+    hour: bucket.hour,
+    dow: bucket.dow,
+    totalMinutes: bucket.totalMinutes,
+    entryCount: bucket.entryCount,
+    avgFulfillment:
+      bucket.fulfillmentCount > 0 ? bucket.fulfillmentSum / bucket.fulfillmentCount : null,
+  }));
+}
+
+/** `get_stats_kpi_summary` / `get_stats_page_data` の contextSwitches CTE 相当。 */
+export function computeContextSwitches(
+  rows: ReadonlyArray<TagTimeRangeRow>,
+  timezone: string,
+): { totalSwitches: number; avgPerDay: number } {
+  const byDay = new Map<string, TagTimeRangeRow[]>();
+  for (const row of rows) {
+    const day = formatInTimeZone(new Date(row.start_at), timezone, 'yyyy-MM-dd');
+    const list = byDay.get(day) ?? [];
+    list.push(row);
+    byDay.set(day, list);
+  }
+
+  let totalSwitches = 0;
+  for (const dayRows of byDay.values()) {
+    const sorted = [...dayRows].sort(
+      (a, b) => new Date(a.start_at).getTime() - new Date(b.start_at).getTime(),
+    );
+    for (let i = 1; i < sorted.length; i++) {
+      if (sorted[i]!.tag_id !== sorted[i - 1]!.tag_id) {
+        totalSwitches++;
+      }
+    }
+  }
+
+  const dayCount = Math.max(byDay.size, 1);
+  return { totalSwitches, avgPerDay: totalSwitches / dayCount };
+}
+
+interface BlankRateRangeInput {
+  startDate?: string | undefined;
+  endDate?: string | undefined;
+  wakeHour: number;
+  sleepHour: number;
+}
+
+/** `get_blank_rate` / `get_stats_kpi_summary` の blankRate 部分と同じ計算式。 */
+export function computeBlankRate(
+  scheduledMinutes: number,
+  { startDate, endDate, wakeHour, sleepHour }: BlankRateRangeInput,
+): { availableMinutes: number; scheduledMinutes: number; blankMinutes: number; blankRate: number } {
+  const days =
+    startDate && endDate
+      ? Math.max(1, (new Date(endDate).getTime() - new Date(startDate).getTime()) / 86_400_000)
+      : 7;
+
+  const dailyMinutes =
+    sleepHour <= wakeHour ? (24 - wakeHour + sleepHour) * 60 : (sleepHour - wakeHour) * 60;
+  const availableMinutes = Math.round(dailyMinutes * days);
+  const blankMinutes = Math.max(0, availableMinutes - scheduledMinutes);
+
+  return {
+    availableMinutes,
+    scheduledMinutes,
+    blankMinutes,
+    blankRate: availableMinutes > 0 ? blankMinutes / availableMinutes : 0,
+  };
+}
+
+interface AvailableMinutesInclusiveInput {
+  startDate: string;
+  endDate: string;
+  wakeHour: number;
+  sleepHour: number;
+  timezone: string;
+}
+
+/** `get_time_pl_data` の available CTE 相当（tz 日付の inclusive 日数差）。 */
+export function computeAvailableMinutesInclusive({
+  startDate,
+  endDate,
+  wakeHour,
+  sleepHour,
+  timezone,
+}: AvailableMinutesInclusiveInput): number {
+  const startDay = formatInTimeZone(new Date(startDate), timezone, 'yyyy-MM-dd');
+  const endDay = formatInTimeZone(new Date(endDate), timezone, 'yyyy-MM-dd');
+  const dayCount =
+    Math.round(
+      (new Date(`${endDay}T00:00:00Z`).getTime() - new Date(`${startDay}T00:00:00Z`).getTime()) /
+        86_400_000,
+    ) + 1;
+
+  const dailyMinutes =
+    sleepHour <= wakeHour ? (24 - wakeHour + sleepHour) * 60 : (sleepHour - wakeHour) * 60;
+  return Math.max(0, dailyMinutes * dayCount);
+}

--- a/apps/product/src/features/entry/server/statistics-service.ts
+++ b/apps/product/src/features/entry/server/statistics-service.ts
@@ -72,17 +72,17 @@ interface TagLookupRow {
   icon: string | null;
 }
 
-export interface DateRangeInput {
+interface DateRangeInput {
   startDate?: string | undefined;
   endDate?: string | undefined;
 }
 
-export interface BlankRateInput extends DateRangeInput {
+interface BlankRateInput extends DateRangeInput {
   wakeHour: number;
   sleepHour: number;
 }
 
-export interface TimePLInput {
+interface TimePLInput {
   startDate: string;
   endDate: string;
   prevStart?: string | undefined;
@@ -91,7 +91,7 @@ export interface TimePLInput {
   sleepHour: number;
 }
 
-export interface StatsPageDataInput {
+interface StatsPageDataInput {
   startDate: string;
   endDate: string;
   prevStart: string;
@@ -102,7 +102,7 @@ export interface StatsPageDataInput {
   sleepHour: number;
 }
 
-export interface TagDashboardInput {
+interface TagDashboardInput {
   tagId: string;
   startDate: string;
   endDate: string;
@@ -698,8 +698,4 @@ export class StatisticsService {
     if (error) throw new Error(`Failed to fetch plans for tag dashboard: ${error.message}`);
     return data ?? [];
   }
-}
-
-export function createStatisticsService(supabase: ServiceSupabaseClient): StatisticsService {
-  return new StatisticsService(supabase);
 }

--- a/apps/product/src/features/entry/server/statistics-service.ts
+++ b/apps/product/src/features/entry/server/statistics-service.ts
@@ -1,0 +1,705 @@
+import 'server-only';
+
+import { formatInTimeZone, fromZonedTime } from 'date-fns-tz';
+
+import { getUserTimezone } from '@/lib/server/user-timezone-cache';
+
+import {
+  aggregateDayOfWeekDistribution,
+  aggregateHourlyDistribution,
+  aggregateMonthlyTrend,
+  aggregatePlanLogEstimationAccuracy,
+  aggregateTagStats,
+  type EstimationAccuracyDbRow,
+  type EstimationAccuracyTagLookup,
+  getMonthlyStartDate,
+  transformEstimationAccuracy,
+} from '../domain';
+import {
+  buildTagDashboard,
+  type TagDashboardEntryRow,
+  type TagDashboardTagRow,
+} from '../domain/tag-dashboard';
+
+import { transformStatsOverviewResponse } from './statistics-overview-transform';
+import {
+  computeAvailableMinutesInclusive,
+  computeBlankRate,
+  computeContextSwitches,
+  groupEnergyMap,
+  groupHoursByDay,
+  groupHoursByMonth,
+  groupMinutesByDow,
+  groupMinutesByHour,
+  minutesBetween,
+} from './statistics-service-grouping';
+import type { StatsPageData, TimePLResponse } from './statistics-shared';
+import { transformTimeByTagResponse } from './statistics-time-by-tag-transform';
+import type { ServiceSupabaseClient } from './types';
+
+/**
+ * Step 4: 統計 TS service。
+ *
+ * Step 0 の Aggregation Source Contract（`docs/projects/time-model-split/step-0-statistics-rpc-policy.md`）
+ * に従い、実績系は `logs`、予定系は `plans`、予実比較は `plans` LEFT JOIN `logs`（`plan_id` 経由）を読む。
+ *
+ * **dormant**: このクラスは router から未接続。既存 RPC ベースの router
+ * (`statistics-general-router.ts` 等) は現状維持のまま、この service は Step 8 の
+ * カットオーバーで router 内部の実装として丸ごと差し替えられる前提のシグネチャを持つ。
+ */
+
+interface StatPlanRow {
+  id: string;
+  tag_id: string | null;
+  start_at: string;
+  end_at: string;
+}
+
+interface StatLogRow {
+  id: string;
+  tag_id: string | null;
+  plan_id: string | null;
+  source: string;
+  start_at: string;
+  end_at: string;
+  fulfillment_score: number | null;
+}
+
+interface TagLookupRow {
+  id: string;
+  name: string;
+  color: string | null;
+  icon: string | null;
+}
+
+export interface DateRangeInput {
+  startDate?: string | undefined;
+  endDate?: string | undefined;
+}
+
+export interface BlankRateInput extends DateRangeInput {
+  wakeHour: number;
+  sleepHour: number;
+}
+
+export interface TimePLInput {
+  startDate: string;
+  endDate: string;
+  prevStart?: string | undefined;
+  prevEnd?: string | undefined;
+  wakeHour: number;
+  sleepHour: number;
+}
+
+export interface StatsPageDataInput {
+  startDate: string;
+  endDate: string;
+  prevStart: string;
+  prevEnd: string;
+  year: number;
+  monthlyMonths: number;
+  wakeHour: number;
+  sleepHour: number;
+}
+
+export interface TagDashboardInput {
+  tagId: string;
+  startDate: string;
+  endDate: string;
+  limit: number;
+}
+
+function roundTo1(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+export class StatisticsService {
+  constructor(private readonly supabase: ServiceSupabaseClient) {}
+
+  // ---------------------------------------------------------------------------
+  // General: タグ別統計・時間帯分布
+  // ---------------------------------------------------------------------------
+
+  /** `get_tag_stats` 相当。実績（logs）ベースのタグ別件数・最終使用日。 */
+  async getTagStats(userId: string): Promise<{
+    counts: Record<string, number>;
+    lastUsed: Record<string, string>;
+  }> {
+    const logs = await this.fetchLogs(userId);
+    const byTag = new Map<string, { count: number; lastUsed: string | null }>();
+    for (const log of logs) {
+      if (log.tag_id == null) continue;
+      const acc = byTag.get(log.tag_id) ?? { count: 0, lastUsed: null };
+      acc.count += 1;
+      if (acc.lastUsed == null || log.start_at > acc.lastUsed) acc.lastUsed = log.start_at;
+      byTag.set(log.tag_id, acc);
+    }
+
+    const rows = Array.from(byTag.entries()).map(([tag_id, v]) => ({
+      tag_id,
+      entry_count: v.count,
+      last_used: v.lastUsed,
+    }));
+    return aggregateTagStats(rows);
+  }
+
+  /** `get_time_by_tag` 相当。実績（logs）のタグ別合計時間。 */
+  async getTimeByTag(userId: string, range: DateRangeInput = {}) {
+    const [logs, tagsById] = await Promise.all([
+      this.fetchLogs(userId, range),
+      this.fetchTagsById(userId),
+    ]);
+
+    const minutesByTag = new Map<string, number>();
+    for (const log of logs) {
+      if (log.tag_id == null) continue;
+      minutesByTag.set(
+        log.tag_id,
+        (minutesByTag.get(log.tag_id) ?? 0) + minutesBetween(log.start_at, log.end_at),
+      );
+    }
+
+    const rows = Array.from(minutesByTag.entries())
+      .filter(([, minutes]) => minutes > 0)
+      .map(([tagId, minutes]) => {
+        const tag = tagsById.get(tagId);
+        return {
+          tag_id: tagId,
+          tag_name: tag?.name ?? '',
+          tag_color: tag?.color ?? 'indigo',
+          hours: minutes / 60,
+        };
+      })
+      .sort((a, b) => b.hours - a.hours);
+
+    return transformTimeByTagResponse(rows);
+  }
+
+  /** `get_daily_hours` 相当。指定年の日別実績時間（ヒートマップ用）。 */
+  async getDailyHours(userId: string, year: number) {
+    const timezone = await getUserTimezone(this.supabase, userId);
+    const startOfYear = fromZonedTime(`${year}-01-01T00:00:00`, timezone).toISOString();
+    const startOfNextYear = fromZonedTime(`${year + 1}-01-01T00:00:00`, timezone).toISOString();
+    const logs = await this.fetchLogs(userId, { startDate: startOfYear, endDate: startOfNextYear });
+    return groupHoursByDay(logs, timezone);
+  }
+
+  /** `get_hourly_distribution` 相当。 */
+  async getHourlyDistribution(userId: string, range: DateRangeInput = {}) {
+    const timezone = await getUserTimezone(this.supabase, userId);
+    const logs = await this.fetchLogs(userId, range);
+    return aggregateHourlyDistribution(groupMinutesByHour(logs, timezone));
+  }
+
+  /** `get_dow_distribution` 相当。 */
+  async getDayOfWeekDistribution(userId: string, range: DateRangeInput = {}) {
+    const timezone = await getUserTimezone(this.supabase, userId);
+    const logs = await this.fetchLogs(userId, range);
+    return aggregateDayOfWeekDistribution(groupMinutesByDow(logs, timezone));
+  }
+
+  /** `get_monthly_hours` 相当。 */
+  async getMonthlyTrend(userId: string, months = 12) {
+    const timezone = await getUserTimezone(this.supabase, userId);
+    const nowStr = formatInTimeZone(new Date(), timezone, 'yyyy-MM');
+    const [nowYear, nowMonth] = nowStr.split('-').map(Number) as [number, number];
+    const startDate = getMonthlyStartDate(nowYear, nowMonth, months);
+
+    const logs = await this.fetchLogs(userId, { startDate: startDate.toISOString() });
+    return aggregateMonthlyTrend(groupHoursByMonth(logs, timezone), nowYear, nowMonth, months);
+  }
+
+  // ---------------------------------------------------------------------------
+  // KPI: 見積もり精度・空白率
+  // ---------------------------------------------------------------------------
+
+  /**
+   * `get_estimation_accuracy` 相当。`plans` LEFT JOIN `logs`（1:N、`auto_migrated` 除外）。
+   * 詳細は `domain/estimation-accuracy.ts` の `aggregatePlanLogEstimationAccuracy` を参照。
+   */
+  async getEstimationAccuracy(userId: string, range: DateRangeInput = {}) {
+    const [plans, tagsById] = await Promise.all([
+      this.fetchPlans(userId, range),
+      this.fetchTagsById(userId),
+    ]);
+    const rows = await this.computeEstimationAccuracy(userId, plans, tagsById);
+    return transformEstimationAccuracy(rows);
+  }
+
+  /** `get_blank_rate` 相当。予定（plans）ベースのスケジュール時間から空白率を算出する。 */
+  async getBlankRate(userId: string, { startDate, endDate, wakeHour, sleepHour }: BlankRateInput) {
+    const plans = await this.fetchPlans(userId, { startDate, endDate });
+    const scheduledMinutes = plans.reduce(
+      (sum, plan) => sum + minutesBetween(plan.start_at, plan.end_at),
+      0,
+    );
+    return computeBlankRate(scheduledMinutes, { startDate, endDate, wakeHour, sleepHour });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Summary: streak / KPI サマリー / Time P/L / Review panel 統合データ
+  // ---------------------------------------------------------------------------
+
+  /** `get_active_dates` 相当。実績（logs）が存在する日付（tz basis）の一覧。 */
+  async getActiveDates(userId: string, startDate: string): Promise<string[]> {
+    const timezone = await getUserTimezone(this.supabase, userId);
+    const logs = await this.fetchLogs(userId, { startDate });
+    const days = new Set(
+      logs.map((log) => formatInTimeZone(new Date(log.start_at), timezone, 'yyyy-MM-dd')),
+    );
+    return Array.from(days).sort();
+  }
+
+  /** `get_stats_kpi_summary` 相当。 */
+  async getStatsOverview(
+    userId: string,
+    { startDate, endDate, wakeHour, sleepHour }: BlankRateInput,
+  ) {
+    const timezone = await getUserTimezone(this.supabase, userId);
+    const [logs, plans] = await Promise.all([
+      this.fetchLogs(userId, { startDate, endDate }),
+      this.fetchPlans(userId, { startDate, endDate }),
+    ]);
+
+    const cumulativeMinutes = logs.reduce(
+      (sum, log) => sum + minutesBetween(log.start_at, log.end_at),
+      0,
+    );
+    const plannedEntries = logs.filter((log) => log.plan_id != null).length;
+    const contextSwitches = computeContextSwitches(logs, timezone);
+    const scheduledMinutes = plans.reduce(
+      (sum, plan) => sum + minutesBetween(plan.start_at, plan.end_at),
+      0,
+    );
+    const blankRate = computeBlankRate(scheduledMinutes, {
+      startDate,
+      endDate,
+      wakeHour,
+      sleepHour,
+    });
+
+    return transformStatsOverviewResponse({
+      cumulativeTime: { totalMinutes: cumulativeMinutes },
+      planRate: {
+        totalEntries: logs.length,
+        plannedEntries,
+        planRate: logs.length > 0 ? plannedEntries / logs.length : 0,
+      },
+      contextSwitches,
+      blankRate,
+    });
+  }
+
+  /** `get_time_pl_data` 相当。タグ別の予実（budget/actual）+ 日次ポイント。 */
+  async getTimePLData(userId: string, input: TimePLInput): Promise<TimePLResponse> {
+    const { startDate, endDate, prevStart, prevEnd, wakeHour, sleepHour } = input;
+    const timezone = await getUserTimezone(this.supabase, userId);
+
+    const [plans, logs, tagsById] = await Promise.all([
+      this.fetchPlans(userId, { startDate, endDate }),
+      this.fetchLogs(userId, { startDate, endDate }),
+      this.fetchTagsById(userId),
+    ]);
+    const tags = this.buildTagPL(plans, logs, tagsById);
+
+    let prevTags: TimePLResponse['prevTags'] = [];
+    if (prevStart && prevEnd) {
+      const [prevPlans, prevLogs] = await Promise.all([
+        this.fetchPlans(userId, { startDate: prevStart, endDate: prevEnd }),
+        this.fetchLogs(userId, { startDate: prevStart, endDate: prevEnd }),
+      ]);
+      prevTags = this.buildTagPL(prevPlans, prevLogs, tagsById);
+    }
+
+    const availableMinutes = computeAvailableMinutesInclusive({
+      startDate,
+      endDate,
+      wakeHour,
+      sleepHour,
+      timezone,
+    });
+
+    return { tags, prevTags, availableMinutes };
+  }
+
+  /** `get_stats_page_data` 相当。Review panel 用データを一括構築する。 */
+  async getStatsPageData(userId: string, input: StatsPageDataInput): Promise<StatsPageData> {
+    const { startDate, endDate, prevStart, prevEnd, year, monthlyMonths, wakeHour, sleepHour } =
+      input;
+    const timezone = await getUserTimezone(this.supabase, userId);
+
+    const startOfYear = fromZonedTime(`${year}-01-01T00:00:00`, timezone).toISOString();
+    const startOfNextYear = fromZonedTime(`${year + 1}-01-01T00:00:00`, timezone).toISOString();
+    const nowStr = formatInTimeZone(new Date(), timezone, 'yyyy-MM');
+    const [nowYear, nowMonth] = nowStr.split('-').map(Number) as [number, number];
+    const monthlyStartDate = getMonthlyStartDate(nowYear, nowMonth, monthlyMonths);
+
+    const [logs, plans, prevLogs, prevPlans, yearLogs, monthlyLogs, tagsById] = await Promise.all([
+      this.fetchLogs(userId, { startDate, endDate }),
+      this.fetchPlans(userId, { startDate, endDate }),
+      this.fetchLogs(userId, { startDate: prevStart, endDate: prevEnd }),
+      this.fetchPlans(userId, { startDate: prevStart, endDate: prevEnd }),
+      this.fetchLogs(userId, { startDate: startOfYear, endDate: startOfNextYear }),
+      this.fetchLogs(userId, { startDate: monthlyStartDate.toISOString() }),
+      this.fetchTagsById(userId),
+    ]);
+
+    const overview = this.buildOverviewSection(logs);
+    const prevOverview = this.buildOverviewSection(prevLogs);
+    const contextSwitches = computeContextSwitches(logs, timezone);
+    const scheduledMinutes = plans.reduce(
+      (sum, plan) => sum + minutesBetween(plan.start_at, plan.end_at),
+      0,
+    );
+    const fullBlankRate = computeBlankRate(scheduledMinutes, {
+      startDate,
+      endDate,
+      wakeHour,
+      sleepHour,
+    });
+
+    const timeByTag = transformTimeByTagResponse(this.buildTimeByTagRows(logs, tagsById));
+    // NOTE: get_stats_page_data の hourly/dow は 24h/7dow の raw bucket をそのまま返す
+    // （getHourlyDistribution/getDayOfWeekDistribution procedure が行う 2h slot 集約や
+    // 曜日ラベル変換は適用しない。RPC 契約どおり）。
+    const hourly = groupMinutesByHour(logs, timezone).map((row) => ({
+      hour: row.hour,
+      totalMinutes: row.total_minutes,
+    }));
+    const dow = groupMinutesByDow(logs, timezone).map((row) => ({
+      dow: row.dow,
+      totalMinutes: row.total_minutes,
+    }));
+    const energyMap = groupEnergyMap(logs, timezone).map(
+      ({ avgFulfillment: _avgFulfillment, ...rest }) => rest,
+    );
+    const prevEnergyMap = groupEnergyMap(prevLogs, timezone).map(
+      ({ avgFulfillment: _avgFulfillment, ...rest }) => rest,
+    );
+
+    const estimationAccuracy = transformEstimationAccuracy(
+      await this.computeEstimationAccuracy(userId, plans, tagsById),
+    );
+    const prevEstimationAccuracy = transformEstimationAccuracy(
+      await this.computeEstimationAccuracy(userId, prevPlans, tagsById),
+    );
+
+    const dailyHours = groupHoursByDay(yearLogs, timezone);
+    const monthlyTrend = aggregateMonthlyTrend(
+      groupHoursByMonth(monthlyLogs, timezone),
+      nowYear,
+      nowMonth,
+      monthlyMonths,
+    );
+
+    return {
+      overview,
+      prevOverview,
+      contextSwitches,
+      blankRate: {
+        availableMinutes: fullBlankRate.availableMinutes,
+        scheduledMinutes: fullBlankRate.scheduledMinutes,
+        blankRate: fullBlankRate.blankRate,
+      },
+      timeByTag,
+      hourly,
+      dow,
+      energyMap,
+      estimationAccuracy,
+      prevEstimationAccuracy,
+      prevEnergyMap,
+      dailyHours,
+      monthlyTrend,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // タグ詳細ダッシュボード（旧 `entriesTagStatisticsRouter.getTagDashboard`）
+  // ---------------------------------------------------------------------------
+
+  async getTagDashboard(userId: string, { tagId, startDate, endDate, limit }: TagDashboardInput) {
+    const timezone = await getUserTimezone(this.supabase, userId);
+    const [tag, logs, plans] = await Promise.all([
+      this.fetchTagById(userId, tagId),
+      this.fetchLogsOverlapping(userId, tagId, startDate, endDate),
+      this.fetchPlansOverlapping(userId, tagId, startDate, endDate),
+    ]);
+
+    const plansById = new Map(plans.map((plan) => [plan.id, plan]));
+
+    // 1 plan に複数 log（分割記録）が紐づく場合、予定時間の二重計上を避けるため
+    // 「代表 log」1 件だけに planned range を割り当てる。from_plan があればそれを優先する。
+    const primaryLogIdByPlanId = new Map<string, string>();
+    for (const log of logs) {
+      if (log.plan_id == null) continue;
+      const currentId = primaryLogIdByPlanId.get(log.plan_id);
+      if (!currentId) {
+        primaryLogIdByPlanId.set(log.plan_id, log.id);
+        continue;
+      }
+      if (log.source === 'from_plan') {
+        primaryLogIdByPlanId.set(log.plan_id, log.id);
+      }
+    }
+
+    const rows: TagDashboardEntryRow[] = logs.map((log) => {
+      const plan = log.plan_id ? plansById.get(log.plan_id) : undefined;
+      const isPrimary = log.plan_id != null && primaryLogIdByPlanId.get(log.plan_id) === log.id;
+      return {
+        id: log.id,
+        title: log.title,
+        description: log.note,
+        start_time: isPrimary && plan ? plan.start_at : null,
+        end_time: isPrimary && plan ? plan.end_at : null,
+        actual_start_time: log.start_at,
+        actual_end_time: log.end_at,
+        tag_id: log.tag_id,
+      };
+    });
+
+    // 未記録・未 skip の plan は「予定のみ」の行として残す（実績時間は 0）。
+    const recordedPlanIds = new Set(
+      logs.map((log) => log.plan_id).filter((id): id is string => id != null),
+    );
+    for (const plan of plans) {
+      if (recordedPlanIds.has(plan.id) || plan.skipped_at) continue;
+      rows.push({
+        id: plan.id,
+        title: plan.title,
+        description: plan.note,
+        start_time: plan.start_at,
+        end_time: plan.end_at,
+        actual_start_time: null,
+        actual_end_time: null,
+        tag_id: plan.tag_id,
+      });
+    }
+
+    return buildTagDashboard({ tag, rows, limit, timezone });
+  }
+
+  // ---------------------------------------------------------------------------
+  // private: 見積もり精度の共通計算
+  // ---------------------------------------------------------------------------
+
+  private async computeEstimationAccuracy(
+    userId: string,
+    plans: ReadonlyArray<StatPlanRow>,
+    tagsById: ReadonlyMap<string, TagLookupRow>,
+  ): Promise<EstimationAccuracyDbRow[]> {
+    const planIds = plans.map((plan) => plan.id);
+    const logs = planIds.length > 0 ? await this.fetchLogsByPlanIds(userId, planIds) : [];
+
+    const planRows = plans
+      .filter((plan): plan is StatPlanRow & { tag_id: string } => plan.tag_id != null)
+      .map((plan) => ({
+        id: plan.id,
+        tag_id: plan.tag_id,
+        planned_minutes: minutesBetween(plan.start_at, plan.end_at),
+      }));
+    const logRows = logs.map((log) => ({
+      plan_id: log.plan_id,
+      source: log.source,
+      minutes: minutesBetween(log.start_at, log.end_at),
+    }));
+    const tagLookup: Map<string, EstimationAccuracyTagLookup> = new Map(
+      Array.from(tagsById.entries()).map(([id, tag]) => [id, { name: tag.name, color: tag.color }]),
+    );
+
+    return aggregatePlanLogEstimationAccuracy(planRows, logRows, tagLookup);
+  }
+
+  private buildOverviewSection(logs: ReadonlyArray<StatLogRow>) {
+    const totalMinutes = logs.reduce(
+      (sum, log) => sum + minutesBetween(log.start_at, log.end_at),
+      0,
+    );
+    const entryCount = logs.filter((log) => log.fulfillment_score != null).length;
+    const totalEntries = logs.length;
+    const plannedEntries = logs.filter((log) => log.plan_id != null).length;
+    return {
+      totalMinutes,
+      entryCount,
+      totalEntries,
+      plannedEntries,
+      planRate: totalEntries > 0 ? plannedEntries / totalEntries : 0,
+    };
+  }
+
+  private buildTimeByTagRows(
+    logs: ReadonlyArray<StatLogRow>,
+    tagsById: ReadonlyMap<string, TagLookupRow>,
+  ) {
+    const minutesByTag = new Map<string, number>();
+    for (const log of logs) {
+      if (log.tag_id == null) continue;
+      minutesByTag.set(
+        log.tag_id,
+        (minutesByTag.get(log.tag_id) ?? 0) + minutesBetween(log.start_at, log.end_at),
+      );
+    }
+    return Array.from(minutesByTag.entries())
+      .filter(([, minutes]) => minutes > 0)
+      .map(([tagId, minutes]) => {
+        const tag = tagsById.get(tagId);
+        return {
+          tag_id: tagId,
+          tag_name: tag?.name ?? '',
+          tag_color: tag?.color ?? 'indigo',
+          hours: minutes / 60,
+        };
+      })
+      .sort((a, b) => b.hours - a.hours);
+  }
+
+  private buildTagPL(
+    plans: ReadonlyArray<StatPlanRow>,
+    logs: ReadonlyArray<StatLogRow>,
+    tagsById: ReadonlyMap<string, TagLookupRow>,
+  ): TimePLResponse['tags'] {
+    interface Accumulator {
+      budget: number;
+      actual: number;
+      hasPlan: boolean;
+    }
+    const byTag = new Map<string, Accumulator>();
+
+    for (const plan of plans) {
+      if (plan.tag_id == null) continue;
+      const acc = byTag.get(plan.tag_id) ?? { budget: 0, actual: 0, hasPlan: false };
+      acc.budget += minutesBetween(plan.start_at, plan.end_at);
+      acc.hasPlan = true;
+      byTag.set(plan.tag_id, acc);
+    }
+    for (const log of logs) {
+      if (log.tag_id == null) continue;
+      const acc = byTag.get(log.tag_id) ?? { budget: 0, actual: 0, hasPlan: false };
+      acc.actual += minutesBetween(log.start_at, log.end_at);
+      byTag.set(log.tag_id, acc);
+    }
+
+    return Array.from(byTag.entries())
+      .filter(([, acc]) => acc.budget > 0 || acc.actual > 0)
+      .map(([tagId, acc]) => {
+        const tag = tagsById.get(tagId);
+        return {
+          tagId,
+          tagName: tag?.name ?? '',
+          tagColor: tag?.color ?? 'indigo',
+          tagIcon: tag?.icon ?? null,
+          budgetMinutes: roundTo1(acc.budget),
+          actualMinutes: roundTo1(acc.actual),
+          isPlanned: acc.hasPlan,
+        };
+      })
+      .sort((a, b) => b.actualMinutes - a.actualMinutes);
+  }
+
+  // ---------------------------------------------------------------------------
+  // private: fetch
+  // ---------------------------------------------------------------------------
+
+  private async fetchLogs(userId: string, range: DateRangeInput = {}): Promise<StatLogRow[]> {
+    let query = this.supabase
+      .from('logs')
+      .select('id, tag_id, plan_id, source, start_at, end_at, fulfillment_score')
+      .eq('user_id', userId)
+      .is('deleted_at', null);
+    if (range.startDate) query = query.gte('start_at', range.startDate);
+    if (range.endDate) query = query.lt('start_at', range.endDate);
+
+    const { data, error } = await query;
+    if (error) throw new Error(`Failed to fetch logs: ${error.message}`);
+    return data ?? [];
+  }
+
+  private async fetchLogsByPlanIds(userId: string, planIds: string[]): Promise<StatLogRow[]> {
+    const { data, error } = await this.supabase
+      .from('logs')
+      .select('id, tag_id, plan_id, source, start_at, end_at, fulfillment_score')
+      .eq('user_id', userId)
+      .is('deleted_at', null)
+      .in('plan_id', planIds);
+    if (error) throw new Error(`Failed to fetch logs by plan ids: ${error.message}`);
+    return data ?? [];
+  }
+
+  private async fetchPlans(userId: string, range: DateRangeInput = {}): Promise<StatPlanRow[]> {
+    let query = this.supabase
+      .from('plans')
+      .select('id, tag_id, start_at, end_at')
+      .eq('user_id', userId)
+      .is('deleted_at', null);
+    if (range.startDate) query = query.gte('start_at', range.startDate);
+    if (range.endDate) query = query.lt('start_at', range.endDate);
+
+    const { data, error } = await query;
+    if (error) throw new Error(`Failed to fetch plans: ${error.message}`);
+    return data ?? [];
+  }
+
+  private async fetchTagsById(userId: string): Promise<Map<string, TagLookupRow>> {
+    const { data, error } = await this.supabase
+      .from('tags')
+      .select('id, name, color, icon')
+      .eq('user_id', userId);
+    if (error) throw new Error(`Failed to fetch tags: ${error.message}`);
+    return new Map((data ?? []).map((tag) => [tag.id, tag]));
+  }
+
+  private async fetchTagById(userId: string, tagId: string): Promise<TagDashboardTagRow> {
+    const { data, error } = await this.supabase
+      .from('tags')
+      .select('id, name, color, icon')
+      .eq('user_id', userId)
+      .eq('id', tagId)
+      .eq('is_active', true)
+      .single();
+    if (error || !data) throw new Error(`Tag not found: ${error?.message ?? tagId}`);
+    return data;
+  }
+
+  private async fetchLogsOverlapping(
+    userId: string,
+    tagId: string,
+    startDate: string,
+    endDate: string,
+  ): Promise<Array<StatLogRow & { title: string; note: string | null }>> {
+    const { data, error } = await this.supabase
+      .from('logs')
+      .select('id, title, note, tag_id, plan_id, source, start_at, end_at, fulfillment_score')
+      .eq('user_id', userId)
+      .eq('tag_id', tagId)
+      .is('deleted_at', null)
+      .lt('start_at', endDate)
+      .gt('end_at', startDate)
+      .order('start_at', { ascending: true });
+    if (error) throw new Error(`Failed to fetch logs for tag dashboard: ${error.message}`);
+    return data ?? [];
+  }
+
+  private async fetchPlansOverlapping(
+    userId: string,
+    tagId: string,
+    startDate: string,
+    endDate: string,
+  ): Promise<
+    Array<StatPlanRow & { title: string; note: string | null; skipped_at: string | null }>
+  > {
+    const { data, error } = await this.supabase
+      .from('plans')
+      .select('id, title, note, tag_id, start_at, end_at, skipped_at')
+      .eq('user_id', userId)
+      .eq('tag_id', tagId)
+      .is('deleted_at', null)
+      .lt('start_at', endDate)
+      .gt('end_at', startDate)
+      .order('start_at', { ascending: true });
+    if (error) throw new Error(`Failed to fetch plans for tag dashboard: ${error.message}`);
+    return data ?? [];
+  }
+}
+
+export function createStatisticsService(supabase: ServiceSupabaseClient): StatisticsService {
+  return new StatisticsService(supabase);
+}

--- a/apps/product/src/features/tags/server/__tests__/tag-statistics-service.test.ts
+++ b/apps/product/src/features/tags/server/__tests__/tag-statistics-service.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Database } from '@/lib/database';
+import { createChainableMock, createMockSupabase } from '@/lib/test/trpc-test-helpers';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { TagStatisticsService } from '../tag-statistics-service';
+
+const USER_ID = 'user-1';
+
+function createService(tableData: Record<string, ReturnType<typeof createChainableMock>>) {
+  const mockSupabase = createMockSupabase();
+  mockSupabase.from.mockImplementation((table: string) => {
+    const mock = tableData[table];
+    if (!mock) throw new Error(`Unexpected table access in test: ${table}`);
+    return mock;
+  });
+  return new TagStatisticsService(mockSupabase as unknown as SupabaseClient<Database>);
+}
+
+describe('TagStatisticsService.getStatsFromLogs', () => {
+  it('logs を実績として集計し entry_count 降順で返す', async () => {
+    const service = createService({
+      tags: createChainableMock([
+        { id: 'tag-1', name: 'Deep Work', color: 'blue', icon: null },
+        { id: 'tag-2', name: 'Meeting', color: 'red', icon: null },
+      ]),
+      logs: createChainableMock([
+        { tag_id: 'tag-2', start_at: '2026-07-01T00:00:00Z' },
+        { tag_id: 'tag-1', start_at: '2026-07-02T00:00:00Z' },
+        { tag_id: 'tag-1', start_at: '2026-07-03T00:00:00Z' },
+      ]),
+    });
+
+    const result = await service.getStatsFromLogs(USER_ID);
+
+    expect(result).toEqual([
+      {
+        id: 'tag-1',
+        name: 'Deep Work',
+        color: 'blue',
+        icon: null,
+        entry_count: 2,
+        last_used_at: '2026-07-03T00:00:00Z',
+      },
+      {
+        id: 'tag-2',
+        name: 'Meeting',
+        color: 'red',
+        icon: null,
+        entry_count: 1,
+        last_used_at: '2026-07-01T00:00:00Z',
+      },
+    ]);
+  });
+
+  it('tag が無ければ空配列を返す（logs は問い合わせない）', async () => {
+    const service = createService({ tags: createChainableMock([]) });
+    expect(await service.getStatsFromLogs(USER_ID)).toEqual([]);
+  });
+
+  it('log の無いタグは entry_count=0, last_used_at=null になる', async () => {
+    const service = createService({
+      tags: createChainableMock([{ id: 'tag-1', name: 'Deep Work', color: 'blue', icon: null }]),
+      logs: createChainableMock([]),
+    });
+
+    const result = await service.getStatsFromLogs(USER_ID);
+    expect(result).toEqual([
+      {
+        id: 'tag-1',
+        name: 'Deep Work',
+        color: 'blue',
+        icon: null,
+        entry_count: 0,
+        last_used_at: null,
+      },
+    ]);
+  });
+});

--- a/apps/product/src/features/tags/server/tag-statistics-service.ts
+++ b/apps/product/src/features/tags/server/tag-statistics-service.ts
@@ -54,4 +54,60 @@ export class TagStatisticsService {
       })
       .sort((a, b) => b.entry_count - a.entry_count);
   }
+
+  /**
+   * Step 4: `get_tag_stats` RPC の代わりに `logs`（実績）を直接集計するタグ統計。
+   *
+   * `tags` は Layer 0 のため `features/entry/domain` を import できない（feature DAG）。
+   * `entries.getTagStats` procedure と同じ意味論（実績ベースの件数・最終使用日）を
+   * ここで独立に計算する。**dormant**: router から未接続。Step 8 で `getStats` の
+   * 呼び出し元を切り替える前提。
+   */
+  async getStatsFromLogs(userId: string): Promise<TagStatsRow[]> {
+    const { data: tags, error: tagsError } = await this.supabase
+      .from('tags')
+      .select('id, name, color, icon')
+      .eq('user_id', userId)
+      .eq('is_active', true);
+    if (tagsError) {
+      throw new TagServiceError('FETCH_FAILED', `Failed to fetch tags: ${tagsError.message}`);
+    }
+    if (!tags || tags.length === 0) return [];
+
+    const { data: logs, error: logsError } = await this.supabase
+      .from('logs')
+      .select('tag_id, start_at')
+      .eq('user_id', userId)
+      .is('deleted_at', null)
+      .not('tag_id', 'is', null);
+    if (logsError) {
+      throw new TagServiceError('FETCH_FAILED', `Failed to fetch logs: ${logsError.message}`);
+    }
+
+    const statsMap = new Map<string, { entry_count: number; last_used: string }>();
+    for (const log of logs ?? []) {
+      if (!log.tag_id) continue;
+      const existing = statsMap.get(log.tag_id);
+      if (existing) {
+        existing.entry_count += 1;
+        if (log.start_at > existing.last_used) existing.last_used = log.start_at;
+      } else {
+        statsMap.set(log.tag_id, { entry_count: 1, last_used: log.start_at });
+      }
+    }
+
+    return tags
+      .map((tag) => {
+        const stats = statsMap.get(tag.id);
+        return {
+          id: tag.id,
+          name: tag.name,
+          color: tag.color,
+          icon: tag.icon,
+          entry_count: stats?.entry_count ?? 0,
+          last_used_at: stats?.last_used ?? null,
+        };
+      })
+      .sort((a, b) => b.entry_count - a.entry_count);
+  }
 }

--- a/apps/product/src/lib/test/integration/statistics-service-comparison.integration.test.ts
+++ b/apps/product/src/lib/test/integration/statistics-service-comparison.integration.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Step 4: 統計 TS service（`StatisticsService`）と旧 PL/pgSQL 統計 RPC の並走比較テスト。
+ *
+ * `entries` に実データを投入し `backfill_entries_to_plans_logs()` で `plans`/`logs`
+ * を実体化した上で、旧 RPC と新 service の出力を突き合わせる。
+ *
+ * 意味論差の許容リスト（step-4-statistics-service.md の指示に基づく既知差分）:
+ * - `get_time_by_tag` / `get_hourly_distribution` / `get_dow_distribution` は旧 RPC が
+ *   `entries.start_time/end_time`（**予定**時間、planned origin のみ）を読むのに対し、
+ *   新 service は Step 0 の Aggregation Source Contract どおり `logs`（**実績**、
+ *   unplanned も含む）を読む。unplanned entry を含む集計では新の方が値が大きくなるのが
+ *   意図した挙動（バグ修正）であり、比較対象からは意図的に除外する。
+ * - `get_tag_stats.last_used` は旧 RPC が `MAX(created_at)`、新 service は
+ *   `MAX(start_at)`（実際に記録した日時）を使う。後者がプロダクト的に正しい意味なので
+ *   値の一致は検証しない。
+ * - `source = 'auto_migrated'` の log は見積もり精度の分母から除外する
+ *   （overview.md §8 未決 4 の決定）。
+ * - 既知の凍結資産バグ: 旧 `get_time_by_tag` RPC は `hours` 列の型宣言
+ *   （`double precision`）と実際の戻り値（`numeric`）が一致しておらず、
+ *   ローカル DB では呼び出し自体が `structure of query does not match
+ *   function result type` で失敗する（本 PR とは無関係の既存不具合）。
+ *   このテストでは同 RPC との突き合わせは行わず、新 service 側の値のみを検証する。
+ *
+ * 実行方法:
+ * 1. supabase start
+ * 2. pnpm test:integration
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { StatisticsService } from '@/features/entry/server/statistics-service';
+import type { Database } from '@/lib/database';
+
+const LOCAL_DB_URL = 'http://127.0.0.1:54321';
+const SUPABASE_URL =
+  process.env.USE_LOCAL_DB === 'true'
+    ? LOCAL_DB_URL
+    : process.env.NEXT_PUBLIC_SUPABASE_URL || LOCAL_DB_URL;
+const SUPABASE_SERVICE_KEY =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU';
+
+const TEST_USER_ID = crypto.randomUUID();
+const TEST_EMAIL = `test-${TEST_USER_ID}@example.com`;
+
+const SKIP_INTEGRATION = process.env.SKIP_INTEGRATION_TESTS === 'true';
+
+function daysAgo(days: number, hour = 10): Date {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - days);
+  d.setUTCHours(hour, 0, 0, 0);
+  return d;
+}
+
+function addHours(date: Date, hours: number): Date {
+  return new Date(date.getTime() + hours * 60 * 60 * 1000);
+}
+
+describe.skipIf(SKIP_INTEGRATION)('StatisticsService vs 旧統計RPC 並走比較', () => {
+  let admin: ReturnType<typeof createClient<Database>>;
+  let service: StatisticsService;
+  let tagAId: string;
+  let tagBId: string;
+
+  // E1: tagA, planned + 明示 actual（実績=予定と同じ時間） → plan + log(from_plan)
+  const e1Start = daysAgo(5, 9);
+  const e1End = addHours(e1Start, 1);
+  // E4: tagA, planned + 明示 actual（別日、見積もり精度の分母 >=2 を満たすため）
+  const e4Start = daysAgo(4, 9);
+  const e4End = addHours(e4Start, 1);
+  // E2: tagB, planned・actual なし・skip なし・過去 → auto-record（backfill で auto_migrated log 化）
+  const e2Start = daysAgo(3, 14);
+  const e2End = addHours(e2Start, 1);
+  // E3: tagA, unplanned（旧 get_time_by_tag / hourly / dow の比較対象からは除外する既知差分）
+  const e3Start = daysAgo(2, 20);
+  const e3End = addHours(e3Start, 0.5);
+
+  const rangeStart = daysAgo(10, 0).toISOString();
+  const rangeEnd = daysAgo(-1, 0).toISOString();
+
+  beforeAll(async () => {
+    admin = createClient<Database>(SUPABASE_URL, SUPABASE_SERVICE_KEY, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    const { error: authError } = await admin.auth.admin.createUser({
+      email: TEST_EMAIL,
+      password: 'test-password-123',
+      email_confirm: true,
+      id: TEST_USER_ID,
+    });
+    if (authError && !authError.message.includes('already exists')) {
+      throw new Error(`Failed to create test user: ${authError.message}`);
+    }
+    await admin.from('profiles').upsert({
+      id: TEST_USER_ID,
+      email: TEST_EMAIL,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+    await admin.from('user_settings').upsert({ user_id: TEST_USER_ID, timezone: 'UTC' });
+
+    const { data: tagA, error: tagAError } = await admin
+      .from('tags')
+      .insert({ user_id: TEST_USER_ID, name: 'Deep Work', color: 'blue', is_active: true })
+      .select('id')
+      .single();
+    if (tagAError || !tagA) throw new Error(`Failed to create tagA: ${tagAError?.message}`);
+    tagAId = tagA.id;
+
+    const { data: tagB, error: tagBError } = await admin
+      .from('tags')
+      .insert({ user_id: TEST_USER_ID, name: 'Meeting', color: 'red', is_active: true })
+      .select('id')
+      .single();
+    if (tagBError || !tagB) throw new Error(`Failed to create tagB: ${tagBError?.message}`);
+    tagBId = tagB.id;
+
+    const { error: insertError } = await admin.from('entries').insert([
+      {
+        user_id: TEST_USER_ID,
+        tag_id: tagAId,
+        title: 'E1 planned+recorded',
+        origin: 'planned',
+        start_time: e1Start.toISOString(),
+        end_time: e1End.toISOString(),
+        actual_start_time: e1Start.toISOString(),
+        actual_end_time: e1End.toISOString(),
+        fulfillment_score: 3,
+      },
+      {
+        user_id: TEST_USER_ID,
+        tag_id: tagAId,
+        title: 'E4 planned+recorded',
+        origin: 'planned',
+        start_time: e4Start.toISOString(),
+        end_time: e4End.toISOString(),
+        actual_start_time: e4Start.toISOString(),
+        actual_end_time: e4End.toISOString(),
+        fulfillment_score: 2,
+      },
+      {
+        user_id: TEST_USER_ID,
+        tag_id: tagBId,
+        title: 'E2 auto-record',
+        origin: 'planned',
+        start_time: e2Start.toISOString(),
+        end_time: e2End.toISOString(),
+      },
+      {
+        user_id: TEST_USER_ID,
+        tag_id: tagAId,
+        title: 'E3 unplanned',
+        origin: 'unplanned',
+        actual_start_time: e3Start.toISOString(),
+        actual_end_time: e3End.toISOString(),
+        fulfillment_score: 1,
+      },
+    ]);
+    if (insertError) throw new Error(`Failed to insert entries: ${insertError.message}`);
+
+    const { error: backfillError } = await admin.rpc('backfill_entries_to_plans_logs');
+    if (backfillError) throw new Error(`Backfill failed: ${backfillError.message}`);
+
+    service = new StatisticsService(admin);
+  });
+
+  afterAll(async () => {
+    await admin.from('entries').delete().eq('user_id', TEST_USER_ID);
+    await admin.from('logs').delete().eq('user_id', TEST_USER_ID);
+    await admin.from('plans').delete().eq('user_id', TEST_USER_ID);
+    await admin.from('tags').delete().eq('user_id', TEST_USER_ID);
+    await admin.auth.admin.deleteUser(TEST_USER_ID);
+  });
+
+  it('backfill が plans 3件・logs 4件を実体化する', async () => {
+    const { data: plans } = await admin.from('plans').select('id').eq('user_id', TEST_USER_ID);
+    const { data: logs } = await admin
+      .from('logs')
+      .select('id, source')
+      .eq('user_id', TEST_USER_ID);
+    expect(plans).toHaveLength(3); // E1, E4, E2
+    expect(logs).toHaveLength(4); // E1(from_plan), E4(from_plan), E2(auto_migrated), E3(manual)
+    expect(logs?.filter((l) => l.source === 'auto_migrated')).toHaveLength(1);
+  });
+
+  it('getTagStats: 実績(logs)ベースの件数が旧 RPC と一致する（この投入データでは deleted 行が無いため一致）', async () => {
+    const { data: oldRows, error } = await admin.rpc('get_tag_stats', { p_user_id: TEST_USER_ID });
+    if (error) throw error;
+    const oldCounts = Object.fromEntries((oldRows ?? []).map((r) => [r.tag_id, r.entry_count]));
+
+    const newResult = await service.getTagStats(TEST_USER_ID);
+
+    // tagA: E1,E4,E3 → 3 logs / tagB: E2(auto_migrated) → 1 log
+    expect(newResult.counts).toEqual({ [tagAId]: 3, [tagBId]: 1 });
+    expect(oldCounts).toEqual({ [tagAId]: 3, [tagBId]: 1 });
+  });
+
+  it('getTimeByTag: 実績(logs)ベースのタグ別合計時間を返す', async () => {
+    // NOTE: 旧 `get_time_by_tag` RPC は本 PR と無関係の既存バグ（`hours` 列が
+    // numeric を double precision として RETURNS TABLE 宣言しており
+    // "structure of query does not match function result type" で例外になる）
+    // により、この worktree のローカル DB では呼び出し自体が失敗する。
+    // 凍結資産のため本 Step では修正せず、旧 RPC との突き合わせは断念して
+    // 新 service 側の値のみを検証する（別途フォローアップとして報告）。
+    const newRows = await service.getTimeByTag(TEST_USER_ID, {
+      startDate: rangeStart,
+      endDate: rangeEnd,
+    });
+    const newByTag = Object.fromEntries(newRows.map((r) => [r.tagId, r.hours]));
+
+    // tagA: E1(1h) + E4(1h) + E3(0.5h, unplanned) = 2.5h
+    expect(newByTag[tagAId]).toBeCloseTo(2.5, 6);
+    // tagB: E2(auto_migrated, 1h) のみ
+    expect(newByTag[tagBId]).toBeCloseTo(1, 6);
+  });
+
+  it('getBlankRate: plans ベースの scheduled minutes が旧 RPC の scheduledMinutes と一致する', async () => {
+    const wakeHour = 7;
+    const sleepHour = 23;
+    const { data: oldResult, error } = await admin.rpc('get_blank_rate', {
+      p_user_id: TEST_USER_ID,
+      p_start_date: rangeStart,
+      p_end_date: rangeEnd,
+      p_wake_hour: wakeHour,
+      p_sleep_hour: sleepHour,
+    });
+    if (error) throw error;
+
+    const newResult = await service.getBlankRate(TEST_USER_ID, {
+      startDate: rangeStart,
+      endDate: rangeEnd,
+      wakeHour,
+      sleepHour,
+    });
+
+    // E1+E4+E2 の予定時間のみが対象（E3 は unplanned で予定時間を持たない）→ 旧・新で一致する
+    const old = oldResult as { scheduledMinutes: number; availableMinutes: number };
+    expect(newResult.scheduledMinutes).toBeCloseTo(old.scheduledMinutes, 6);
+    expect(newResult.availableMinutes).toBe(old.availableMinutes);
+  });
+
+  it('getEstimationAccuracy: auto_migrated を除外した 1:N 集計が旧 RPC の explicit-actual 集計と一致する', async () => {
+    const { data: oldRows, error } = await admin.rpc('get_estimation_accuracy', {
+      p_user_id: TEST_USER_ID,
+      p_start_date: rangeStart,
+      p_end_date: rangeEnd,
+    });
+    if (error) throw error;
+
+    const newRows = await service.getEstimationAccuracy(TEST_USER_ID, {
+      startDate: rangeStart,
+      endDate: rangeEnd,
+    });
+
+    // tagA: E1・E4 とも明示 actual = 予定と同じ時間 → 旧・新とも deviation=0 で一致する。
+    // tagB: auto_migrated 1 件のみのため HAVING COUNT(*)>=2 を満たさず旧・新とも該当なし。
+    const oldTagA = (oldRows ?? []).find((r) => r.tag_id === tagAId);
+    const newTagA = newRows.find((r) => r.tagId === tagAId);
+
+    expect(oldTagA).toBeDefined();
+    expect(newTagA).toBeDefined();
+    expect(newTagA?.entryCount).toBe(oldTagA?.entry_count);
+    expect(newTagA?.avgPlannedMinutes).toBeCloseTo(oldTagA?.avg_planned_minutes ?? 0, 6);
+    expect(newTagA?.avgActualMinutes).toBeCloseTo(oldTagA?.avg_actual_minutes ?? 0, 6);
+    expect(newTagA?.avgDeviationMinutes).toBeCloseTo(0, 6);
+
+    expect((oldRows ?? []).find((r) => r.tag_id === tagBId)).toBeUndefined();
+    expect(newRows.find((r) => r.tagId === tagBId)).toBeUndefined();
+  });
+
+  it('getActiveDates: 実績(logs)が存在する日付一覧を返す', async () => {
+    const dates = await service.getActiveDates(TEST_USER_ID, rangeStart);
+    // E1, E4, E2, E3 は 4 つの異なる日付に記録されている
+    expect(dates).toHaveLength(4);
+    expect(dates).toEqual([...dates].sort());
+  });
+});


### PR DESCRIPTION
## Summary

[docs/projects/time-model-split/step-4-statistics-service.md](../blob/main/docs/projects/time-model-split/step-4-statistics-service.md) に基づき、time-model-split Phase 1 Step 4「統計 TS service」を実装。

Step 0 の Aggregation Source Contract に従い、実績は `logs`、予定は `plans`、見積もり精度は `plans` LEFT JOIN `logs`（1:N、`source=auto_migrated` 除外）を読む TS 集計層を追加。**router には未接続の dormant 実装**で、既存の PL/pgSQL 統計 RPC ベースの router (`statistics-general-router.ts` 等) は現状のまま動作し続ける。接続は Step 8 のカットオーバーで行う。

- `entry/server/statistics-service.ts`: 12 procedure 相当（tag stats / time-by-tag / daily・hourly・dow・monthly / estimation accuracy / blank rate / active dates / stats overview / time P·L / stats page data）+ タグダッシュボード
- `entry/server/statistics-service-grouping.ts`: TZ-aware なグルーピング（時間帯/曜日/日次/月次/energy map/context switches/blank rate 計算式）
- `entry/domain/estimation-accuracy.ts`: `aggregatePlanLogEstimationAccuracy` を追加し、1 plan に複数 log が紐づくケースを合算・`auto_migrated` を分母から除外
- `tags/server/tag-statistics-service.ts`: `get_tag_stats` RPC 依存を残さない `getStatsFromLogs` を追加（dormant）
- 並走比較 integration テスト: backfill 済みデータに対し旧 RPC と新 service の出力を突き合わせ

## 副産物: 既存バグの発見

旧 `get_time_by_tag` RPC がローカル DB で `structure of query does not match function result type`（`hours` 列の `numeric`/`double precision` 型不一致）により **呼び出し自体が失敗する**ことを発見した。本 PR の変更とは無関係の凍結資産側の既存不具合のため、この Step では修正せず、比較テストからは除外している（テスト内コメントに詳細記載）。別途フォローアップが必要。

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm lint:boundaries`
- [x] `pnpm check`（CI Stage 1 相当、knip 含めて全通過）
- [x] `pnpm test:run`（1902 tests）
- [x] `pnpm test:integration`（ローカル Supabase、旧 RPC vs 新 service 比較込み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)