### PR TITLE
fix: Supabase RPC権限を整理

### DIFF
--- a/apps/product/src/features/auth/server/__tests__/recovery-service.test.ts
+++ b/apps/product/src/features/auth/server/__tests__/recovery-service.test.ts
@@ -7,12 +7,14 @@ import { RecoveryService } from '../recovery-service';
 const listFactors = vi.hoisted(() => vi.fn());
 const deleteFactor = vi.hoisted(() => vi.fn());
 const verifyRecoveryCode = vi.hoisted(() => vi.fn());
+const adminRpc = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/auth/recovery-codes', () => ({ verifyRecoveryCode }));
 
 vi.mock('@/lib/supabase/oauth', () => ({
   createServiceRoleClient: () => ({
     auth: { admin: { mfa: { listFactors, deleteFactor } } },
+    rpc: adminRpc,
   }),
 }));
 
@@ -23,10 +25,12 @@ function createService(options?: {
   codes?: unknown[] | null;
   fetchError?: { message: string; code?: string } | null;
   rpcResults?: Array<{ data: unknown; error: { message: string } | null }>;
+  adminRpcResult?: { data: unknown; error: { message: string } | null };
 }) {
   const query = createChainableMock(options?.codes ?? [], options?.fetchError ?? null);
   const rpcResults = [...(options?.rpcResults ?? [])];
   const rpc = vi.fn(async () => rpcResults.shift() ?? { data: null, error: null });
+  adminRpc.mockResolvedValue(options?.adminRpcResult ?? { data: true, error: null });
   const from = vi.fn(() => query);
 
   return {
@@ -50,10 +54,7 @@ describe('RecoveryService', () => {
     const hash = 'matching-hash';
     const { service, query, rpc } = createService({
       codes: [{ id: 'code-1', code_hash: hash }],
-      rpcResults: [
-        { data: true, error: null },
-        { data: 7, error: null },
-      ],
+      rpcResults: [{ data: 7, error: null }],
     });
     listFactors.mockResolvedValue({
       data: {
@@ -71,10 +72,11 @@ describe('RecoveryService', () => {
     });
     expect(query.eq).toHaveBeenCalledWith('user_id', USER_ID);
     expect(query.is).toHaveBeenCalledWith('used_at', null);
-    expect(rpc).toHaveBeenNthCalledWith(1, 'use_recovery_code', {
+    expect(adminRpc).toHaveBeenCalledWith('use_recovery_code', {
       p_user_id: USER_ID,
       p_code_hash: hash,
     });
+    expect(rpc).toHaveBeenCalledWith('count_unused_recovery_codes', { p_user_id: USER_ID });
     expect(deleteFactor).toHaveBeenCalledWith({ userId: USER_ID, id: 'verified-1' });
     expect(deleteFactor).not.toHaveBeenCalledWith({ userId: USER_ID, id: 'unverified-1' });
   });
@@ -113,7 +115,7 @@ describe('RecoveryService', () => {
   it('コード消費に失敗した場合はfactorを削除しない', async () => {
     const { service } = createService({
       codes: [{ id: 'code-1', code_hash: 'matching-hash' }],
-      rpcResults: [{ data: false, error: null }],
+      adminRpcResult: { data: false, error: null },
     });
 
     await expect(service.verify({ userId: USER_ID, code: CODE })).rejects.toMatchObject({
@@ -126,10 +128,7 @@ describe('RecoveryService', () => {
   it('残数取得の失敗は非致命的として0を返す', async () => {
     const { service } = createService({
       codes: [{ id: 'code-1', code_hash: 'matching-hash' }],
-      rpcResults: [
-        { data: true, error: null },
-        { data: null, error: { message: 'count failed' } },
-      ],
+      rpcResults: [{ data: null, error: { message: 'count failed' } }],
     });
 
     await expect(service.verify({ userId: USER_ID, code: CODE })).resolves.toEqual({

--- a/apps/product/src/features/auth/server/recovery-service.ts
+++ b/apps/product/src/features/auth/server/recovery-service.ts
@@ -43,7 +43,8 @@ export class RecoveryService {
       throw new RecoveryServiceError('RECOVERY_INVALID', 'RECOVERY_INVALID');
     }
 
-    const { data: used, error: rpcError } = await this.supabase.rpc('use_recovery_code', {
+    const adminClient = createServiceRoleClient();
+    const { data: used, error: rpcError } = await adminClient.rpc('use_recovery_code', {
       p_user_id: userId,
       p_code_hash: matchedCode.code_hash,
     });
@@ -57,7 +58,6 @@ export class RecoveryService {
     }
 
     try {
-      const adminClient = createServiceRoleClient();
       const { data: factors } = await adminClient.auth.admin.mfa.listFactors({ userId });
 
       if (factors?.factors) {

--- a/apps/product/src/features/tags/server/__tests__/tag-service.test.ts
+++ b/apps/product/src/features/tags/server/__tests__/tag-service.test.ts
@@ -9,9 +9,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createChainableMock, createMockSupabase } from '@/lib/test/trpc-test-helpers';
 
 const adminFrom = vi.hoisted(() => vi.fn());
+const adminRpc = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/supabase/oauth', () => ({
-  createServiceRoleClient: () => ({ from: adminFrom }),
+  createServiceRoleClient: () => ({ from: adminFrom, rpc: adminRpc }),
 }));
 
 import { createTagService, TagService, TagServiceError } from '../tag-service';
@@ -25,6 +26,7 @@ describe('TagService', () => {
     vi.clearAllMocks();
     mockSupabase = createMockSupabase();
     adminFrom.mockImplementation(() => createChainableMock([], null));
+    adminRpc.mockResolvedValue({ data: null, error: null });
     service = createTagService(mockSupabase as unknown as Parameters<typeof createTagService>[0]);
   });
 
@@ -478,7 +480,7 @@ describe('TagService', () => {
         targetTag,
         sourceChildrenCount: 0,
       });
-      mockSupabase.rpc.mockResolvedValueOnce({
+      adminRpc.mockResolvedValueOnce({
         data: { migrated: 5, children_reparented: 0 },
         error: null,
       });
@@ -489,11 +491,15 @@ describe('TagService', () => {
         targetTagId: 'tgt',
       });
 
-      expect(mockSupabase.rpc).toHaveBeenCalledWith('merge_tags_with_hierarchy', {
+      expect(adminRpc).toHaveBeenCalledWith('merge_tags_with_hierarchy', {
         p_user_id: userId,
         p_source_tag_id: 'src',
         p_target_tag_id: 'tgt',
       });
+      expect(mockSupabase.rpc).not.toHaveBeenCalledWith(
+        'merge_tags_with_hierarchy',
+        expect.anything(),
+      );
       expect(result.success).toBe(true);
       expect(result.mergedAssociations).toBe(5);
       expect(result.targetTag).toMatchObject(targetTag);
@@ -515,7 +521,7 @@ describe('TagService', () => {
       ).rejects.toMatchObject({ code: 'INVALID_INPUT' });
 
       // RPC は呼ばれない（早期 throw）
-      expect(mockSupabase.rpc).not.toHaveBeenCalled();
+      expect(adminRpc).not.toHaveBeenCalled();
     });
 
     it('should throw MERGE_FAILED on RPC error', async () => {
@@ -527,7 +533,7 @@ describe('TagService', () => {
         targetTag,
         sourceChildrenCount: 0,
       });
-      mockSupabase.rpc.mockResolvedValueOnce({
+      adminRpc.mockResolvedValueOnce({
         data: null,
         error: { message: 'rpc failed' },
       });
@@ -546,7 +552,7 @@ describe('TagService', () => {
         targetTag,
         sourceChildrenCount: 0,
       });
-      mockSupabase.rpc.mockResolvedValueOnce({ data: null, error: null });
+      adminRpc.mockResolvedValueOnce({ data: null, error: null });
 
       const result = await service.merge({
         userId,

--- a/apps/product/src/features/tags/server/tag-service.ts
+++ b/apps/product/src/features/tags/server/tag-service.ts
@@ -741,14 +741,12 @@ export class TagService {
       throw new TagServiceError('INVALID_INPUT', 'Cannot merge a parent tag into a child tag.');
     }
 
-    const { data: rpcData, error: rpcError } = await this.supabase.rpc(
-      'merge_tags_with_hierarchy',
-      {
-        p_user_id: userId,
-        p_source_tag_id: sourceTagId,
-        p_target_tag_id: targetTagId,
-      },
-    );
+    const adminClient = createServiceRoleClient();
+    const { data: rpcData, error: rpcError } = await adminClient.rpc('merge_tags_with_hierarchy', {
+      p_user_id: userId,
+      p_source_tag_id: sourceTagId,
+      p_target_tag_id: targetTagId,
+    });
 
     if (rpcError) {
       throw new TagServiceError(

--- a/apps/product/src/features/timeblock/server/__tests__/plan-record-service.test.ts
+++ b/apps/product/src/features/timeblock/server/__tests__/plan-record-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createChainableMock, createMockSupabase } from '@/lib/test/trpc-test-helpers';
 import { PlanService } from '../plan-service';
@@ -7,7 +7,18 @@ import { TimeblockServiceError } from '../timeblock-service-error';
 import type { PlanRow, RecordRow } from '../timeblock-types';
 import type { ServiceSupabaseClient } from '../types';
 
+const adminRpc = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/supabase/oauth', () => ({
+  createServiceRoleClient: () => ({ rpc: adminRpc }),
+}));
+
 const USER_ID = 'test-user-id';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  adminRpc.mockResolvedValue({ data: null, error: null });
+});
 
 function createPlanService(mockSupabase = createMockSupabase()) {
   return {
@@ -242,6 +253,29 @@ describe('PlanService.skip', () => {
   });
 });
 
+describe('PlanService soft delete', () => {
+  it('deleteはuser client、restoreはservice-role clientを使う', async () => {
+    const { service, mockSupabase } = createPlanService();
+    mockSupabase.rpc.mockResolvedValue({ data: null, error: null });
+
+    await expect(service.delete({ userId: USER_ID, planId: 'plan-1' })).resolves.toEqual({
+      success: true,
+    });
+    await expect(service.restore({ userId: USER_ID, planId: 'plan-1' })).resolves.toEqual({
+      success: true,
+    });
+
+    expect(mockSupabase.rpc).toHaveBeenCalledWith('soft_delete_plan', {
+      p_plan_id: 'plan-1',
+      p_user_id: USER_ID,
+    });
+    expect(adminRpc).toHaveBeenCalledWith('restore_plan', {
+      p_plan_id: 'plan-1',
+      p_user_id: USER_ID,
+    });
+  });
+});
+
 describe('PlanService.confirmDay', () => {
   it('confirm_day_plans_to_records RPC へ user と day range を渡す', async () => {
     const record = createRecord({ source: 'from_plan' });
@@ -369,7 +403,7 @@ describe('RecordService.create', () => {
 });
 
 describe('RecordService soft delete', () => {
-  it('Record 正本 RPC で delete / restore する', async () => {
+  it('deleteはuser client、restoreはservice-role clientを使う', async () => {
     const { service, mockSupabase } = createRecordService();
     mockSupabase.rpc.mockResolvedValue({ data: null, error: null });
 
@@ -380,11 +414,11 @@ describe('RecordService soft delete', () => {
       success: true,
     });
 
-    expect(mockSupabase.rpc).toHaveBeenNthCalledWith(1, 'soft_delete_record', {
+    expect(mockSupabase.rpc).toHaveBeenCalledWith('soft_delete_record', {
       p_record_id: 'record-1',
       p_user_id: USER_ID,
     });
-    expect(mockSupabase.rpc).toHaveBeenNthCalledWith(2, 'restore_record', {
+    expect(adminRpc).toHaveBeenCalledWith('restore_record', {
       p_record_id: 'record-1',
       p_user_id: USER_ID,
     });
@@ -393,6 +427,7 @@ describe('RecordService soft delete', () => {
   it('delete / restore失敗時もRecord語彙でエラーを返す', async () => {
     const { service, mockSupabase } = createRecordService();
     mockSupabase.rpc.mockResolvedValue({ data: null, error: { message: 'denied' } });
+    adminRpc.mockResolvedValue({ data: null, error: { message: 'denied' } });
 
     await expect(service.delete({ userId: USER_ID, recordId: 'record-1' })).rejects.toThrow(
       'Failed to delete record: denied',

--- a/apps/product/src/features/timeblock/server/plan-service.ts
+++ b/apps/product/src/features/timeblock/server/plan-service.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import { databaseTables } from '@/lib/database';
+import { createServiceRoleClient } from '@/lib/supabase/oauth';
 
 import { TimeblockOverlapService } from './timeblock-overlap-service';
 import { TimeblockServiceError } from './timeblock-service-error';
@@ -183,7 +184,8 @@ export class PlanService {
 
   async restore(options: DeletePlanOptions): Promise<{ success: boolean }> {
     const { userId, planId } = options;
-    const { error } = await this.supabase.rpc('restore_plan', {
+    const adminClient = createServiceRoleClient();
+    const { error } = await adminClient.rpc('restore_plan', {
       p_plan_id: planId,
       p_user_id: userId,
     });

--- a/apps/product/src/features/timeblock/server/record-service.ts
+++ b/apps/product/src/features/timeblock/server/record-service.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import { databaseTables } from '@/lib/database';
+import { createServiceRoleClient } from '@/lib/supabase/oauth';
 
 import { TimeblockOverlapService } from './timeblock-overlap-service';
 import { TimeblockServiceError } from './timeblock-service-error';
@@ -193,7 +194,8 @@ export class RecordService {
 
   async restore(options: DeleteRecordOptions): Promise<{ success: boolean }> {
     const { userId, recordId } = options;
-    const { error } = await this.supabase.rpc('restore_record', {
+    const adminClient = createServiceRoleClient();
+    const { error } = await adminClient.rpc('restore_record', {
       p_record_id: recordId,
       p_user_id: userId,
     });

--- a/apps/product/src/lib/test/integration-setup.ts
+++ b/apps/product/src/lib/test/integration-setup.ts
@@ -1,4 +1,12 @@
 import { vi } from 'vitest';
 
+// Server services create their own Supabase client. Keep those clients on the
+// same local project as the direct integration-test clients when env is absent.
+process.env.NEXT_PUBLIC_SUPABASE_URL ??= 'http://127.0.0.1:54321';
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??=
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5Nn0.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0';
+process.env.SUPABASE_SERVICE_ROLE_KEY ??=
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU';
+
 // server-only: テスト環境ではサーバーコンポーネント制約を無効化
 vi.mock('server-only', () => ({}));

--- a/apps/product/src/lib/test/integration/rls-access.integration.test.ts
+++ b/apps/product/src/lib/test/integration/rls-access.integration.test.ts
@@ -20,6 +20,24 @@ const TEST_USER_A_ID = crypto.randomUUID();
 const TEST_USER_B_ID = crypto.randomUUID();
 const TEST_USER_B_PLAN_ID = crypto.randomUUID();
 const TEST_USER_B_RECORD_ID = crypto.randomUUID();
+const RPC_BATCH_TAG_ID = crypto.randomUUID();
+const RPC_REORDER_TAG_ID = crypto.randomUUID();
+const RPC_PARENT_TAG_ID = crypto.randomUUID();
+const RPC_GROUP_TAG_ID = crypto.randomUUID();
+const RPC_MERGE_SOURCE_TAG_ID = crypto.randomUUID();
+const RPC_MERGE_TARGET_TAG_ID = crypto.randomUUID();
+const RPC_FOREIGN_CHILD_TAG_ID = crypto.randomUUID();
+const RPC_SOFT_DELETE_PLAN_ID = crypto.randomUUID();
+const RPC_CONFIRM_PLAN_ID = crypto.randomUUID();
+const RPC_RESTORE_PLAN_ID = crypto.randomUUID();
+const RPC_SOFT_DELETE_RECORD_ID = crypto.randomUUID();
+const RPC_RESTORE_RECORD_ID = crypto.randomUUID();
+const RPC_AUTO_ACTIVE_RECORD_ID = crypto.randomUUID();
+const RPC_AUTO_DELETED_RECORD_ID = crypto.randomUUID();
+const RPC_COUNT_CODE_ID = crypto.randomUUID();
+const RPC_USE_CODE_ID = crypto.randomUUID();
+const RPC_COUNT_CODE_HASH = `rpc-count-${crypto.randomUUID()}`;
+const RPC_USE_CODE_HASH = `rpc-use-${crypto.randomUUID()}`;
 const TEST_EMAIL_A = `test-rls-a-${TEST_USER_A_ID}@example.com`;
 const TEST_EMAIL_B = `test-rls-b-${TEST_USER_B_ID}@example.com`;
 const TEST_PASSWORD = 'test-password-123';
@@ -476,6 +494,473 @@ describe.skipIf(SKIP_INTEGRATION)('RLS access matrix', () => {
 
       expect(settingsError).toBeNull();
       expect(JSON.stringify(settings?.personalization ?? {})).toContain('rlsServiceRole');
+    });
+  });
+
+  describe('Issue #1564 RPC permission matrix', () => {
+    beforeAll(async () => {
+      const { error: tagError } = await adminSupabase.from('tags').insert([
+        {
+          id: RPC_BATCH_TAG_ID,
+          user_id: TEST_USER_B_ID,
+          name: 'RPC Batch',
+          sort_order: 0,
+        },
+        {
+          id: RPC_REORDER_TAG_ID,
+          user_id: TEST_USER_B_ID,
+          name: 'RPC Reorder',
+          sort_order: 1,
+        },
+        {
+          id: RPC_PARENT_TAG_ID,
+          user_id: TEST_USER_B_ID,
+          name: 'RPC Parent',
+          sort_order: 2,
+        },
+        {
+          id: RPC_GROUP_TAG_ID,
+          user_id: TEST_USER_B_ID,
+          name: 'RPC Old:Child',
+          sort_order: 3,
+        },
+        {
+          id: RPC_MERGE_SOURCE_TAG_ID,
+          user_id: TEST_USER_B_ID,
+          name: 'RPC Merge Source',
+          sort_order: 4,
+        },
+        {
+          id: RPC_MERGE_TARGET_TAG_ID,
+          user_id: TEST_USER_B_ID,
+          name: 'RPC Merge Target',
+          sort_order: 5,
+        },
+        {
+          id: RPC_FOREIGN_CHILD_TAG_ID,
+          user_id: TEST_USER_A_ID,
+          name: 'RPC Foreign Child',
+          sort_order: 0,
+        },
+      ]);
+      if (tagError) throw tagError;
+
+      const { error: planError } = await adminSupabase.from('plans').insert([
+        {
+          id: RPC_SOFT_DELETE_PLAN_ID,
+          user_id: TEST_USER_B_ID,
+          title: 'RPC soft-delete plan',
+          source: 'manual',
+          start_at: '2026-01-10T00:00:00.000Z',
+          end_at: '2026-01-10T01:00:00.000Z',
+        },
+        {
+          id: RPC_CONFIRM_PLAN_ID,
+          user_id: TEST_USER_B_ID,
+          title: 'RPC confirm plan',
+          source: 'manual',
+          start_at: '2026-01-11T00:00:00.000Z',
+          end_at: '2026-01-11T01:00:00.000Z',
+        },
+        {
+          id: RPC_RESTORE_PLAN_ID,
+          user_id: TEST_USER_B_ID,
+          title: 'RPC restore plan',
+          source: 'manual',
+          start_at: '2026-01-12T00:00:00.000Z',
+          end_at: '2026-01-12T01:00:00.000Z',
+          deleted_at: '2026-01-12T02:00:00.000Z',
+        },
+      ]);
+      if (planError) throw planError;
+
+      const { error: recordError } = await adminSupabase.from('records').insert([
+        {
+          id: RPC_SOFT_DELETE_RECORD_ID,
+          user_id: TEST_USER_B_ID,
+          title: 'RPC soft-delete record',
+          source: 'manual',
+          start_at: '2026-01-13T00:00:00.000Z',
+          end_at: '2026-01-13T01:00:00.000Z',
+        },
+        {
+          id: RPC_RESTORE_RECORD_ID,
+          user_id: TEST_USER_B_ID,
+          title: 'RPC restore record',
+          source: 'manual',
+          start_at: '2026-01-14T00:00:00.000Z',
+          end_at: '2026-01-14T01:00:00.000Z',
+          deleted_at: '2026-01-14T02:00:00.000Z',
+        },
+        {
+          id: RPC_AUTO_ACTIVE_RECORD_ID,
+          user_id: TEST_USER_B_ID,
+          title: 'RPC protected active record',
+          source: 'auto_migrated',
+          start_at: '2026-01-15T00:00:00.000Z',
+          end_at: '2026-01-15T01:00:00.000Z',
+        },
+        {
+          id: RPC_AUTO_DELETED_RECORD_ID,
+          user_id: TEST_USER_B_ID,
+          title: 'RPC protected deleted record',
+          source: 'auto_migrated',
+          start_at: '2026-01-16T00:00:00.000Z',
+          end_at: '2026-01-16T01:00:00.000Z',
+          deleted_at: '2026-01-16T02:00:00.000Z',
+        },
+      ]);
+      if (recordError) throw recordError;
+
+      const { error: recoveryError } = await adminSupabase.from('mfa_recovery_codes').insert([
+        {
+          id: RPC_COUNT_CODE_ID,
+          user_id: TEST_USER_B_ID,
+          code_hash: RPC_COUNT_CODE_HASH,
+        },
+        {
+          id: RPC_USE_CODE_ID,
+          user_id: TEST_USER_B_ID,
+          code_hash: RPC_USE_CODE_HASH,
+        },
+      ]);
+      if (recoveryError) throw recoveryError;
+    });
+
+    afterAll(async () => {
+      await adminSupabase.from('records').delete().eq('plan_id', RPC_CONFIRM_PLAN_ID);
+      await adminSupabase
+        .from('records')
+        .delete()
+        .in('id', [
+          RPC_SOFT_DELETE_RECORD_ID,
+          RPC_RESTORE_RECORD_ID,
+          RPC_AUTO_ACTIVE_RECORD_ID,
+          RPC_AUTO_DELETED_RECORD_ID,
+        ]);
+      await adminSupabase
+        .from('plans')
+        .delete()
+        .in('id', [RPC_SOFT_DELETE_PLAN_ID, RPC_CONFIRM_PLAN_ID, RPC_RESTORE_PLAN_ID]);
+      await adminSupabase
+        .from('mfa_recovery_codes')
+        .delete()
+        .in('id', [RPC_COUNT_CODE_ID, RPC_USE_CODE_ID]);
+      await adminSupabase
+        .from('tags')
+        .delete()
+        .in('id', [
+          RPC_BATCH_TAG_ID,
+          RPC_REORDER_TAG_ID,
+          RPC_PARENT_TAG_ID,
+          RPC_GROUP_TAG_ID,
+          RPC_MERGE_SOURCE_TAG_ID,
+          RPC_MERGE_TARGET_TAG_ID,
+          RPC_FOREIGN_CHILD_TAG_ID,
+        ]);
+    });
+
+    it('8つのinvoker RPCはcross-userのp_user_idを拒否し対象を変更しない', async () => {
+      const calls = [
+        () =>
+          supabaseA.rpc('batch_rename_tags', {
+            p_new_names: ['RPC Cross-user Rename'],
+            p_tag_ids: [RPC_BATCH_TAG_ID],
+            p_user_id: TEST_USER_B_ID,
+          }),
+        () =>
+          supabaseA.rpc('batch_reorder_tags_hierarchy', {
+            p_parent_ids: [RPC_PARENT_TAG_ID],
+            p_sort_orders: [99],
+            p_tag_ids: [RPC_REORDER_TAG_ID],
+            p_user_id: TEST_USER_B_ID,
+          }),
+        () =>
+          supabaseA.rpc('rename_tag_group', {
+            p_new_prefix: 'RPC Cross-user',
+            p_old_prefix: 'RPC Old',
+            p_user_id: TEST_USER_B_ID,
+          }),
+        () =>
+          supabaseA.rpc('confirm_day_plans_to_records', {
+            p_confirmed_at: '2026-01-12T00:00:00.000Z',
+            p_end_at: '2026-01-12T00:00:00.000Z',
+            p_start_at: '2026-01-11T00:00:00.000Z',
+            p_user_id: TEST_USER_B_ID,
+          }),
+        () => supabaseA.rpc('count_unused_recovery_codes', { p_user_id: TEST_USER_B_ID }),
+        () =>
+          supabaseA.rpc('update_personalization', {
+            p_path: 'rpcCrossUser',
+            p_user_id: TEST_USER_B_ID,
+            p_value: { blocked: true },
+          }),
+        () =>
+          supabaseA.rpc('soft_delete_plan', {
+            p_plan_id: RPC_SOFT_DELETE_PLAN_ID,
+            p_user_id: TEST_USER_B_ID,
+          }),
+        () =>
+          supabaseA.rpc('soft_delete_record', {
+            p_record_id: RPC_SOFT_DELETE_RECORD_ID,
+            p_user_id: TEST_USER_B_ID,
+          }),
+      ];
+
+      for (const call of calls) {
+        const { error } = await call();
+        expect(error?.message).toContain(ACCESS_DENIED_MESSAGE);
+      }
+
+      const [
+        { data: tags },
+        { data: plan },
+        { data: record },
+        { data: confirmed },
+        { data: settings },
+      ] = await Promise.all([
+        adminSupabase
+          .from('tags')
+          .select('id, name, parent_id, sort_order')
+          .in('id', [RPC_BATCH_TAG_ID, RPC_REORDER_TAG_ID, RPC_GROUP_TAG_ID]),
+        adminSupabase.from('plans').select('deleted_at').eq('id', RPC_SOFT_DELETE_PLAN_ID).single(),
+        adminSupabase
+          .from('records')
+          .select('deleted_at')
+          .eq('id', RPC_SOFT_DELETE_RECORD_ID)
+          .single(),
+        adminSupabase.from('records').select('id').eq('plan_id', RPC_CONFIRM_PLAN_ID),
+        adminSupabase
+          .from('user_settings')
+          .select('personalization')
+          .eq('user_id', TEST_USER_B_ID)
+          .single(),
+      ]);
+
+      expect(tags).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: RPC_BATCH_TAG_ID, name: 'RPC Batch' }),
+          expect.objectContaining({ id: RPC_REORDER_TAG_ID, parent_id: null, sort_order: 1 }),
+          expect.objectContaining({ id: RPC_GROUP_TAG_ID, name: 'RPC Old:Child' }),
+        ]),
+      );
+      expect(plan?.deleted_at).toBeNull();
+      expect(record?.deleted_at).toBeNull();
+      expect(confirmed).toEqual([]);
+      expect(JSON.stringify(settings?.personalization ?? {})).not.toContain('rpcCrossUser');
+    });
+
+    it('8つのinvoker RPCはowner経路で成功する', async () => {
+      const { data: renamed, error: renameError } = await supabaseB.rpc('batch_rename_tags', {
+        p_new_names: ['RPC Batch Renamed'],
+        p_tag_ids: [RPC_BATCH_TAG_ID],
+        p_user_id: TEST_USER_B_ID,
+      });
+      expect(renameError).toBeNull();
+      expect(renamed).toBe(1);
+
+      const { data: reordered, error: reorderError } = await supabaseB.rpc(
+        'batch_reorder_tags_hierarchy',
+        {
+          p_parent_ids: [RPC_PARENT_TAG_ID],
+          p_sort_orders: [9],
+          p_tag_ids: [RPC_REORDER_TAG_ID],
+          p_user_id: TEST_USER_B_ID,
+        },
+      );
+      expect(reorderError).toBeNull();
+      expect(reordered).toBe(1);
+
+      const { error: groupError } = await supabaseB.rpc('rename_tag_group', {
+        p_new_prefix: 'RPC New',
+        p_old_prefix: 'RPC Old',
+        p_user_id: TEST_USER_B_ID,
+      });
+      expect(groupError).toBeNull();
+
+      const { data: confirmed, error: confirmError } = await supabaseB.rpc(
+        'confirm_day_plans_to_records',
+        {
+          p_confirmed_at: '2026-01-12T00:00:00.000Z',
+          p_end_at: '2026-01-12T00:00:00.000Z',
+          p_start_at: '2026-01-11T00:00:00.000Z',
+          p_user_id: TEST_USER_B_ID,
+        },
+      );
+      expect(confirmError).toBeNull();
+      expect(confirmed).toHaveLength(1);
+
+      const { data: count, error: countError } = await supabaseB.rpc(
+        'count_unused_recovery_codes',
+        { p_user_id: TEST_USER_B_ID },
+      );
+      expect(countError).toBeNull();
+      expect(count).toBeGreaterThanOrEqual(2);
+
+      const { error: personalizationError } = await supabaseB.rpc('update_personalization', {
+        p_path: 'rpcOwner',
+        p_user_id: TEST_USER_B_ID,
+        p_value: { allowed: true },
+      });
+      expect(personalizationError).toBeNull();
+
+      const { error: planError } = await supabaseB.rpc('soft_delete_plan', {
+        p_plan_id: RPC_SOFT_DELETE_PLAN_ID,
+        p_user_id: TEST_USER_B_ID,
+      });
+      expect(planError).toBeNull();
+
+      const { error: recordError } = await supabaseB.rpc('soft_delete_record', {
+        p_record_id: RPC_SOFT_DELETE_RECORD_ID,
+        p_user_id: TEST_USER_B_ID,
+      });
+      expect(recordError).toBeNull();
+
+      const [{ data: deletedPlans }, { data: deletedRecords }] = await Promise.all([
+        supabaseB.from('plans').select('id').eq('id', RPC_SOFT_DELETE_PLAN_ID),
+        supabaseB.from('records').select('id').eq('id', RPC_SOFT_DELETE_RECORD_ID),
+      ]);
+      expect(deletedPlans).toEqual([]);
+      expect(deletedRecords).toEqual([]);
+    });
+
+    it('4つのprivileged RPCはauthenticated直接実行を42501で拒否する', async () => {
+      const calls = [
+        () =>
+          supabaseB.rpc('merge_tags_with_hierarchy', {
+            p_source_tag_id: RPC_MERGE_SOURCE_TAG_ID,
+            p_target_tag_id: RPC_MERGE_TARGET_TAG_ID,
+            p_user_id: TEST_USER_B_ID,
+          }),
+        () =>
+          supabaseB.rpc('restore_plan', {
+            p_plan_id: RPC_RESTORE_PLAN_ID,
+            p_user_id: TEST_USER_B_ID,
+          }),
+        () =>
+          supabaseB.rpc('restore_record', {
+            p_record_id: RPC_RESTORE_RECORD_ID,
+            p_user_id: TEST_USER_B_ID,
+          }),
+        () =>
+          supabaseB.rpc('use_recovery_code', {
+            p_code_hash: RPC_USE_CODE_HASH,
+            p_user_id: TEST_USER_B_ID,
+          }),
+      ];
+
+      for (const call of calls) {
+        const { error } = await call();
+        expect(error?.code).toBe('42501');
+      }
+    });
+
+    it('4つのprivileged RPCはservice-role経路で成功する', async () => {
+      const { error: mergeError } = await adminSupabase.rpc('merge_tags_with_hierarchy', {
+        p_source_tag_id: RPC_MERGE_SOURCE_TAG_ID,
+        p_target_tag_id: RPC_MERGE_TARGET_TAG_ID,
+        p_user_id: TEST_USER_B_ID,
+      });
+      expect(mergeError).toBeNull();
+
+      const { error: planError } = await adminSupabase.rpc('restore_plan', {
+        p_plan_id: RPC_RESTORE_PLAN_ID,
+        p_user_id: TEST_USER_B_ID,
+      });
+      expect(planError).toBeNull();
+
+      const { error: recordError } = await adminSupabase.rpc('restore_record', {
+        p_record_id: RPC_RESTORE_RECORD_ID,
+        p_user_id: TEST_USER_B_ID,
+      });
+      expect(recordError).toBeNull();
+
+      const { data: used, error: recoveryError } = await adminSupabase.rpc('use_recovery_code', {
+        p_code_hash: RPC_USE_CODE_HASH,
+        p_user_id: TEST_USER_B_ID,
+      });
+      expect(recoveryError).toBeNull();
+      expect(used).toBe(true);
+    });
+
+    it('auto_migrated Recordはcaller roleに関係なくdelete/restoreできない', async () => {
+      const { error: userDeleteError } = await supabaseB.rpc('soft_delete_record', {
+        p_record_id: RPC_AUTO_ACTIVE_RECORD_ID,
+        p_user_id: TEST_USER_B_ID,
+      });
+      expect(userDeleteError).not.toBeNull();
+
+      const { error: serviceDeleteError } = await adminSupabase.rpc('soft_delete_record', {
+        p_record_id: RPC_AUTO_ACTIVE_RECORD_ID,
+        p_user_id: TEST_USER_B_ID,
+      });
+      expect(serviceDeleteError).not.toBeNull();
+
+      const { error: serviceRestoreError } = await adminSupabase.rpc('restore_record', {
+        p_record_id: RPC_AUTO_DELETED_RECORD_ID,
+        p_user_id: TEST_USER_B_ID,
+      });
+      expect(serviceRestoreError).not.toBeNull();
+
+      const [{ data: active }, { data: deleted }] = await Promise.all([
+        adminSupabase
+          .from('records')
+          .select('deleted_at')
+          .eq('id', RPC_AUTO_ACTIVE_RECORD_ID)
+          .single(),
+        adminSupabase
+          .from('records')
+          .select('deleted_at')
+          .eq('id', RPC_AUTO_DELETED_RECORD_ID)
+          .single(),
+      ]);
+      expect(active?.deleted_at).toBeNull();
+      expect(deleted?.deleted_at).not.toBeNull();
+    });
+
+    it('foreign parentをRPCと直接INSERT/UPDATEの全経路で拒否する', async () => {
+      const insertedTagId = crypto.randomUUID();
+      const { error: insertError } = await supabaseA.from('tags').insert({
+        id: insertedTagId,
+        user_id: TEST_USER_A_ID,
+        name: 'RPC Foreign Insert',
+        parent_id: RPC_PARENT_TAG_ID,
+      });
+      expect(insertError?.code).toBe('23514');
+
+      const { error: updateError } = await supabaseA
+        .from('tags')
+        .update({ parent_id: RPC_PARENT_TAG_ID })
+        .eq('id', RPC_FOREIGN_CHILD_TAG_ID);
+      expect(updateError?.code).toBe('23514');
+
+      const { error: rpcError } = await supabaseA.rpc('batch_reorder_tags_hierarchy', {
+        p_parent_ids: [RPC_PARENT_TAG_ID],
+        p_sort_orders: [1],
+        p_tag_ids: [RPC_FOREIGN_CHILD_TAG_ID],
+        p_user_id: TEST_USER_A_ID,
+      });
+      expect(rpcError?.code).toBe('23514');
+
+      const { data: child } = await adminSupabase
+        .from('tags')
+        .select('parent_id')
+        .eq('id', RPC_FOREIGN_CHILD_TAG_ID)
+        .single();
+      expect(child?.parent_id).toBeNull();
+    });
+
+    it('Production-only merge_tags overloadは存在しない', async () => {
+      const { error } = await adminSupabase.rpc(
+        'merge_tags' as never,
+        {
+          p_source_tag_ids: [RPC_MERGE_SOURCE_TAG_ID],
+          p_target_tag_id: RPC_MERGE_TARGET_TAG_ID,
+          p_user_id: TEST_USER_B_ID,
+        } as never,
+      );
+
+      expect(error?.code).toBe('PGRST202');
     });
   });
 

--- a/docs/engineering/data/db/rls-snapshot.md
+++ b/docs/engineering/data/db/rls-snapshot.md
@@ -5,7 +5,7 @@
 > **手で編集しない**。migration 変更時は CI（`pnpm rls:snapshot:check`）が drift を検出する。
 > 再生成で更新すること。
 >
-> 集計: public スキーマの policy 38 件 / RLS 対象テーブル 13 件 / GRANT 88 件 / Realtime publication 0 件。
+> 集計: public スキーマの policy 38 件 / RLS 対象テーブル 13 件 / GRANT 84 件 / Realtime publication 0 件。
 
 ## RLS 有効状態（public テーブル）
 
@@ -69,13 +69,13 @@
 
 ### plans
 
-| policy                                | cmd    | permissive | roles           | USING                                                              | WITH CHECK                              |
-| ------------------------------------- | ------ | ---------- | --------------- | ------------------------------------------------------------------ | --------------------------------------- |
-| Service role has full access to plans | ALL    | PERMISSIVE | {service_role}  | true                                                               | true                                    |
-| Users can delete own plans            | DELETE | PERMISSIVE | {authenticated} | (( SELECT auth.uid() AS uid) = user_id)                            | —                                       |
-| Users can insert own plans            | INSERT | PERMISSIVE | {authenticated} | —                                                                  | (( SELECT auth.uid() AS uid) = user_id) |
-| Users can view own plans              | SELECT | PERMISSIVE | {authenticated} | ((( SELECT auth.uid() AS uid) = user_id) AND (deleted_at IS NULL)) | —                                       |
-| Users can update own plans            | UPDATE | PERMISSIVE | {authenticated} | (( SELECT auth.uid() AS uid) = user_id)                            | (( SELECT auth.uid() AS uid) = user_id) |
+| policy                                | cmd    | permissive | roles           | USING                                                                                                                                                 | WITH CHECK                              |
+| ------------------------------------- | ------ | ---------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| Service role has full access to plans | ALL    | PERMISSIVE | {service_role}  | true                                                                                                                                                  | true                                    |
+| Users can delete own plans            | DELETE | PERMISSIVE | {authenticated} | (( SELECT auth.uid() AS uid) = user_id)                                                                                                               | —                                       |
+| Users can insert own plans            | INSERT | PERMISSIVE | {authenticated} | —                                                                                                                                                     | (( SELECT auth.uid() AS uid) = user_id) |
+| Users can view own plans              | SELECT | PERMISSIVE | {authenticated} | ((( SELECT auth.uid() AS uid) = user_id) AND ((deleted_at IS NULL) OR (current_setting('dayopt.soft_delete_user_id'::text, true) = (user_id)::text))) | —                                       |
+| Users can update own plans            | UPDATE | PERMISSIVE | {authenticated} | (( SELECT auth.uid() AS uid) = user_id)                                                                                                               | (( SELECT auth.uid() AS uid) = user_id) |
 
 ### profiles
 
@@ -90,13 +90,13 @@
 
 ### records
 
-| policy                                  | cmd    | permissive | roles           | USING                                                                           | WITH CHECK                                                                      |
-| --------------------------------------- | ------ | ---------- | --------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| Service role has full access to records | ALL    | PERMISSIVE | {service_role}  | true                                                                            | true                                                                            |
-| Users can delete own records            | DELETE | PERMISSIVE | {authenticated} | ((( SELECT auth.uid() AS uid) = user_id) AND (source <> 'auto_migrated'::text)) | —                                                                               |
-| Users can insert own records            | INSERT | PERMISSIVE | {authenticated} | —                                                                               | ((( SELECT auth.uid() AS uid) = user_id) AND (source <> 'auto_migrated'::text)) |
-| Users can view own records              | SELECT | PERMISSIVE | {authenticated} | ((( SELECT auth.uid() AS uid) = user_id) AND (deleted_at IS NULL))              | —                                                                               |
-| Users can update own records            | UPDATE | PERMISSIVE | {authenticated} | ((( SELECT auth.uid() AS uid) = user_id) AND (source <> 'auto_migrated'::text)) | ((( SELECT auth.uid() AS uid) = user_id) AND (source <> 'auto_migrated'::text)) |
+| policy                                  | cmd    | permissive | roles           | USING                                                                                                                                                 | WITH CHECK                                                                      |
+| --------------------------------------- | ------ | ---------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Service role has full access to records | ALL    | PERMISSIVE | {service_role}  | true                                                                                                                                                  | true                                                                            |
+| Users can delete own records            | DELETE | PERMISSIVE | {authenticated} | ((( SELECT auth.uid() AS uid) = user_id) AND (source <> 'auto_migrated'::text))                                                                       | —                                                                               |
+| Users can insert own records            | INSERT | PERMISSIVE | {authenticated} | —                                                                                                                                                     | ((( SELECT auth.uid() AS uid) = user_id) AND (source <> 'auto_migrated'::text)) |
+| Users can view own records              | SELECT | PERMISSIVE | {authenticated} | ((( SELECT auth.uid() AS uid) = user_id) AND ((deleted_at IS NULL) OR (current_setting('dayopt.soft_delete_user_id'::text, true) = (user_id)::text))) | —                                                                               |
+| Users can update own records            | UPDATE | PERMISSIVE | {authenticated} | ((( SELECT auth.uid() AS uid) = user_id) AND (source <> 'auto_migrated'::text))                                                                       | ((( SELECT auth.uid() AS uid) = user_id) AND (source <> 'auto_migrated'::text)) |
 
 ### reports
 
@@ -165,14 +165,11 @@
 | routine     | public.increment_tag_sort_orders(p_user_id uuid)                                                                                                                                                                                                 | service_role        | EXECUTE                        |
 | routine     | public.invoke_edge_function(p_function_name text, p_body jsonb)                                                                                                                                                                                  | service_role        | EXECUTE                        |
 | routine     | public.issue_oauth_token_pair(p_user_id uuid, p_client_id text, p_scopes text[], p_refresh_hash text, p_access_hash text, p_refresh_expires_at timestamp with time zone, p_access_expires_at timestamp with time zone, p_parent_refresh_id uuid) | service_role        | EXECUTE                        |
-| routine     | public.merge_tags_with_hierarchy(p_user_id uuid, p_source_tag_id uuid, p_target_tag_id uuid)                                                                                                                                                     | authenticated       | EXECUTE                        |
 | routine     | public.merge_tags_with_hierarchy(p_user_id uuid, p_source_tag_id uuid, p_target_tag_id uuid)                                                                                                                                                     | service_role        | EXECUTE                        |
 | routine     | public.prevent_time_model_source_change()                                                                                                                                                                                                        | service_role        | EXECUTE                        |
 | routine     | public.rename_tag_group(p_user_id uuid, p_old_prefix text, p_new_prefix text)                                                                                                                                                                    | authenticated       | EXECUTE                        |
 | routine     | public.rename_tag_group(p_user_id uuid, p_old_prefix text, p_new_prefix text)                                                                                                                                                                    | service_role        | EXECUTE                        |
-| routine     | public.restore_plan(p_plan_id uuid, p_user_id uuid)                                                                                                                                                                                              | authenticated       | EXECUTE                        |
 | routine     | public.restore_plan(p_plan_id uuid, p_user_id uuid)                                                                                                                                                                                              | service_role        | EXECUTE                        |
-| routine     | public.restore_record(p_record_id uuid, p_user_id uuid)                                                                                                                                                                                          | authenticated       | EXECUTE                        |
 | routine     | public.restore_record(p_record_id uuid, p_user_id uuid)                                                                                                                                                                                          | service_role        | EXECUTE                        |
 | routine     | public.soft_delete_plan(p_plan_id uuid, p_user_id uuid)                                                                                                                                                                                          | authenticated       | EXECUTE                        |
 | routine     | public.soft_delete_plan(p_plan_id uuid, p_user_id uuid)                                                                                                                                                                                          | service_role        | EXECUTE                        |
@@ -183,7 +180,6 @@
 | routine     | public.update_personalization(p_user_id uuid, p_path text, p_value jsonb)                                                                                                                                                                        | authenticated       | EXECUTE                        |
 | routine     | public.update_personalization(p_user_id uuid, p_path text, p_value jsonb)                                                                                                                                                                        | service_role        | EXECUTE                        |
 | routine     | public.update_updated_at()                                                                                                                                                                                                                       | service_role        | EXECUTE                        |
-| routine     | public.use_recovery_code(p_user_id uuid, p_code_hash text)                                                                                                                                                                                       | authenticated       | EXECUTE                        |
 | routine     | public.use_recovery_code(p_user_id uuid, p_code_hash text)                                                                                                                                                                                       | service_role        | EXECUTE                        |
 | routine     | public.vault_secret_exists(p_name text)                                                                                                                                                                                                          | service_role        | EXECUTE                        |
 | table       | public.email_suppressions                                                                                                                                                                                                                        | anon                | DELETE, INSERT, SELECT, UPDATE |

--- a/docs/operations/security.md
+++ b/docs/operations/security.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_verified: 2026-07-13
+last_verified: 2026-07-14
 ---
 
 # セキュリティ方針
@@ -441,3 +441,55 @@ LIMIT 20;
 環境変数と Secrets の値そのものの管理（1Password 経由の注入、schema、ローテーション手順）は [secrets.md](./secrets.md) を正本とする。本ファイルでは重複を避けるため、GitHub Actions 側の利用箇所（第1部）とセキュリティ監視の対象範囲（第2部）のみを扱う。
 
 > **統合作業メモ**: 統合元の `docs/operations/security/environment-secrets.md` は、ファイル名が `*secret*` パターンに一致するためツール権限（deny rule）でAIから読み取れず、本ファイルへの内容統合ができなかった。`secrets.md` と同様に現状のまま残置している。内容を確認・統合する場合は人間が直接編集するか、deny rule の一時的な例外設定が必要。
+
+---
+
+# 第4部: Supabase RPC 権限
+
+Issue #1564 で、Production Security Advisorの
+`authenticated_security_definer_function_executable` 13件を次の契約へ整理した。
+
+## RPC判断表
+
+| RPC                              | server caller                          | EXECUTE role                    | 実行属性           | 判断                                                                                          |
+| -------------------------------- | -------------------------------------- | ------------------------------- | ------------------ | --------------------------------------------------------------------------------------------- |
+| `batch_rename_tags`              | `TagService`のuser-scoped client       | `authenticated`, `service_role` | `SECURITY INVOKER` | owner RLSと`p_user_id` guardで更新する                                                        |
+| `batch_reorder_tags_hierarchy`   | `TagService`のuser-scoped client       | `authenticated`, `service_role` | `SECURITY INVOKER` | owner RLS、`p_user_id` guard、tag parent owner triggerで更新する                              |
+| `rename_tag_group`               | `TagService`のuser-scoped client       | `authenticated`, `service_role` | `SECURITY INVOKER` | owner RLSと`p_user_id` guardで更新する                                                        |
+| `confirm_day_plans_to_records`   | `PlanService`のuser-scoped client      | `authenticated`, `service_role` | `SECURITY INVOKER` | owner RLSと`p_user_id` guardでPlanをRecordへ確定する                                          |
+| `count_unused_recovery_codes`    | `RecoveryService`のuser-scoped client  | `authenticated`, `service_role` | `SECURITY INVOKER` | owner RLSと`p_user_id` guardで件数だけ返す                                                    |
+| `update_personalization`         | user-scoped client                     | `authenticated`, `service_role` | `SECURITY INVOKER` | owner RLSと`p_user_id` guardで設定を更新する                                                  |
+| `soft_delete_plan`               | `PlanService`のuser-scoped client      | `authenticated`, `service_role` | `SECURITY INVOKER` | owner RLSと`p_user_id` guardで論理削除する                                                    |
+| `soft_delete_record`             | `RecordService`のuser-scoped client    | `authenticated`, `service_role` | `SECURITY INVOKER` | owner RLSと`p_user_id` guardを使い、`auto_migrated`を常に拒否する                             |
+| `merge_tags(uuid, uuid[], uuid)` | callerなし                             | なし                            | DROP               | Productionだけに残った旧table参照overloadを`CASCADE`なしで削除する                            |
+| `merge_tags_with_hierarchy`      | `TagService`のservice-role client      | `service_role`                  | `SECURITY DEFINER` | deleted Plan/Recordを含む関連更新が必要。service-role JWTを確認し、全更新を`p_user_id`で絞る  |
+| `restore_plan`                   | `PlanService`のservice-role client     | `service_role`                  | `SECURITY DEFINER` | authenticated SELECTから隠れたdeleted rowを復元するためdefinerを維持する                      |
+| `restore_record`                 | `RecordService`のservice-role client   | `service_role`                  | `SECURITY DEFINER` | deleted row復元のためdefinerを維持し、`auto_migrated`を常に拒否する                           |
+| `use_recovery_code`              | `RecoveryService`のservice-role client | `service_role`                  | `SECURITY DEFINER` | recovery codeにauthenticated UPDATE policyを追加せず、service-role JWTと`p_user_id`で消費する |
+
+全対象で`PUBLIC`と`anon`の`EXECUTE`を明示的にREVOKEする。service-role-onlyの4 RPCは
+`authenticated`もREVOKEし、`search_path = ''`と完全修飾したrelation名を必須とする。
+protected routerは入力からuser IDを受けず、`ctx.userId`だけをserviceへ渡す。
+
+## soft-delete時のRLS境界
+
+PlanとRecordの通常SELECTは`deleted_at IS NULL`を維持する。invoker RPCが更新した直後の行にも
+SELECT policyが評価されるため、`soft_delete_plan`と`soft_delete_record`はtransaction-localな
+`dayopt.soft_delete_user_id`を設定する。SELECT policyはこの値がrow ownerと一致する同一RPC
+transaction内だけdeleted rowを許可する。PostgRESTの通常SELECTや次のtransactionには値が残らず、
+deleted rowはauthenticated clientへ露出しない。
+
+## tag hierarchy
+
+migration適用前にcross-user parentを検査し、1件でもあれば自動修復せず失敗させる。
+`check_tag_hierarchy()`はINSERTとUPDATEの両方で、parentとchildの`user_id`をNULL安全に比較する。
+RPC、直接table操作、service-role操作のすべてに同じ制約を適用する。
+
+## 検証
+
+- LocalとPR PreviewでSecurity Advisorの該当WARNが0件
+- 8 invoker RPCのowner成功とcross-user拒否
+- 4 definer RPCのauthenticated `42501`とservice-role成功
+- `auto_migrated` Recordのdelete/restore拒否
+- foreign parentのRPC、直接INSERT、直接UPDATE拒否
+- [RLS snapshot](../engineering/data/db/rls-snapshot.md)のdrift check

--- a/supabase/migrations/20260714065248_harden_rpc_permissions.sql
+++ b/supabase/migrations/20260714065248_harden_rpc_permissions.sql
@@ -1,0 +1,503 @@
+-- Issue #1564: separate authenticated SECURITY INVOKER RPCs from
+-- service-role-only SECURITY DEFINER RPCs and close cross-user paths.
+
+-- Production drift: this obsolete overload references tables removed from the
+-- repository schema. It is intentionally absent in local databases.
+DROP FUNCTION IF EXISTS public.merge_tags(UUID, UUID[], UUID);
+
+-- Refuse to apply over existing cross-user tag hierarchy drift. Repair, if ever
+-- needed, must be reviewed separately instead of being hidden in this migration.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM public.tags AS child
+    JOIN public.tags AS parent ON parent.id = child.parent_id
+    WHERE child.user_id IS DISTINCT FROM parent.user_id
+  ) THEN
+    RAISE EXCEPTION 'Cannot harden tag hierarchy while cross-user parent relationships exist'
+      USING ERRCODE = '23514';
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.check_tag_hierarchy()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  v_parent_user_id UUID;
+  v_grandparent_id UUID;
+BEGIN
+  IF NEW.parent_id IS NOT NULL THEN
+    IF NEW.parent_id = NEW.id THEN
+      RAISE EXCEPTION 'A tag cannot be its own parent.';
+    END IF;
+
+    SELECT parent.user_id, parent.parent_id
+    INTO v_parent_user_id, v_grandparent_id
+    FROM public.tags AS parent
+    WHERE parent.id = NEW.parent_id;
+
+    IF NOT FOUND OR v_parent_user_id IS DISTINCT FROM NEW.user_id THEN
+      RAISE EXCEPTION 'Parent tag must belong to the same user.'
+        USING ERRCODE = '23514';
+    END IF;
+
+    IF v_grandparent_id IS NOT NULL THEN
+      RAISE EXCEPTION 'Maximum nesting depth is 1 level. Parent tag cannot be a child of another tag.';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- Authenticated callers execute these with their own RLS context. The explicit
+-- user guard also preserves the existing service-role server path.
+CREATE OR REPLACE FUNCTION public.batch_rename_tags(
+  p_user_id UUID,
+  p_tag_ids UUID[],
+  p_new_names TEXT[]
+)
+RETURNS INT
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  updated_count INT;
+BEGIN
+  IF COALESCE(auth.jwt() ->> 'role', '') <> 'service_role'
+    AND p_user_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Access denied: user_id mismatch';
+  END IF;
+
+  IF array_length(p_tag_ids, 1) IS DISTINCT FROM array_length(p_new_names, 1) THEN
+    RAISE EXCEPTION 'tag_ids and new_names must have the same length';
+  END IF;
+
+  UPDATE public.tags
+  SET name = batch.new_name,
+      updated_at = pg_catalog.now()
+  FROM unnest(p_tag_ids, p_new_names) AS batch(tag_id, new_name)
+  WHERE public.tags.id = batch.tag_id
+    AND public.tags.user_id = p_user_id;
+
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+  RETURN updated_count;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.batch_reorder_tags_hierarchy(
+  p_user_id UUID,
+  p_tag_ids UUID[],
+  p_parent_ids UUID[],
+  p_sort_orders INT[]
+)
+RETURNS INT
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  updated_count INT;
+BEGIN
+  IF COALESCE(auth.jwt() ->> 'role', '') <> 'service_role'
+    AND p_user_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Access denied: user_id mismatch';
+  END IF;
+
+  IF array_length(p_tag_ids, 1) IS DISTINCT FROM array_length(p_parent_ids, 1)
+     OR array_length(p_tag_ids, 1) IS DISTINCT FROM array_length(p_sort_orders, 1) THEN
+    RAISE EXCEPTION 'tag_ids, parent_ids and sort_orders must have the same length';
+  END IF;
+
+  UPDATE public.tags
+  SET parent_id = batch.parent_id,
+      sort_order = batch.new_order,
+      updated_at = pg_catalog.now()
+  FROM unnest(p_tag_ids, p_parent_ids, p_sort_orders) AS batch(tag_id, parent_id, new_order)
+  WHERE public.tags.id = batch.tag_id
+    AND public.tags.user_id = p_user_id;
+
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+  RETURN updated_count;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.rename_tag_group(
+  p_user_id UUID,
+  p_old_prefix TEXT,
+  p_new_prefix TEXT
+)
+RETURNS SETOF public.tags
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+BEGIN
+  IF COALESCE(auth.jwt() ->> 'role', '') <> 'service_role'
+    AND p_user_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Access denied: user_id mismatch';
+  END IF;
+
+  RETURN QUERY
+  UPDATE public.tags
+  SET name = p_new_prefix || substring(name FROM length(p_old_prefix) + 1),
+      updated_at = pg_catalog.now()
+  WHERE user_id = p_user_id
+    AND starts_with(name, p_old_prefix || ':')
+  RETURNING *;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.confirm_day_plans_to_records(
+  p_user_id UUID,
+  p_start_at TIMESTAMPTZ,
+  p_end_at TIMESTAMPTZ,
+  p_confirmed_at TIMESTAMPTZ DEFAULT pg_catalog.now()
+)
+RETURNS SETOF public.records
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  v_confirmed_at CONSTANT TIMESTAMPTZ := LEAST(
+    COALESCE(p_confirmed_at, pg_catalog.now()),
+    pg_catalog.now()
+  );
+BEGIN
+  IF COALESCE(auth.jwt() ->> 'role', '') <> 'service_role'
+    AND p_user_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Access denied: user_id mismatch';
+  END IF;
+
+  IF p_end_at <= p_start_at THEN
+    RAISE EXCEPTION 'confirm day range end must be after start'
+      USING ERRCODE = '22023';
+  END IF;
+
+  RETURN QUERY
+  WITH target_plans AS (
+    SELECT p.*
+    FROM public.plans AS p
+    WHERE p.user_id = p_user_id
+      AND p.deleted_at IS NULL
+      AND p.skipped_at IS NULL
+      AND p.end_at <= v_confirmed_at
+      AND p.start_at >= p_start_at
+      AND p.start_at < p_end_at
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.records AS r
+        WHERE r.plan_id = p.id AND r.deleted_at IS NULL
+      )
+    ORDER BY p.start_at, p.id
+  )
+  INSERT INTO public.records (
+    user_id, tag_id, plan_id, external_calendar_event_id, title, note,
+    start_at, end_at, source, created_at, updated_at
+  )
+  SELECT
+    p.user_id, p.tag_id, p.id, NULL, p.title, p.note,
+    p.start_at, p.end_at, 'from_plan', v_confirmed_at, v_confirmed_at
+  FROM target_plans AS p
+  RETURNING public.records.*;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.count_unused_recovery_codes(p_user_id UUID)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  v_count INTEGER;
+BEGIN
+  IF COALESCE(auth.jwt() ->> 'role', '') <> 'service_role'
+    AND p_user_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Access denied: user_id mismatch';
+  END IF;
+
+  SELECT COUNT(*) INTO v_count
+  FROM public.mfa_recovery_codes
+  WHERE user_id = p_user_id AND used_at IS NULL;
+
+  RETURN v_count;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.update_personalization(
+  p_user_id UUID,
+  p_path TEXT,
+  p_value JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+BEGIN
+  IF COALESCE(auth.jwt() ->> 'role', '') <> 'service_role'
+    AND p_user_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Access denied: user_id mismatch';
+  END IF;
+
+  UPDATE public.user_settings
+  SET personalization = CASE
+    WHEN personalization IS NULL THEN pg_catalog.jsonb_build_object(p_path, p_value)
+    ELSE pg_catalog.jsonb_set(personalization, ARRAY[p_path], p_value, true)
+  END,
+  updated_at = pg_catalog.now()
+  WHERE user_id = p_user_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.soft_delete_plan(p_plan_id UUID, p_user_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+BEGIN
+  IF COALESCE(auth.jwt() ->> 'role', '') <> 'service_role'
+    AND p_user_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Access denied: user_id mismatch';
+  END IF;
+
+  UPDATE public.plans
+  SET deleted_at = pg_catalog.now()
+  WHERE id = p_plan_id AND user_id = p_user_id AND deleted_at IS NULL;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Plan not found or already deleted';
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.soft_delete_record(p_record_id UUID, p_user_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+BEGIN
+  IF COALESCE(auth.jwt() ->> 'role', '') <> 'service_role'
+    AND p_user_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Access denied: user_id mismatch';
+  END IF;
+
+  UPDATE public.records
+  SET deleted_at = pg_catalog.now()
+  WHERE id = p_record_id
+    AND user_id = p_user_id
+    AND deleted_at IS NULL
+    AND source IS DISTINCT FROM 'auto_migrated';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Record not found, already deleted, or protected';
+  END IF;
+END;
+$$;
+
+-- These operations must see rows hidden by normal SELECT RLS. They retain
+-- SECURITY DEFINER but require the service-role JWT and always scope by user.
+CREATE OR REPLACE FUNCTION public.merge_tags_with_hierarchy(
+  p_user_id UUID,
+  p_source_tag_id UUID,
+  p_target_tag_id UUID
+)
+RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_migrated_count INTEGER := 0;
+  v_row_count INTEGER := 0;
+  v_target_parent_id UUID;
+  v_children_count INTEGER := 0;
+  v_next_sort_order INTEGER;
+BEGIN
+  IF COALESCE(auth.jwt() ->> 'role', '') <> 'service_role' THEN
+    RAISE EXCEPTION 'Access denied: service role required' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_source_tag_id = p_target_tag_id THEN
+    RAISE EXCEPTION 'Cannot merge a tag with itself' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT parent_id INTO v_target_parent_id
+  FROM public.tags
+  WHERE id = p_target_tag_id AND user_id = p_user_id AND is_active = true;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Target tag not found or inactive: %', p_target_tag_id
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  PERFORM 1
+  FROM public.tags
+  WHERE id = p_source_tag_id AND user_id = p_user_id AND is_active = true;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Source tag not found or inactive: %', p_source_tag_id
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  SELECT COUNT(*) INTO v_children_count
+  FROM public.tags
+  WHERE user_id = p_user_id AND parent_id = p_source_tag_id AND is_active = true;
+
+  IF v_children_count > 0 AND v_target_parent_id IS NOT NULL THEN
+    RAISE EXCEPTION 'Cannot merge a parent tag into a child tag.'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  UPDATE public.plans
+  SET tag_id = p_target_tag_id
+  WHERE user_id = p_user_id AND tag_id = p_source_tag_id;
+  GET DIAGNOSTICS v_row_count = ROW_COUNT;
+  v_migrated_count := v_migrated_count + v_row_count;
+
+  UPDATE public.records
+  SET tag_id = p_target_tag_id
+  WHERE user_id = p_user_id AND tag_id = p_source_tag_id;
+  GET DIAGNOSTICS v_row_count = ROW_COUNT;
+  v_migrated_count := v_migrated_count + v_row_count;
+
+  IF v_children_count > 0 THEN
+    SELECT COALESCE(MAX(sort_order), -1) + 1 INTO v_next_sort_order
+    FROM public.tags
+    WHERE user_id = p_user_id AND parent_id = p_target_tag_id;
+
+    UPDATE public.tags AS tag
+    SET parent_id = p_target_tag_id,
+        sort_order = v_next_sort_order + children.idx,
+        updated_at = pg_catalog.now()
+    FROM (
+      SELECT id, (ROW_NUMBER() OVER (ORDER BY sort_order, id) - 1)::INTEGER AS idx
+      FROM public.tags
+      WHERE user_id = p_user_id
+        AND parent_id = p_source_tag_id
+        AND is_active = true
+    ) AS children
+    WHERE tag.id = children.id AND tag.user_id = p_user_id;
+  END IF;
+
+  UPDATE public.tags
+  SET is_active = false, updated_at = pg_catalog.now()
+  WHERE id = p_source_tag_id AND user_id = p_user_id;
+
+  RETURN pg_catalog.json_build_object(
+    'migrated', v_migrated_count,
+    'children_reparented', v_children_count
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.restore_plan(p_plan_id UUID, p_user_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF COALESCE(auth.jwt() ->> 'role', '') <> 'service_role' THEN
+    RAISE EXCEPTION 'Access denied: service role required' USING ERRCODE = '42501';
+  END IF;
+
+  UPDATE public.plans
+  SET deleted_at = NULL
+  WHERE id = p_plan_id AND user_id = p_user_id AND deleted_at IS NOT NULL;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Plan not found or not deleted';
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.restore_record(p_record_id UUID, p_user_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF COALESCE(auth.jwt() ->> 'role', '') <> 'service_role' THEN
+    RAISE EXCEPTION 'Access denied: service role required' USING ERRCODE = '42501';
+  END IF;
+
+  UPDATE public.records
+  SET deleted_at = NULL
+  WHERE id = p_record_id
+    AND user_id = p_user_id
+    AND deleted_at IS NOT NULL
+    AND source IS DISTINCT FROM 'auto_migrated';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Record not found, not deleted, or protected';
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.use_recovery_code(p_user_id UUID, p_code_hash TEXT)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_code_id UUID;
+BEGIN
+  IF COALESCE(auth.jwt() ->> 'role', '') <> 'service_role' THEN
+    RAISE EXCEPTION 'Access denied: service role required' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT id INTO v_code_id
+  FROM public.mfa_recovery_codes
+  WHERE user_id = p_user_id AND code_hash = p_code_hash AND used_at IS NULL;
+
+  IF v_code_id IS NULL THEN
+    RETURN false;
+  END IF;
+
+  UPDATE public.mfa_recovery_codes
+  SET used_at = pg_catalog.now()
+  WHERE id = v_code_id AND user_id = p_user_id;
+
+  RETURN true;
+END;
+$$;
+
+-- Explicit ACLs avoid PostgreSQL's default PUBLIC EXECUTE grant.
+REVOKE EXECUTE ON FUNCTION public.batch_rename_tags(UUID, UUID[], TEXT[]) FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.batch_reorder_tags_hierarchy(UUID, UUID[], UUID[], INT[]) FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.rename_tag_group(UUID, TEXT, TEXT) FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.confirm_day_plans_to_records(UUID, TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ) FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.count_unused_recovery_codes(UUID) FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.update_personalization(UUID, TEXT, JSONB) FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.soft_delete_plan(UUID, UUID) FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.soft_delete_record(UUID, UUID) FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.batch_rename_tags(UUID, UUID[], TEXT[]) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.batch_reorder_tags_hierarchy(UUID, UUID[], UUID[], INT[]) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.rename_tag_group(UUID, TEXT, TEXT) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.confirm_day_plans_to_records(UUID, TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.count_unused_recovery_codes(UUID) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.update_personalization(UUID, TEXT, JSONB) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.soft_delete_plan(UUID, UUID) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.soft_delete_record(UUID, UUID) TO authenticated, service_role;
+
+REVOKE EXECUTE ON FUNCTION public.merge_tags_with_hierarchy(UUID, UUID, UUID) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.restore_plan(UUID, UUID) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.restore_record(UUID, UUID) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.use_recovery_code(UUID, TEXT) FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.merge_tags_with_hierarchy(UUID, UUID, UUID) TO service_role;
+GRANT EXECUTE ON FUNCTION public.restore_plan(UUID, UUID) TO service_role;
+GRANT EXECUTE ON FUNCTION public.restore_record(UUID, UUID) TO service_role;
+GRANT EXECUTE ON FUNCTION public.use_recovery_code(UUID, TEXT) TO service_role;

--- a/supabase/migrations/20260714070227_allow_invoker_soft_delete.sql
+++ b/supabase/migrations/20260714070227_allow_invoker_soft_delete.sql
@@ -1,0 +1,73 @@
+-- PostgreSQL also applies SELECT policy visibility while evaluating UPDATE.
+-- Permit the owner to see the just-deleted row only inside the soft-delete RPC
+-- transaction. A normal authenticated SELECT has no transaction-local marker
+-- and continues to hide every deleted row.
+
+ALTER POLICY "Users can view own plans" ON public.plans
+  USING (
+    (SELECT auth.uid()) = user_id
+    AND (
+      deleted_at IS NULL
+      OR current_setting('dayopt.soft_delete_user_id', true) = user_id::TEXT
+    )
+  );
+
+ALTER POLICY "Users can view own records" ON public.records
+  USING (
+    (SELECT auth.uid()) = user_id
+    AND (
+      deleted_at IS NULL
+      OR current_setting('dayopt.soft_delete_user_id', true) = user_id::TEXT
+    )
+  );
+
+CREATE OR REPLACE FUNCTION public.soft_delete_plan(p_plan_id UUID, p_user_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+BEGIN
+  IF COALESCE(auth.jwt() ->> 'role', '') <> 'service_role'
+    AND p_user_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Access denied: user_id mismatch';
+  END IF;
+
+  PERFORM pg_catalog.set_config('dayopt.soft_delete_user_id', p_user_id::TEXT, true);
+
+  UPDATE public.plans
+  SET deleted_at = pg_catalog.now()
+  WHERE id = p_plan_id AND user_id = p_user_id AND deleted_at IS NULL;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Plan not found or already deleted';
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.soft_delete_record(p_record_id UUID, p_user_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+BEGIN
+  IF COALESCE(auth.jwt() ->> 'role', '') <> 'service_role'
+    AND p_user_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Access denied: user_id mismatch';
+  END IF;
+
+  PERFORM pg_catalog.set_config('dayopt.soft_delete_user_id', p_user_id::TEXT, true);
+
+  UPDATE public.records
+  SET deleted_at = pg_catalog.now()
+  WHERE id = p_record_id
+    AND user_id = p_user_id
+    AND deleted_at IS NULL
+    AND source IS DISTINCT FROM 'auto_migrated';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Record not found, already deleted, or protected';
+  END IF;
+END;
+$$;


### PR DESCRIPTION
Closes #1564

## 変更内容

- Productionだけに残る旧 `merge_tags(uuid, uuid[], uuid)` overloadを、`CASCADE`なしのforward migrationで削除
- 8 RPCをowner RLSで動く `SECURITY INVOKER`へ変更し、4 RPCをservice-role-onlyの `SECURITY DEFINER`へ限定
- privileged caller（tag merge、Plan/Record restore、recovery code消費）だけservice-role clientへ切替
- tag hierarchyへNULL安全なsame-owner triggerとmigration preflightを追加
- `auto_migrated` Recordのdelete/restoreをcaller roleに関係なく拒否
- 13件の判断表をsecurity運用文書へ記録し、RLS snapshotを再生成

## 背景と影響

Production Security Advisorの `authenticated_security_definer_function_executable` 13件は、authenticated callerが必要なRPCと、RLSで隠れた行を扱うprivileged RPCが同じdefiner契約になっていたことが原因です。

tRPCの入力・戻り値とユーザー挙動は変更しません。protected routerは従来どおり `ctx.userId`のみをserviceへ渡します。deleted rowの通常authenticated SELECTも引き続き拒否します。

## 検証

- `pnpm db:fresh`
- `pnpm test:integration`（100 tests）
- `pnpm rls:snapshot`
- `pnpm rls:snapshot:check`
- `pnpm test:run`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:boundaries`
- `pnpm check`
- `pnpm docs:check`
- `pnpm secrets:check`
- Local Supabase Security Advisor 0件

## Rollout

Local検証済み。PR PreviewでmigrationとSecurity Advisor 0件を確認後、別途承認を受けてmergeします。Productionへの手動 `db push` は行いません。