### PR TITLE
fix(docs): logのsupersede契約を厳密化

### DIFF
--- a/scripts/docs-guard/__tests__/append-only-guard.test.ts
+++ b/scripts/docs-guard/__tests__/append-only-guard.test.ts
@@ -31,6 +31,24 @@ function createRepository(): string {
   return root;
 }
 
+function addFrozenLog(root: string): string {
+  const path = 'docs/product/log/2026-07-14-frozen.md';
+  write(
+    root,
+    path,
+    `---
+status: frozen
+date: 2026-07-14
+---
+
+# Frozen log
+`,
+  );
+  git(root, 'add', path);
+  git(root, 'commit', '-qm', 'add frozen log');
+  return path;
+}
+
 afterEach(() => {
   for (const directory of temporaryDirectories.splice(0)) {
     rmSync(directory, { force: true, recursive: true });
@@ -79,9 +97,121 @@ describe('isSupersedeOnlyDiff', () => {
 `),
     ).toBe(false);
   });
+
+  it('エラー系: metadata追記と同時の空行追加も拒否する', () => {
+    expect(
+      isSupersedeOnlyDiff(`--- a/log.md
++++ b/log.md
+@@ -3,0 +4,2 @@
++superseded_by: docs/product/log/2026-08-01-new.md
++
+`),
+    ).toBe(false);
+  });
+
+  it('エラー系: hunk内の+++で始まる追加行をfile headerと誤認しない', () => {
+    expect(
+      isSupersedeOnlyDiff(`--- a/log.md
++++ b/log.md
+@@ -3,0 +4,2 @@
++superseded_by: docs/product/log/2026-08-01-new.md
++++ hidden body
+`),
+    ).toBe(false);
+  });
+
+  it('エラー系: hunk内の---で始まる削除行をfile headerと誤認しない', () => {
+    expect(
+      isSupersedeOnlyDiff(`--- a/log.md
++++ b/log.md
+@@ -3,1 +3,1 @@
+--- hidden body
++superseded_by: docs/product/log/2026-08-01-new.md
+`),
+    ).toBe(false);
+  });
 });
 
 describe('runAppendOnlyGuard', () => {
+  it('正常系: 新契約logのfrontmatterへのsuperseded_by追記を許可する', () => {
+    const root = createRepository();
+    const path = addFrozenLog(root);
+    write(
+      root,
+      path,
+      `---
+status: frozen
+date: 2026-07-14
+superseded_by: docs/product/log/2026-08-01-new.md
+---
+
+# Frozen log
+`,
+    );
+
+    expect(runAppendOnlyGuard({ baseRef: 'HEAD', root })).toEqual([]);
+  });
+
+  it('正常系: legacy logのstatus追記は互換性のため許可する', () => {
+    const root = createRepository();
+    write(
+      root,
+      'docs/product/log/2026-07-01-source.md',
+      '---\ntitle: Source\nstatus: superseded\n---\n',
+    );
+
+    expect(runAppendOnlyGuard({ baseRef: 'HEAD', root })).toEqual([]);
+  });
+
+  it('エラー系: 新契約logへのlegacy status追記を拒否する', () => {
+    const root = createRepository();
+    const path = addFrozenLog(root);
+    write(
+      root,
+      path,
+      `---
+status: frozen
+status: superseded
+date: 2026-07-14
+---
+
+# Frozen log
+`,
+    );
+
+    expect(runAppendOnlyGuard({ baseRef: 'HEAD', root })).toEqual([
+      {
+        file: path,
+        reason: '新契約logの変更はfrontmatterへのsuperseded_by追記だけ許可',
+      },
+    ]);
+  });
+
+  it('エラー系: 新契約logの本文へのsuperseded_by追記を拒否する', () => {
+    const root = createRepository();
+    const path = addFrozenLog(root);
+    write(
+      root,
+      path,
+      `---
+status: frozen
+date: 2026-07-14
+---
+
+# Frozen log
+
+superseded_by: docs/product/log/2026-08-01-new.md
+`,
+    );
+
+    expect(runAppendOnlyGuard({ baseRef: 'HEAD', root })).toEqual([
+      {
+        file: path,
+        reason: '新契約logの変更はfrontmatterへのsuperseded_by追記だけ許可',
+      },
+    ]);
+  });
+
   it('base refが同じlogを先行更新していてもbranch側の追記だけを検査する', () => {
     const root = createRepository();
     git(root, 'branch', 'base');

--- a/scripts/docs-guard/__tests__/frontmatter-check.test.ts
+++ b/scripts/docs-guard/__tests__/frontmatter-check.test.ts
@@ -66,6 +66,49 @@ code: apps/product
     expect(reasons).toEqual([]);
   });
 
+  it('正常系: codeのarrayにある実在pathをすべて検証する', () => {
+    const root = createRoot();
+    createFile(root, 'apps/product/index.ts');
+    createFile(root, 'packages/domain/index.ts');
+
+    const reasons = validateDocumentMetadata({
+      content: `---
+status: current
+last_verified: 2026-07-14
+code:
+  - apps/product
+  - packages/domain
+---
+`,
+      relativePath: 'docs/engineering/architecture.md',
+      root,
+      today: '2026-07-14',
+    });
+
+    expect(reasons).toEqual([]);
+  });
+
+  it('エラー系: codeのarrayに含まれる不在pathを報告する', () => {
+    const root = createRoot();
+    createFile(root, 'apps/product/index.ts');
+
+    const reasons = validateDocumentMetadata({
+      content: `---
+status: current
+last_verified: 2026-07-14
+code:
+  - apps/product
+  - packages/missing
+---
+`,
+      relativePath: 'docs/engineering/architecture.md',
+      root,
+      today: '2026-07-14',
+    });
+
+    expect(reasons).toEqual(['codeのpathが存在しない: packages/missing']);
+  });
+
   it('エラー系: stockの不正status・未来日・不在pathを報告する', () => {
     const reasons = validateDocumentMetadata({
       content: `---
@@ -84,6 +127,21 @@ code: apps/missing
       'last_verifiedが有効な過去日付ではない: 2026-07-15',
       'codeのpathが存在しない: apps/missing',
     ]);
+  });
+
+  it('エラー系: stockの実在しないカレンダー日付を拒否する', () => {
+    const reasons = validateDocumentMetadata({
+      content: `---
+status: current
+last_verified: 2026-02-30
+---
+`,
+      relativePath: 'docs/engineering/architecture.md',
+      root: createRoot(),
+      today: '2026-07-14',
+    });
+
+    expect(reasons).toEqual(['last_verifiedが有効な過去日付ではない: 2026-02-30']);
   });
 
   it('境界: done Projectにはsummary.mdを要求する', () => {
@@ -133,7 +191,7 @@ status: frozen
 date: 2026-07-14
 ---
 `,
-      relativePath: 'docs/product/log/latest.md',
+      relativePath: 'docs/engineering/log/latest.md',
       root: createRoot(),
       today: '2026-07-14',
     });
@@ -158,6 +216,56 @@ superseded_by: docs/product/log/2026-08-01-new.md
     });
 
     expect(reasons).toEqual([]);
+  });
+
+  it('エラー系: superseded_byのarray指定を拒否する', () => {
+    const root = createRoot();
+    createFile(root, 'docs/product/log/2026-08-01-new.md');
+
+    const reasons = validateDocumentMetadata({
+      content: `---
+status: frozen
+date: 2026-07-14
+superseded_by:
+  - docs/product/log/2026-08-01-new.md
+---
+`,
+      relativePath: 'docs/product/log/2026-07-14-old.md',
+      root,
+      today: '2026-08-01',
+    });
+
+    expect(reasons).toEqual(['superseded_byはscalarのrepo-relative pathで指定する']);
+  });
+
+  it('境界: secrets.mdはstock契約の検証対象にする', () => {
+    const reasons = validateDocumentMetadata({
+      content: '# Secrets\n',
+      relativePath: 'docs/operations/secrets.md',
+      root: createRoot(),
+      today: '2026-07-14',
+    });
+
+    expect(reasons).toEqual([
+      'frontmatterがない',
+      'frontmatterにstatusがない',
+      'frontmatterにlast_verifiedがない',
+    ]);
+  });
+
+  it('境界: RLS snapshotと似たpathはgenerated例外にしない', () => {
+    const reasons = validateDocumentMetadata({
+      content: '# snapshot\n',
+      relativePath: 'docs/engineering/data/db/rls-snapshot-copy.md',
+      root: createRoot(),
+      today: '2026-07-14',
+    });
+
+    expect(reasons).toEqual([
+      'frontmatterがない',
+      'frontmatterにstatusがない',
+      'frontmatterにlast_verifiedがない',
+    ]);
   });
 
   it('generated snapshotは生成情報だけを検証する', () => {

--- a/scripts/docs-guard/checks/append-only-guard.ts
+++ b/scripts/docs-guard/checks/append-only-guard.ts
@@ -6,6 +6,8 @@
  */
 
 import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 import {
   APPEND_ONLY_DIRS,
@@ -16,6 +18,7 @@ import {
   ROOT,
 } from '../config.ts';
 import { listGitChanges } from '../git-changes.ts';
+import { isFrontmatterSupersededByAddition, usesFrozenLogContract } from './frontmatter-check.ts';
 
 export interface AppendOnlyViolation {
   file: string;
@@ -27,25 +30,38 @@ interface RunAppendOnlyGuardOptions {
   root?: string;
 }
 
-const SUPERSEDE_LINE_RE = /^\+(superseded_by:\s*\S+|status:\s*superseded)\s*$/;
-const BLANK_ADDITION_RE = /^\+\s*$/;
+const SUPERSEDED_BY_LINE_RE = /^\+superseded_by:\s*\S+\s*$/;
+const LEGACY_STATUS_LINE_RE = /^\+status:\s*superseded\s*$/;
 
-export function isSupersedeOnlyDiff(diff: string): boolean {
+interface SupersedeDiffOptions {
+  allowLegacyStatus?: boolean;
+}
+
+export function isSupersedeOnlyDiff(
+  diff: string,
+  { allowLegacyStatus = true }: SupersedeDiffOptions = {},
+): boolean {
   const lines = diff.split('\n');
-  let hasAddition = false;
+  const additions: string[] = [];
+  let inHunk = false;
 
   for (const line of lines) {
-    if (line.startsWith('+++') || line.startsWith('---') || line.startsWith('@@')) continue;
+    if (line.startsWith('@@')) {
+      inHunk = true;
+      continue;
+    }
+    if (!inHunk) continue;
     if (line.startsWith('-')) return false;
 
-    if (line.startsWith('+')) {
-      if (BLANK_ADDITION_RE.test(line)) continue;
-      if (!SUPERSEDE_LINE_RE.test(line)) return false;
-      hasAddition = true;
-    }
+    if (line.startsWith('+')) additions.push(line);
   }
 
-  return hasAddition;
+  if (additions.length !== 1) return false;
+  const [addition] = additions;
+  return (
+    (addition !== undefined && SUPERSEDED_BY_LINE_RE.test(addition)) ||
+    (allowLegacyStatus && addition !== undefined && LEGACY_STATUS_LINE_RE.test(addition))
+  );
 }
 
 function isLogPath(path: string): boolean {
@@ -86,11 +102,24 @@ export function runAppendOnlyGuard({
     }
 
     const diff = runGit(`diff -U0 ${mergeBase} -- "${change.path}"`);
-    if (isSupersedeOnlyDiff(diff)) continue;
+    const previousContent = runGit(`show ${mergeBase}:"${change.path}"`);
+    const usesFrozenContract = usesFrozenLogContract(previousContent, change.path);
+    const hasAllowedDiff = isSupersedeOnlyDiff(diff, {
+      allowLegacyStatus: !usesFrozenContract,
+    });
+
+    if (hasAllowedDiff && !usesFrozenContract) continue;
+
+    if (hasAllowedDiff && usesFrozenContract) {
+      const currentContent = readFileSync(resolve(root, change.path), 'utf8');
+      if (isFrontmatterSupersededByAddition(previousContent, currentContent)) continue;
+    }
 
     violations.push({
       file: change.path,
-      reason: '凍結済みlogの変更はsuperseded_by（legacyはstatus: superseded）の追記だけ許可',
+      reason: usesFrozenContract
+        ? '新契約logの変更はfrontmatterへのsuperseded_by追記だけ許可'
+        : 'legacy logの変更はsuperseded_byまたはstatus: supersededの単一行追記だけ許可',
     });
   }
 

--- a/scripts/docs-guard/checks/frontmatter-check.ts
+++ b/scripts/docs-guard/checks/frontmatter-check.ts
@@ -108,10 +108,14 @@ function currentDateInTokyo(): string {
   return new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Tokyo' });
 }
 
-function isValidDate(value: string, today: string): boolean {
-  if (!DATE_RE.test(value) || value > today) return false;
+function isCalendarDate(value: string): boolean {
+  if (!DATE_RE.test(value)) return false;
   const parsed = new Date(`${value}T00:00:00Z`);
   return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+}
+
+function isValidDate(value: string, today: string): boolean {
+  return value <= today && isCalendarDate(value);
 }
 
 function getString(fields: ReadonlyMap<string, MetadataValue>, key: string): string | undefined {
@@ -134,6 +138,40 @@ function isReadme(path: string): boolean {
 
 function isLogDocument(path: string): boolean {
   return /^docs\/(business|product|marketing|engineering|operations|company)\/log\//.test(path);
+}
+
+function getLogFilenameDate(relativePath: string): string | undefined {
+  return relativePath.match(/\/log\/(?:\d{4}\/)?(\d{4}-\d{2}-\d{2})-/)?.[1];
+}
+
+export function usesFrozenLogContract(content: string, relativePath: string): boolean {
+  const parsed = parseFrontmatter(content);
+  const date = getString(parsed.fields, 'date');
+
+  return (
+    parsed.errors.length === 0 &&
+    getString(parsed.fields, 'status') === 'frozen' &&
+    date !== undefined &&
+    date === getLogFilenameDate(relativePath) &&
+    isCalendarDate(date)
+  );
+}
+
+export function isFrontmatterSupersededByAddition(
+  previousContent: string,
+  currentContent: string,
+): boolean {
+  const previous = parseFrontmatter(previousContent);
+  const current = parseFrontmatter(currentContent);
+  const currentValue = current.fields.get('superseded_by');
+
+  return (
+    previous.errors.length === 0 &&
+    !previous.fields.has('superseded_by') &&
+    current.errors.length === 0 &&
+    typeof currentValue === 'string' &&
+    currentValue.length > 0
+  );
 }
 
 export function classifyDocument(
@@ -219,7 +257,7 @@ function validateLog(
   const reasons: string[] = [];
   const status = getString(fields, 'status');
   const date = getString(fields, 'date');
-  const filenameDate = relativePath.match(/\/log\/(?:\d{4}\/)?(\d{4}-\d{2}-\d{2})-/)?.[1];
+  const filenameDate = getLogFilenameDate(relativePath);
 
   if (status !== 'frozen') reasons.push('新規logのstatusはfrozenにする');
   if (!filenameDate) reasons.push('新規logのfilenameはYYYY-MM-DD-slug.mdにする');
@@ -281,10 +319,14 @@ export function validateDocumentMetadata({
     if (reason) reasons.push(reason);
   }
 
-  const supersededBy = getString(parsed.fields, 'superseded_by');
-  if (supersededBy) {
-    const reason = validateRepoPath(root, supersededBy, 'superseded_by');
-    if (reason) reasons.push(reason);
+  const supersededBy = parsed.fields.get('superseded_by');
+  if (supersededBy !== undefined) {
+    if (typeof supersededBy !== 'string' || supersededBy.length === 0) {
+      reasons.push('superseded_byはscalarのrepo-relative pathで指定する');
+    } else {
+      const reason = validateRepoPath(root, supersededBy, 'superseded_by');
+      if (reason) reasons.push(reason);
+    }
   }
 
   return reasons;


### PR DESCRIPTION
## 概要

#1611 では、当初のPR 1とPR 2を分離せず、内部docs修復とdocs guard強化を同じPRで導入していました。本PRは、その実装を受入条件へ再照合して見つかったappend-only境界の抜けを修正するfollow-upです。

## 変更内容

- 新契約logはfrontmatterへの単一の `superseded_by` 追記だけを許可
- legacy logだけは互換性のため単一の `status: superseded` 追記も許可
- `superseded_by` のarray指定を拒否し、scalarのrepo-relative pathに限定
- unified diffのfile headerと、hunk内で `+++` / `---` から始まる本文を区別
- code pathのarray、実在しない日付、`latest.md`、secrets、RLS snapshot完全一致例外を回帰テストで明示

## 原因

append-only判定が追加行の文字列だけを見ており、新契約logとlegacy logを区別していませんでした。また、`superseded_by` がfrontmatter内にあることとscalarであることを検証せず、diff headerもprefixだけで除外していました。

## 影響

runtime、DB、公開API、ユーザー向けdocsには影響しません。新契約logの訂正方法を文書化済みの契約どおりに制限し、既存legacy logの互換性は維持します。

## 検証

- `pnpm test:scripts`（5 files / 38 tests）
- `pnpm docs:check`（stock link violation 0、legacy log warning 15件据え置き）
- `pnpm check`
