### PR TITLE
feat: planとlogの作成編集フローを追加

### DIFF
--- a/apps/product/messages/en/entry.json
+++ b/apps/product/messages/en/entry.json
@@ -34,6 +34,30 @@
       "placed": "Added {name} at {time}",
       "overlapError": "{time} overlaps with an existing block"
     },
+    "timeModel": {
+      "destination": {
+        "plan": "Save as plan",
+        "log": "Save as record"
+      },
+      "title": "Title",
+      "titlePlaceholder": "What did you do?",
+      "date": "Date",
+      "time": "Time",
+      "note": "Note",
+      "notePlaceholder": "Add a note...",
+      "save": "Save",
+      "timeLocked": "Time is fixed for past plans",
+      "recordAsIs": "Record as planned",
+      "confirmDay": "Confirm day",
+      "toast": {
+        "recorded": "Recorded ✓",
+        "dayConfirmed": "Day recorded ✓",
+        "overlap": "This time slot is already taken",
+        "saveFailed": "Could not save. Please try again",
+        "recordFailed": "Could not record. Please try again",
+        "confirmFailed": "Could not confirm the day. Please try again"
+      }
+    },
     "sidebar": {
       "tabs": {
         "calendar": "Calendar",

--- a/apps/product/messages/ja/entry.json
+++ b/apps/product/messages/ja/entry.json
@@ -34,6 +34,30 @@
       "placed": "{name} を {time} に追加しました",
       "overlapError": "{time} は既存のブロックと重複しています"
     },
+    "timeModel": {
+      "destination": {
+        "plan": "予定として保存",
+        "log": "記録として保存"
+      },
+      "title": "タイトル",
+      "titlePlaceholder": "何をしましたか？",
+      "date": "日付",
+      "time": "時間",
+      "note": "メモ",
+      "notePlaceholder": "例: 集中できた",
+      "save": "保存",
+      "timeLocked": "過去の予定の時間は変更できません",
+      "recordAsIs": "そのまま記録",
+      "confirmDay": "この日を確定",
+      "toast": {
+        "recorded": "記録しました ✓",
+        "dayConfirmed": "この日を記録しました ✓",
+        "overlap": "この時間帯には既に記録があります",
+        "saveFailed": "保存できませんでした。もう一度お試しください",
+        "recordFailed": "記録できませんでした。もう一度お試しください",
+        "confirmFailed": "この日を確定できませんでした。もう一度お試しください"
+      }
+    },
     "sidebar": {
       "tabs": {
         "calendar": "カレンダー",

--- a/apps/product/src/features/calendar/stores/__tests__/useInlineCreateStore.test.ts
+++ b/apps/product/src/features/calendar/stores/__tests__/useInlineCreateStore.test.ts
@@ -36,6 +36,12 @@ describe('useInlineCreateStore', () => {
       expect(useInlineCreateStore.getState().pendingSelection?.creationSource).toBe('planned-gap');
     });
 
+    it('レーン起点を保持できる', () => {
+      useInlineCreateStore.getState().setPendingSelection({ ...mockSelection, lane: 'log' });
+
+      expect(useInlineCreateStore.getState().pendingSelection?.lane).toBe('log');
+    });
+
     it('既存の選択を上書きできる', () => {
       useInlineCreateStore.getState().setPendingSelection(mockSelection);
       const newSelection = { ...mockSelection, startHour: 14, endHour: 15 };

--- a/apps/product/src/features/calendar/stores/useCalendarDragStore.test.ts
+++ b/apps/product/src/features/calendar/stores/useCalendarDragStore.test.ts
@@ -34,13 +34,15 @@ describe('useCalendarDragStore', () => {
 
   describe('startDrag', () => {
     it('カレンダー内ドラッグを開始できる', () => {
-      useCalendarDragStore.getState().startDrag('plan-1', mockCalendarEvent, 2);
+      useCalendarDragStore.getState().startDrag('plan-1', mockCalendarEvent, 2, 'plan');
       const state = useCalendarDragStore.getState();
       expect(state.isDragging).toBe(true);
       expect(state.draggedEntryId).toBe('plan-1');
       expect(state.draggedEntry).toEqual(mockCalendarEvent);
       expect(state.originalDateIndex).toBe(2);
       expect(state.targetDateIndex).toBe(2);
+      expect(state.sourceLane).toBe('plan');
+      expect(state.targetLane).toBe('plan');
     });
   });
 
@@ -56,6 +58,12 @@ describe('useCalendarDragStore', () => {
       useCalendarDragStore.getState().startDrag('plan-1', mockCalendarEvent, 0);
       useCalendarDragStore.getState().updateDrag({ targetDateIndex: 5 });
       expect(useCalendarDragStore.getState().targetDateIndex).toBe(5);
+    });
+
+    it('ドロップ先レーンを更新できる', () => {
+      useCalendarDragStore.getState().startDrag('plan-1', mockCalendarEvent, 0, 'plan');
+      useCalendarDragStore.getState().updateDrag({ targetLane: 'log' });
+      expect(useCalendarDragStore.getState().targetLane).toBe('log');
     });
 
     it('プレビュー時間を設定できる', () => {

--- a/apps/product/src/features/calendar/stores/useCalendarDragStore.ts
+++ b/apps/product/src/features/calendar/stores/useCalendarDragStore.ts
@@ -24,11 +24,19 @@ interface CalendarDragState {
   previewTime: { start: Date; end: Date } | null;
   /** スナップされた位置（top, height） */
   snappedPosition: { top: number; height?: number } | null;
+  /** Step 5 の 2 レーン接続用。Plan → Log は record mutation に委譲する。 */
+  sourceLane: 'plan' | 'log' | null;
+  targetLane: 'plan' | 'log' | null;
 }
 
 interface CalendarDragActions {
   /** カレンダー内ドラッグ開始 */
-  startDrag: (entryId: string, entry: CalendarEvent, dateIndex: number) => void;
+  startDrag: (
+    entryId: string,
+    entry: CalendarEvent,
+    dateIndex: number,
+    lane?: 'plan' | 'log',
+  ) => void;
   /** ドラッグ中の状態更新 */
   updateDrag: (
     updates: Partial<Omit<CalendarDragState, 'draggedEntryId' | 'draggedEntry'>>,
@@ -45,13 +53,15 @@ const initialState: CalendarDragState = {
   isDragging: false,
   previewTime: null,
   snappedPosition: null,
+  sourceLane: null,
+  targetLane: null,
 };
 
 /** カレンダーのドラッグ状態を管理するZustandストア */
 export const useCalendarDragStore = create<CalendarDragState & CalendarDragActions>((set) => ({
   ...initialState,
 
-  startDrag: (entryId, entry, dateIndex) =>
+  startDrag: (entryId, entry, dateIndex, lane = 'plan') =>
     set({
       draggedEntryId: entryId,
       draggedEntry: entry,
@@ -60,6 +70,8 @@ export const useCalendarDragStore = create<CalendarDragState & CalendarDragActio
       isDragging: true,
       previewTime: null,
       snappedPosition: null,
+      sourceLane: lane,
+      targetLane: lane,
     }),
 
   updateDrag: (updates) =>

--- a/apps/product/src/features/calendar/stores/useInlineCreateStore.ts
+++ b/apps/product/src/features/calendar/stores/useInlineCreateStore.ts
@@ -18,6 +18,8 @@ interface PendingSelection {
   endHour: number;
   endMinute: number;
   creationSource?: 'planned-gap' | undefined;
+  /** Step 5 のレーン起点。保存先は最終的に end_at のルールが優先する。 */
+  lane?: 'plan' | 'log' | undefined;
   /**
    * 「スキップして記録」で作成する場合、この記録を作る前にスキップする自動記録の id。
    * 作成が実際に確定する時にだけスキップする（パレットを閉じてキャンセルした時は何も変えない）。

--- a/apps/product/src/features/entry/components/time-model/TimeModelDestinationChip.stories.tsx
+++ b/apps/product/src/features/entry/components/time-model/TimeModelDestinationChip.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { TimeModelDestinationChip } from './TimeModelDestinationChip';
+
+const meta = {
+  title: 'Product/Features/Entry/TimeModelDestinationChip',
+  component: TimeModelDestinationChip,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof TimeModelDestinationChip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** 未来の終了時刻から導出された予定の保存先。 */
+export const Plan: Story = { args: { destination: 'plan' } };
+
+/** 過去の終了時刻から導出された記録の保存先。 */
+export const Log: Story = { args: { destination: 'log' } };
+
+/** 全パターン一覧。 */
+export const AllPatterns: Story = {
+  args: { destination: 'plan' },
+  render: () => (
+    <div className="flex items-center gap-3">
+      <TimeModelDestinationChip destination="plan" />
+      <TimeModelDestinationChip destination="log" />
+    </div>
+  ),
+};

--- a/apps/product/src/features/entry/components/time-model/TimeModelDestinationChip.tsx
+++ b/apps/product/src/features/entry/components/time-model/TimeModelDestinationChip.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import { cn } from '@dayopt/components';
+
+import type { TimeModelDestination } from '../../domain/time-model-destination';
+
+interface TimeModelDestinationChipProps {
+  destination: TimeModelDestination;
+}
+
+/** 終了時刻から導出した保存先を表示するチップ。選択操作は提供しない。 */
+export function TimeModelDestinationChip({ destination }: TimeModelDestinationChipProps) {
+  const t = useTranslations('entry.timeModel.destination');
+  const isPlan = destination === 'plan';
+
+  return (
+    <span
+      className={cn(
+        'inline-flex h-7 items-center rounded-full px-3 text-xs font-medium',
+        isPlan ? 'bg-muted text-muted-foreground' : 'bg-primary text-primary-foreground',
+      )}
+      aria-live="polite"
+    >
+      {isPlan ? t('plan') : t('log')}
+    </span>
+  );
+}

--- a/apps/product/src/features/entry/components/time-model/TimeModelEditor.stories.tsx
+++ b/apps/product/src/features/entry/components/time-model/TimeModelEditor.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { useState } from 'react';
+
+import { TimeModelEditor, type TimeModelEditorValue } from './TimeModelEditor';
+
+const meta = {
+  title: 'Product/Features/Entry/TimeModelEditor',
+  component: TimeModelEditor,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof TimeModelEditor>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const futureValue: TimeModelEditorValue = {
+  title: 'Deep work',
+  note: '',
+  tagId: null,
+  startAt: new Date('2026-07-11T09:00:00'),
+  endAt: new Date('2026-07-11T10:00:00'),
+  source: 'plan',
+};
+
+/** 終了時刻が未来の Plan 編集。 */
+export const Plan: Story = {
+  args: { value: futureValue, onChange: () => undefined, onSubmit: () => undefined },
+  render: function PlanStory() {
+    const [value, setValue] = useState(futureValue);
+    return <TimeModelEditor value={value} onChange={setValue} onSubmit={() => undefined} />;
+  },
+};
+
+/** 過去 Plan は時間だけ変更できない。 */
+export const PastPlan: Story = {
+  args: { value: futureValue, onChange: () => undefined, onSubmit: () => undefined },
+  render: function PastPlanStory() {
+    const [value, setValue] = useState<TimeModelEditorValue>({
+      ...futureValue,
+      endAt: new Date('2026-07-09T10:00:00'),
+    });
+    return <TimeModelEditor value={value} onChange={setValue} onSubmit={() => undefined} />;
+  },
+};
+
+/** 全パターン一覧。 */
+export const AllPatterns: Story = {
+  args: { value: futureValue, onChange: () => undefined, onSubmit: () => undefined },
+  render: function AllPatternsStory() {
+    const [value, setValue] = useState(futureValue);
+    return <TimeModelEditor value={value} onChange={setValue} onSubmit={() => undefined} />;
+  },
+};

--- a/apps/product/src/features/entry/components/time-model/TimeModelEditor.tsx
+++ b/apps/product/src/features/entry/components/time-model/TimeModelEditor.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { Calendar, Clock, StickyNote } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+import { DateRow, TimeRow } from '@/features/entry';
+import { Button, Input, Textarea } from '@dayopt/components';
+
+import {
+  isPlanTimeEditable,
+  resolveTimeModelDestination,
+  type TimeModelDestination,
+} from '../../domain/time-model-destination';
+import { TimeModelDestinationChip } from './TimeModelDestinationChip';
+
+export interface TimeModelEditorValue {
+  title: string;
+  note: string;
+  tagId: string | null;
+  startAt: Date;
+  endAt: Date;
+  /** 既存 Plan の編集時だけ指定する。 */
+  source?: TimeModelDestination | undefined;
+}
+
+interface TimeModelEditorProps {
+  value: TimeModelEditorValue;
+  onChange: (next: TimeModelEditorValue) => void;
+  onSubmit: (destination: TimeModelDestination) => void;
+  isSubmitting?: boolean | undefined;
+}
+
+function formatTime(date: Date): string {
+  return `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
+}
+
+function withTime(date: Date, value: string): Date {
+  const [hour, minute] = value.split(':').map(Number);
+  const next = new Date(date);
+  next.setHours(hour ?? 0, minute ?? 0, 0, 0);
+  return next;
+}
+
+/** Plan / Log 共通エディタ。保存先は end_at から表示専用で導出する。 */
+export function TimeModelEditor({ value, onChange, onSubmit, isSubmitting }: TimeModelEditorProps) {
+  const t = useTranslations('entry.timeModel');
+  const destination = resolveTimeModelDestination(value.endAt);
+  const timeLocked = value.source === 'plan' && !isPlanTimeEditable(value.endAt);
+
+  return (
+    <form
+      className="space-y-3"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSubmit(destination);
+      }}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <TimeModelDestinationChip destination={destination} />
+        {timeLocked && <span className="text-muted-foreground text-xs">{t('timeLocked')}</span>}
+      </div>
+      <Input
+        value={value.title}
+        onChange={(event) => onChange({ ...value, title: event.target.value })}
+        placeholder={t('titlePlaceholder')}
+        aria-label={t('title')}
+        disabled={isSubmitting}
+      />
+      <div className="bg-muted rounded-2xl px-4 py-2">
+        <DateRow
+          label={t('date')}
+          icon={Calendar}
+          selectedDate={value.startAt}
+          onDateChange={(date) => {
+            if (!date || timeLocked) return;
+            const startAt = new Date(date);
+            startAt.setHours(value.startAt.getHours(), value.startAt.getMinutes(), 0, 0);
+            const endAt = new Date(date);
+            endAt.setHours(value.endAt.getHours(), value.endAt.getMinutes(), 0, 0);
+            onChange({ ...value, startAt, endAt });
+          }}
+        />
+        <TimeRow
+          label={t('time')}
+          icon={Clock}
+          startTime={formatTime(value.startAt)}
+          endTime={formatTime(value.endAt)}
+          onStartChange={(next) => onChange({ ...value, startAt: withTime(value.startAt, next) })}
+          onEndChange={(next) => onChange({ ...value, endAt: withTime(value.endAt, next) })}
+          disabled={timeLocked || isSubmitting === true}
+          isPrimary={destination === 'log'}
+        />
+      </div>
+      <div className="space-y-1">
+        <label
+          className="text-muted-foreground flex items-center gap-2 text-sm"
+          htmlFor="time-model-note"
+        >
+          <StickyNote className="size-4" />
+          {t('note')}
+        </label>
+        <Textarea
+          id="time-model-note"
+          value={value.note}
+          onChange={(event) => onChange({ ...value, note: event.target.value })}
+          placeholder={t('notePlaceholder')}
+          disabled={isSubmitting}
+        />
+      </div>
+      <div className="flex justify-end">
+        <Button type="submit" size="sm" disabled={isSubmitting || value.title.trim().length === 0}>
+          {t('save')}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/product/src/features/entry/components/time-model/TimeModelRecordActions.test.ts
+++ b/apps/product/src/features/entry/components/time-model/TimeModelRecordActions.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+
+import { ConfirmDayButton, RecordPlanButton } from './TimeModelRecordActions';
+
+describe('TimeModelRecordActions', () => {
+  it('日次確定とワンタップ記録の UI を提供する', () => {
+    expect(RecordPlanButton).toBeTypeOf('function');
+    expect(ConfirmDayButton).toBeTypeOf('function');
+  });
+});

--- a/apps/product/src/features/entry/components/time-model/TimeModelRecordActions.tsx
+++ b/apps/product/src/features/entry/components/time-model/TimeModelRecordActions.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { Button } from '@dayopt/components';
+import { useTranslations } from 'next-intl';
+
+import { useTimeModelRecordMutations } from '../../hooks/useTimeModelRecordMutations';
+
+interface RecordPlanButtonProps {
+  planId: string;
+  disabled?: boolean | undefined;
+}
+
+/** 過去 Plan を同じ時間帯の Log として記録するワンタップ導線。 */
+export function RecordPlanButton({ planId, disabled = false }: RecordPlanButtonProps) {
+  const t = useTranslations('entry.timeModel');
+  const { recordPlan } = useTimeModelRecordMutations();
+
+  return (
+    <Button
+      type="button"
+      size="sm"
+      onClick={() => recordPlan.mutate({ id: planId })}
+      disabled={disabled || recordPlan.isPending}
+    >
+      {t('recordAsIs')}
+    </Button>
+  );
+}
+
+interface ConfirmDayButtonProps {
+  startAt: Date;
+  endAt: Date;
+  disabled?: boolean | undefined;
+}
+
+/** 日ヘッダーに置く、一日の未記録 Plan をまとめて記録する導線。 */
+export function ConfirmDayButton({ startAt, endAt, disabled = false }: ConfirmDayButtonProps) {
+  const t = useTranslations('entry.timeModel');
+  const { confirmDay } = useTimeModelRecordMutations();
+
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="outline"
+      onClick={() =>
+        confirmDay.mutate({ start_at: startAt.toISOString(), end_at: endAt.toISOString() })
+      }
+      disabled={disabled || confirmDay.isPending}
+    >
+      {t('confirmDay')}
+    </Button>
+  );
+}

--- a/apps/product/src/features/entry/domain/__tests__/time-model-destination.test.ts
+++ b/apps/product/src/features/entry/domain/__tests__/time-model-destination.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isPlanRecordDrop,
+  isPlanTimeEditable,
+  resolveTimeModelDestination,
+} from '../time-model-destination';
+
+const now = new Date('2026-07-10T12:00:00.000Z');
+
+describe('resolveTimeModelDestination', () => {
+  it('終了が現在より未来なら Plan を返す', () => {
+    expect(resolveTimeModelDestination('2026-07-10T12:00:00.001Z', now)).toBe('plan');
+  });
+
+  it('終了が現在以前なら Log を返す', () => {
+    expect(resolveTimeModelDestination('2026-07-10T12:00:00.000Z', now)).toBe('log');
+  });
+});
+
+describe('isPlanTimeEditable', () => {
+  it('終了が未来の Plan だけ時間編集を許可する', () => {
+    expect(isPlanTimeEditable('2026-07-10T12:01:00.000Z', now)).toBe(true);
+    expect(isPlanTimeEditable('2026-07-10T12:00:00.000Z', now)).toBe(false);
+  });
+});
+
+describe('isPlanRecordDrop', () => {
+  it('Plan から Log レーンへのドロップだけを記録化とみなす', () => {
+    expect(isPlanRecordDrop('plan', 'log')).toBe(true);
+    expect(isPlanRecordDrop('log', 'plan')).toBe(false);
+    expect(isPlanRecordDrop('plan', 'plan')).toBe(false);
+  });
+});

--- a/apps/product/src/features/entry/domain/time-model-destination.ts
+++ b/apps/product/src/features/entry/domain/time-model-destination.ts
@@ -1,0 +1,22 @@
+export type TimeModelDestination = 'plan' | 'log';
+
+/** 保存先はユーザー選択ではなく終了時刻だけから決める。 */
+export function resolveTimeModelDestination(
+  endAt: Date | string,
+  now: Date = new Date(),
+): TimeModelDestination {
+  return new Date(endAt).getTime() > now.getTime() ? 'plan' : 'log';
+}
+
+/** 過去 Plan は title / tag / note だけ編集でき、時間は凍結する。 */
+export function isPlanTimeEditable(endAt: Date | string, now: Date = new Date()): boolean {
+  return new Date(endAt).getTime() > now.getTime();
+}
+
+/** Plan を Log レーンへ落とす操作は記録化として扱う。 */
+export function isPlanRecordDrop(
+  sourceLane: TimeModelDestination,
+  targetLane: TimeModelDestination,
+): boolean {
+  return sourceLane === 'plan' && targetLane === 'log';
+}

--- a/apps/product/src/features/entry/hooks/useTimeModelRecordMutations.ts
+++ b/apps/product/src/features/entry/hooks/useTimeModelRecordMutations.ts
@@ -1,0 +1,72 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+import { useTranslations } from 'next-intl';
+
+import { toast } from '@/lib/toast';
+import { api } from '@/lib/trpc';
+
+function isTimeModelListQuery(query: { queryKey: unknown }): boolean {
+  const key = query.queryKey;
+  return (
+    Array.isArray(key) &&
+    Array.isArray(key[0]) &&
+    (key[0][0] === 'plans' || key[0][0] === 'logs') &&
+    key[0][1] === 'list'
+  );
+}
+
+function isTimeOverlapError(error: { message: string }): boolean {
+  return error.message.includes('TIME_OVERLAP');
+}
+
+/** Plan → Log の記録導線に共通の rollback / 再検証を提供する。 */
+export function useTimeModelRecordMutations() {
+  const utils = api.useUtils();
+  const queryClient = useQueryClient();
+  const t = useTranslations('entry.timeModel');
+
+  const recordPlan = api.plans.record.useMutation({
+    onMutate: async () => {
+      await Promise.all([utils.plans.list.cancel(), utils.logs.list.cancel()]);
+      return { snapshots: queryClient.getQueriesData({ predicate: isTimeModelListQuery }) };
+    },
+    onSuccess: (log) => {
+      utils.logs.list.setData(undefined, (old) => (old ? [...old, log] : [log]));
+      toast.success(t('toast.recorded'));
+    },
+    onError: (error, _input, context) => {
+      for (const [queryKey, data] of context?.snapshots ?? []) {
+        queryClient.setQueryData(queryKey, data);
+      }
+      toast.error(isTimeOverlapError(error) ? t('toast.overlap') : t('toast.recordFailed'));
+    },
+    onSettled: () => {
+      void utils.plans.list.invalidate();
+      void utils.logs.list.invalidate();
+    },
+  });
+
+  const confirmDay = api.plans.confirmDay.useMutation({
+    onMutate: async () => {
+      await Promise.all([utils.plans.list.cancel(), utils.logs.list.cancel()]);
+      return { snapshots: queryClient.getQueriesData({ predicate: isTimeModelListQuery }) };
+    },
+    onSuccess: (logs) => {
+      utils.logs.list.setData(undefined, (old) => (old ? [...old, ...logs] : logs));
+      toast.success(t('toast.dayConfirmed'));
+    },
+    onError: (error, _input, context) => {
+      for (const [queryKey, data] of context?.snapshots ?? []) {
+        queryClient.setQueryData(queryKey, data);
+      }
+      toast.error(isTimeOverlapError(error) ? t('toast.overlap') : t('toast.confirmFailed'));
+    },
+    onSettled: () => {
+      void utils.plans.list.invalidate();
+      void utils.logs.list.invalidate();
+    },
+  });
+
+  return { confirmDay, recordPlan };
+}

--- a/apps/product/src/features/entry/hooks/useTimeModelWriteMutations.test.ts
+++ b/apps/product/src/features/entry/hooks/useTimeModelWriteMutations.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+
+import { useTimeModelWriteMutations } from './useTimeModelWriteMutations';
+
+describe('useTimeModelWriteMutations', () => {
+  it('Plan と Log の作成・編集 mutation をまとめる hook を提供する', () => {
+    expect(useTimeModelWriteMutations).toBeTypeOf('function');
+  });
+});

--- a/apps/product/src/features/entry/hooks/useTimeModelWriteMutations.ts
+++ b/apps/product/src/features/entry/hooks/useTimeModelWriteMutations.ts
@@ -1,0 +1,92 @@
+'use client';
+
+import { type QueryKey, useQueryClient } from '@tanstack/react-query';
+import { useTranslations } from 'next-intl';
+
+import { toast } from '@/lib/toast';
+import { api } from '@/lib/trpc';
+
+function isTimeModelListQuery(query: { queryKey: unknown }): boolean {
+  const key = query.queryKey;
+  return (
+    Array.isArray(key) &&
+    Array.isArray(key[0]) &&
+    (key[0][0] === 'plans' || key[0][0] === 'logs') &&
+    key[0][1] === 'list'
+  );
+}
+
+function isTimeOverlapError(error: { message: string }): boolean {
+  return error.message.includes('TIME_OVERLAP');
+}
+
+/** Plan / Log 作成・編集のキャッシュ rollback と再検証を共通化する。 */
+export function useTimeModelWriteMutations() {
+  const utils = api.useUtils();
+  const queryClient = useQueryClient();
+  const t = useTranslations('entry.timeModel');
+
+  const snapshot = async () => {
+    await Promise.all([utils.plans.list.cancel(), utils.logs.list.cancel()]);
+    return {
+      snapshots: queryClient.getQueriesData({ predicate: isTimeModelListQuery }) as Array<
+        [QueryKey, unknown]
+      >,
+    };
+  };
+
+  const restore = (
+    context: { snapshots: ReadonlyArray<readonly [QueryKey, unknown]> } | undefined,
+  ) => {
+    for (const [queryKey, data] of context?.snapshots ?? []) {
+      queryClient.setQueryData(queryKey, data);
+    }
+  };
+
+  const reportError = (error: { message: string }) => {
+    toast.error(isTimeOverlapError(error) ? t('toast.overlap') : t('toast.saveFailed'));
+  };
+
+  const invalidate = () => {
+    void utils.plans.list.invalidate();
+    void utils.logs.list.invalidate();
+  };
+
+  const createPlan = api.plans.create.useMutation({
+    onMutate: snapshot,
+    onError: (error, _input, context) => {
+      restore(context);
+      reportError(error);
+    },
+    onSettled: invalidate,
+  });
+
+  const updatePlan = api.plans.update.useMutation({
+    onMutate: snapshot,
+    onError: (error, _input, context) => {
+      restore(context);
+      reportError(error);
+    },
+    onSettled: invalidate,
+  });
+
+  const createLog = api.logs.create.useMutation({
+    onMutate: snapshot,
+    onError: (error, _input, context) => {
+      restore(context);
+      reportError(error);
+    },
+    onSettled: invalidate,
+  });
+
+  const updateLog = api.logs.update.useMutation({
+    onMutate: snapshot,
+    onError: (error, _input, context) => {
+      restore(context);
+      reportError(error);
+    },
+    onSettled: invalidate,
+  });
+
+  return { createLog, createPlan, updateLog, updatePlan };
+}


### PR DESCRIPTION
## 変更内容

- 終了時刻から Plan / Log の保存先を導出する共有エディタと表示専用チップを追加
- 過去 Plan の時間編集ロック、Plan → Log のワンタップ記録、日次確定の導線を追加
- 作成・更新・記録 mutation にキャッシュのスナップショット、失敗時ロールバック、再検証を追加
- Step 5 接続用にインライン作成・ドラッグストアへレーン情報を追加

## Step 5 との関係

`claude/calendar-two-lane-step-5` と変更ファイルの重複がないことを確認済みです。Step 8 で接続する dormant 実装として追加しています。

## 検証

- `pnpm check`
- `pnpm --filter @dayopt/product exec vitest run --project unit ...` (5 files, 20 tests)
