### PR TITLE
chore: Stripe webhook migrationを先行適用する

### DIFF
--- a/docs/engineering/data/db/rls-snapshot.md
+++ b/docs/engineering/data/db/rls-snapshot.md
@@ -5,7 +5,7 @@
 > **手で編集しない**。migration 変更時は CI（`pnpm rls:snapshot:check`）が drift を検出する。
 > 再生成で更新すること。
 >
-> 集計: public スキーマの policy 38 件 / RLS 対象テーブル 13 件 / GRANT 84 件 / Realtime publication 0 件。
+> 集計: public スキーマの policy 38 件 / RLS 対象テーブル 13 件 / GRANT 85 件 / Realtime publication 0 件。
 
 ## RLS 有効状態（public テーブル）
 
@@ -147,6 +147,7 @@
 | routine     | public.batch_reorder_tags_hierarchy(p_user_id uuid, p_tag_ids uuid[], p_parent_ids uuid[], p_sort_orders integer[])                                                                                                                              | service_role        | EXECUTE                        |
 | routine     | public.check_tag_has_children()                                                                                                                                                                                                                  | service_role        | EXECUTE                        |
 | routine     | public.check_tag_hierarchy()                                                                                                                                                                                                                     | service_role        | EXECUTE                        |
+| routine     | public.claim_stripe_webhook_event(p_event_id text, p_event_type text, p_stale_before timestamp with time zone)                                                                                                                                   | service_role        | EXECUTE                        |
 | routine     | public.confirm_day_plans_to_records(p_user_id uuid, p_start_at timestamp with time zone, p_end_at timestamp with time zone, p_confirmed_at timestamp with time zone)                                                                             | authenticated       | EXECUTE                        |
 | routine     | public.confirm_day_plans_to_records(p_user_id uuid, p_start_at timestamp with time zone, p_end_at timestamp with time zone, p_confirmed_at timestamp with time zone)                                                                             | service_role        | EXECUTE                        |
 | routine     | public.count_unused_recovery_codes(p_user_id uuid)                                                                                                                                                                                               | authenticated       | EXECUTE                        |

--- a/supabase/migrations/20260716031801_stripe_webhook_state_machine.sql
+++ b/supabase/migrations/20260716031801_stripe_webhook_state_machine.sql
@@ -1,0 +1,77 @@
+-- Existing rows and legacy-handler inserts are terminal. The new claimant writes processing explicitly.
+ALTER TABLE public.stripe_webhook_events
+  ADD COLUMN status TEXT NOT NULL DEFAULT 'processed',
+  ADD COLUMN claimed_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+UPDATE public.stripe_webhook_events
+SET claimed_at = processed_at;
+
+ALTER TABLE public.stripe_webhook_events
+  ALTER COLUMN processed_at DROP NOT NULL,
+  ADD CONSTRAINT stripe_webhook_events_status_check
+    CHECK (status IN ('processing', 'processed', 'failed'));
+
+CREATE INDEX stripe_webhook_events_retryable_idx
+  ON public.stripe_webhook_events (status, claimed_at)
+  WHERE status <> 'processed';
+
+CREATE OR REPLACE FUNCTION public.claim_stripe_webhook_event(
+  p_event_id TEXT,
+  p_event_type TEXT,
+  p_stale_before TIMESTAMPTZ
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  claimed_status TEXT;
+BEGIN
+  INSERT INTO public.stripe_webhook_events (
+    event_id,
+    event_type,
+    status,
+    claimed_at,
+    processed_at
+  )
+  VALUES (p_event_id, p_event_type, 'processing', now(), NULL)
+  ON CONFLICT (event_id) DO UPDATE
+  SET
+    event_type = EXCLUDED.event_type,
+    status = 'processing',
+    claimed_at = now(),
+    processed_at = NULL
+  WHERE public.stripe_webhook_events.status = 'failed'
+    OR (
+      public.stripe_webhook_events.status = 'processing'
+      AND public.stripe_webhook_events.claimed_at < p_stale_before
+    )
+  RETURNING status INTO claimed_status;
+
+  IF claimed_status IS NOT NULL THEN
+    RETURN 'claimed';
+  END IF;
+
+  SELECT status
+  INTO claimed_status
+  FROM public.stripe_webhook_events
+  WHERE event_id = p_event_id;
+
+  IF claimed_status = 'processed' THEN
+    RETURN 'already_processed';
+  END IF;
+
+  RETURN 'in_progress';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.claim_stripe_webhook_event(TEXT, TEXT, TIMESTAMPTZ)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.claim_stripe_webhook_event(TEXT, TEXT, TIMESTAMPTZ)
+  TO service_role;
+
+COMMENT ON COLUMN public.stripe_webhook_events.status IS
+  'Delivery state: processing claims may be reclaimed after a timeout; processed rows are terminal; failed rows are retryable.';
+COMMENT ON FUNCTION public.claim_stripe_webhook_event(TEXT, TEXT, TIMESTAMPTZ) IS
+  'Atomically claims a new, failed, or stale Stripe delivery. Callable only by service_role.';

--- a/supabase/schemas/014_tables_billing.sql
+++ b/supabase/schemas/014_tables_billing.sql
@@ -1,11 +1,12 @@
 -- ============================================================
 -- 課金・メール関連テーブル（読み物用 — CLIでは使用しない）
 -- ============================================================
--- 最終同期日: 2026-06-17
+-- 最終同期日: 2026-07-16
 -- 同期対象 migration:
 --   - 20260318091249_create_email_suppressions.sql
 --   - 20260319090000_create_stripe_webhook_events.sql
 --   - 20260604230607_harden_function_execute_privileges.sql
+--   - 20260716031801_stripe_webhook_state_machine.sql
 --
 
 -- stripe_webhook_events: Stripe Webhook 冪等性キー
@@ -15,8 +16,71 @@ CREATE TABLE public.stripe_webhook_events (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   event_id TEXT NOT NULL UNIQUE,
   event_type TEXT NOT NULL,
-  processed_at TIMESTAMPTZ NOT NULL DEFAULT now()
+  status TEXT NOT NULL DEFAULT 'processed'
+    CHECK (status IN ('processing', 'processed', 'failed')),
+  claimed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  processed_at TIMESTAMPTZ DEFAULT now()
 );
+
+CREATE INDEX stripe_webhook_events_retryable_idx
+  ON public.stripe_webhook_events (status, claimed_at)
+  WHERE status <> 'processed';
+
+CREATE OR REPLACE FUNCTION public.claim_stripe_webhook_event(
+  p_event_id TEXT,
+  p_event_type TEXT,
+  p_stale_before TIMESTAMPTZ
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  claimed_status TEXT;
+BEGIN
+  INSERT INTO public.stripe_webhook_events (
+    event_id,
+    event_type,
+    status,
+    claimed_at,
+    processed_at
+  )
+  VALUES (p_event_id, p_event_type, 'processing', now(), NULL)
+  ON CONFLICT (event_id) DO UPDATE
+  SET
+    event_type = EXCLUDED.event_type,
+    status = 'processing',
+    claimed_at = now(),
+    processed_at = NULL
+  WHERE public.stripe_webhook_events.status = 'failed'
+    OR (
+      public.stripe_webhook_events.status = 'processing'
+      AND public.stripe_webhook_events.claimed_at < p_stale_before
+    )
+  RETURNING status INTO claimed_status;
+
+  IF claimed_status IS NOT NULL THEN
+    RETURN 'claimed';
+  END IF;
+
+  SELECT status
+  INTO claimed_status
+  FROM public.stripe_webhook_events
+  WHERE event_id = p_event_id;
+
+  IF claimed_status = 'processed' THEN
+    RETURN 'already_processed';
+  END IF;
+
+  RETURN 'in_progress';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.claim_stripe_webhook_event(TEXT, TEXT, TIMESTAMPTZ)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.claim_stripe_webhook_event(TEXT, TEXT, TIMESTAMPTZ)
+  TO service_role;
 
 -- email_suppressions: メール送信抑制リスト
 -- バウンス・苦情のあったアドレスを記録し、再送を防止


### PR DESCRIPTION
## 目的

Sentry hardening のアプリ側を Production へ出す前に、Stripe webhook の新しい claim RPC を後方互換で先行適用します。旧 handler は従来どおり `event_id` / `event_type` の insert を継続できるため、DB-first 後も現行 Production と互換です。

Closes ではなく #1566 の先行安全策です。

## 変更

- `stripe_webhook_events` に `status` / `claimed_at` を追加
- `processed_at` を retry state 用に nullable 化
- retryable event の部分 index を追加
- `claim_stripe_webhook_event` RPC を `SECURITY INVOKER` で追加
- RPC execute を `service_role` のみに限定
- canonical schema を migration と同期

## 検証

- `supabase migration up --local`
- 列の nullability/default、RPC、grant を SQL で確認
- 同時 claim: 先行呼び出し `claimed`、並行呼び出し `in_progress`
- Supabase local security advisors: 0
- `pnpm check`: pass
  - Product: 201 files / 2012 tests
  - Web: 6 files / 78 tests
  - i18n: 2 files / 4 tests
  - scripts: 8 files / 45 tests
- `git diff --check origin/main...HEAD`: pass

## Production 手順

1. Supabase Preview Branch と CI を確認
2. merge commit で main へ取り込む
3. Supabase GitHub integration による Production migration を監視
4. migration history、列、RPC、service-role-only grant を read-only 確認
5. その後に Sentry アプリ変更を展開

## Rollback / roll-forward

migration は additive で旧 handler と互換です。問題時はアプリを現行 Production のまま維持し、DB は保持して修正 migration を追加します。適用済み Production migration の手動巻き戻しは行いません。