### PR TITLE
feat: time model cutoverの外部公開面を切り替え

### DIFF
--- a/apps/product/src/app/[locale]/(app)/(workspace)/_server/calendar-prefetch.ts
+++ b/apps/product/src/app/[locale]/(app)/(workspace)/_server/calendar-prefetch.ts
@@ -82,7 +82,18 @@ export async function prefetchCalendarData(view: CalendarViewType, targetDate: D
 
   try {
     await Promise.all([
-      helpers.entries.list.prefetch(dateFilter),
+      helpers.plans.list.prefetch({
+        ...dateFilter,
+        sortBy: 'start_at',
+        sortOrder: 'asc',
+        limit: 100,
+      }),
+      helpers.logs.list.prefetch({
+        ...dateFilter,
+        sortBy: 'start_at',
+        sortOrder: 'asc',
+        limit: 100,
+      }),
       helpers.entries.getTagStats.prefetch(),
       helpers.tags.list.prefetch(),
     ]);

--- a/apps/product/src/app/api/mcp/_server.ts
+++ b/apps/product/src/app/api/mcp/_server.ts
@@ -5,6 +5,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { OAuthClientId, SupportedScope } from '@/lib/oauth-server';
 
 import { registerEntriesListTool } from './_tools/entries-list';
+import { registerTimeModelListTools } from './_tools/time-model-list';
 
 export interface McpRequestContext {
   userId: string;
@@ -31,6 +32,7 @@ export function createMcpServer(ctx: McpRequestContext): McpServer {
   });
 
   registerEntriesListTool(server, ctx);
+  registerTimeModelListTools(server, ctx);
 
   return server;
 }

--- a/apps/product/src/app/api/mcp/_tools/entries-list.ts
+++ b/apps/product/src/app/api/mcp/_tools/entries-list.ts
@@ -95,14 +95,62 @@ export function registerEntriesListTool(server: McpServer, ctx: McpRequestContex
           clientId: ctx.clientId,
           scopes: ctx.scopes,
         });
-        const entries = await trpc.entries.list({
+        const [plans, logs] = await Promise.all([
+          trpc.plans.list({
+            limit: limit ?? 50,
+            sortBy: 'start_at',
+            sortOrder: 'desc',
+            ...(startDate ? { startDate } : {}),
+            ...(endDate ? { endDate } : {}),
+            ...(tagId ? { tagId } : {}),
+          }),
+          trpc.logs.list({
+            limit: limit ?? 50,
+            sortBy: 'start_at',
+            sortOrder: 'desc',
+            ...(startDate ? { startDate } : {}),
+            ...(endDate ? { endDate } : {}),
+            ...(tagId ? { tagId } : {}),
+          }),
+        ]);
+        const entries = [
+          ...plans.map((plan) => ({
+            id: plan.id,
+            title: plan.title,
+            description: plan.note,
+            origin: 'planned',
+            start_time: plan.start_at,
+            end_time: plan.end_at,
+            actual_start_time: null,
+            actual_end_time: null,
+            planned_duration_minutes: null,
+            tag_id: plan.tag_id,
+            created_at: plan.created_at,
+            updated_at: plan.updated_at,
+          })),
+          ...logs.map((log) => ({
+            id: log.id,
+            title: log.title,
+            description: log.note,
+            origin: log.plan_id ? 'planned' : 'unplanned',
+            start_time: log.start_at,
+            end_time: log.end_at,
+            actual_start_time: log.start_at,
+            actual_end_time: log.end_at,
+            planned_duration_minutes: null,
+            tag_id: log.tag_id,
+            created_at: log.created_at,
+            updated_at: log.updated_at,
+          })),
+        ];
+        /* const entries = await trpc.entries.list({
           limit: limit ?? 50,
           sortBy: 'start_time',
           sortOrder: 'desc',
           ...(startDate ? { startDate } : {}),
           ...(endDate ? { endDate } : {}),
           ...(tagId ? { tagId } : {}),
-        });
+        }); */
 
         const normalized = (entries as EntryRowLike[]).map(normalizeEntry);
         return {

--- a/apps/product/src/app/api/mcp/_tools/entries-list.ts
+++ b/apps/product/src/app/api/mcp/_tools/entries-list.ts
@@ -12,9 +12,8 @@ import type { McpRequestContext } from '../_server';
 /**
  * `entries.list` tool — Dayopt entries (timeboxes / records) を取得する。
  *
- * Phase 1 の唯一の tool。read-only。`createMcpTrpcCaller` 経由で `entries.list`
- * tRPC procedure を呼び、`proProcedure` の Pro gate と `protectedProcedure` の
- * userId 注入を再利用する (docs/projects/mcp-server/overview.md Decision 9)。
+ * Step 8 以降の互換 tool。`createMcpTrpcCaller` 経由で plans / logs の read procedure
+ * を呼び、従来の entry 形式へ合成して返す。
  */
 
 const inputSchema = {
@@ -68,6 +67,10 @@ interface EntryRowLike {
   updated_at: string | null;
 }
 
+function durationMinutes(startTime: string, endTime: string): number {
+  return Math.round((new Date(endTime).getTime() - new Date(startTime).getTime()) / 60_000);
+}
+
 export function registerEntriesListTool(server: McpServer, ctx: McpRequestContext) {
   server.registerTool(
     'entries.list',
@@ -113,7 +116,7 @@ export function registerEntriesListTool(server: McpServer, ctx: McpRequestContex
             ...(tagId ? { tagId } : {}),
           }),
         ]);
-        const entries = [
+        const entries: EntryRowLike[] = [
           ...plans.map((plan) => ({
             id: plan.id,
             title: plan.title,
@@ -123,7 +126,7 @@ export function registerEntriesListTool(server: McpServer, ctx: McpRequestContex
             end_time: plan.end_at,
             actual_start_time: null,
             actual_end_time: null,
-            planned_duration_minutes: null,
+            planned_duration_minutes: durationMinutes(plan.start_at, plan.end_at),
             tag_id: plan.tag_id,
             created_at: plan.created_at,
             updated_at: plan.updated_at,
@@ -137,22 +140,18 @@ export function registerEntriesListTool(server: McpServer, ctx: McpRequestContex
             end_time: log.end_at,
             actual_start_time: log.start_at,
             actual_end_time: log.end_at,
-            planned_duration_minutes: null,
+            planned_duration_minutes: log.plan_id
+              ? durationMinutes(log.start_at, log.end_at)
+              : null,
             tag_id: log.tag_id,
             created_at: log.created_at,
             updated_at: log.updated_at,
           })),
-        ];
-        /* const entries = await trpc.entries.list({
-          limit: limit ?? 50,
-          sortBy: 'start_time',
-          sortOrder: 'desc',
-          ...(startDate ? { startDate } : {}),
-          ...(endDate ? { endDate } : {}),
-          ...(tagId ? { tagId } : {}),
-        }); */
+        ]
+          .sort((a, b) => (b.start_time ?? '').localeCompare(a.start_time ?? ''))
+          .slice(0, limit ?? 50);
 
-        const normalized = (entries as EntryRowLike[]).map(normalizeEntry);
+        const normalized = entries.map(normalizeEntry);
         return {
           content: [
             {

--- a/apps/product/src/app/api/mcp/_tools/time-model-list.ts
+++ b/apps/product/src/app/api/mcp/_tools/time-model-list.ts
@@ -2,6 +2,7 @@ import 'server-only';
 
 import { z } from 'zod';
 
+import { logger } from '@/lib/logger';
 import { createMcpTrpcCaller } from '@/lib/mcp/trpc-bridge';
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -29,29 +30,39 @@ export function registerTimeModelListTools(server: McpServer, ctx: McpRequestCon
         if (!ctx.scopes.includes('read:entries')) {
           return { content: [{ type: 'text' as const, text: 'Access denied.' }], isError: true };
         }
-        const trpc = createMcpTrpcCaller({
-          userId: ctx.userId,
-          clientId: ctx.clientId,
-          scopes: ctx.scopes,
-        });
-        const input = {
-          limit: limit ?? 50,
-          ...(startDate ? { startDate } : {}),
-          ...(endDate ? { endDate } : {}),
-          ...(tagId ? { tagId } : {}),
-        };
-        const rows =
-          model === 'plans'
-            ? await trpc.plans.list({ ...input, sortBy: 'start_at', sortOrder: 'desc' })
-            : await trpc.logs.list({ ...input, sortBy: 'start_at', sortOrder: 'desc' });
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({ count: rows.length, [model]: rows }, null, 2),
-            },
-          ],
-        };
+        try {
+          const trpc = createMcpTrpcCaller({
+            userId: ctx.userId,
+            clientId: ctx.clientId,
+            scopes: ctx.scopes,
+          });
+          const input = {
+            limit: limit ?? 50,
+            ...(startDate ? { startDate } : {}),
+            ...(endDate ? { endDate } : {}),
+            ...(tagId ? { tagId } : {}),
+          };
+          const rows =
+            model === 'plans'
+              ? await trpc.plans.list({ ...input, sortBy: 'start_at', sortOrder: 'desc' })
+              : await trpc.logs.list({ ...input, sortBy: 'start_at', sortOrder: 'desc' });
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({ count: rows.length, [model]: rows }, null, 2),
+              },
+            ],
+          };
+        } catch (error) {
+          logger.error({ error, model, userId: ctx.userId }, `[mcp] ${model}.list failed`);
+          return {
+            content: [
+              { type: 'text' as const, text: `Failed to list ${model}. Please try again.` },
+            ],
+            isError: true,
+          };
+        }
       },
     );
   }

--- a/apps/product/src/app/api/mcp/_tools/time-model-list.ts
+++ b/apps/product/src/app/api/mcp/_tools/time-model-list.ts
@@ -1,0 +1,58 @@
+import 'server-only';
+
+import { z } from 'zod';
+
+import { createMcpTrpcCaller } from '@/lib/mcp/trpc-bridge';
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type { McpRequestContext } from '../_server';
+
+const inputSchema = {
+  startDate: z.string().datetime().optional(),
+  endDate: z.string().datetime().optional(),
+  tagId: z.string().uuid().optional(),
+  limit: z.number().int().min(1).max(100).optional(),
+};
+
+/** Step 8: Plan / Log を個別に公開する。entries.list は互換のため残す。 */
+export function registerTimeModelListTools(server: McpServer, ctx: McpRequestContext) {
+  for (const model of ['plans', 'logs'] as const) {
+    server.registerTool(
+      `${model}.list`,
+      {
+        title: `List Dayopt ${model}`,
+        description: `List authenticated user's ${model}.`,
+        inputSchema,
+      },
+      async ({ startDate, endDate, tagId, limit }) => {
+        if (!ctx.scopes.includes('read:entries')) {
+          return { content: [{ type: 'text' as const, text: 'Access denied.' }], isError: true };
+        }
+        const trpc = createMcpTrpcCaller({
+          userId: ctx.userId,
+          clientId: ctx.clientId,
+          scopes: ctx.scopes,
+        });
+        const input = {
+          limit: limit ?? 50,
+          ...(startDate ? { startDate } : {}),
+          ...(endDate ? { endDate } : {}),
+          ...(tagId ? { tagId } : {}),
+        };
+        const rows =
+          model === 'plans'
+            ? await trpc.plans.list({ ...input, sortBy: 'start_at', sortOrder: 'desc' })
+            : await trpc.logs.list({ ...input, sortBy: 'start_at', sortOrder: 'desc' });
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({ count: rows.length, [model]: rows }, null, 2),
+            },
+          ],
+        };
+      },
+    );
+  }
+}

--- a/apps/product/src/app/api/v1/calendar/[token]/route.ts
+++ b/apps/product/src/app/api/v1/calendar/[token]/route.ts
@@ -36,7 +36,7 @@ async function getUserIdByToken(token: string): Promise<string | null> {
 /**
  * ユーザーのエントリを取得（タグ名含む）
  */
-async function getEntriesForFeed(userId: string) {
+async function getPlansForFeed(userId: string) {
   const supabase = createServiceRoleClient();
 
   // 過去90日〜未来90日のエントリを取得
@@ -44,47 +44,45 @@ async function getEntriesForFeed(userId: string) {
   const past = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000).toISOString();
   const future = new Date(now.getTime() + 90 * 24 * 60 * 60 * 1000).toISOString();
 
-  const { data: entries, error } = await supabase
-    .from('entries')
+  const { data: plans, error } = await supabase
+    .from('plans')
     .select(
       `
       id,
       title,
-      description,
-      start_time,
-      end_time,
+      note,
+      start_at,
+      end_at,
       created_at,
       updated_at,
       tag_id,
-      tags!entries_tag_id_fkey(name)
+      tags(name)
     `,
     )
     .eq('user_id', userId)
     .is('deleted_at', null)
-    .not('start_time', 'is', null)
-    .not('end_time', 'is', null)
-    .gte('start_time', past)
-    .lte('start_time', future)
-    .order('start_time', { ascending: true })
+    .gte('start_at', past)
+    .lte('start_at', future)
+    .order('start_at', { ascending: true })
     .limit(1000);
 
   if (error) {
-    logger.error('[iCal Feed] entries fetch error', error);
+    logger.error('[iCal Feed] plans fetch error', error);
     return [];
   }
 
   // tags リレーションからタグ名を抽出
-  return (entries ?? []).map((entry) => {
-    const tags = entry.tags as unknown as { name: string } | null;
+  return (plans ?? []).map((plan) => {
+    const tags = plan.tags as unknown as { name: string } | null;
     const tagName = tags?.name ?? null;
     return {
-      id: entry.id,
-      title: entry.title,
-      description: entry.description,
-      start_time: entry.start_time,
-      end_time: entry.end_time,
-      created_at: entry.created_at,
-      updated_at: entry.updated_at,
+      id: plan.id,
+      title: plan.title,
+      description: plan.note,
+      start_time: plan.start_at,
+      end_time: plan.end_at,
+      created_at: plan.created_at,
+      updated_at: plan.updated_at,
       tag_name: tagName,
     };
   });
@@ -199,8 +197,8 @@ export async function GET(
   }
 
   // エントリ取得 → iCal変換
-  const entries = await getEntriesForFeed(userId);
-  const ical = entriesToICal(entries);
+  const plans = await getPlansForFeed(userId);
+  const ical = entriesToICal(plans);
 
   return new NextResponse(ical, {
     status: 200,

--- a/apps/product/src/features/calendar/components/controller/hooks/useCalendarData.ts
+++ b/apps/product/src/features/calendar/components/controller/hooks/useCalendarData.ts
@@ -5,13 +5,11 @@ import { useCallback, useDeferredValue, useEffect, useMemo } from 'react';
 import { addDays, subDays } from 'date-fns';
 import { fromZonedTime } from 'date-fns-tz';
 
-import type { EntryWithTags } from '@/features/entry';
-import { useEntries } from '@/features/entry';
 import { useTags } from '@/features/tags';
 import { getDateKey } from '@/lib/date';
+import { tzIsSameDay } from '@/lib/date/timezone';
 import { useUserPreferences } from '@/lib/hooks/useUserPreferences';
 import { api } from '@/lib/trpc';
-import { expandEntriesToCalendarEvents } from '../../../lib/entry-adapter';
 
 import { useCalendarFilterStore } from '@/features/calendar/stores/useCalendarFilterStore';
 
@@ -57,15 +55,14 @@ interface UseCalendarDataResult {
   viewDateRange: ViewDateRange;
   filteredEvents: CalendarEvent[];
   allCalendarEvents: CalendarEvent[];
-  entriesData: ReturnType<typeof useEntries>['data'];
-  /** エントリ取得エラー */
-  entriesError: ReturnType<typeof useEntries>['error'];
-  /** エントリ取得中かどうか（初回のみ true） */
+  /** time model 取得エラー */
+  entriesError: unknown | null;
+  /** time model 取得中かどうか（初回のみ true） */
   isEntriesLoading: boolean;
   /** バックグラウンド再取得中も含めて取得中かどうか */
   isEntriesFetching: boolean;
   /** エントリ取得を手動で再試行する */
-  refetchEntries: ReturnType<typeof useEntries>['refetch'];
+  refetchEntries: () => Promise<unknown>;
   /** ナビゲーション方向に対応する日付範囲を事前取得する */
   prefetchDirection: (direction: 'prev' | 'next' | 'today') => void;
   /** ビュー切り替え先の日付範囲を即座に事前取得する */
@@ -75,7 +72,7 @@ interface UseCalendarDataResult {
 /**
  * カレンダーデータ取得・変換フック
  *
- * ビュータイプと日付からエントリを取得し、CalendarEvent型に変換・フィルタリングして返す
+ * ビュータイプと日付から plan / log を取得し、既存カレンダー表示型に射影して返す
  */
 export function useCalendarData({
   viewType,
@@ -100,14 +97,26 @@ export function useCalendarData({
     [viewDateRange, timezone],
   );
 
-  // entries を取得（単一クエリ）
-  const {
-    data: entriesData,
-    error: entriesError,
-    isLoading: isEntriesLoading,
-    isFetching: isEntriesFetching,
-    refetch: refetchEntries,
-  } = useEntries(dateFilter);
+  // Step 8: entries を読まず、plans / logs をそれぞれ取得する。
+  const plansQuery = api.plans.list.useQuery({
+    ...dateFilter,
+    sortBy: 'start_at',
+    sortOrder: 'asc',
+    limit: 100,
+  });
+  const logsQuery = api.logs.list.useQuery({
+    ...dateFilter,
+    sortBy: 'start_at',
+    sortOrder: 'asc',
+    limit: 100,
+  });
+  const entriesError = plansQuery.error ?? logsQuery.error;
+  const isEntriesLoading = plansQuery.isLoading || logsQuery.isLoading;
+  const isEntriesFetching = plansQuery.isFetching || logsQuery.isFetching;
+  const refetchEntries = useCallback(
+    () => Promise.all([plansQuery.refetch(), logsQuery.refetch()]),
+    [logsQuery, plansQuery],
+  );
 
   // タグマスタ取得（EntryCard等で使用するためキャッシュをwarm up + フィルタ同期）
   const { data: tagsData } = useTags();
@@ -128,10 +137,14 @@ export function useCalendarData({
   useEffect(() => {
     const prefetchRange = (date: Date, view: CalendarViewType = viewType) => {
       const range = calculateViewDateRange(view, date, weekStartsOn);
-      void utils.entries.list.prefetch({
+      const input = {
         startDate: toTZStartISO(range.start, timezone),
         endDate: toTZEndISO(range.end, timezone),
-      });
+        sortBy: 'start_at' as const,
+        sortOrder: 'asc' as const,
+        limit: 100,
+      };
+      void Promise.all([utils.plans.list.prefetch(input), utils.logs.list.prefetch(input)]);
     };
 
     if (viewType === 'day') {
@@ -150,7 +163,7 @@ export function useCalendarData({
       prefetchRange(subDays(currentDate, 7));
       prefetchRange(addDays(currentDate, 7));
     }
-  }, [currentDate, viewType, weekStartsOn, timezone, utils.entries.list]);
+  }, [currentDate, viewType, weekStartsOn, timezone, utils.logs.list, utils.plans.list]);
 
   // 指定方向のナビゲーション先を事前取得（ホバー/タッチ時に呼ばれる）
   const prefetchDirection = useCallback(
@@ -178,24 +191,32 @@ export function useCalendarData({
       }
 
       const range = calculateViewDateRange(viewType, targetDate, weekStartsOn);
-      void utils.entries.list.prefetch({
+      const input = {
         startDate: toTZStartISO(range.start, timezone),
         endDate: toTZEndISO(range.end, timezone),
-      });
+        sortBy: 'start_at' as const,
+        sortOrder: 'asc' as const,
+        limit: 100,
+      };
+      void Promise.all([utils.plans.list.prefetch(input), utils.logs.list.prefetch(input)]);
     },
-    [currentDate, viewType, weekStartsOn, timezone, utils.entries.list],
+    [currentDate, viewType, weekStartsOn, timezone, utils.logs.list, utils.plans.list],
   );
 
   // ビュー切り替え先の日付範囲を即座にprefetch（useEffect経由の1レンダー遅延を回避）
   const prefetchForView = useCallback(
     (newViewType: CalendarViewType) => {
       const range = calculateViewDateRange(newViewType, currentDate, weekStartsOn);
-      void utils.entries.list.prefetch({
+      const input = {
         startDate: toTZStartISO(range.start, timezone),
         endDate: toTZEndISO(range.end, timezone),
-      });
+        sortBy: 'start_at' as const,
+        sortOrder: 'asc' as const,
+        limit: 100,
+      };
+      void Promise.all([utils.plans.list.prefetch(input), utils.logs.list.prefetch(input)]);
     },
-    [currentDate, weekStartsOn, timezone, utils.entries.list],
+    [currentDate, weekStartsOn, timezone, utils.logs.list, utils.plans.list],
   );
 
   // フィルター関数と状態を取得（ストアに統一）
@@ -205,24 +226,74 @@ export function useCalendarData({
   // チェックボックスUIの即時応答を維持する
   const visibleTagIds = useDeferredValue(useCalendarFilterStore((state) => state.visibleTagIds));
 
-  // 全エントリをCalendarEvent型に変換
+  // Step 8 の表示互換射影。既存のカードと DnD の段階的置換が完了するまで
+  // CalendarEvent は view model としてだけ維持し、データ取得は time model に固定する。
   const allCalendarEvents = useMemo(() => {
-    const calendarPlans: CalendarEvent[] = [];
-
-    if (entriesData) {
-      // サーバー型 → コア型に正規化（tagId を保証）
-      const normalized: EntryWithTags[] = entriesData.map((e) => ({
-        ...e,
-        tagId: e.tagId ?? null,
-      })) as EntryWithTags[];
-      const expandedEvents = expandEntriesToCalendarEvents(normalized, timezone);
-      calendarPlans.push(
-        ...expandedEvents.map((event) => applyTimezoneToDisplayDates(event, timezone)),
+    const plans = plansQuery.data ?? [];
+    const logs = logsQuery.data ?? [];
+    const now = new Date();
+    const planEvents = plans.map((plan) => {
+      const startDate = new Date(plan.start_at);
+      const endDate = new Date(plan.end_at);
+      const entryState = endDate <= now ? 'past' : startDate <= now ? 'active' : 'upcoming';
+      return applyTimezoneToDisplayDates(
+        {
+          id: plan.id,
+          title: plan.title,
+          description: plan.note ?? undefined,
+          startDate,
+          endDate,
+          status: entryState === 'past' ? 'closed' : 'open',
+          color: '',
+          tagId: plan.tag_id,
+          createdAt: new Date(plan.created_at),
+          updatedAt: new Date(plan.updated_at),
+          displayStartDate: startDate,
+          displayEndDate: endDate,
+          duration: Math.round((endDate.getTime() - startDate.getTime()) / 60_000),
+          isMultiDay: !tzIsSameDay(startDate, endDate, timezone),
+          origin: 'planned',
+          entryState,
+          plannedStartDate: startDate,
+          plannedEndDate: endDate,
+          actualStartDate: null,
+          actualEndDate: null,
+          isSkipped: plan.skipped_at != null,
+        },
+        timezone,
       );
-    }
-
-    return calendarPlans;
-  }, [entriesData, timezone]);
+    });
+    const logEvents = logs.map((log) => {
+      const startDate = new Date(log.start_at);
+      const endDate = new Date(log.end_at);
+      return applyTimezoneToDisplayDates(
+        {
+          id: log.id,
+          title: log.title,
+          description: log.note ?? undefined,
+          startDate,
+          endDate,
+          status: 'closed' as const,
+          color: '',
+          tagId: log.tag_id,
+          createdAt: new Date(log.created_at),
+          updatedAt: new Date(log.updated_at),
+          displayStartDate: startDate,
+          displayEndDate: endDate,
+          duration: Math.round((endDate.getTime() - startDate.getTime()) / 60_000),
+          isMultiDay: !tzIsSameDay(startDate, endDate, timezone),
+          origin: log.plan_id ? 'planned' : 'unplanned',
+          entryState: 'past' as const,
+          actualStartDate: startDate,
+          actualEndDate: endDate,
+          plannedStartDate: null,
+          plannedEndDate: null,
+        },
+        timezone,
+      );
+    });
+    return [...planEvents, ...logEvents];
+  }, [logsQuery.data, plansQuery.data, timezone]);
 
   // 表示範囲のイベントをフィルタリング
   const filteredEvents = useMemo(() => {
@@ -262,7 +333,6 @@ export function useCalendarData({
     viewDateRange,
     filteredEvents,
     allCalendarEvents,
-    entriesData,
     entriesError,
     isEntriesLoading,
     isEntriesFetching,

--- a/apps/product/src/features/entry/hooks/index.ts
+++ b/apps/product/src/features/entry/hooks/index.ts
@@ -1,4 +1,3 @@
 // Custom Hooks
-export { useEntries } from './useEntries';
 export { useEntryMutations } from './useEntryMutations';
 export { useFindSkippableAutoRecords } from './useFindSkippableAutoRecords';

--- a/apps/product/src/features/entry/index.ts
+++ b/apps/product/src/features/entry/index.ts
@@ -18,7 +18,7 @@ export type { PlanEvent, PlanEventStatus } from './types/plan-event';
 // =============================================================================
 // Hooks
 // =============================================================================
-export { useEntries, useEntryMutations, useFindSkippableAutoRecords } from './hooks';
+export { useEntryMutations, useFindSkippableAutoRecords } from './hooks';
 
 // =============================================================================
 // Stores

--- a/apps/product/src/features/entry/server/statistics-summary-router.ts
+++ b/apps/product/src/features/entry/server/statistics-summary-router.ts
@@ -8,14 +8,13 @@ import { createTRPCRouter, proProcedure, protectedProcedure } from '@/lib/trpc/p
 import { calculateStreak } from '../domain';
 
 import { transformStatsOverviewResponse } from './statistics-overview-transform';
+import { StatisticsService } from './statistics-service';
 import {
   dateRangeInput,
   getTodayInTimezone,
   getUserTimezone,
   handleStatsError,
   stripUndefined,
-  type StatsPageData,
-  type TimePLResponse,
 } from './statistics-shared';
 
 export const entriesStatisticsSummaryRouter = createTRPCRouter({
@@ -123,34 +122,7 @@ export const entriesStatisticsSummaryRouter = createTRPCRouter({
     )
     .query(async ({ ctx, input }) => {
       try {
-        const { supabase, userId } = ctx;
-
-        // NOTE: get_time_pl_data は新規追加のため database.types.ts にまだ含まれない。
-        // 型生成後にこの as never キャストを除去する。
-        const { data, error } = await traceDbQuery('stats.get_time_pl_data', async () =>
-          supabase.rpc(
-            'get_time_pl_data' as never,
-            stripUndefined({
-              p_user_id: userId,
-              p_start_date: input.startDate,
-              p_end_date: input.endDate,
-              p_prev_start: input.prevStart,
-              p_prev_end: input.prevEnd,
-              p_wake_hour: input.wakeHour,
-              p_sleep_hour: input.sleepHour,
-            }) as never,
-          ),
-        );
-
-        if (error) {
-          throw new TRPCError({
-            code: 'INTERNAL_SERVER_ERROR',
-            message: `Failed to fetch time PL data: ${error.message}`,
-            cause: error,
-          });
-        }
-
-        return data as unknown as TimePLResponse;
+        return await new StatisticsService(ctx.supabase).getTimePLData(ctx.userId, input);
       } catch (error) {
         handleStatsError('getTimePL', error);
       }
@@ -177,32 +149,7 @@ export const entriesStatisticsSummaryRouter = createTRPCRouter({
     )
     .query(async ({ ctx, input }) => {
       try {
-        const { supabase, userId } = ctx;
-
-        const { data, error } = await traceDbQuery('stats.get_stats_page_data', async () =>
-          supabase.rpc('get_stats_page_data', {
-            p_user_id: userId,
-            p_start_date: input.startDate,
-            p_end_date: input.endDate,
-            p_prev_start: input.prevStart,
-            p_prev_end: input.prevEnd,
-            p_year: input.year,
-            p_monthly_months: input.monthlyMonths,
-            p_wake_hour: input.wakeHour,
-            p_sleep_hour: input.sleepHour,
-          }),
-        );
-
-        if (error) {
-          throw new TRPCError({
-            code: 'INTERNAL_SERVER_ERROR',
-            message: `Failed to fetch review panel data: ${error.message}`,
-            cause: error,
-          });
-        }
-
-        // DB関数が返すJSONをそのまま返す（型はクライアント側で定義）
-        return data as unknown as StatsPageData;
+        return await new StatisticsService(ctx.supabase).getStatsPageData(ctx.userId, input);
       } catch (error) {
         handleStatsError('getStatsPageData', error);
       }


### PR DESCRIPTION
## 変更内容

- iCal feed を plans 読みに切り替え
- MCP に `plans.list` / `logs.list` を追加
- `entries.list` を Plan / Log 合成の互換レスポンスへ切り替え（全体ソート・上限・エラー処理を含む）
- Time P/L と Review 統計を Step 4 の `StatisticsService` 経由へ切り替え
- Calendar と SSR prefetch の読取りを `plans.list` / `logs.list` へ切り替え
- Dead-code check を通すため、未使用になった `useEntries` の公開 export を削除

## 検証

- `pnpm typecheck`
- `pnpm test -- src/features/entry/server/__tests__/statistics-service.test.ts`
- `pnpm test -- src/features/calendar/components/views/DayView/__tests__/useDayView.test.ts`
- `pnpm quality:deadcode:ci`
- `pnpm lint`