### PR TITLE
refactor: chronotypeと充実度のDB列を削除する

### DIFF
--- a/apps/product/src/app/api/mcp/_tools/__tests__/list-tools.test.ts
+++ b/apps/product/src/app/api/mcp/_tools/__tests__/list-tools.test.ts
@@ -1,0 +1,123 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { McpRequestContext } from '../../_server';
+import { registerEntriesListTool } from '../entries-list';
+import { registerTimeblockListTools } from '../timeblock-list';
+
+const createMcpTrpcCaller = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/mcp/trpc-bridge', () => ({ createMcpTrpcCaller }));
+
+interface ListInput {
+  startDate?: string;
+  endDate?: string;
+  tagId?: string;
+  limit?: number;
+}
+
+interface TextToolResult {
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: boolean;
+}
+
+type ToolHandler = (input: ListInput) => Promise<TextToolResult>;
+
+const context: McpRequestContext = {
+  userId: 'user-1',
+  clientId: 'chatgpt',
+  scopes: ['read:entries'],
+};
+
+const plan = {
+  created_at: '2026-07-01T00:00:00.000Z',
+  deleted_at: null,
+  end_at: '2026-07-01T11:00:00.000Z',
+  external_calendar_event_id: null,
+  id: 'plan-1',
+  note: null,
+  skipped_at: null,
+  source: 'manual',
+  start_at: '2026-07-01T10:00:00.000Z',
+  tag_id: null,
+  title: 'Plan',
+  updated_at: '2026-07-01T00:00:00.000Z',
+  user_id: context.userId,
+};
+
+const record = {
+  created_at: '2026-07-01T00:00:00.000Z',
+  deleted_at: null,
+  end_at: '2026-07-01T12:00:00.000Z',
+  external_calendar_event_id: null,
+  id: 'record-1',
+  note: null,
+  plan_id: null,
+  source: 'manual',
+  start_at: '2026-07-01T11:00:00.000Z',
+  tag_id: null,
+  title: 'Record',
+  updated_at: '2026-07-01T00:00:00.000Z',
+  user_id: context.userId,
+};
+
+function createServerDouble() {
+  const handlers = new Map<string, ToolHandler>();
+  const registerTool = vi.fn((name: string, _config: unknown, handler: unknown) => {
+    handlers.set(name, handler as ToolHandler);
+  });
+
+  return {
+    handlers,
+    server: { registerTool } as unknown as McpServer,
+  };
+}
+
+function getHandler(handlers: Map<string, ToolHandler>, name: string): ToolHandler {
+  const handler = handlers.get(name);
+  if (!handler) throw new Error(`Missing MCP handler: ${name}`);
+  return handler;
+}
+
+function parseText(result: TextToolResult): Record<string, unknown> {
+  const content = result.content[0];
+  if (!content) throw new Error('Missing MCP text content');
+  return JSON.parse(content.text) as Record<string, unknown>;
+}
+
+describe('MCP list tools public contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createMcpTrpcCaller.mockReturnValue({
+      plans: { list: vi.fn().mockResolvedValue([plan]) },
+      records: { list: vi.fn().mockResolvedValue([record]) },
+    });
+  });
+
+  it('records.listはnon-empty結果にfulfillment_scoreを含めない', async () => {
+    const { handlers, server } = createServerDouble();
+    registerTimeblockListTools(server, context);
+
+    const result = parseText(await getHandler(handlers, 'records.list')({}));
+    const records = result.records as Array<Record<string, unknown>>;
+
+    expect(result.count).toBe(1);
+    expect(records).toHaveLength(1);
+    expect(records[0]).not.toHaveProperty('fulfillment_score');
+  });
+
+  it('entries.listはnon-empty結果に削除対象キーを含めない', async () => {
+    const { handlers, server } = createServerDouble();
+    registerEntriesListTool(server, context);
+
+    const result = parseText(await getHandler(handlers, 'entries.list')({}));
+    const entries = result.entries as Array<Record<string, unknown>>;
+
+    expect(result.count).toBe(2);
+    expect(entries).toHaveLength(2);
+    for (const entry of entries) {
+      expect(entry).not.toHaveProperty('fulfillment_score');
+      expect(entry).not.toHaveProperty('chronotype_settings');
+    }
+  });
+});

--- a/apps/product/src/features/auth/server/__tests__/user-service.test.ts
+++ b/apps/product/src/features/auth/server/__tests__/user-service.test.ts
@@ -295,6 +295,9 @@ describe('createUserService', () => {
         tags,
         userSettings: settings,
       });
+      expect(result.data.records).toHaveLength(1);
+      expect(result.data.records[0]).not.toHaveProperty('fulfillment_score');
+      expect(result.data.userSettings).not.toHaveProperty('chronotype_settings');
       expect(adminQueries.get('records')?.select).toHaveBeenCalledWith(publicRecordSelect);
       expect(query('user_settings').select).toHaveBeenCalledWith(publicUserSettingsSelect);
     });

--- a/apps/product/src/features/settings/server/__tests__/settings-service.test.ts
+++ b/apps/product/src/features/settings/server/__tests__/settings-service.test.ts
@@ -79,6 +79,7 @@ describe('SettingsService', () => {
           paymentErrorDialogLastShownAt: '2026-06-15T00:00:00.000Z',
         },
       });
+      expect(result).not.toHaveProperty('chronotype_settings');
       expect(query.select).toHaveBeenCalledWith(publicUserSettingsSelect);
       expect(query.eq).toHaveBeenCalledWith('user_id', USER_ID);
     });

--- a/apps/product/src/features/timeblock/server/__tests__/plan-record-service.test.ts
+++ b/apps/product/src/features/timeblock/server/__tests__/plan-record-service.test.ts
@@ -205,6 +205,18 @@ describe('RecordService.list', () => {
     expect(recordQuery.or).toHaveBeenCalledWith('id.is.null');
   });
 
+  it('non-empty一覧にfulfillment_scoreを含めない', async () => {
+    const record = createRecord();
+    const query = createChainableMock([record]);
+    const { service, mockSupabase } = createRecordService();
+    mockSupabase.from.mockReturnValue(query);
+
+    const result = await service.list({ userId: USER_ID });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).not.toHaveProperty('fulfillment_score');
+  });
+
   it('tag名一致をrecordのOR条件へ加える', async () => {
     const record = createRecord({ tag_id: TAG_ID });
     const recordQuery = createChainableMock([record]);
@@ -533,9 +545,8 @@ describe('PlanService soft delete', () => {
 describe('PlanService.confirmDay', () => {
   it('confirm_day_plans_to_records RPC へ user と day range を渡す', async () => {
     const record = createRecord({ source: 'from_plan' });
-    const legacyRecord = { ...record, fulfillment_score: 3 };
     const { service, mockSupabase } = createPlanService();
-    mockSupabase.rpc.mockResolvedValue({ data: [legacyRecord], error: null });
+    mockSupabase.rpc.mockResolvedValue({ data: [record], error: null });
 
     await expect(
       service.confirmDay({

--- a/apps/product/src/lib/database/generated/database.types.ts
+++ b/apps/product/src/lib/database/generated/database.types.ts
@@ -359,7 +359,6 @@ export type Database = {
           deleted_at: string | null;
           end_at: string;
           external_calendar_event_id: string | null;
-          fulfillment_score: number | null;
           id: string;
           note: string | null;
           plan_id: string | null;
@@ -375,7 +374,6 @@ export type Database = {
           deleted_at?: string | null;
           end_at: string;
           external_calendar_event_id?: string | null;
-          fulfillment_score?: number | null;
           id?: string;
           note?: string | null;
           plan_id?: string | null;
@@ -391,7 +389,6 @@ export type Database = {
           deleted_at?: string | null;
           end_at?: string;
           external_calendar_event_id?: string | null;
-          fulfillment_score?: number | null;
           id?: string;
           note?: string | null;
           plan_id?: string | null;
@@ -529,7 +526,6 @@ export type Database = {
       };
       user_settings: {
         Row: {
-          chronotype_settings: Json | null;
           created_at: string;
           default_duration: number;
           default_view: string;
@@ -549,7 +545,6 @@ export type Database = {
           week_starts_on: number;
         };
         Insert: {
-          chronotype_settings?: Json | null;
           created_at?: string;
           default_duration?: number;
           default_view?: string;
@@ -569,7 +564,6 @@ export type Database = {
           week_starts_on?: number;
         };
         Update: {
-          chronotype_settings?: Json | null;
           created_at?: string;
           default_duration?: number;
           default_view?: string;
@@ -628,7 +622,6 @@ export type Database = {
           deleted_at: string | null;
           end_at: string;
           external_calendar_event_id: string | null;
-          fulfillment_score: number | null;
           id: string;
           note: string | null;
           plan_id: string | null;

--- a/apps/product/src/lib/test/integration/gdpr.integration.test.ts
+++ b/apps/product/src/lib/test/integration/gdpr.integration.test.ts
@@ -119,6 +119,12 @@ describe.skipIf(SKIP_INTEGRATION)('GDPR Router Integration', () => {
       start_at: '2026-01-03T09:00:00Z',
       end_at: '2026-01-03T10:00:00Z',
     });
+
+    const { error: settingsError } = await adminSupabase.from('user_settings').insert({
+      user_id: TEST_USER_ID,
+      timezone: 'Asia/Tokyo',
+    });
+    expect(settingsError).toBeNull();
   });
 
   afterAll(async () => {
@@ -133,6 +139,7 @@ describe.skipIf(SKIP_INTEGRATION)('GDPR Router Integration', () => {
     await adminSupabase.from('records').delete().eq('user_id', TEST_USER_ID);
     await adminSupabase.from('plans').delete().eq('user_id', TEST_USER_ID);
     await adminSupabase.from('tags').delete().eq('user_id', TEST_USER_ID);
+    await adminSupabase.from('user_settings').delete().eq('user_id', TEST_USER_ID);
 
     // テスト用ユーザーを削除（auth.usersから削除するとprofilesもカスケード削除される）
     await adminSupabase.auth.admin.deleteUser(TEST_USER_ID);
@@ -191,6 +198,9 @@ describe.skipIf(SKIP_INTEGRATION)('GDPR Router Integration', () => {
         (record: { title?: string }) => record.title === 'GDPR Test Record',
       );
       expect(testRecord).toBeDefined();
+      expect(testRecord).not.toHaveProperty('fulfillment_score');
+      expect(result.data.userSettings).not.toBeNull();
+      expect(result.data.userSettings).not.toHaveProperty('chronotype_settings');
     });
 
     it('should include user tags in export', async () => {

--- a/apps/product/src/lib/test/integration/rls-access.integration.test.ts
+++ b/apps/product/src/lib/test/integration/rls-access.integration.test.ts
@@ -789,6 +789,7 @@ describe.skipIf(SKIP_INTEGRATION)('RLS access matrix', () => {
       );
       expect(confirmError).toBeNull();
       expect(confirmed).toHaveLength(1);
+      expect(confirmed?.[0]).not.toHaveProperty('fulfillment_score');
 
       const { data: count, error: countError } = await supabaseB.rpc(
         'count_unused_recovery_codes',

--- a/apps/product/src/lib/test/integration/user-settings.integration.test.ts
+++ b/apps/product/src/lib/test/integration/user-settings.integration.test.ts
@@ -126,6 +126,7 @@ describe.skipIf(SKIP_INTEGRATION)('UserSettings Router Integration', () => {
       expect(result).toBeDefined();
       expect(result?.timezone).toBe('Asia/Tokyo');
       expect(result?.timeFormat).toBe('24h');
+      expect(result).not.toHaveProperty('chronotype_settings');
     });
 
     it('should create and regenerate an iCal feed token', async () => {

--- a/supabase/migrations/20260716022141_drop_chronotype_fulfillment_columns.sql
+++ b/supabase/migrations/20260716022141_drop_chronotype_fulfillment_columns.sql
@@ -1,0 +1,90 @@
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+LOCK TABLE public.records, public.user_settings IN ACCESS EXCLUSIVE MODE;
+
+DO $$
+DECLARE
+  fulfillment_score_count BIGINT;
+  chronotype_settings_count BIGINT;
+BEGIN
+  SELECT count(*)
+  INTO fulfillment_score_count
+  FROM public.records
+  WHERE fulfillment_score IS NOT NULL;
+
+  SELECT count(*)
+  INTO chronotype_settings_count
+  FROM public.user_settings
+  WHERE chronotype_settings IS NOT NULL;
+
+  RAISE NOTICE 'approved column cleanup counts: fulfillment_score=%, chronotype_settings=%',
+    fulfillment_score_count,
+    chronotype_settings_count;
+
+  IF fulfillment_score_count > 1 THEN
+    RAISE EXCEPTION
+      'fulfillment_score non-null count % exceeds approved maximum 1',
+      fulfillment_score_count;
+  END IF;
+
+  IF chronotype_settings_count > 2 THEN
+    RAISE EXCEPTION
+      'chronotype_settings non-null count % exceeds approved maximum 2',
+      chronotype_settings_count;
+  END IF;
+END;
+$$;
+
+ALTER TABLE public.records DROP COLUMN fulfillment_score;
+ALTER TABLE public.user_settings DROP COLUMN chronotype_settings;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_attribute
+    WHERE attrelid = 'public.records'::regclass
+      AND attname = 'fulfillment_score'
+      AND attnum > 0
+      AND NOT attisdropped
+  ) THEN
+    RAISE EXCEPTION 'public.records.fulfillment_score still exists';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM pg_attribute
+    WHERE attrelid = 'public.user_settings'::regclass
+      AND attname = 'chronotype_settings'
+      AND attnum > 0
+      AND NOT attisdropped
+  ) THEN
+    RAISE EXCEPTION 'public.user_settings.chronotype_settings still exists';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.records'::regclass
+      AND conname = 'records_fulfillment_score_check'
+  ) THEN
+    RAISE EXCEPTION 'records_fulfillment_score_check still exists';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM pg_class index_relation
+    JOIN pg_index index_metadata
+      ON index_metadata.indexrelid = index_relation.oid
+    WHERE index_metadata.indrelid = 'public.records'::regclass
+      AND index_relation.relname = 'records_fulfillment_score_idx'
+  ) THEN
+    RAISE EXCEPTION 'records_fulfillment_score_idx still exists';
+  END IF;
+END;
+$$;
+
+COMMIT;

--- a/supabase/schemas/010_tables_core.sql
+++ b/supabase/schemas/010_tables_core.sql
@@ -93,7 +93,6 @@ CREATE TABLE public.records (
   start_at TIMESTAMPTZ NOT NULL,
   end_at TIMESTAMPTZ NOT NULL,
   source TEXT NOT NULL DEFAULT 'manual', -- manual / from_plan / auto_migrated / external_calendar / api
-  fulfillment_score INTEGER,
   deleted_at TIMESTAMPTZ,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
@@ -166,8 +165,6 @@ CREATE TABLE public.user_settings (
   show_week_numbers BOOLEAN NOT NULL DEFAULT false,
   default_view TEXT NOT NULL DEFAULT 'week',
   hour_height_density TEXT NOT NULL DEFAULT 'default', -- compact / default / comfortable
-  -- クロノタイプ
-  chronotype_settings JSONB,      -- { type: 'bear'|'lion'|'wolf'|'dolphin' } or null
   -- ロケール
   preferred_locale TEXT NOT NULL DEFAULT 'en',   -- en / ja
   -- テーマ


### PR DESCRIPTION
## 概要

Refs #1625

承認済みの既存値（`records.fulfillment_score` 1件、`user_settings.chronotype_settings` 2件）を、件数上限と依存関係でguardしたtransactional migrationにより削除します。手動の本番`db push`は行わず、merge後はSupabase GitHub integrationだけで適用します。

## 安全策

- `ACCESS EXCLUSIVE` lock取得後に非null件数を再取得
- 承認上限（1件 / 2件）超過時は例外で全rollback
- `CASCADE` / `IF EXISTS`なし。既定`RESTRICT`で未知の外部依存を拒否
- drop後にcolumn/check/index不在をcatalog assertion
- `lock_timeout=5s` / `statement_timeout=30s`

## 事前証拠

- #1630 production health gate完了: 逐次20/20、並列20/20がHTTP 200 + healthy、503=0、Vercel/Sentry error/fatal=0
- 本番監査: nonnull 1件 / 2件、外部column dependency 0、30秒超transaction 0
- 本番のCalendar / Settings / non-empty Record / JSON exportを確認し、対象キー0件
- Vercel/Sentryで対象列参照エラー0

## ローカル検証

- `pnpm db:fresh`
- `pnpm types:generate:local`
- `pnpm rls:snapshot:check`
- `pnpm test:run`
- `pnpm test:integration`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:boundaries`
- `pnpm check`
- `pnpm docs:check`

すべて成功。Project overviewは本番gate完了後の別PRまで`active`を維持します。