### PR TITLE
chore(ai): ブラウザ視覚確認ルールを統一する

### DIFF
--- a/.claude/rules/mcp-usage.md
+++ b/.claude/rules/mcp-usage.md
@@ -92,13 +92,15 @@
 ### Playwright (`mcp__playwright__*`)
 
 - **Invoke when**:
-  - UI 変更実装後、Stats ページ / Hero / block-visual 等のビジュアル結果をスクリーンショットで確認する
+  - 同じ操作を反復できる形で検証する必要がある時、または複数 viewport / variant のスクリーンショット比較を行う時
   - E2E スモーク（`apps/product/playwright.config.ts`）が失敗した際の再現状況を撮影する
-  - Storybook の variant レンダリングを検証する
+  - 共有 browser surface が利用できず、独立した browser で視覚 evidence を取得する必要がある時
 - **Before use**:
   - 検証対象（`pnpm storybook` の localhost:6006、または `pnpm dev` の app）が起動していることを確認する
   - 初回は `@playwright/mcp` がブラウザバイナリを取得するため、`browser_navigate` の初回呼び出しが遅延しうる
-- **境界ケース**: 「型チェック・lint は通った」だけで完了報告しない。UI 変更は Playwright スクリーンショットで視覚確認するまでが完了。
+- **境界ケース**:
+  - 「型チェック・lint は通った」だけで完了報告しない。UI 変更は provider の共有 browser、Preview、または Playwright のいずれかで視覚確認する
+  - 既存の共有 browser で単発の視覚確認を完了できる時は、同じ evidence のために独立 Playwright browser を追加で起動しない
 
 ### Storybook (`mcp__storybook__*`)
 
@@ -111,7 +113,7 @@
 - **Before use**:
   - `pnpm storybook`（localhost:6006）が起動していることを確認する（`nc -z localhost 6006`）。トークンは不要
   - Storybook が落ちている場合は MCP 接続失敗を異常扱いしない（eagle / supabase-local と同じオンデマンド運用）
-- **境界ケース**: 視覚的な regression 確認は Playwright スクリーンショットの領域。Storybook MCP は props / story 構成 / docs の「構造化知識」取得に使い、見た目の検証には使わない。
+- **境界ケース**: Storybook MCP は props / story 構成 / docs の「構造化知識」取得に使い、見た目の検証には使わない。視覚確認は共有 browser surface を優先し、反復可能な自動回帰確認が必要な時だけ Playwright を使う。
 
 ### GitHub (`mcp__github__*`)
 

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -157,10 +157,12 @@ commit 前に必ず `git diff --cached` で index 内容を確認する。Edit �
 
 ### Storybook 視覚確認
 
-UI 変更を含む作業では、Storybook 起動して視覚確認を Tomoya 側で実施:
+UI 変更を含む作業では、関連 Story がある場合は Storybook を起動し、Main が視覚確認する。ユーザーと画面を共有できる provider では、同じ browser surface を優先する:
 
 - 既存 stories の regression なし
 - 新規 stories の描画確認
+- browser の選択は provider 固有の overlay に従う。Codex は `.codex/rules/browser.md` を正本とする
+- Tomoya の確認は最終的なプロダクト判断として追加できるが、Main 自身の検証の代替にはしない
 
 ## マージ方式
 

--- a/.codex/rules/README.md
+++ b/.codex/rules/README.md
@@ -29,6 +29,7 @@ Codex review agent は `sandbox_mode = "read-only"`、`approval_policy = "never"
 
 - `git-workflow.md` — Codex での branch / commit / PR / merge 運用
 - `mcp.md` — Codex 固有の MCP 起動範囲と 1Password masking 運用
+- `browser.md` — Codex での共有 Chrome、内蔵 Browser、Playwright の選択順
 
 ## Canonical References
 

--- a/.codex/rules/browser.md
+++ b/.codex/rules/browser.md
@@ -8,6 +8,7 @@ Codex で Dayopt の UI、Storybook、Preview を視覚確認する時の browse
    - 視覚確認が必要になってから、開いている tab の title / URL を read-only で確認する
    - 対象の Dayopt、Storybook、Preview tab があれば、その exact tab を claim して再利用する
    - 同じ URL への `goto` や不要な reload を行わず、ユーザーの表示状態とログイン済み session を保つ
+   - final evidence にする前に、現在の変更が反映済みかを確認する。HMR 完了や変更箇所の描画から freshness を証明できない時は 1 回 reload し、必要な UI state を復元してから確認する
 2. **必要な時だけ同じ Chrome に tab を開く**
    - 関連 tab がなく、画面を開かないと確認できない時だけ、接続済み Chrome に対象 URL を 1 tab 開く
    - Tomoya が続けて確認する画面は、作業後もその tab を残す

--- a/.codex/rules/browser.md
+++ b/.codex/rules/browser.md
@@ -1,0 +1,40 @@
+# Codex Browser Rules
+
+Codex で Dayopt の UI、Storybook、Preview を視覚確認する時の browser surface 選択を定める。目的は Tomoya と Main が同じ画面を確認し、不要な browser 起動と再ログインを避けること。
+
+## Priority
+
+1. **既存の関連 Chrome tab を使う**
+   - 視覚確認が必要になってから、開いている tab の title / URL を read-only で確認する
+   - 対象の Dayopt、Storybook、Preview tab があれば、その exact tab を claim して再利用する
+   - 同じ URL への `goto` や不要な reload を行わず、ユーザーの表示状態とログイン済み session を保つ
+2. **必要な時だけ同じ Chrome に tab を開く**
+   - 関連 tab がなく、画面を開かないと確認できない時だけ、接続済み Chrome に対象 URL を 1 tab 開く
+   - Tomoya が続けて確認する画面は、作業後もその tab を残す
+3. **Chrome を使えない時だけ内蔵 Browser を使う**
+   - localhost、Storybook、公開ページなど、認証不要の確認に限定する
+   - ログイン済み状態が必要な時は内蔵 Browser で再ログインせず、Chrome の接続またはユーザーのログインを依頼する
+4. **独立 Playwright browser は自動化が必要な時だけ使う**
+   - E2E の再現、反復可能な操作、複数 viewport / variant の比較、明示的な自動回帰確認に限定する
+   - 単発の見た目確認や Storybook preview のためだけには起動しない
+
+同じ evidence を得るために複数の browser surface を並行して使わない。既存 Chrome tab で確認できた後に、内蔵 Browser や独立 Playwright で同じ確認を繰り返さない。
+
+## Storybook
+
+- Storybook MCP は props、story 構成、docs の構造化情報を取得するために使う
+- pixel / layout / interaction の確認は上記 Priority に従い、原則として既存 Chrome tab で行う
+- Storybook が開いておらず視覚確認が必要なら、接続済み Chrome に `localhost:6006` の必要な story だけを開く
+
+## Authentication and 1Password
+
+- Chrome の既存ログイン session を最優先し、cookie、local storage、browser profile、password store を直接 inspect しない
+- browser login と repo の `op run` / MCP secret 解決は別の仕組みとして扱う
+- 1Password の password を読み出して表示・転記する運用にしない。browser 側で利用可能なら Chrome の 1Password autofill を使い、unlock、生体認証、MFA、CAPTCHA は Tomoya に handoff する
+- full CDP access は console、network、DOM、performance の調査が必要な時だけ使い、通常の視覚確認では要求しない
+
+## Privacy
+
+- browser history や無関係な tab を探索しない
+- tab 一覧から取得した無関係な title / URL を作業報告へ載せない
+- 既存 tab を claim した場合は、依頼範囲外の navigation / reset を行わず release し、ユーザーの tab を閉じない

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,7 @@ Claude Code は `Skill` tool、Codex は該当ファイルを直接読んで手�
 | `.claude/rules/mcp-usage.md` | Sentry / Supabase / Context7 / Vercel / Eagle |
 | `.claude/rules/skill-design.md` | project skill の設計・更新 |
 | `.codex/rules/README.md` | Codex 固有の薄い overlay |
+| `.codex/rules/browser.md` | Codex で UI / Storybook を視覚確認する時の browser 優先順位 |
 
 ## Skills
 


### PR DESCRIPTION
## 変更点

- CodexのUI確認で既存Chromeタブを最優先するルールを追加
- 関連タブがない場合のChrome・内蔵Browser・Playwrightの選択順を明文化
- Storybook MCPと視覚確認の責務を分離
- 1Passwordとブラウザログインの安全な境界を明記
- 共通のStorybook・Playwrightルールとの矛盾を解消

## 理由

ユーザーとMainが同じログイン済み画面を確認できる場合でも、独立ブラウザを起動して再ログインや重複検証が発生していたためです。

## 影響

単発のUI確認は共有Chromeを使い、独立PlaywrightはE2E・複数viewport・反復可能な自動回帰確認に限定されます。

## 検証

- pnpm docs:check
- pnpm exec prettier --check AGENTS.md .claude/rules/workflow.md .claude/rules/mcp-usage.md .codex/rules/README.md .codex/rules/browser.md
- git diff --check