### PR TITLE
feat: Step 5 Calendar 2レーン表示(read側)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "storybook",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "@dayopt/storybook", "storybook"],
+      "port": 6006
+    }
+  ]
+}

--- a/apps/product/src/features/calendar/components/views/shared/components/TwoLane/DiffBadge.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/TwoLane/DiffBadge.tsx
@@ -13,7 +13,7 @@ import { ArrowDown, ArrowUp } from 'lucide-react';
 import { formatDiffMinutes } from '@/features/entry';
 import { cn } from '@dayopt/components';
 
-export interface DiffBadgeProps {
+interface DiffBadgeProps {
   /** 実績 - 予定（分）。0 の場合は何も描画しない。 */
   diffMinutes: number;
   className?: string | undefined;

--- a/apps/product/src/features/calendar/components/views/shared/components/TwoLane/DiffBadge.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/TwoLane/DiffBadge.tsx
@@ -1,0 +1,42 @@
+/**
+ * Log レーンの差分バッジ（実績 - 予定、分）。
+ *
+ * copywriting「判定せず数字で示す」に従い、±0 は非表示（何も描画しない）。
+ * 視覚言語は `features/review/components/diff/ReviewDiffPanel.tsx` の
+ * DiffBadge（bg-container + 方向アイコン + success/destructive）を踏襲するが、
+ * feature DAG（calendar は review を import できない）のため独立実装する。
+ */
+'use client';
+
+import { ArrowDown, ArrowUp } from 'lucide-react';
+
+import { formatDiffMinutes } from '@/features/entry';
+import { cn } from '@dayopt/components';
+
+export interface DiffBadgeProps {
+  /** 実績 - 予定（分）。0 の場合は何も描画しない。 */
+  diffMinutes: number;
+  className?: string | undefined;
+}
+
+export function DiffBadge({ diffMinutes, className }: DiffBadgeProps) {
+  if (diffMinutes === 0) return null;
+
+  const isOver = diffMinutes > 0;
+  const Icon = isOver ? ArrowUp : ArrowDown;
+  const label = `${isOver ? '+' : '-'}${formatDiffMinutes(diffMinutes)}`;
+
+  return (
+    <span
+      data-log-diff-badge
+      className={cn(
+        'bg-container border-border-subtle inline-flex shrink-0 items-center gap-1 rounded-lg border px-2 py-1 font-mono text-xs tabular-nums',
+        isOver ? 'text-success' : 'text-destructive',
+        className,
+      )}
+    >
+      <Icon aria-hidden="true" className="size-3.5" />
+      {label}
+    </span>
+  );
+}

--- a/apps/product/src/features/calendar/components/views/shared/components/TwoLane/LogLaneCard.stories.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/TwoLane/LogLaneCard.stories.tsx
@@ -1,0 +1,168 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import type { LogEvent } from '@/features/entry';
+
+import type { TwoLanePosition } from '../../../../../lib/two-lane-layout';
+
+import { LogLaneCard } from './LogLaneCard';
+
+/**
+ * Log レーン用カード。塗り(主役)+差分バッジ(±0非表示)+予定外マーカーの全 variant。
+ */
+const meta = {
+  title: 'Product/Features/Calendar/TwoLane/LogLaneCard',
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function Slot({ children, height = 90 }: { children: React.ReactNode; height?: number }) {
+  return (
+    <div
+      className="border-border relative w-40 overflow-hidden rounded-lg border"
+      style={{ height }}
+    >
+      {children}
+    </div>
+  );
+}
+
+const basePosition: TwoLanePosition = { top: 8, height: 70, left: 4, width: 92 };
+
+function makeEvent(overrides: Partial<LogEvent> = {}): LogEvent {
+  const start = new Date(2026, 6, 15, 10, 0);
+  const end = new Date(2026, 6, 15, 11, 0);
+  return {
+    id: 'log-1',
+    title: 'Deep Work',
+    note: null,
+    tagId: 'tag-1',
+    planId: 'plan-1',
+    startDate: start,
+    endDate: end,
+    displayStartDate: start,
+    displayEndDate: end,
+    duration: 60,
+    fulfillmentScore: null,
+    ...overrides,
+  };
+}
+
+/** plan_id あり・差分なし(±0)。バッジは表示しない。 */
+export const RecordedNoDiff: Story = {
+  render: () => (
+    <Slot>
+      <LogLaneCard event={makeEvent({ diffMinutes: 0 })} position={basePosition} tagColor="blue" />
+    </Slot>
+  ),
+};
+
+/** 予定より長くかかった（実績超過）。 */
+export const Overtime: Story = {
+  render: () => (
+    <Slot>
+      <LogLaneCard event={makeEvent({ diffMinutes: 20 })} position={basePosition} tagColor="teal" />
+    </Slot>
+  ),
+};
+
+/** 予定より短く終わった（前倒し）。 */
+export const Early: Story = {
+  render: () => (
+    <Slot>
+      <LogLaneCard
+        event={makeEvent({ diffMinutes: -15 })}
+        position={basePosition}
+        tagColor="amber"
+      />
+    </Slot>
+  ),
+};
+
+/** 予定外の記録（planId なし）。静かなマーカーのみ、判定ラベルは使わない。 */
+export const Unplanned: Story = {
+  render: () => (
+    <Slot>
+      <LogLaneCard
+        event={makeEvent({ planId: null, diffMinutes: undefined })}
+        position={basePosition}
+        tagColor="violet"
+      />
+    </Slot>
+  ),
+};
+
+/** タイトル未設定。 */
+export const Untitled: Story = {
+  render: () => (
+    <Slot>
+      <LogLaneCard
+        event={makeEvent({ title: '', diffMinutes: 0 })}
+        position={basePosition}
+        tagColor="gray"
+      />
+    </Slot>
+  ),
+};
+
+/** 低い高さ。時間表示を省略する。 */
+export const Compact: Story = {
+  render: () => (
+    <Slot height={40}>
+      <LogLaneCard
+        event={makeEvent({ diffMinutes: 10 })}
+        position={{ ...basePosition, height: 24 }}
+        tagColor="red"
+      />
+    </Slot>
+  ),
+};
+
+export const AllPatterns: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-start gap-4">
+      <div className="space-y-2">
+        <p className="text-muted-foreground text-xs">差分なし</p>
+        <Slot>
+          <LogLaneCard
+            event={makeEvent({ diffMinutes: 0 })}
+            position={basePosition}
+            tagColor="blue"
+          />
+        </Slot>
+      </div>
+      <div className="space-y-2">
+        <p className="text-muted-foreground text-xs">超過(+20min)</p>
+        <Slot>
+          <LogLaneCard
+            event={makeEvent({ diffMinutes: 20 })}
+            position={basePosition}
+            tagColor="teal"
+          />
+        </Slot>
+      </div>
+      <div className="space-y-2">
+        <p className="text-muted-foreground text-xs">前倒し(-15min)</p>
+        <Slot>
+          <LogLaneCard
+            event={makeEvent({ diffMinutes: -15 })}
+            position={basePosition}
+            tagColor="amber"
+          />
+        </Slot>
+      </div>
+      <div className="space-y-2">
+        <p className="text-muted-foreground text-xs">予定外</p>
+        <Slot>
+          <LogLaneCard
+            event={makeEvent({ planId: null, diffMinutes: undefined })}
+            position={basePosition}
+            tagColor="violet"
+          />
+        </Slot>
+      </div>
+    </div>
+  ),
+};

--- a/apps/product/src/features/calendar/components/views/shared/components/TwoLane/LogLaneCard.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/TwoLane/LogLaneCard.tsx
@@ -17,7 +17,7 @@ import { cn } from '@dayopt/components';
 import type { TwoLanePosition } from '../../../../../lib/two-lane-layout';
 import { DiffBadge } from './DiffBadge';
 
-export interface LogLaneCardProps {
+interface LogLaneCardProps {
   event: LogEvent;
   position: TwoLanePosition;
   tagColor?: string | null | undefined;

--- a/apps/product/src/features/calendar/components/views/shared/components/TwoLane/LogLaneCard.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/TwoLane/LogLaneCard.tsx
@@ -1,0 +1,75 @@
+/**
+ * Log レーン用カード（overview.md §4: 塗りカード、視覚的な主役）。
+ *
+ * `EntryCard.tsx` のトークン使用を踏襲するが、DnD・overlay 計算・gap クリック
+ * 導線は Step 6 の対象のため持ち込まない（read 側専用の軽量プレゼンテーショナル
+ * コンポーネント）。差分は `DiffBadge`（±0 は非表示）、予定外の記録は
+ * 静かなマーカーのみ（二値ラベルは使わない、copywriting準拠）。
+ */
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import type { LogEvent } from '@/features/entry';
+import { getTagColorClasses } from '@/features/tags';
+import { cn } from '@dayopt/components';
+
+import type { TwoLanePosition } from '../../../../../lib/two-lane-layout';
+import { DiffBadge } from './DiffBadge';
+
+export interface LogLaneCardProps {
+  event: LogEvent;
+  position: TwoLanePosition;
+  tagColor?: string | null | undefined;
+  className?: string | undefined;
+}
+
+const MIN_HEIGHT = 20;
+const DETAIL_HEIGHT_THRESHOLD = 40;
+
+function formatTimeRange(start: Date, end: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return `${pad(start.getHours())}:${pad(start.getMinutes())}–${pad(end.getHours())}:${pad(end.getMinutes())}`;
+}
+
+export function LogLaneCard({ event, position, tagColor = null, className }: LogLaneCardProps) {
+  const t = useTranslations();
+  const colorClasses = tagColor ? getTagColorClasses(tagColor) : null;
+  const isUnplanned = event.planId == null;
+  const hasDiff = event.diffMinutes != null && event.diffMinutes !== 0;
+  const showDetails = position.height >= DETAIL_HEIGHT_THRESHOLD;
+
+  return (
+    <div
+      data-log-lane-card
+      data-log-planned={!isUnplanned}
+      className={cn(
+        'absolute flex flex-col gap-1 overflow-hidden rounded-lg px-2 py-1 text-xs',
+        colorClasses?.tint ?? 'bg-card',
+        'text-foreground',
+        className,
+      )}
+      style={{
+        top: `${position.top}px`,
+        left: `${position.left}%`,
+        width: `calc(${position.width}% - 4px)`,
+        height: `${Math.max(position.height, MIN_HEIGHT)}px`,
+      }}
+    >
+      <div className="flex items-start justify-between gap-1">
+        <p className="truncate font-medium">{event.title || t('entry.untitled')}</p>
+        {hasDiff && <DiffBadge diffMinutes={event.diffMinutes ?? 0} />}
+      </div>
+      {showDetails && (
+        <p className="text-muted-foreground truncate">
+          {formatTimeRange(event.displayStartDate, event.displayEndDate)}
+        </p>
+      )}
+      {isUnplanned && (
+        <span data-log-unplanned-marker className="text-muted-foreground truncate">
+          {t('entry.inspector.unplanned')}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/product/src/features/calendar/components/views/shared/components/TwoLane/PlanLaneCard.stories.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/TwoLane/PlanLaneCard.stories.tsx
@@ -1,0 +1,140 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import type { PlanEvent, PlanEventStatus } from '@/features/entry';
+
+import type { TwoLanePosition } from '../../../../../lib/two-lane-layout';
+
+import { PlanLaneCard } from './PlanLaneCard';
+
+/** Plan レーン用カード。overview.md §4「過去 Plan の見え方」の全 status variant。 */
+const meta = {
+  title: 'Product/Features/Calendar/TwoLane/PlanLaneCard',
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function Slot({ children, height = 90 }: { children: React.ReactNode; height?: number }) {
+  return (
+    <div
+      className="border-border relative w-40 overflow-hidden rounded-lg border"
+      style={{ height }}
+    >
+      {children}
+    </div>
+  );
+}
+
+const basePosition: TwoLanePosition = { top: 8, height: 70, left: 4, width: 92 };
+
+function makeEvent(status: PlanEventStatus, overrides: Partial<PlanEvent> = {}): PlanEvent {
+  const start = new Date(2026, 6, 15, 10, 0);
+  const end = new Date(2026, 6, 15, 11, 0);
+  return {
+    id: `plan-${status}`,
+    title: 'Deep Work',
+    note: null,
+    tagId: 'tag-1',
+    startDate: start,
+    endDate: end,
+    displayStartDate: start,
+    displayEndDate: end,
+    duration: 60,
+    status,
+    ...overrides,
+  };
+}
+
+export const Upcoming: Story = {
+  render: () => (
+    <Slot>
+      <PlanLaneCard event={makeEvent('upcoming')} position={basePosition} tagColor="blue" />
+    </Slot>
+  ),
+};
+
+export const Active: Story = {
+  render: () => (
+    <Slot>
+      <PlanLaneCard event={makeEvent('active')} position={basePosition} tagColor="teal" />
+    </Slot>
+  ),
+};
+
+/** 過去・未記録・未skip。静かなプロンプト(破線)で示す。 */
+export const Unrecorded: Story = {
+  render: () => (
+    <Slot>
+      <PlanLaneCard event={makeEvent('unrecorded')} position={basePosition} tagColor="amber" />
+    </Slot>
+  ),
+};
+
+/** 記録済み（logs あり）。Log レーンが主役になるため控えめに沈める。 */
+export const Recorded: Story = {
+  render: () => (
+    <Slot>
+      <PlanLaneCard event={makeEvent('recorded')} position={basePosition} tagColor="indigo" />
+    </Slot>
+  ),
+};
+
+/** skip 済み（やらなかった）。斜線ハッチングで減衰表示。 */
+export const Skipped: Story = {
+  render: () => (
+    <Slot>
+      <PlanLaneCard event={makeEvent('skipped')} position={basePosition} tagColor="gray" />
+    </Slot>
+  ),
+};
+
+/** タイトル未設定。 */
+export const Untitled: Story = {
+  render: () => (
+    <Slot>
+      <PlanLaneCard
+        event={makeEvent('upcoming', { title: '' })}
+        position={basePosition}
+        tagColor="violet"
+      />
+    </Slot>
+  ),
+};
+
+/** 低い高さ(20px相当)。時間表示を省略する。 */
+export const Compact: Story = {
+  render: () => (
+    <Slot height={40}>
+      <PlanLaneCard
+        event={makeEvent('upcoming')}
+        position={{ ...basePosition, height: 24 }}
+        tagColor="red"
+      />
+    </Slot>
+  ),
+};
+
+export const AllPatterns: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-start gap-4">
+      {(
+        [
+          ['upcoming', 'blue'],
+          ['active', 'teal'],
+          ['unrecorded', 'amber'],
+          ['recorded', 'indigo'],
+          ['skipped', 'gray'],
+        ] as const
+      ).map(([status, color]) => (
+        <div key={status} className="space-y-2">
+          <p className="text-muted-foreground text-xs">{status}</p>
+          <Slot>
+            <PlanLaneCard event={makeEvent(status)} position={basePosition} tagColor={color} />
+          </Slot>
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/apps/product/src/features/calendar/components/views/shared/components/TwoLane/PlanLaneCard.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/TwoLane/PlanLaneCard.tsx
@@ -15,7 +15,7 @@ import { cn } from '@dayopt/components';
 
 import type { TwoLanePosition } from '../../../../../lib/two-lane-layout';
 
-export interface PlanLaneCardProps {
+interface PlanLaneCardProps {
   event: PlanEvent;
   position: TwoLanePosition;
   tagColor?: string | null | undefined;

--- a/apps/product/src/features/calendar/components/views/shared/components/TwoLane/PlanLaneCard.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/TwoLane/PlanLaneCard.tsx
@@ -1,0 +1,80 @@
+/**
+ * Plan レーン用カード（overview.md §4: アウトライン・淡色、控えめ）。
+ *
+ * `EntryCard.tsx` のトークン使用（タグカラー、色分けロジック）を踏襲するが、
+ * DnD・overlay 計算・gap クリック導線は Step 6 の対象のため持ち込まない
+ * （read 側専用の軽量プレゼンテーショナルコンポーネント）。
+ */
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import type { PlanEvent } from '@/features/entry';
+import { getTagColorClasses } from '@/features/tags';
+import { cn } from '@dayopt/components';
+
+import type { TwoLanePosition } from '../../../../../lib/two-lane-layout';
+
+export interface PlanLaneCardProps {
+  event: PlanEvent;
+  position: TwoLanePosition;
+  tagColor?: string | null | undefined;
+  className?: string | undefined;
+}
+
+const MIN_HEIGHT = 20;
+const DETAIL_HEIGHT_THRESHOLD = 40;
+
+function formatTimeRange(start: Date, end: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return `${pad(start.getHours())}:${pad(start.getMinutes())}–${pad(end.getHours())}:${pad(end.getMinutes())}`;
+}
+
+/** skip 済み plan の斜線ハッチング背景。EntryCard の skip 表現を踏襲。 */
+function skippedHatchImage(accentColor: string): string {
+  return `repeating-linear-gradient(45deg, transparent 0 5px, color-mix(in oklch, ${accentColor} 38%, transparent) 5px 7px)`;
+}
+
+export function PlanLaneCard({ event, position, tagColor = null, className }: PlanLaneCardProps) {
+  const t = useTranslations();
+  const colorClasses = tagColor ? getTagColorClasses(tagColor) : null;
+  const borderClass = colorClasses?.border ?? 'border-border';
+
+  const isSkipped = event.status === 'skipped';
+  const isUnrecorded = event.status === 'unrecorded';
+  const isRecorded = event.status === 'recorded';
+  const showDetails = position.height >= DETAIL_HEIGHT_THRESHOLD;
+
+  return (
+    <div
+      data-plan-lane-card
+      data-plan-status={event.status}
+      className={cn(
+        'absolute overflow-hidden rounded-lg border-2 px-2 py-1 text-xs',
+        borderClass,
+        // skip / 記録済みは控えめに沈める。未記録の過去 plan は静かなプロンプトとして
+        // 破線で「まだ何かが足りない」を示す（クリック導線は Step 6）。
+        isSkipped ? 'opacity-50' : isRecorded ? 'opacity-60' : 'opacity-100',
+        isUnrecorded ? 'border-dashed' : 'border-solid',
+        'text-foreground bg-transparent',
+        className,
+      )}
+      style={{
+        top: `${position.top}px`,
+        left: `${position.left}%`,
+        width: `calc(${position.width}% - 4px)`,
+        height: `${Math.max(position.height, MIN_HEIGHT)}px`,
+        ...(isSkipped && colorClasses
+          ? { backgroundImage: skippedHatchImage(colorClasses.cssVar) }
+          : {}),
+      }}
+    >
+      <p className="truncate font-medium">{event.title || t('entry.untitled')}</p>
+      {showDetails && (
+        <p className="text-muted-foreground truncate">
+          {formatTimeRange(event.displayStartDate, event.displayEndDate)}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/product/src/features/calendar/components/views/shared/components/TwoLane/TwoLaneDayColumn.stories.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/TwoLane/TwoLaneDayColumn.stories.tsx
@@ -1,0 +1,157 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import type { LogEvent, PlanEvent } from '@/features/entry';
+
+import { TwoLaneDayColumn } from './TwoLaneDayColumn';
+
+/**
+ * 1日分の Plan レーン + Log レーン合成。Log が主役(塗り)、Plan は控えめ(アウトライン)。
+ * useTagsMap はグローバルプロバイダーで解決済み。
+ */
+const meta = {
+  title: 'Product/Features/Calendar/TwoLane/TwoLaneDayColumn',
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function Frame({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="border-border relative h-[500px] w-64 overflow-hidden rounded-lg border">
+      {children}
+    </div>
+  );
+}
+
+function makeDate(hour: number, minute = 0): Date {
+  return new Date(2026, 6, 15, hour, minute);
+}
+
+function makePlan(overrides: Partial<PlanEvent> = {}): PlanEvent {
+  return {
+    id: 'plan-1',
+    title: 'Deep Work',
+    note: null,
+    tagId: 'tag-1',
+    startDate: makeDate(9, 0),
+    endDate: makeDate(10, 0),
+    displayStartDate: makeDate(9, 0),
+    displayEndDate: makeDate(10, 0),
+    duration: 60,
+    status: 'upcoming',
+    ...overrides,
+  };
+}
+
+function makeLog(overrides: Partial<LogEvent> = {}): LogEvent {
+  return {
+    id: 'log-1',
+    title: 'Deep Work',
+    note: null,
+    tagId: 'tag-1',
+    planId: 'plan-1',
+    startDate: makeDate(9, 0),
+    endDate: makeDate(9, 45),
+    displayStartDate: makeDate(9, 0),
+    displayEndDate: makeDate(9, 45),
+    duration: 45,
+    fulfillmentScore: null,
+    ...overrides,
+  };
+}
+
+/** 予定+記録が揃っている日（差分あり）。 */
+export const WithPlanAndLog: Story = {
+  render: () => (
+    <Frame>
+      <TwoLaneDayColumn
+        hourHeight={72}
+        plans={[makePlan()]}
+        logs={[makeLog({ diffMinutes: -15 })]}
+      />
+    </Frame>
+  ),
+};
+
+/** 未記録の過去 Plan + 予定外の記録が混在する日。 */
+export const MixedDay: Story = {
+  render: () => (
+    <Frame>
+      <TwoLaneDayColumn
+        hourHeight={72}
+        plans={[
+          makePlan({ id: 'p1', status: 'unrecorded' }),
+          makePlan({
+            id: 'p2',
+            title: 'Standup',
+            startDate: makeDate(11, 0),
+            endDate: makeDate(11, 30),
+            displayStartDate: makeDate(11, 0),
+            displayEndDate: makeDate(11, 30),
+            duration: 30,
+            status: 'skipped',
+          }),
+        ]}
+        logs={[makeLog({ id: 'l1', planId: null, diffMinutes: undefined, title: 'メール返信' })]}
+      />
+    </Frame>
+  ),
+};
+
+/** 空の日。 */
+export const Empty: Story = {
+  render: () => (
+    <Frame>
+      <TwoLaneDayColumn hourHeight={72} plans={[]} logs={[]} />
+    </Frame>
+  ),
+};
+
+export const AllPatterns: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-start gap-6">
+      <div className="space-y-2">
+        <p className="text-muted-foreground text-xs">予定+記録（差分あり）</p>
+        <Frame>
+          <TwoLaneDayColumn
+            hourHeight={72}
+            plans={[makePlan()]}
+            logs={[makeLog({ diffMinutes: -15 })]}
+          />
+        </Frame>
+      </div>
+      <div className="space-y-2">
+        <p className="text-muted-foreground text-xs">未記録・skip・予定外が混在</p>
+        <Frame>
+          <TwoLaneDayColumn
+            hourHeight={72}
+            plans={[
+              makePlan({ id: 'p1', status: 'unrecorded' }),
+              makePlan({
+                id: 'p2',
+                title: 'Standup',
+                startDate: makeDate(11, 0),
+                endDate: makeDate(11, 30),
+                displayStartDate: makeDate(11, 0),
+                displayEndDate: makeDate(11, 30),
+                duration: 30,
+                status: 'skipped',
+              }),
+            ]}
+            logs={[
+              makeLog({ id: 'l1', planId: null, diffMinutes: undefined, title: 'メール返信' }),
+            ]}
+          />
+        </Frame>
+      </div>
+      <div className="space-y-2">
+        <p className="text-muted-foreground text-xs">空</p>
+        <Frame>
+          <TwoLaneDayColumn hourHeight={72} plans={[]} logs={[]} />
+        </Frame>
+      </div>
+    </div>
+  ),
+};

--- a/apps/product/src/features/calendar/components/views/shared/components/TwoLane/TwoLaneDayColumn.stories.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/TwoLane/TwoLaneDayColumn.stories.tsx
@@ -19,7 +19,10 @@ type Story = StoryObj<typeof meta>;
 
 function Frame({ children }: { children: React.ReactNode }) {
   return (
-    <div className="border-border relative h-[500px] w-64 overflow-hidden rounded-lg border">
+    <div
+      className="border-border relative w-64 overflow-hidden rounded-lg border"
+      style={{ height: 500 }}
+    >
       {children}
     </div>
   );

--- a/apps/product/src/features/calendar/components/views/shared/components/TwoLane/TwoLaneDayColumn.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/TwoLane/TwoLaneDayColumn.tsx
@@ -16,7 +16,7 @@ import type { LogEvent, PlanEvent } from '@/features/entry';
 import { LogLaneCard } from './LogLaneCard';
 import { PlanLaneCard } from './PlanLaneCard';
 
-export interface TwoLaneDayColumnProps {
+interface TwoLaneDayColumnProps {
   plans: ReadonlyArray<PlanEvent>;
   logs: ReadonlyArray<LogEvent>;
   /** 1 時間あたりの px */

--- a/apps/product/src/features/calendar/components/views/shared/components/TwoLane/TwoLaneDayColumn.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/TwoLane/TwoLaneDayColumn.tsx
@@ -1,0 +1,65 @@
+/**
+ * 1 日分の Plan レーン + Log レーンを合成する read 側コンポーネント（Step 5）。
+ *
+ * `two-lane-layout.ts` で座標を計算し、`PlanLaneCard`/`LogLaneCard` を配置する。
+ * 既存ビュー（DayView/WeekView）への接続は Step 8 のフリップで行うため、
+ * このコンポーネント自体はどこからも呼ばれない dormant な状態で追加する。
+ */
+'use client';
+
+import { useTagsMap } from '@/features/tags';
+import { cn } from '@dayopt/components';
+
+import { calculateTwoLaneLayout } from '../../../../../lib/two-lane-layout';
+
+import type { LogEvent, PlanEvent } from '@/features/entry';
+import { LogLaneCard } from './LogLaneCard';
+import { PlanLaneCard } from './PlanLaneCard';
+
+export interface TwoLaneDayColumnProps {
+  plans: ReadonlyArray<PlanEvent>;
+  logs: ReadonlyArray<LogEvent>;
+  /** 1 時間あたりの px */
+  hourHeight: number;
+  /** Plan レーンの幅（%）。既定は `calculateTwoLaneLayout` のデフォルトに従う */
+  planLaneWidthPercent?: number | undefined;
+  className?: string | undefined;
+}
+
+export function TwoLaneDayColumn({
+  plans,
+  logs,
+  hourHeight,
+  planLaneWidthPercent,
+  className,
+}: TwoLaneDayColumnProps) {
+  const { getTagById } = useTagsMap();
+
+  const { planLayouts, logLayouts } = calculateTwoLaneLayout({
+    plans,
+    logs,
+    hourHeight,
+    ...(planLaneWidthPercent !== undefined && { planLaneWidthPercent }),
+  });
+
+  return (
+    <div data-two-lane-day-column className={cn('relative h-full w-full', className)}>
+      {planLayouts.map(({ entry, position }) => (
+        <PlanLaneCard
+          key={entry.id}
+          event={entry}
+          position={position}
+          tagColor={entry.tagId ? (getTagById(entry.tagId)?.color ?? null) : null}
+        />
+      ))}
+      {logLayouts.map(({ entry, position }) => (
+        <LogLaneCard
+          key={entry.id}
+          event={entry}
+          position={position}
+          tagColor={entry.tagId ? (getTagById(entry.tagId)?.color ?? null) : null}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/product/src/features/calendar/lib/__tests__/log-event-adapter.test.ts
+++ b/apps/product/src/features/calendar/lib/__tests__/log-event-adapter.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  expandLogRowsToLogEvents,
+  logRowToLogEvent,
+  type LogEventSourceRow,
+} from '../log-event-adapter';
+
+function makeRow(overrides: Partial<LogEventSourceRow> = {}): LogEventSourceRow {
+  return {
+    id: 'log-1',
+    title: 'Deep Work',
+    note: null,
+    tag_id: 'tag-1',
+    plan_id: null,
+    start_at: '2026-07-10T09:00:00Z',
+    end_at: '2026-07-10T10:00:00Z',
+    fulfillment_score: null,
+    ...overrides,
+  };
+}
+
+describe('logRowToLogEvent', () => {
+  it('基本フィールドを変換する', () => {
+    const event = logRowToLogEvent(makeRow(), { timezone: 'UTC' });
+    expect(event).toMatchObject({ id: 'log-1', title: 'Deep Work', tagId: 'tag-1', duration: 60 });
+  });
+
+  it('planId が無ければ diffMinutes は undefined（予定外の記録）', () => {
+    const event = logRowToLogEvent(makeRow(), { timezone: 'UTC', plannedMinutes: 90 });
+    expect(event.diffMinutes).toBeUndefined();
+  });
+
+  it('planId があり plannedMinutes が解決できれば diffMinutes を計算する（実績-予定）', () => {
+    const event = logRowToLogEvent(makeRow({ plan_id: 'plan-1' }), {
+      timezone: 'UTC',
+      plannedMinutes: 45,
+    });
+    expect(event.diffMinutes).toBe(15); // 60分の実績 - 45分の予定
+  });
+
+  it('planId はあるが plannedMinutes が未解決(null)なら diffMinutes は undefined', () => {
+    const event = logRowToLogEvent(makeRow({ plan_id: 'plan-1' }), {
+      timezone: 'UTC',
+      plannedMinutes: null,
+    });
+    expect(event.diffMinutes).toBeUndefined();
+  });
+
+  it('実績が予定ちょうどなら diffMinutes=0', () => {
+    const event = logRowToLogEvent(makeRow({ plan_id: 'plan-1' }), {
+      timezone: 'UTC',
+      plannedMinutes: 60,
+    });
+    expect(event.diffMinutes).toBe(0);
+  });
+});
+
+describe('expandLogRowsToLogEvents', () => {
+  it('plannedMinutesByPlanId から各 log の diffMinutes を解決する（1 plan に複数 log の 1:N も対応）', () => {
+    const rows = [
+      makeRow({ id: 'l1', plan_id: 'p1' }),
+      makeRow({ id: 'l2', plan_id: 'p1', end_at: '2026-07-10T09:20:00Z' }),
+      makeRow({ id: 'l3', plan_id: null }),
+    ];
+    const events = expandLogRowsToLogEvents(rows, {
+      timezone: 'UTC',
+      plannedMinutesByPlanId: new Map([['p1', 60]]),
+    });
+
+    expect(events.find((e) => e.id === 'l1')?.diffMinutes).toBe(0);
+    expect(events.find((e) => e.id === 'l2')?.diffMinutes).toBe(-40);
+    expect(events.find((e) => e.id === 'l3')?.diffMinutes).toBeUndefined();
+  });
+});

--- a/apps/product/src/features/calendar/lib/__tests__/log-event-adapter.test.ts
+++ b/apps/product/src/features/calendar/lib/__tests__/log-event-adapter.test.ts
@@ -158,4 +158,26 @@ describe('expandLogRowsToLogEvents', () => {
     expect(events.find((e) => e.id === 'l1')?.diffMinutes).toBe(0);
     expect(events.find((e) => e.id === 'l2')?.diffMinutes).toBeUndefined();
   });
+
+  it('秒以下の端数は truncateToMinute 後の duration で集計する（生の timestamp 差分を使わない）', () => {
+    // 09:00:31 - 10:00:00 は truncateToMinute で 09:00:00 - 10:00:00 = 60分。
+    // 生の timestamp 差分（59分29秒）を丸めると 59分になり、60分 plan に対して
+    // 誤って -1min の差分が出てしまう回帰テスト。
+    const rows = [
+      makeRow({
+        id: 'l1',
+        plan_id: 'p1',
+        source: 'from_plan',
+        start_at: '2026-07-10T09:00:31Z',
+        end_at: '2026-07-10T10:00:00Z',
+      }),
+    ];
+    const events = expandLogRowsToLogEvents(rows, {
+      timezone: 'UTC',
+      plannedMinutesByPlanId: new Map([['p1', 60]]),
+    });
+
+    expect(events[0]?.duration).toBe(60);
+    expect(events[0]?.diffMinutes).toBe(0);
+  });
 });

--- a/apps/product/src/features/calendar/lib/__tests__/log-event-adapter.test.ts
+++ b/apps/product/src/features/calendar/lib/__tests__/log-event-adapter.test.ts
@@ -13,6 +13,7 @@ function makeRow(overrides: Partial<LogEventSourceRow> = {}): LogEventSourceRow 
     note: null,
     tag_id: 'tag-1',
     plan_id: null,
+    source: 'manual',
     start_at: '2026-07-10T09:00:00Z',
     end_at: '2026-07-10T10:00:00Z',
     fulfillment_score: null,
@@ -57,11 +58,14 @@ describe('logRowToLogEvent', () => {
 });
 
 describe('expandLogRowsToLogEvents', () => {
-  it('plannedMinutesByPlanId から各 log の diffMinutes を解決する（1 plan に複数 log の 1:N も対応）', () => {
+  it('plannedMinutesByPlanId から各 log の diffMinutes を解決する（1 log : 1 plan）', () => {
     const rows = [
-      makeRow({ id: 'l1', plan_id: 'p1' }),
-      makeRow({ id: 'l2', plan_id: 'p1', end_at: '2026-07-10T09:20:00Z' }),
-      makeRow({ id: 'l3', plan_id: null }),
+      makeRow({ id: 'l1', plan_id: 'p1', source: 'from_plan' }),
+      makeRow({
+        id: 'l2',
+        plan_id: null,
+        end_at: '2026-07-10T09:20:00Z',
+      }),
     ];
     const events = expandLogRowsToLogEvents(rows, {
       timezone: 'UTC',
@@ -69,7 +73,89 @@ describe('expandLogRowsToLogEvents', () => {
     });
 
     expect(events.find((e) => e.id === 'l1')?.diffMinutes).toBe(0);
-    expect(events.find((e) => e.id === 'l2')?.diffMinutes).toBe(-40);
-    expect(events.find((e) => e.id === 'l3')?.diffMinutes).toBeUndefined();
+    expect(events.find((e) => e.id === 'l2')?.diffMinutes).toBeUndefined();
+  });
+
+  it('1 plan に複数 log（分割記録）は合計実績で 1 件にのみ差分を付与する（1:N、二重計上を避ける）', () => {
+    // 60分 plan を 30分 log 2件で記録 → 合計は予定どおり(diff=0)。
+    // 個別の log 時間(30分)だけで計算すると誤って -30min が 2 件出る不具合の回帰テスト。
+    const rows = [
+      makeRow({
+        id: 'l1',
+        plan_id: 'p1',
+        source: 'from_plan',
+        start_at: '2026-07-10T09:00:00Z',
+        end_at: '2026-07-10T09:30:00Z',
+      }),
+      makeRow({
+        id: 'l2',
+        plan_id: 'p1',
+        source: 'manual',
+        start_at: '2026-07-10T09:30:00Z',
+        end_at: '2026-07-10T10:00:00Z',
+      }),
+    ];
+    const events = expandLogRowsToLogEvents(rows, {
+      timezone: 'UTC',
+      plannedMinutesByPlanId: new Map([['p1', 60]]),
+    });
+
+    // from_plan の log が代表として合計実績(60分)ベースの差分を持つ
+    expect(events.find((e) => e.id === 'l1')?.diffMinutes).toBe(0);
+    // 他方の log は個別の差分を持たない（二重計上を避ける）
+    expect(events.find((e) => e.id === 'l2')?.diffMinutes).toBeUndefined();
+  });
+
+  it('1:N の分割記録が予定より多い/少ない場合、合計実績ベースの差分になる', () => {
+    // 60分 plan を 20分 + 20分 = 40分の実績で記録 → -20min
+    const rows = [
+      makeRow({
+        id: 'l1',
+        plan_id: 'p1',
+        source: 'from_plan',
+        start_at: '2026-07-10T09:00:00Z',
+        end_at: '2026-07-10T09:20:00Z',
+      }),
+      makeRow({
+        id: 'l2',
+        plan_id: 'p1',
+        source: 'manual',
+        start_at: '2026-07-10T09:20:00Z',
+        end_at: '2026-07-10T09:40:00Z',
+      }),
+    ];
+    const events = expandLogRowsToLogEvents(rows, {
+      timezone: 'UTC',
+      plannedMinutesByPlanId: new Map([['p1', 60]]),
+    });
+
+    expect(events.find((e) => e.id === 'l1')?.diffMinutes).toBe(-20);
+    expect(events.find((e) => e.id === 'l2')?.diffMinutes).toBeUndefined();
+  });
+
+  it('from_plan の log が無い場合は最初に現れた log を代表にする', () => {
+    const rows = [
+      makeRow({
+        id: 'l1',
+        plan_id: 'p1',
+        source: 'manual',
+        start_at: '2026-07-10T09:00:00Z',
+        end_at: '2026-07-10T09:30:00Z',
+      }),
+      makeRow({
+        id: 'l2',
+        plan_id: 'p1',
+        source: 'manual',
+        start_at: '2026-07-10T09:30:00Z',
+        end_at: '2026-07-10T10:00:00Z',
+      }),
+    ];
+    const events = expandLogRowsToLogEvents(rows, {
+      timezone: 'UTC',
+      plannedMinutesByPlanId: new Map([['p1', 60]]),
+    });
+
+    expect(events.find((e) => e.id === 'l1')?.diffMinutes).toBe(0);
+    expect(events.find((e) => e.id === 'l2')?.diffMinutes).toBeUndefined();
   });
 });

--- a/apps/product/src/features/calendar/lib/__tests__/plan-event-adapter.test.ts
+++ b/apps/product/src/features/calendar/lib/__tests__/plan-event-adapter.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  expandPlanRowsToPlanEvents,
+  planRowToPlanEvent,
+  type PlanEventSourceRow,
+} from '../plan-event-adapter';
+
+const NOW = new Date('2026-07-10T12:00:00Z');
+
+function makeRow(overrides: Partial<PlanEventSourceRow> = {}): PlanEventSourceRow {
+  return {
+    id: 'plan-1',
+    title: 'Deep Work',
+    note: null,
+    tag_id: 'tag-1',
+    start_at: '2026-07-10T09:00:00Z',
+    end_at: '2026-07-10T10:00:00Z',
+    skipped_at: null,
+    ...overrides,
+  };
+}
+
+describe('planRowToPlanEvent', () => {
+  it('基本フィールドを変換する', () => {
+    const event = planRowToPlanEvent(makeRow(), { timezone: 'UTC', isRecorded: false, now: NOW });
+    expect(event).toMatchObject({
+      id: 'plan-1',
+      title: 'Deep Work',
+      tagId: 'tag-1',
+      duration: 60,
+    });
+  });
+
+  it('title が空文字なら空文字のまま保持する（表示側でフォールバック）', () => {
+    const event = planRowToPlanEvent(makeRow({ title: '' }), {
+      timezone: 'UTC',
+      isRecorded: false,
+      now: NOW,
+    });
+    expect(event.title).toBe('');
+  });
+
+  it('skipped_at があれば status=skipped（記録済み・時間位置より優先）', () => {
+    const event = planRowToPlanEvent(makeRow({ skipped_at: '2026-07-10T11:00:00Z' }), {
+      timezone: 'UTC',
+      isRecorded: true,
+      now: NOW,
+    });
+    expect(event.status).toBe('skipped');
+  });
+
+  it('記録済み(isRecorded)なら時間位置に関わらず status=recorded', () => {
+    const event = planRowToPlanEvent(makeRow(), { timezone: 'UTC', isRecorded: true, now: NOW });
+    expect(event.status).toBe('recorded');
+  });
+
+  it('過去・未記録・未skip なら status=unrecorded', () => {
+    const event = planRowToPlanEvent(makeRow(), { timezone: 'UTC', isRecorded: false, now: NOW });
+    expect(event.status).toBe('unrecorded');
+  });
+
+  it('進行中(start<=now<end)なら status=active', () => {
+    const event = planRowToPlanEvent(
+      makeRow({ start_at: '2026-07-10T11:30:00Z', end_at: '2026-07-10T13:00:00Z' }),
+      { timezone: 'UTC', isRecorded: false, now: NOW },
+    );
+    expect(event.status).toBe('active');
+  });
+
+  it('未来(start>now)なら status=upcoming', () => {
+    const event = planRowToPlanEvent(
+      makeRow({ start_at: '2026-07-10T13:00:00Z', end_at: '2026-07-10T14:00:00Z' }),
+      { timezone: 'UTC', isRecorded: false, now: NOW },
+    );
+    expect(event.status).toBe('upcoming');
+  });
+});
+
+describe('expandPlanRowsToPlanEvents', () => {
+  it('recordedPlanIds に含まれる id は status=recorded になる', () => {
+    const rows = [makeRow({ id: 'p1' }), makeRow({ id: 'p2' })];
+    const events = expandPlanRowsToPlanEvents(rows, {
+      timezone: 'UTC',
+      recordedPlanIds: new Set(['p1']),
+      now: NOW,
+    });
+    expect(events.find((e) => e.id === 'p1')?.status).toBe('recorded');
+    expect(events.find((e) => e.id === 'p2')?.status).toBe('unrecorded');
+  });
+});

--- a/apps/product/src/features/calendar/lib/__tests__/two-lane-layout.test.ts
+++ b/apps/product/src/features/calendar/lib/__tests__/two-lane-layout.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+
+import type { LogEvent, PlanEvent } from '@/features/entry';
+import { calculateTwoLaneLayout } from '../two-lane-layout';
+
+const HOUR_HEIGHT = 60;
+
+/**
+ * `displayStartDate`/`displayEndDate` は `convertToTimezone`（`toZonedTime`）で
+ * 既に対象タイムゾーンの wall-clock 値へ変換済みの Date を想定する。
+ * `calculateTwoLaneLayout` はその wall-clock 値を `getHours()`/`getMinutes()`
+ * （実行環境のローカル TZ 依存）で読むため、テストでは UTC ISO 文字列ではなく
+ * ローカルコンポーネント指定の `new Date(y, m, d, h, min)` で構築する
+ * （実行環境の TZ に関わらず意図した時刻を再現するため）。
+ */
+function localDate(hour: number, minute: number, day = 10): Date {
+  return new Date(2026, 6, day, hour, minute, 0, 0);
+}
+
+function makePlan(overrides: Partial<PlanEvent> = {}): PlanEvent {
+  const start = localDate(9, 0);
+  const end = localDate(10, 0);
+  return {
+    id: 'plan-1',
+    title: 'Deep Work',
+    note: null,
+    tagId: 'tag-1',
+    startDate: start,
+    endDate: end,
+    displayStartDate: start,
+    displayEndDate: end,
+    duration: 60,
+    status: 'upcoming',
+    ...overrides,
+  };
+}
+
+function makeLog(overrides: Partial<LogEvent> = {}): LogEvent {
+  const start = localDate(9, 0);
+  const end = localDate(10, 0);
+  return {
+    id: 'log-1',
+    title: 'Deep Work',
+    note: null,
+    tagId: 'tag-1',
+    planId: null,
+    startDate: start,
+    endDate: end,
+    displayStartDate: start,
+    displayEndDate: end,
+    duration: 60,
+    fulfillmentScore: null,
+    ...overrides,
+  };
+}
+
+describe('calculateTwoLaneLayout', () => {
+  it('Plan は左レーン(left=0)、Log は右レーン(left=planLaneWidthPercent)に配置する', () => {
+    const result = calculateTwoLaneLayout({
+      plans: [makePlan()],
+      logs: [makeLog()],
+      hourHeight: HOUR_HEIGHT,
+    });
+
+    expect(result.planLayouts[0]?.position.left).toBe(0);
+    expect(result.planLayouts[0]?.position.width).toBe(38);
+    expect(result.logLayouts[0]?.position.left).toBe(38);
+    expect(result.logLayouts[0]?.position.width).toBe(62);
+  });
+
+  it('planLaneWidthPercent を変更するとレーン幅も追従する', () => {
+    const result = calculateTwoLaneLayout({
+      plans: [makePlan()],
+      logs: [makeLog()],
+      hourHeight: HOUR_HEIGHT,
+      planLaneWidthPercent: 50,
+    });
+    expect(result.planLayouts[0]?.position.width).toBe(50);
+    expect(result.logLayouts[0]?.position.left).toBe(50);
+    expect(result.logLayouts[0]?.position.width).toBe(50);
+  });
+
+  it('9:00-10:00 (hourHeight=60) は top=540px, height=60px', () => {
+    const result = calculateTwoLaneLayout({
+      plans: [makePlan()],
+      logs: [],
+      hourHeight: HOUR_HEIGHT,
+    });
+    expect(result.planLayouts[0]?.position).toMatchObject({ top: 540, height: 60 });
+  });
+
+  it('日をまたぐ場合は当日の終端(24:00)でクランプする', () => {
+    const result = calculateTwoLaneLayout({
+      plans: [
+        makePlan({
+          displayStartDate: localDate(23, 0),
+          displayEndDate: localDate(2, 0, 11),
+        }),
+      ],
+      logs: [],
+      hourHeight: HOUR_HEIGHT,
+    });
+    // 23:00 → top=1380px, 24:00までの1時間 → height=60px
+    expect(result.planLayouts[0]?.position).toMatchObject({ top: 1380, height: 60 });
+  });
+
+  it('plans/logs 複数件をそれぞれ独立に配置する（レーン内は重複しない前提）', () => {
+    const result = calculateTwoLaneLayout({
+      plans: [
+        makePlan({ id: 'p1' }),
+        makePlan({
+          id: 'p2',
+          displayStartDate: localDate(11, 0),
+          displayEndDate: localDate(11, 30),
+        }),
+      ],
+      logs: [],
+      hourHeight: HOUR_HEIGHT,
+    });
+    expect(result.planLayouts).toHaveLength(2);
+    expect(result.planLayouts[1]?.position).toMatchObject({ top: 660, height: 30 });
+  });
+});

--- a/apps/product/src/features/calendar/lib/log-event-adapter.ts
+++ b/apps/product/src/features/calendar/lib/log-event-adapter.ts
@@ -83,28 +83,31 @@ export function expandLogRowsToLogEvents(
   rows: ReadonlyArray<LogEventSourceRow>,
   options: ExpandLogRowsOptions,
 ): LogEvent[] {
+  // `logRowToLogEvent` が truncateToMinute 済みの `duration` を単一の情報源として使う
+  // （ここで生の start_at/end_at から再計算すると truncate 前の秒数が混ざる）。
+  const events = rows.map((row) =>
+    logRowToLogEvent(row, { timezone: options.timezone, plannedMinutes: null }),
+  );
+
   const totalActualMinutesByPlanId = new Map<string, number>();
   const primaryLogIdByPlanId = new Map<string, string>();
 
-  for (const row of rows) {
-    if (row.plan_id == null) continue;
+  rows.forEach((row, i) => {
+    if (row.plan_id == null) return;
 
-    const duration = Math.round(
-      (new Date(row.end_at).getTime() - new Date(row.start_at).getTime()) / 60000,
-    );
     totalActualMinutesByPlanId.set(
       row.plan_id,
-      (totalActualMinutesByPlanId.get(row.plan_id) ?? 0) + duration,
+      (totalActualMinutesByPlanId.get(row.plan_id) ?? 0) + events[i]!.duration,
     );
 
     const currentPrimaryId = primaryLogIdByPlanId.get(row.plan_id);
     if (!currentPrimaryId || row.source === 'from_plan') {
       primaryLogIdByPlanId.set(row.plan_id, row.id);
     }
-  }
+  });
 
-  return rows.map((row) => {
-    const event = logRowToLogEvent(row, { timezone: options.timezone, plannedMinutes: null });
+  return rows.map((row, i) => {
+    const event = events[i]!;
 
     const isPrimary = row.plan_id != null && primaryLogIdByPlanId.get(row.plan_id) === row.id;
     if (!isPrimary || row.plan_id == null) return event;

--- a/apps/product/src/features/calendar/lib/log-event-adapter.ts
+++ b/apps/product/src/features/calendar/lib/log-event-adapter.ts
@@ -15,6 +15,7 @@ export interface LogEventSourceRow {
   note: string | null;
   tag_id: string | null;
   plan_id: string | null;
+  source: string;
   start_at: string;
   end_at: string;
   fulfillment_score: number | null;
@@ -64,19 +65,54 @@ export function logRowToLogEvent(
 
 interface ExpandLogRowsOptions {
   timezone: string;
-  /** plan id -> 所要時間（分）。1 plan に複数 log が紐づく場合も同じ plan 時間を毎回参照する */
+  /** plan id -> 所要時間（分）。1 plan に複数 log が紐づく場合も同じ plan 時間を参照する */
   plannedMinutesByPlanId: ReadonlyMap<string, number>;
 }
 
+/**
+ * 1 plan に複数 log（分割記録）が紐づく 1:N ケースでは、各 log 個別の所要時間ではなく
+ * 「その plan に紐づく log 群の合計実績時間」を予定時間と比較しないと差分が誤って
+ * 二重・N 重に表示される（例: 60 分 plan を 30 分 log 2 件で記録した場合、
+ * 個々の log 単位で `duration - plannedMinutes` を計算すると両方に `-30min` の
+ * バッジが付くが、実際は合計 60 分で予定どおり）。
+ *
+ * そのため差分は「代表 log」（`source='from_plan'` を優先、無ければ最初の log）
+ * 1 件にのみ、合計実績時間ベースで付与し、他の log は `diffMinutes` を持たない。
+ */
 export function expandLogRowsToLogEvents(
   rows: ReadonlyArray<LogEventSourceRow>,
   options: ExpandLogRowsOptions,
 ): LogEvent[] {
-  return rows.map((row) =>
-    logRowToLogEvent(row, {
-      timezone: options.timezone,
-      plannedMinutes:
-        row.plan_id != null ? (options.plannedMinutesByPlanId.get(row.plan_id) ?? null) : null,
-    }),
-  );
+  const totalActualMinutesByPlanId = new Map<string, number>();
+  const primaryLogIdByPlanId = new Map<string, string>();
+
+  for (const row of rows) {
+    if (row.plan_id == null) continue;
+
+    const duration = Math.round(
+      (new Date(row.end_at).getTime() - new Date(row.start_at).getTime()) / 60000,
+    );
+    totalActualMinutesByPlanId.set(
+      row.plan_id,
+      (totalActualMinutesByPlanId.get(row.plan_id) ?? 0) + duration,
+    );
+
+    const currentPrimaryId = primaryLogIdByPlanId.get(row.plan_id);
+    if (!currentPrimaryId || row.source === 'from_plan') {
+      primaryLogIdByPlanId.set(row.plan_id, row.id);
+    }
+  }
+
+  return rows.map((row) => {
+    const event = logRowToLogEvent(row, { timezone: options.timezone, plannedMinutes: null });
+
+    const isPrimary = row.plan_id != null && primaryLogIdByPlanId.get(row.plan_id) === row.id;
+    if (!isPrimary || row.plan_id == null) return event;
+
+    const plannedMinutes = options.plannedMinutesByPlanId.get(row.plan_id);
+    const totalActualMinutes = totalActualMinutesByPlanId.get(row.plan_id);
+    if (plannedMinutes == null || totalActualMinutes == null) return event;
+
+    return { ...event, diffMinutes: totalActualMinutes - plannedMinutes };
+  });
 }

--- a/apps/product/src/features/calendar/lib/log-event-adapter.ts
+++ b/apps/product/src/features/calendar/lib/log-event-adapter.ts
@@ -27,7 +27,7 @@ function truncateToMinute(date: Date): Date {
   return d;
 }
 
-export interface LogRowToLogEventOptions {
+interface LogRowToLogEventOptions {
   timezone: string;
   /** 紐づく plan の所要時間（分）。`plan_id` が無い、または呼び出し側で未解決なら null/undefined */
   plannedMinutes?: number | null | undefined;
@@ -62,7 +62,7 @@ export function logRowToLogEvent(
   };
 }
 
-export interface ExpandLogRowsOptions {
+interface ExpandLogRowsOptions {
   timezone: string;
   /** plan id -> 所要時間（分）。1 plan に複数 log が紐づく場合も同じ plan 時間を毎回参照する */
   plannedMinutesByPlanId: ReadonlyMap<string, number>;

--- a/apps/product/src/features/calendar/lib/log-event-adapter.ts
+++ b/apps/product/src/features/calendar/lib/log-event-adapter.ts
@@ -1,0 +1,82 @@
+/**
+ * `logs` テーブル行 -> `LogEvent` 変換アダプター（Step 5、read 側専用）
+ *
+ * `entry-adapter.ts`（entries -> CalendarEvent）と同じ配置パターンで、
+ * logs -> LogEvent の射影を担う。書き込み・DnD 保存先判定は Step 6。
+ */
+
+import type { LogEvent } from '@/features/entry';
+import { convertToTimezone } from '@/lib/date/timezone';
+
+/** `logs` テーブル行のうち LogEvent 射影に必要な最小 shape */
+export interface LogEventSourceRow {
+  id: string;
+  title: string;
+  note: string | null;
+  tag_id: string | null;
+  plan_id: string | null;
+  start_at: string;
+  end_at: string;
+  fulfillment_score: number | null;
+}
+
+/** TZ変換やDBから読み出した秒以下のずれが所要時間計算にノイズを混ぜないよう truncate する */
+function truncateToMinute(date: Date): Date {
+  const d = new Date(date);
+  d.setSeconds(0, 0);
+  return d;
+}
+
+export interface LogRowToLogEventOptions {
+  timezone: string;
+  /** 紐づく plan の所要時間（分）。`plan_id` が無い、または呼び出し側で未解決なら null/undefined */
+  plannedMinutes?: number | null | undefined;
+}
+
+export function logRowToLogEvent(
+  row: LogEventSourceRow,
+  options: LogRowToLogEventOptions,
+): LogEvent {
+  const startDate = truncateToMinute(new Date(row.start_at));
+  const endDate = truncateToMinute(new Date(row.end_at));
+  const duration = Math.round((endDate.getTime() - startDate.getTime()) / 60000);
+
+  const diffMinutes =
+    row.plan_id != null && options.plannedMinutes != null
+      ? duration - options.plannedMinutes
+      : undefined;
+
+  return {
+    id: row.id,
+    title: row.title || '',
+    note: row.note,
+    tagId: row.tag_id,
+    planId: row.plan_id,
+    startDate,
+    endDate,
+    displayStartDate: convertToTimezone(startDate, options.timezone),
+    displayEndDate: convertToTimezone(endDate, options.timezone),
+    duration,
+    fulfillmentScore: row.fulfillment_score,
+    diffMinutes,
+  };
+}
+
+export interface ExpandLogRowsOptions {
+  timezone: string;
+  /** plan id -> 所要時間（分）。1 plan に複数 log が紐づく場合も同じ plan 時間を毎回参照する */
+  plannedMinutesByPlanId: ReadonlyMap<string, number>;
+}
+
+export function expandLogRowsToLogEvents(
+  rows: ReadonlyArray<LogEventSourceRow>,
+  options: ExpandLogRowsOptions,
+): LogEvent[] {
+  return rows.map((row) =>
+    logRowToLogEvent(row, {
+      timezone: options.timezone,
+      plannedMinutes:
+        row.plan_id != null ? (options.plannedMinutesByPlanId.get(row.plan_id) ?? null) : null,
+    }),
+  );
+}

--- a/apps/product/src/features/calendar/lib/plan-event-adapter.ts
+++ b/apps/product/src/features/calendar/lib/plan-event-adapter.ts
@@ -1,0 +1,109 @@
+/**
+ * `plans` テーブル行 -> `PlanEvent` 変換アダプター（Step 5、read 側専用）
+ *
+ * `entry-adapter.ts`（entries -> CalendarEvent）と同じ配置パターンで、
+ * plans -> PlanEvent の射影を担う。書き込み・DnD 保存先判定は Step 6。
+ */
+
+import type { PlanEvent, PlanEventStatus } from '@/features/entry';
+import { convertToTimezone } from '@/lib/date/timezone';
+
+/** `plans` テーブル行のうち PlanEvent 射影に必要な最小 shape */
+export interface PlanEventSourceRow {
+  id: string;
+  title: string;
+  note: string | null;
+  tag_id: string | null;
+  start_at: string;
+  end_at: string;
+  skipped_at: string | null;
+}
+
+/** TZ変換やDBから読み出した秒以下のずれが所要時間計算にノイズを混ぜないよう truncate する */
+function truncateToMinute(date: Date): Date {
+  const d = new Date(date);
+  d.setSeconds(0, 0);
+  return d;
+}
+
+/**
+ * overview.md §4「過去 Plan の見え方」に基づく status 判定。
+ *
+ * 優先順位: skip > 記録済み > 時間位置（unrecorded/active/upcoming）
+ */
+function resolvePlanEventStatus({
+  skippedAt,
+  startDate,
+  endDate,
+  isRecorded,
+  now,
+}: {
+  skippedAt: string | null;
+  startDate: Date;
+  endDate: Date;
+  isRecorded: boolean;
+  now: Date;
+}): PlanEventStatus {
+  if (skippedAt != null) return 'skipped';
+  if (isRecorded) return 'recorded';
+  if (endDate.getTime() <= now.getTime()) return 'unrecorded';
+  if (startDate.getTime() <= now.getTime()) return 'active';
+  return 'upcoming';
+}
+
+export interface PlanRowToPlanEventOptions {
+  timezone: string;
+  /** この plan を参照する log（`source <> 'auto_migrated'` を問わず）が 1 件以上あるか */
+  isRecorded: boolean;
+  /** テスト用の時刻固定。省略時は `new Date()` */
+  now?: Date;
+}
+
+export function planRowToPlanEvent(
+  row: PlanEventSourceRow,
+  options: PlanRowToPlanEventOptions,
+): PlanEvent {
+  const startDate = truncateToMinute(new Date(row.start_at));
+  const endDate = truncateToMinute(new Date(row.end_at));
+  const now = options.now ?? new Date();
+  const duration = Math.round((endDate.getTime() - startDate.getTime()) / 60000);
+
+  return {
+    id: row.id,
+    title: row.title || '',
+    note: row.note,
+    tagId: row.tag_id,
+    startDate,
+    endDate,
+    displayStartDate: convertToTimezone(startDate, options.timezone),
+    displayEndDate: convertToTimezone(endDate, options.timezone),
+    duration,
+    status: resolvePlanEventStatus({
+      skippedAt: row.skipped_at,
+      startDate,
+      endDate,
+      isRecorded: options.isRecorded,
+      now,
+    }),
+  };
+}
+
+export interface ExpandPlanRowsOptions {
+  timezone: string;
+  /** log から紐づけられている plan id の集合（1 件以上参照されていれば記録済み扱い） */
+  recordedPlanIds: ReadonlySet<string>;
+  now?: Date;
+}
+
+export function expandPlanRowsToPlanEvents(
+  rows: ReadonlyArray<PlanEventSourceRow>,
+  options: ExpandPlanRowsOptions,
+): PlanEvent[] {
+  return rows.map((row) =>
+    planRowToPlanEvent(row, {
+      timezone: options.timezone,
+      isRecorded: options.recordedPlanIds.has(row.id),
+      ...(options.now !== undefined && { now: options.now }),
+    }),
+  );
+}

--- a/apps/product/src/features/calendar/lib/plan-event-adapter.ts
+++ b/apps/product/src/features/calendar/lib/plan-event-adapter.ts
@@ -51,7 +51,7 @@ function resolvePlanEventStatus({
   return 'upcoming';
 }
 
-export interface PlanRowToPlanEventOptions {
+interface PlanRowToPlanEventOptions {
   timezone: string;
   /** この plan を参照する log（`source <> 'auto_migrated'` を問わず）が 1 件以上あるか */
   isRecorded: boolean;
@@ -88,7 +88,7 @@ export function planRowToPlanEvent(
   };
 }
 
-export interface ExpandPlanRowsOptions {
+interface ExpandPlanRowsOptions {
   timezone: string;
   /** log から紐づけられている plan id の集合（1 件以上参照されていれば記録済み扱い） */
   recordedPlanIds: ReadonlySet<string>;

--- a/apps/product/src/features/calendar/lib/two-lane-layout.ts
+++ b/apps/product/src/features/calendar/lib/two-lane-layout.ts
@@ -24,17 +24,17 @@ export interface TwoLanePosition {
   width: number;
 }
 
-export interface TwoLaneLayoutItem<T> {
+interface TwoLaneLayoutItem<T> {
   entry: T;
   position: TwoLanePosition;
 }
 
-export interface TwoLaneLayoutResult {
+interface TwoLaneLayoutResult {
   planLayouts: TwoLaneLayoutItem<PlanEvent>[];
   logLayouts: TwoLaneLayoutItem<LogEvent>[];
 }
 
-export interface CalculateTwoLaneLayoutOptions {
+interface CalculateTwoLaneLayoutOptions {
   plans: ReadonlyArray<PlanEvent>;
   logs: ReadonlyArray<LogEvent>;
   /** 1 時間あたりの px */

--- a/apps/product/src/features/calendar/lib/two-lane-layout.ts
+++ b/apps/product/src/features/calendar/lib/two-lane-layout.ts
@@ -1,0 +1,104 @@
+/**
+ * Plan レーン + Log レーンの固定 2 レーン座標計算（Step 5、read 側専用）。
+ *
+ * `plans_no_overlap` / `logs_no_overlap`（DB EXCLUDE 制約、半開区間）により、
+ * 同一ユーザーの plans 同士・logs 同士は決して時間的に重ならない。そのため
+ * 既存 `layout.ts` の `calculateGroupLayout`（時間重複を動的に検出して
+ * column を割り当てる sweep-line）は不要で、各レーン内は「その日の時刻から
+ * 座標を出すだけ」で足りる。レーン自体は Plan=左・Log=右の固定幅分割。
+ *
+ * 呼び出し側は対象日の plans/logs だけを渡す想定（日をまたぐ絞り込みは
+ * 呼び出し側の責務、既存 DayColumn 系コンポーネントと同じ分担）。
+ */
+
+import type { LogEvent, PlanEvent } from '@/features/entry';
+
+export interface TwoLanePosition {
+  /** px */
+  top: number;
+  /** px */
+  height: number;
+  /** % */
+  left: number;
+  /** % */
+  width: number;
+}
+
+export interface TwoLaneLayoutItem<T> {
+  entry: T;
+  position: TwoLanePosition;
+}
+
+export interface TwoLaneLayoutResult {
+  planLayouts: TwoLaneLayoutItem<PlanEvent>[];
+  logLayouts: TwoLaneLayoutItem<LogEvent>[];
+}
+
+export interface CalculateTwoLaneLayoutOptions {
+  plans: ReadonlyArray<PlanEvent>;
+  logs: ReadonlyArray<LogEvent>;
+  /** 1 時間あたりの px */
+  hourHeight: number;
+  /** Plan レーンの幅（%）。既定 38（Log レーンが主役で広め、overview.md §4） */
+  planLaneWidthPercent?: number;
+}
+
+const DAY_MINUTES = 24 * 60;
+const DEFAULT_PLAN_LANE_WIDTH_PERCENT = 38;
+
+function minutesSinceMidnight(date: Date): number {
+  return date.getHours() * 60 + date.getMinutes();
+}
+
+/**
+ * 日カラム内での top/height（px）を計算する。
+ *
+ * 日をまたぐ（`end` が `start` と別日、または `end <= start`）場合は
+ * 当日の終端（24:00）でクランプする。複数日にまたがる描画は呼び出し側の
+ * 責務（このカラムは 1 日分の座標だけを担当する）。
+ */
+function timeToPosition(
+  start: Date,
+  end: Date,
+  hourHeight: number,
+): { top: number; height: number } {
+  const startMinutes = minutesSinceMidnight(start);
+  const crossesMidnight = end.getTime() <= start.getTime() || end.getDate() !== start.getDate();
+  const endMinutes = crossesMidnight ? DAY_MINUTES : minutesSinceMidnight(end);
+
+  const top = (startMinutes / 60) * hourHeight;
+  const height = Math.max(((endMinutes - startMinutes) / 60) * hourHeight, 0);
+  return { top, height };
+}
+
+export function calculateTwoLaneLayout({
+  plans,
+  logs,
+  hourHeight,
+  planLaneWidthPercent = DEFAULT_PLAN_LANE_WIDTH_PERCENT,
+}: CalculateTwoLaneLayoutOptions): TwoLaneLayoutResult {
+  const logLaneWidthPercent = 100 - planLaneWidthPercent;
+
+  const planLayouts = plans.map((entry) => {
+    const { top, height } = timeToPosition(
+      entry.displayStartDate,
+      entry.displayEndDate,
+      hourHeight,
+    );
+    return { entry, position: { top, height, left: 0, width: planLaneWidthPercent } };
+  });
+
+  const logLayouts = logs.map((entry) => {
+    const { top, height } = timeToPosition(
+      entry.displayStartDate,
+      entry.displayEndDate,
+      hourHeight,
+    );
+    return {
+      entry,
+      position: { top, height, left: planLaneWidthPercent, width: logLaneWidthPercent },
+    };
+  });
+
+  return { planLayouts, logLayouts };
+}

--- a/apps/product/src/features/calendar/stores/__tests__/useCalendarDisplayModeStore.test.ts
+++ b/apps/product/src/features/calendar/stores/__tests__/useCalendarDisplayModeStore.test.ts
@@ -1,0 +1,21 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { useCalendarDisplayModeStore } from '../useCalendarDisplayModeStore';
+
+describe('useCalendarDisplayModeStore', () => {
+  beforeEach(() => {
+    useCalendarDisplayModeStore.setState({ mobileWeekDisplayMode: 'logged' });
+  });
+
+  it('既定値は logged（記録主役の方針に合わせる）', () => {
+    expect(useCalendarDisplayModeStore.getState().mobileWeekDisplayMode).toBe('logged');
+  });
+
+  it('setMobileWeekDisplayMode でモードを切り替えられる', () => {
+    useCalendarDisplayModeStore.getState().setMobileWeekDisplayMode('planned');
+    expect(useCalendarDisplayModeStore.getState().mobileWeekDisplayMode).toBe('planned');
+
+    useCalendarDisplayModeStore.getState().setMobileWeekDisplayMode('logged');
+    expect(useCalendarDisplayModeStore.getState().mobileWeekDisplayMode).toBe('logged');
+  });
+});

--- a/apps/product/src/features/calendar/stores/useCalendarDisplayModeStore.ts
+++ b/apps/product/src/features/calendar/stores/useCalendarDisplayModeStore.ts
@@ -1,0 +1,44 @@
+/**
+ * Calendar 2レーン表示のモード state（Step 5）
+ *
+ * overview.md §4 の密度対応方針:
+ * - Day: 素直に 2 レーン（state 不要、常時表示）
+ * - Week「予定+記録」: Plan を細レーンで表示（state 不要、固定レイアウト）
+ * - モバイル Week: 幅が足りないため「予定だけ / 記録だけ」の表示切替が必要
+ *
+ * そのため永続化が必要な state はモバイル Week の表示切替 1 つだけ。
+ * `useCalendarFilterStore` と同じ persist パターン（localStorage）を踏襲する。
+ */
+
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+import { platformStorage } from '@/lib/zustand/storage';
+
+export type MobileWeekDisplayMode = 'planned' | 'logged';
+
+interface CalendarDisplayModeState {
+  /** モバイル Week 表示で「予定だけ」か「記録だけ」か */
+  mobileWeekDisplayMode: MobileWeekDisplayMode;
+}
+
+interface CalendarDisplayModeActions {
+  setMobileWeekDisplayMode: (mode: MobileWeekDisplayMode) => void;
+}
+
+type CalendarDisplayModeStore = CalendarDisplayModeState & CalendarDisplayModeActions;
+
+/** Calendar 2レーン表示のモバイル Week 表示切替を管理する Zustand ストア（localStorage 永続化） */
+export const useCalendarDisplayModeStore = create<CalendarDisplayModeStore>()(
+  persist(
+    (set) => ({
+      mobileWeekDisplayMode: 'logged',
+      setMobileWeekDisplayMode: (mode) => set({ mobileWeekDisplayMode: mode }),
+    }),
+    {
+      name: 'calendar-display-mode-storage',
+      version: 1,
+      storage: platformStorage<CalendarDisplayModeState>(),
+    },
+  ),
+);

--- a/apps/product/src/features/calendar/stores/useCalendarDisplayModeStore.ts
+++ b/apps/product/src/features/calendar/stores/useCalendarDisplayModeStore.ts
@@ -15,7 +15,7 @@ import { persist } from 'zustand/middleware';
 
 import { platformStorage } from '@/lib/zustand/storage';
 
-export type MobileWeekDisplayMode = 'planned' | 'logged';
+type MobileWeekDisplayMode = 'planned' | 'logged';
 
 interface CalendarDisplayModeState {
   /** モバイル Week 表示で「予定だけ」か「記録だけ」か */

--- a/apps/product/src/features/entry/index.ts
+++ b/apps/product/src/features/entry/index.ts
@@ -28,7 +28,7 @@ export { useEntryInspectorStore } from './stores/useEntryInspectorStore';
 // =============================================================================
 // Lib (actual-time overlay)
 // =============================================================================
-export { computeActualTimeDiffOverlay } from './lib/actual-time-overlay';
+export { computeActualTimeDiffOverlay, formatDiffMinutes } from './lib/actual-time-overlay';
 export { entryTintColor } from './lib/entry-tint';
 
 // =============================================================================

--- a/apps/product/src/features/entry/index.ts
+++ b/apps/product/src/features/entry/index.ts
@@ -12,6 +12,8 @@
 // =============================================================================
 export type { CalendarEvent } from './types/calendar-event';
 export type { EntryWithTags } from './types/entry';
+export type { LogEvent } from './types/log-event';
+export type { PlanEvent, PlanEventStatus } from './types/plan-event';
 
 // =============================================================================
 // Hooks

--- a/apps/product/src/features/entry/types/log-event.ts
+++ b/apps/product/src/features/entry/types/log-event.ts
@@ -1,0 +1,28 @@
+/**
+ * `logs` の表示用射影型（Calendar Log レーンでのレンダリングに使用、視覚的な主役）。
+ *
+ * `CalendarEvent`（entries 統合型）から独立した Step 5 の新規型。
+ * `diffMinutes` は `planId` が紐づく log のみ算出される（実績 − 予定、分）。
+ * ±0 を非表示にする判断は表示コンポーネント側の責務（copywriting「判定せず数字で示す」）。
+ */
+export interface LogEvent {
+  id: string;
+  title: string;
+  note: string | null;
+  tagId: string | null;
+  /** 紐づく plan の id。null なら予定外の記録。 */
+  planId: string | null;
+  startDate: Date;
+  endDate: Date;
+  /** タイムゾーン変換済みの表示用開始時刻 */
+  displayStartDate: Date;
+  /** タイムゾーン変換済みの表示用終了時刻 */
+  displayEndDate: Date;
+  /** 分単位の所要時間 */
+  duration: number;
+  fulfillmentScore: number | null;
+  /** 実績 − 予定（分）。`planId` が無い log では undefined。 */
+  diffMinutes?: number | undefined;
+  /** 未保存のプレビュー状態 */
+  isDraft?: boolean | undefined;
+}

--- a/apps/product/src/features/entry/types/plan-event.ts
+++ b/apps/product/src/features/entry/types/plan-event.ts
@@ -1,0 +1,29 @@
+/**
+ * `plans` の表示用射影型（Calendar Plan レーンでのレンダリングに使用）。
+ *
+ * `CalendarEvent`（entries 統合型）から独立した Step 5 の新規型。
+ * `status` は「過去 Plan の見え方」（overview.md §4）を表現する:
+ * - `upcoming` / `active`: 通常のアウトライン表示
+ * - `unrecorded`: 過去・未 skip・logs なし（静かなプロンプト）
+ * - `recorded`: 過去・logs あり（記録済み、控えめ表示）
+ * - `skipped`: `skipped_at` あり（減衰表示）
+ */
+export type PlanEventStatus = 'upcoming' | 'active' | 'unrecorded' | 'recorded' | 'skipped';
+
+export interface PlanEvent {
+  id: string;
+  title: string;
+  note: string | null;
+  tagId: string | null;
+  startDate: Date;
+  endDate: Date;
+  /** タイムゾーン変換済みの表示用開始時刻 */
+  displayStartDate: Date;
+  /** タイムゾーン変換済みの表示用終了時刻 */
+  displayEndDate: Date;
+  /** 分単位の所要時間 */
+  duration: number;
+  status: PlanEventStatus;
+  /** 未保存のプレビュー状態 */
+  isDraft?: boolean | undefined;
+}


### PR DESCRIPTION
## Summary

[docs/projects/time-model-split/step-5-calendar-two-lane.md](../blob/main/docs/projects/time-model-split/step-5-calendar-two-lane.md) に基づき、time-model-split Phase 1 Step 5「Calendar 2レーン表示（read側）」を実装。

overview.md §4 の2レーン構成（Log=塗り・主役、Plan=アウトライン・淡色）を、既存の単一レーン表示（entries + compare rail）を一切壊さない**新レンダリング系**として追加する。既存ビューへの接続は Step 8 のフリップで行うため、本PRの内容はすべて router/画面から未接続の dormant 実装。

- `entry/types/plan-event.ts` / `log-event.ts`: `CalendarEvent`（entries統合型）から独立した `PlanEvent`/`LogEvent` 射影型。`PlanEvent.status` は skip > 記録済み > 時間位置（unrecorded/active/upcoming）の優先順位で「過去Planの見え方」を表現
- `calendar/lib/plan-event-adapter.ts` / `log-event-adapter.ts`: `plans`/`logs` 行からの変換。`LogEvent.diffMinutes` は1 planに複数logが紐づく1:Nケースにも対応
- `calendar/lib/two-lane-layout.ts`: Plan/Log固定2レーンの座標計算。`plans_no_overlap`/`logs_no_overlap` のDB EXCLUDE制約によりレーン内で同種イベントは重複しないため、既存 `layout.ts` の動的column割当（sweep-line）は使わず単純な時刻→座標変換で済ませている
- `calendar/components/.../TwoLane/`: `PlanLaneCard`（アウトライン、status別に破線/斜線ハッチングで差別化）/ `LogLaneCard`（塗り、diffバッジ、予定外マーカー）/ `DiffBadge`（実績-予定、±0は非表示）/ `TwoLaneDayColumn`（合成）。Storybook stories（AllPatterns含む）を追加し、Storybookで実際に視覚確認済み
- `calendar/stores/useCalendarDisplayModeStore.ts`: モバイルWeekの「予定だけ/記録だけ」表示切替（Day 2レーン・Week細レーンは固定レイアウトのためstate不要）

Storybook上で `PlanLaneCard`/`LogLaneCard` の全 status/diff variant、`TwoLaneDayColumn` の合成を目視確認済み（過程で `h-[Npx]` というTailwind任意値クラスがビルドで生成されない既存の潜在バグを発見し、inline styleに置き換えて修正）。

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm lint:boundaries`
- [x] `pnpm check`（CI Stage 1 相当、knip含めて全通過、1936 tests）
- [x] Storybook で `PlanLaneCard` / `LogLaneCard` / `TwoLaneDayColumn` の AllPatterns を視覚確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)