### PR TITLE
feat: reviewのplanとlog差分を追加

### DIFF
--- a/apps/product/messages/en/calendar.json
+++ b/apps/product/messages/en/calendar.json
@@ -33,13 +33,17 @@
           "actual": "Actual",
           "diff": "Diff",
           "unplanned": "Unplanned",
-          "missed": "Missed"
+          "missed": "Missed",
+          "unrecorded": "Unrecorded"
         },
         "kind": {
           "unplanned": "Added",
           "missed": "Missed",
           "shifted": "Moved",
-          "resized": "Resized"
+          "resized": "Resized",
+          "recorded": "Recorded",
+          "skipped": "Skipped",
+          "unrecorded": "Unrecorded"
         },
         "badge": {
           "late": "{duration} late",

--- a/apps/product/messages/ja/calendar.json
+++ b/apps/product/messages/ja/calendar.json
@@ -33,13 +33,17 @@
           "actual": "実績",
           "diff": "差分",
           "unplanned": "予定外",
-          "missed": "未実施"
+          "missed": "未実施",
+          "unrecorded": "未記録"
         },
         "kind": {
           "unplanned": "追加",
           "missed": "未実施",
           "shifted": "移動",
-          "resized": "長さ変更"
+          "resized": "長さ変更",
+          "recorded": "記録",
+          "skipped": "やらなかった",
+          "unrecorded": "未記録"
         },
         "badge": {
           "late": "{duration}遅れ",

--- a/apps/product/src/features/calendar/lib/__tests__/time-model-day-diff.test.ts
+++ b/apps/product/src/features/calendar/lib/__tests__/time-model-day-diff.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeTimeModelDayDiffs } from '../time-model-day-diff';
+
+const at = (hour: number) => new Date(`2026-07-10T${String(hour).padStart(2, '0')}:00:00.000Z`);
+const plan = {
+  id: 'plan-1',
+  title: 'Plan',
+  tagId: 'tag-1',
+  color: 'blue',
+  startAt: at(9),
+  endAt: at(10),
+  skippedAt: null,
+};
+
+describe('computeTimeModelDayDiffs', () => {
+  it('記録のない Plan を未記録として集計する', () => {
+    const result = computeTimeModelDayDiffs([plan], []);
+    expect(result.summary).toMatchObject({
+      plannedMinutes: 60,
+      actualMinutes: 0,
+      unrecordedMinutes: 60,
+    });
+    expect(result.items[0]?.kind).toBe('unrecorded');
+  });
+
+  it('複数 Log を一つの Plan に合算する', () => {
+    const result = computeTimeModelDayDiffs(
+      [plan],
+      [
+        {
+          id: 'log-1',
+          planId: 'plan-1',
+          title: 'Log',
+          tagId: 'tag-1',
+          color: 'blue',
+          startAt: at(9),
+          endAt: at(10),
+        },
+        {
+          id: 'log-2',
+          planId: 'plan-1',
+          title: 'Log',
+          tagId: 'tag-1',
+          color: 'blue',
+          startAt: at(10),
+          endAt: at(11),
+        },
+      ],
+    );
+    expect(result.items[0]).toMatchObject({
+      kind: 'recorded',
+      actualMinutes: 120,
+      diffMinutes: 60,
+    });
+  });
+
+  it('Plan のない、または削除済み Plan の Log を予定外として扱う', () => {
+    const log = {
+      id: 'log-1',
+      planId: 'deleted',
+      title: 'Log',
+      tagId: null,
+      color: 'gray',
+      startAt: at(9),
+      endAt: at(10),
+    };
+    const result = computeTimeModelDayDiffs([{ ...plan, id: 'deleted', deletedAt: at(11) }], [log]);
+    expect(result.summary.unplannedMinutes).toBe(60);
+    expect(result.items[0]?.kind).toBe('unplanned');
+  });
+
+  it('skip は予定を残し、未記録には含めない', () => {
+    const result = computeTimeModelDayDiffs([{ ...plan, skippedAt: at(11) }], []);
+    expect(result.summary).toMatchObject({ plannedMinutes: 60, unrecordedMinutes: 0 });
+    expect(result.items[0]?.kind).toBe('skipped');
+  });
+});

--- a/apps/product/src/features/calendar/lib/time-model-day-diff.ts
+++ b/apps/product/src/features/calendar/lib/time-model-day-diff.ts
@@ -1,0 +1,169 @@
+export type TimeModelDayDiffKind = 'recorded' | 'skipped' | 'unplanned' | 'unrecorded';
+
+export interface TimeModelPlanDiffInput {
+  id: string;
+  title: string;
+  tagId: string | null;
+  color: string;
+  startAt: Date;
+  endAt: Date;
+  skippedAt: Date | null;
+  deletedAt?: Date | null | undefined;
+}
+
+export interface TimeModelLogDiffInput {
+  id: string;
+  planId: string | null;
+  title: string;
+  tagId: string | null;
+  color: string;
+  startAt: Date;
+  endAt: Date;
+}
+
+export interface TimeModelDayDiffItem {
+  id: string;
+  kind: TimeModelDayDiffKind;
+  title: string;
+  tagId: string | null;
+  color: string;
+  planId: string | null;
+  plannedMinutes: number;
+  actualMinutes: number;
+  diffMinutes: number;
+  sortTime: number;
+}
+
+export interface TimeModelDayDiffResult {
+  summary: {
+    plannedMinutes: number;
+    actualMinutes: number;
+    diffMinutes: number;
+    unplannedMinutes: number;
+    unrecordedMinutes: number;
+  };
+  items: TimeModelDayDiffItem[];
+}
+
+export interface TimeModelDayDiffBounds {
+  dayStart?: Date | null | undefined;
+  dayEnd?: Date | null | undefined;
+}
+
+function clippedMinutes(start: Date, end: Date, bounds: TimeModelDayDiffBounds): number {
+  const clippedStart = bounds.dayStart && start < bounds.dayStart ? bounds.dayStart : start;
+  const clippedEnd = bounds.dayEnd && end > bounds.dayEnd ? bounds.dayEnd : end;
+  return Math.max(0, Math.round((clippedEnd.getTime() - clippedStart.getTime()) / 60_000));
+}
+
+/**
+ * Step 7 の Plan / Log 1:N 差分。既存 entries ベースの day-diff とは並存し、Step 8 で接続する。
+ * Log は Log 自身の日に、Plan は Plan 自身の日に集計される。
+ */
+export function computeTimeModelDayDiffs(
+  plans: readonly TimeModelPlanDiffInput[],
+  logs: readonly TimeModelLogDiffInput[],
+  bounds: TimeModelDayDiffBounds = {},
+): TimeModelDayDiffResult {
+  const activePlans = plans.filter((plan) => plan.deletedAt == null);
+  const plansById = new Map(activePlans.map((plan) => [plan.id, plan]));
+  const logsByPlanId = new Map<string, TimeModelLogDiffInput[]>();
+  const items: TimeModelDayDiffItem[] = [];
+  let plannedMinutes = 0;
+  let actualMinutes = 0;
+  let unplannedMinutes = 0;
+  let unrecordedMinutes = 0;
+
+  for (const log of logs) {
+    const duration = clippedMinutes(log.startAt, log.endAt, bounds);
+    if (duration === 0) continue;
+    actualMinutes += duration;
+    if (log.planId && plansById.has(log.planId)) {
+      const linked = logsByPlanId.get(log.planId) ?? [];
+      linked.push(log);
+      logsByPlanId.set(log.planId, linked);
+      continue;
+    }
+    unplannedMinutes += duration;
+    items.push({
+      id: `unplanned:${log.id}`,
+      kind: 'unplanned',
+      title: log.title,
+      tagId: log.tagId,
+      color: log.color,
+      planId: null,
+      plannedMinutes: 0,
+      actualMinutes: duration,
+      diffMinutes: duration,
+      sortTime: log.startAt.getTime(),
+    });
+  }
+
+  for (const plan of activePlans) {
+    const duration = clippedMinutes(plan.startAt, plan.endAt, bounds);
+    if (duration === 0) continue;
+    plannedMinutes += duration;
+    if (plan.skippedAt) {
+      items.push({
+        id: `skipped:${plan.id}`,
+        kind: 'skipped',
+        title: plan.title,
+        tagId: plan.tagId,
+        color: plan.color,
+        planId: plan.id,
+        plannedMinutes: duration,
+        actualMinutes: 0,
+        diffMinutes: -duration,
+        sortTime: plan.startAt.getTime(),
+      });
+      continue;
+    }
+
+    const linkedLogs = logsByPlanId.get(plan.id) ?? [];
+    if (linkedLogs.length === 0) {
+      unrecordedMinutes += duration;
+      items.push({
+        id: `unrecorded:${plan.id}`,
+        kind: 'unrecorded',
+        title: plan.title,
+        tagId: plan.tagId,
+        color: plan.color,
+        planId: plan.id,
+        plannedMinutes: duration,
+        actualMinutes: 0,
+        diffMinutes: -duration,
+        sortTime: plan.startAt.getTime(),
+      });
+      continue;
+    }
+
+    const linkedMinutes = linkedLogs.reduce(
+      (total, log) => total + clippedMinutes(log.startAt, log.endAt, bounds),
+      0,
+    );
+    items.push({
+      id: `recorded:${plan.id}`,
+      kind: 'recorded',
+      title: plan.title,
+      tagId: plan.tagId,
+      color: plan.color,
+      planId: plan.id,
+      plannedMinutes: duration,
+      actualMinutes: linkedMinutes,
+      diffMinutes: linkedMinutes - duration,
+      sortTime: plan.startAt.getTime(),
+    });
+  }
+
+  items.sort((a, b) => a.sortTime - b.sortTime || a.title.localeCompare(b.title));
+  return {
+    summary: {
+      plannedMinutes,
+      actualMinutes,
+      diffMinutes: actualMinutes - plannedMinutes,
+      unplannedMinutes,
+      unrecordedMinutes,
+    },
+    items,
+  };
+}

--- a/apps/product/src/features/calendar/lib/time-model-day-diff.ts
+++ b/apps/product/src/features/calendar/lib/time-model-day-diff.ts
@@ -1,6 +1,6 @@
-export type TimeModelDayDiffKind = 'recorded' | 'skipped' | 'unplanned' | 'unrecorded';
+type TimeModelDayDiffKind = 'recorded' | 'skipped' | 'unplanned' | 'unrecorded';
 
-export interface TimeModelPlanDiffInput {
+interface TimeModelPlanDiffInput {
   id: string;
   title: string;
   tagId: string | null;
@@ -11,7 +11,7 @@ export interface TimeModelPlanDiffInput {
   deletedAt?: Date | null | undefined;
 }
 
-export interface TimeModelLogDiffInput {
+interface TimeModelLogDiffInput {
   id: string;
   planId: string | null;
   title: string;
@@ -21,7 +21,7 @@ export interface TimeModelLogDiffInput {
   endAt: Date;
 }
 
-export interface TimeModelDayDiffItem {
+interface TimeModelDayDiffItem {
   id: string;
   kind: TimeModelDayDiffKind;
   title: string;
@@ -34,7 +34,7 @@ export interface TimeModelDayDiffItem {
   sortTime: number;
 }
 
-export interface TimeModelDayDiffResult {
+interface TimeModelDayDiffResult {
   summary: {
     plannedMinutes: number;
     actualMinutes: number;
@@ -45,7 +45,7 @@ export interface TimeModelDayDiffResult {
   items: TimeModelDayDiffItem[];
 }
 
-export interface TimeModelDayDiffBounds {
+interface TimeModelDayDiffBounds {
   dayStart?: Date | null | undefined;
   dayEnd?: Date | null | undefined;
 }

--- a/apps/product/src/features/review/components/diff/ReviewDiffPanel.tsx
+++ b/apps/product/src/features/review/components/diff/ReviewDiffPanel.tsx
@@ -8,7 +8,8 @@ import { useTagsMap } from '@/features/tags';
 import { useUserPreferences } from '@/lib/hooks/useUserPreferences';
 import { Button, cn } from '@dayopt/components';
 
-export type ReviewDiffKind = 'unplanned' | 'missed' | 'shifted' | 'resized';
+export type ReviewDiffKind =
+  'unplanned' | 'missed' | 'recorded' | 'resized' | 'shifted' | 'skipped' | 'unrecorded';
 
 export interface ReviewDiffItem {
   id: string;
@@ -35,6 +36,7 @@ export interface ReviewDiffSummary {
   diffMinutes: number;
   unplannedMinutes: number;
   missedMinutes: number;
+  unrecordedMinutes?: number | undefined;
 }
 
 export interface ReviewDiffResult {
@@ -55,6 +57,9 @@ const KIND_ICON = {
   missed: Minus,
   shifted: GitCompareArrows,
   resized: GitCompareArrows,
+  recorded: GitCompareArrows,
+  skipped: Minus,
+  unrecorded: Minus,
 } satisfies Record<ReviewDiffKind, typeof Plus>;
 
 export function ReviewDiffPanel({
@@ -127,6 +132,12 @@ export function ReviewDiffPanel({
             label={t('calendar.compare.rail.summary.missed')}
             value={formatDuration(t, diff.summary.missedMinutes)}
           />
+          {diff.summary.unrecordedMinutes != null ? (
+            <SummaryMetric
+              label={t('calendar.compare.rail.summary.unrecorded')}
+              value={formatDuration(t, diff.summary.unrecordedMinutes)}
+            />
+          ) : null}
         </dl>
       </header>
 
@@ -240,7 +251,9 @@ function DiffBadge({ item }: { item: ReviewDiffItem }) {
 
 function diffBadgeLabel(t: ReturnType<typeof useTranslations>, item: ReviewDiffItem): string {
   if (item.kind === 'unplanned') return formatSignedDuration(t, item.actualMinutes);
-  if (item.kind === 'missed') return formatSignedDuration(t, -item.plannedMinutes);
+  if (item.kind === 'missed' || item.kind === 'skipped' || item.kind === 'unrecorded') {
+    return formatSignedDuration(t, -item.plannedMinutes);
+  }
 
   if (item.kind === 'shifted' && item.startDiffMinutes !== 0) {
     const duration = formatDuration(t, Math.abs(item.startDiffMinutes));
@@ -262,6 +275,12 @@ function kindLabel(t: ReturnType<typeof useTranslations>, kind: ReviewDiffKind):
       return t('calendar.compare.rail.kind.shifted');
     case 'resized':
       return t('calendar.compare.rail.kind.resized');
+    case 'recorded':
+      return t('calendar.compare.rail.kind.recorded');
+    case 'skipped':
+      return t('calendar.compare.rail.kind.skipped');
+    case 'unrecorded':
+      return t('calendar.compare.rail.kind.unrecorded');
   }
 }
 

--- a/apps/product/src/features/review/domain/__tests__/time-model-review-diff.test.ts
+++ b/apps/product/src/features/review/domain/__tests__/time-model-review-diff.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { toTimeModelReviewDiff } from '../time-model-review-diff';
+
+describe('toTimeModelReviewDiff', () => {
+  it('未記録を含む1:N差分の表示契約を保持する', () => {
+    const result = toTimeModelReviewDiff({
+      summary: {
+        plannedMinutes: 60,
+        actualMinutes: 0,
+        diffMinutes: -60,
+        unplannedMinutes: 0,
+        unrecordedMinutes: 60,
+      },
+      items: [
+        {
+          id: 'unrecorded:plan-1',
+          kind: 'unrecorded',
+          title: 'Plan',
+          tagId: null,
+          color: 'gray',
+          planId: 'plan-1',
+          plannedMinutes: 60,
+          actualMinutes: 0,
+          diffMinutes: -60,
+          sortTime: 0,
+        },
+      ],
+    });
+    expect(result.items[0]?.kind).toBe('unrecorded');
+    expect(result.summary.unrecordedMinutes).toBe(60);
+  });
+});

--- a/apps/product/src/features/review/domain/time-model-review-diff.ts
+++ b/apps/product/src/features/review/domain/time-model-review-diff.ts
@@ -1,6 +1,6 @@
-export type TimeModelReviewDiffKind = 'recorded' | 'skipped' | 'unplanned' | 'unrecorded';
+type TimeModelReviewDiffKind = 'recorded' | 'skipped' | 'unplanned' | 'unrecorded';
 
-export interface TimeModelReviewDiffResult {
+interface TimeModelReviewDiffResult {
   summary: {
     plannedMinutes: number;
     actualMinutes: number;

--- a/apps/product/src/features/review/domain/time-model-review-diff.ts
+++ b/apps/product/src/features/review/domain/time-model-review-diff.ts
@@ -1,0 +1,30 @@
+export type TimeModelReviewDiffKind = 'recorded' | 'skipped' | 'unplanned' | 'unrecorded';
+
+export interface TimeModelReviewDiffResult {
+  summary: {
+    plannedMinutes: number;
+    actualMinutes: number;
+    diffMinutes: number;
+    unplannedMinutes: number;
+    unrecordedMinutes: number;
+  };
+  items: Array<{
+    id: string;
+    kind: TimeModelReviewDiffKind;
+    title: string;
+    tagId: string | null;
+    color: string;
+    planId: string | null;
+    plannedMinutes: number;
+    actualMinutes: number;
+    diffMinutes: number;
+    sortTime: number;
+  }>;
+}
+
+/** Calendar の新差分を Review が消費する表示契約へ固定する。 */
+export function toTimeModelReviewDiff(
+  result: TimeModelReviewDiffResult,
+): TimeModelReviewDiffResult {
+  return { summary: result.summary, items: result.items };
+}


### PR DESCRIPTION
## 変更内容

- Plan / Log 1:N の日次差分と未記録・skip・予定外分類を追加
- Review 用の新差分契約と未記録表示を追加
- Step 8 まで既存 runtime には接続しない dormant 実装

## 検証

- `pnpm typecheck`
- `pnpm lint:i18n`
- 新規差分ユニットテスト