### PR TITLE
fix: production migrationの制約順序を復旧

### DIFF
--- a/docs/operations/log/2026-07-08-supabase-migration-drift.md
+++ b/docs/operations/log/2026-07-08-supabase-migration-drift.md
@@ -1,6 +1,6 @@
 ---
 status: active
-superseded_by: 2026-07-12-incident-supabase-production-migration-stall.md
+superseded_by: ./2026-07-12-incident-supabase-production-migration-stall.md
 last_verified: 2026-07-08
 issue: 1462
 code: supabase/migrations

--- a/docs/operations/log/2026-07-08-supabase-migration-drift.md
+++ b/docs/operations/log/2026-07-08-supabase-migration-drift.md
@@ -1,5 +1,6 @@
 ---
 status: active
+superseded_by: 2026-07-12-incident-supabase-production-migration-stall.md
 last_verified: 2026-07-08
 issue: 1462
 code: supabase/migrations

--- a/docs/operations/log/2026-07-12-incident-supabase-production-migration-stall.md
+++ b/docs/operations/log/2026-07-12-incident-supabase-production-migration-stall.md
@@ -1,6 +1,6 @@
 ---
 status: frozen
-updated: 2026-07-12
+last_verified: 2026-07-12
 issue: 1462
 ---
 

--- a/docs/operations/log/2026-07-12-incident-supabase-production-migration-stall.md
+++ b/docs/operations/log/2026-07-12-incident-supabase-production-migration-stall.md
@@ -1,0 +1,34 @@
+---
+status: frozen
+updated: 2026-07-12
+issue: 1462
+---
+
+# Supabase production migration 停止
+
+Supabase GitHub integration は production migration を起動していたが、最初の未適用 migration の CHECK 制約違反により、2026-06-10 以降の schema change が production に反映されていなかった。
+
+---
+
+## 起きた事実
+
+- 2026-07-08 に main branch の `MIGRATIONS_FAILED` と、production migration history が `20260604232051_grant_authenticated_rpc_helpers` で停止していることを確認した。
+- 2026-07-12 の PR #1581 merge 後、GitHub integration は production deployment を再実行した。
+- `20260610000000_entry_auto_record_model.sql` の statement 9 で `entries_actual_time_order` 違反が発生し、後続 migration は適用されなかった。
+- 当該 migration は、旧 CHECK 制約を残したまま planned entry の actual range を `NULL` に正規化し、その後で制約を再定義する順序だった。
+- production では entries 51件のうち26件が正規化対象だった。partial actual range は0件だった。
+- production には `plans` / `logs` / `records` table がなく、time-model-split の DB migration は未到達だった。
+
+## 影響範囲
+
+- repository と production schema の migration history が不一致になった。
+- Step 8 / Step 9a のアプリケーション deploy は成功したが、production DB に Plan / Record 保存先がない状態になった。
+- #1579 の entries drop と `logs` → `records` rename は、前提 table がないため着手できなかった。
+- clean database と空データの Preview Branch では対象 backfill が0件となり、操作順序の不具合を検知できなかった。
+
+## 学び
+
+- data cleanup で既存 CHECK が許可しない中間状態を作る場合、旧制約を backfill より前に解除し、同じ deploy 内で新制約を再作成する。
+- clean migration replay だけでなく、production catalog と集約件数を read-only で確認し、既存データを持つ schema への適用順序をレビューする。
+- Supabase Preview が green でも、production migration history と branch-action log を merge 後に確認する。
+- 後続 migration では先行 migration の失敗を越えられない。既存 migration を改変せず、production の最終適用版と失敗版の間に forward-only bridge migration を置く。

--- a/docs/projects/time-model-split/step-9-cleanup.md
+++ b/docs/projects/time-model-split/step-9-cleanup.md
@@ -26,7 +26,8 @@ Step 8 で runtime の正を Plan / Record に切り替えた後、旧コード�
 2. **稼働確認**
    - Step 9a merge 後の Sentry と Calendar / Review / GDPR / MCP 主要動線を確認する
    - #1462 を解決し、production migration history と repository の同期を確認する
-   - Step 8 から約 1 週間の安定、backup / PITR、Step 2 の件数・時間・`plan_id` 突合を確認する
+   - backup / PITR、Step 2 の件数・時間・`plan_id` 突合を確認する
+   - 約1週間の待機条件は 2026-07-12 の Tomoya 判断で解除済み。期間ではなく上記の実測ゲートで判断する
 3. **Step 9b destructive migration**（#1579）
    - `logs` table を `records` へ rename し、旧 deploy 用の一時 `logs` view / RPC alias を作る
    - catalog で完全 signature と依存を確認してから、entries 依存 RPC、`entries_effective`、`entries` を drop する

--- a/supabase/migrations/20260609235959_pre_drop_entry_auto_record_constraints.sql
+++ b/supabase/migrations/20260609235959_pre_drop_entry_auto_record_constraints.sql
@@ -12,6 +12,9 @@ ALTER TABLE public.entries
   DROP CONSTRAINT IF EXISTS entries_actual_time_order;
 
 ALTER TABLE public.entries
+  DROP CONSTRAINT IF EXISTS entries_actual_time_order_check;
+
+ALTER TABLE public.entries
   DROP CONSTRAINT IF EXISTS entries_two_layer_shape;
 
 ALTER TABLE public.entries

--- a/supabase/migrations/20260609999999_pre_drop_entry_auto_record_constraints.sql
+++ b/supabase/migrations/20260609999999_pre_drop_entry_auto_record_constraints.sql
@@ -1,0 +1,63 @@
+-- Recovery bridge for production, where 20260610000000 fails while clearing
+-- legacy actual ranges before replacing the old two-layer constraints.
+--
+-- This migration is intentionally ordered immediately before 20260610000000.
+-- NOT VALID keeps legacy rows available for that migration's cleanup while the
+-- constraints still protect writes made between the two migration commits.
+
+ALTER TABLE public.entries
+  ADD COLUMN IF NOT EXISTS skipped_at TIMESTAMPTZ;
+
+ALTER TABLE public.entries
+  DROP CONSTRAINT IF EXISTS entries_actual_time_order;
+
+ALTER TABLE public.entries
+  DROP CONSTRAINT IF EXISTS entries_two_layer_shape;
+
+ALTER TABLE public.entries
+  DROP CONSTRAINT IF EXISTS entries_skip_shape;
+
+ALTER TABLE public.entries
+  ADD CONSTRAINT entries_actual_time_order
+  CHECK (
+    deleted_at IS NOT NULL
+    OR (actual_start_time IS NULL AND actual_end_time IS NULL)
+    OR (
+      actual_start_time IS NOT NULL
+      AND actual_end_time IS NOT NULL
+      AND actual_end_time > actual_start_time
+    )
+  ) NOT VALID;
+
+ALTER TABLE public.entries
+  ADD CONSTRAINT entries_two_layer_shape
+  CHECK (
+    deleted_at IS NOT NULL
+    OR (
+      origin = 'planned'
+      AND start_time IS NOT NULL
+      AND end_time IS NOT NULL
+      AND (
+        (actual_start_time IS NULL AND actual_end_time IS NULL)
+        OR (actual_start_time IS NOT NULL AND actual_end_time IS NOT NULL)
+      )
+    )
+    OR (
+      origin = 'unplanned'
+      AND start_time IS NULL
+      AND end_time IS NULL
+      AND actual_start_time IS NOT NULL
+      AND actual_end_time IS NOT NULL
+    )
+  ) NOT VALID;
+
+ALTER TABLE public.entries
+  ADD CONSTRAINT entries_skip_shape
+  CHECK (
+    skipped_at IS NULL
+    OR (
+      origin = 'planned'
+      AND actual_start_time IS NULL
+      AND actual_end_time IS NULL
+    )
+  ) NOT VALID;


### PR DESCRIPTION
## Summary

- production の最初の未適用 migration より前に forward-only bridge migration を追加
- legacy `entries_actual_time_order` / `entries_two_layer_shape` を新モデルの `NOT VALID` 制約へ置換
- 後続 `20260610000000_entry_auto_record_model.sql` の data cleanup が CHECK 違反せず進める順序へ復旧
- incident log と Step 9 の実測ゲートを更新

Relates #1462

## Root cause

Supabase main branch-action は `20260610000000_entry_auto_record_model.sql` statement 9 で停止していました。旧制約が actual range の NULL を許可しない一方、migration は制約を外す前に26件の planned entry を NULL 化していました。

production migration history は `20260604232051` で停止し、production には `plans` / `logs` が未作成です。

## Safety

- 既存 migration は変更しない
- bridge は production 最終適用版と失敗版の間にのみ配置
- `NOT VALID` により既存 legacy row は後続 cleanup へ渡しつつ、新規 write は制約で保護
- RLS / GRANT / Data API / Realtime は変更しない
- production への手動 SQL / `db push` は行わない
- #1579 の destructive migration は本 PR に含めない
- Draft を維持し、backup / PITR 確認後にのみ ready / merge する

## Verification

- [x] `pnpm check`（unit 1695件 + scripts 5件）
- [x] `pnpm docs:check`
- [x] Integration Tests
- [x] Supabase Preview migration replay
- [x] Preview migration history が `20260711065312` まで到達
- [x] `entries` / `plans` / `logs` の RLS 有効
- [x] bridge 対象3制約が最終的に validated
- [x] Realtime publication が空
- [x] E2E / build / typecheck / lint / CodeQL
- [ ] production backup / PITR 確認
- [ ] merge 後に production migration history / branch status / catalog を再確認

## Local limitation

Docker daemon が停止していたため local `supabase db reset` は未実行です。GitHub Integration Tests と Supabase Preview の full replay は green です。