### PR TITLE
chore(release): v0.32.0 へ version bump

### DIFF
--- a/apps/product/next.config.mjs
+++ b/apps/product/next.config.mjs
@@ -6,6 +6,7 @@ import createNextIntlPlugin from 'next-intl/plugin';
 import { fileURLToPath } from 'url';
 
 import { assertProductOperationalProductionBuildEnv } from './production-build-gate.mjs';
+import { releaseVersion } from './release-version.mjs';
 
 const { loadEnvConfig } = nextEnv;
 const repoRoot = fileURLToPath(new URL('../..', import.meta.url));
@@ -37,7 +38,7 @@ const nextConfig = {
       process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co',
     NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder',
     NEXT_PUBLIC_TURNSTILE_SITE_KEY: process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY || '',
-    NEXT_PUBLIC_APP_VERSION: process.env.npm_package_version || '0.0.0',
+    NEXT_PUBLIC_APP_VERSION: releaseVersion,
     // client 側で Vercel 環境を判別するため露出。preview は NODE_ENV=production だが
     // VERCEL_ENV=preview なので、Sentry を production のみ有効化する gate に必要。
     NEXT_PUBLIC_VERCEL_ENV: process.env.VERCEL_ENV || '',

--- a/apps/product/release-version.mjs
+++ b/apps/product/release-version.mjs
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const moduleDirectory =
+  typeof __dirname !== 'undefined' ? __dirname : dirname(fileURLToPath(import.meta.url));
+export const rootPackageJsonPath = join(moduleDirectory, '../../package.json');
+
+export function parseReleaseVersion(packageJsonText) {
+  const manifest = JSON.parse(packageJsonText);
+  if (typeof manifest.version !== 'string' || manifest.version.length === 0) {
+    throw new Error('Root package.json must define a release version');
+  }
+  return manifest.version;
+}
+
+export const releaseVersion = parseReleaseVersion(readFileSync(rootPackageJsonPath, 'utf8'));

--- a/apps/product/release-version.test.mjs
+++ b/apps/product/release-version.test.mjs
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { parseReleaseVersion, releaseVersion, rootPackageJsonPath } from './release-version.mjs';
+
+describe('Product release version', () => {
+  it('root package.jsonをrelease versionの正本として読む', () => {
+    expect(rootPackageJsonPath).toBe(resolve(process.cwd(), '../../package.json'));
+    const rootManifest = JSON.parse(readFileSync(rootPackageJsonPath, 'utf8'));
+
+    expect(releaseVersion).toBe(rootManifest.version);
+  });
+
+  it('versionがないmanifestを拒否する', () => {
+    expect(() => parseReleaseVersion('{}')).toThrow(
+      'Root package.json must define a release version',
+    );
+  });
+});

--- a/apps/product/src/app/[locale]/(app)/(workspace)/[nday]/page.tsx
+++ b/apps/product/src/app/[locale]/(app)/(workspace)/[nday]/page.tsx
@@ -8,22 +8,15 @@ import { HydrationBoundary } from '@/lib/trpc/server';
 import type { Locale } from '@dayopt/i18n/routing';
 
 import { CalendarViewClient } from '../_composition/CalendarViewClient';
-import { getCalendarTranslations, parseDateParam } from '../_server/calendar-page-params';
+import {
+  getCalendarTranslations,
+  parseDateParam,
+  parseMultiDayViewParam,
+} from '../_server/calendar-page-params';
 import { prefetchCalendarData } from '../_server/calendar-prefetch';
 import { CalendarSkeleton } from '../_server/CalendarSkeleton';
 
 export const dynamic = 'force-dynamic';
-
-/**
- * 有効な multi-day ビュー（2day〜9day）かバリデーション
- */
-function parseMultiDay(nday: string): MultiDayViewType | null {
-  const match = nday.match(/^(\d+)day$/);
-  if (!match) return null;
-  const n = parseInt(match[1]!);
-  if (n < 2 || n > 9) return null;
-  return nday as MultiDayViewType;
-}
 
 export async function generateMetadata({
   params,
@@ -73,7 +66,7 @@ const MultiDayPage = async ({
   const { nday, locale = 'ja' } = await params;
   const { date } = await searchParams;
 
-  const viewType = parseMultiDay(nday);
+  const viewType = parseMultiDayViewParam(nday);
   if (!viewType) {
     notFound();
   }

--- a/apps/product/src/app/[locale]/(app)/(workspace)/_composition/useCalendarComposition.ts
+++ b/apps/product/src/app/[locale]/(app)/(workspace)/_composition/useCalendarComposition.ts
@@ -37,7 +37,7 @@ interface CalendarCompositionInput {
   /** 現在の表示日付 */
   currentDate: Date;
   /** 相対ナビゲーション */
-  navigateRelative: (direction: 'prev' | 'next' | 'today') => void;
+  navigateRelative: (direction: 'prev' | 'next' | 'today', showWeekends?: boolean) => void;
   /** 日付指定ナビゲーション */
   navigateToDate: (date: Date) => void;
   /** ビュー変更 */

--- a/apps/product/src/app/[locale]/(app)/(workspace)/_composition/useCalendarNavHandlers.ts
+++ b/apps/product/src/app/[locale]/(app)/(workspace)/_composition/useCalendarNavHandlers.ts
@@ -24,7 +24,7 @@ import { useUserSettings } from '@/features/settings';
 interface CalendarNavHandlersInput {
   viewType: CalendarViewType;
   currentDate: Date;
-  navigateRelative: (direction: 'prev' | 'next' | 'today') => void;
+  navigateRelative: (direction: 'prev' | 'next' | 'today', showWeekends?: boolean) => void;
   navigateToDate: (date: Date) => void;
   changeView: (view: CalendarViewType) => void;
 }

--- a/apps/product/src/app/[locale]/(app)/(workspace)/_server/__tests__/calendar-page-params.test.ts
+++ b/apps/product/src/app/[locale]/(app)/(workspace)/_server/__tests__/calendar-page-params.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseMultiDayViewParam } from '../calendar-page-params';
+
+describe('parseMultiDayViewParam', () => {
+  it.each(['2day', '3day', '7day'])('%sをmulti-day viewとして受理する', (value) => {
+    expect(parseMultiDayViewParam(value)).toBe(value);
+  });
+
+  it.each(['1day', '8day', '9day', '10day', 'week', '3days'])('%sを拒否する', (value) => {
+    expect(parseMultiDayViewParam(value)).toBeNull();
+  });
+});

--- a/apps/product/src/app/[locale]/(app)/(workspace)/_server/calendar-page-params.ts
+++ b/apps/product/src/app/[locale]/(app)/(workspace)/_server/calendar-page-params.ts
@@ -1,5 +1,6 @@
 import { getTranslations } from 'next-intl/server';
 
+import type { MultiDayViewType } from '@/features/calendar';
 import { parseCalendarDateParam } from '@/features/calendar';
 import type { Locale } from '@dayopt/i18n/routing';
 
@@ -8,6 +9,11 @@ import type { Locale } from '@dayopt/i18n/routing';
  */
 export function parseDateParam(date: string | undefined): Date | undefined {
   return parseCalendarDateParam(date);
+}
+
+/** URL segmentをサポート対象のmulti-day view（2day〜7day）として解析する。 */
+export function parseMultiDayViewParam(nday: string): MultiDayViewType | null {
+  return /^[2-7]day$/.test(nday) ? (nday as MultiDayViewType) : null;
 }
 
 /**

--- a/apps/product/src/app/api/health/__tests__/route.test.ts
+++ b/apps/product/src/app/api/health/__tests__/route.test.ts
@@ -51,6 +51,7 @@ describe('GET /api/health', () => {
     vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://example.supabase.co');
     vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'service-role-sentinel');
     vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', 'anon-key-sentinel');
+    vi.stubEnv('NEXT_PUBLIC_APP_VERSION', '0.32.0');
     vi.stubEnv('VERCEL_ENV', '');
     vi.stubEnv('UPSTASH_REDIS_REST_URL', '');
     vi.stubEnv('UPSTASH_REDIS_REST_TOKEN', '');
@@ -77,6 +78,7 @@ describe('GET /api/health', () => {
 
     expect(response.status).toBe(200);
     expect(body.status).toBe('healthy');
+    expect(body.version).toBe('0.32.0');
     expect(body.checks).toEqual({ database: 'ok', redis: 'skipped' });
     expect(body.checks).not.toHaveProperty('memory');
     expect(mocks.from).toHaveBeenCalledWith('profiles');

--- a/apps/product/src/app/api/health/route.ts
+++ b/apps/product/src/app/api/health/route.ts
@@ -117,12 +117,7 @@ function getUptime(): number {
  * アプリケーションバージョンを取得
  */
 function getVersion(): string {
-  try {
-    // package.json から版数取得
-    return process.env.npm_package_version || '0.0.0';
-  } catch {
-    return 'unknown';
-  }
+  return process.env.NEXT_PUBLIC_APP_VERSION || '0.0.0';
 }
 
 /**

--- a/apps/product/src/features/calendar/components/Calendar.docs.mdx
+++ b/apps/product/src/features/calendar/components/Calendar.docs.mdx
@@ -12,7 +12,7 @@ PlanとRecordを時間gridに描画するcomponent群。Storybookではviewご�
 | ----------- | ---------------------------------------------------- |
 | Day         | 1日grid、Plan / Record lane、current time            |
 | Week        | 7日密度、weekend、複数日の差分marker                 |
-| Multi-Day   | 2〜9日の可変column                                   |
+| Multi-Day   | 2〜7日の可変column                                   |
 | Interaction | selection、drag preview、context menu、inline create |
 
 - Planはoutline / 淡色、Recordは塗りを基本にする

--- a/apps/product/src/features/calendar/components/controller/hooks/__tests__/useCalendarNavigationHandlers.test.tsx
+++ b/apps/product/src/features/calendar/components/controller/hooks/__tests__/useCalendarNavigationHandlers.test.tsx
@@ -1,0 +1,32 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useCalendarNavigationHandlers } from '../useCalendarNavigationHandlers';
+
+vi.mock('@/lib/hooks/useUpdateUserSettings', () => ({
+  useUpdateUserSettings: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { log: vi.fn() },
+}));
+
+describe('useCalendarNavigationHandlers', () => {
+  it('週末非表示のmulti-day navigationへ営業日設定を渡す', () => {
+    const navigateRelative = vi.fn();
+    const { result } = renderHook(() =>
+      useCalendarNavigationHandlers({
+        viewType: '7day',
+        currentDate: new Date('2026-01-15T12:00:00'),
+        showWeekends: false,
+        navigateRelative,
+        navigateToDate: vi.fn(),
+        changeView: vi.fn(),
+      }),
+    );
+
+    act(() => result.current.handleNavigate('next'));
+
+    expect(navigateRelative).toHaveBeenCalledWith('next', false);
+  });
+});

--- a/apps/product/src/features/calendar/components/controller/hooks/useCalendarData.ts
+++ b/apps/product/src/features/calendar/components/controller/hooks/useCalendarData.ts
@@ -13,12 +13,16 @@ import { api } from '@/lib/trpc';
 
 import { useCalendarFilterStore } from '@/features/calendar/stores/useCalendarFilterStore';
 
-import { calculateViewDateRange } from '../../../domain/view-range';
+import {
+  calculateViewDateRange,
+  getNextPeriod,
+  getPreviousPeriod,
+} from '../../../domain/view-range';
 import { applyTimezoneToDisplayDates } from '../../../lib/plan-data-adapter';
 import { expandRecordRowsToRecordEvents } from '../../../lib/record-event-adapter';
 
 import type { CalendarEvent, CalendarViewType, ViewDateRange } from '../../../types/calendar.types';
-import { getMultiDayCount, isMultiDayView } from '../../../types/calendar.types';
+import { isMultiDayView } from '../../../types/calendar.types';
 
 /**
  * ローカル日付の 00:00:00 をユーザーTZのUTC ISO文字列に変換
@@ -229,9 +233,8 @@ export function useCalendarData({
       }
     } else if (isMultiDayView(viewType)) {
       // multi-dayビュー: 前後1期間分をprefetch
-      const count = getMultiDayCount(viewType);
-      prefetchRange(subDays(currentDate, count));
-      prefetchRange(addDays(currentDate, count));
+      prefetchRange(getPreviousPeriod(viewType, currentDate, showWeekends));
+      prefetchRange(getNextPeriod(viewType, currentDate, showWeekends));
     } else {
       // weekビュー: 前後1週間をprefetch
       prefetchRange(subDays(currentDate, 7));
@@ -255,12 +258,14 @@ export function useCalendarData({
       if (direction === 'today') {
         targetDate = new Date();
       } else {
-        const multiplier = direction === 'next' ? 1 : -1;
-        targetDate = new Date(currentDate);
-
         if (isMultiDayView(viewType)) {
-          targetDate.setDate(currentDate.getDate() + getMultiDayCount(viewType) * multiplier);
+          targetDate =
+            direction === 'next'
+              ? getNextPeriod(viewType, currentDate, showWeekends)
+              : getPreviousPeriod(viewType, currentDate, showWeekends);
         } else {
+          const multiplier = direction === 'next' ? 1 : -1;
+          targetDate = new Date(currentDate);
           switch (viewType) {
             case 'day':
               targetDate.setDate(currentDate.getDate() + 1 * multiplier);

--- a/apps/product/src/features/calendar/components/controller/hooks/useCalendarNavigationHandlers.ts
+++ b/apps/product/src/features/calendar/components/controller/hooks/useCalendarNavigationHandlers.ts
@@ -13,7 +13,7 @@ interface UseCalendarNavigationHandlersOptions {
   viewType: CalendarViewType;
   currentDate: Date;
   showWeekends: boolean;
-  navigateRelative: (direction: 'prev' | 'next' | 'today') => void;
+  navigateRelative: (direction: 'prev' | 'next' | 'today', showWeekends?: boolean) => void;
   navigateToDate: (date: Date) => void;
   changeView: (view: CalendarViewType) => void;
 }
@@ -53,10 +53,10 @@ export function useCalendarNavigationHandlers({
       );
 
       // 特別な処理が必要かチェック
-      const needsWeekendSkip = (viewType === 'day' || viewType === '3day') && !showWeekends;
+      const needsWeekendSkip = viewType === 'day' && !showWeekends;
 
       if (!needsWeekendSkip) {
-        navigateRelative(direction);
+        navigateRelative(direction, showWeekends);
         return;
       }
 
@@ -65,7 +65,7 @@ export function useCalendarNavigationHandlers({
         if (handleTodayWithWeekendSkip()) {
           return;
         }
-        navigateRelative(direction);
+        navigateRelative(direction, showWeekends);
         return;
       }
 
@@ -75,7 +75,7 @@ export function useCalendarNavigationHandlers({
       }
 
       // フォールバックとして通常処理
-      navigateRelative(direction);
+      navigateRelative(direction, showWeekends);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps -- advanced-use-latest パターンで安定化済み
     [navigateRelative, currentDate, viewType, showWeekends],

--- a/apps/product/src/features/calendar/components/views/MultiDayView/MultiDayView.tsx
+++ b/apps/product/src/features/calendar/components/views/MultiDayView/MultiDayView.tsx
@@ -22,7 +22,7 @@ import { CalendarGridContent } from '../shared/components/CalendarGridContent';
 import { useMultiDayView } from './hooks/useMultiDayView';
 
 /**
- * MultiDayView - N日間表示の汎用コンポーネント（2〜9日間）
+ * MultiDayView - N日間表示の汎用コンポーネント（2〜7日間）
  */
 export function MultiDayView({
   dayCount,

--- a/apps/product/src/features/calendar/components/views/MultiDayView/hooks/useMultiDayView.ts
+++ b/apps/product/src/features/calendar/components/views/MultiDayView/hooks/useMultiDayView.ts
@@ -27,7 +27,7 @@ interface UseMultiDayViewReturn {
  *
  * @description
  * - centerDateを中心にdayCount日間を生成
- * - 2〜9日間に対応
+ * - 2〜7日間に対応
  */
 export function useMultiDayView({
   centerDate,

--- a/apps/product/src/features/calendar/components/views/shared/hooks/useDateUtilities.ts
+++ b/apps/product/src/features/calendar/components/views/shared/hooks/useDateUtilities.ts
@@ -15,7 +15,7 @@ interface UseDateUtilitiesOptions {
   viewType: 'week' | 'threeday' | 'fiveday' | 'multiday';
   weekStartsOn?: 0 | 1 | 6;
   showWeekends?: boolean;
-  dayCount?: number; // multiday用の表示日数（2-9）
+  dayCount?: number; // multiday用の表示日数（2-7）
 }
 
 /** useDateUtilities フックの戻り値 */
@@ -35,7 +35,7 @@ interface UseDateUtilitiesReturn {
  * - WeekView: 週の7日間
  * - MultiDayView(3day): 中央日±1日の3日間
  * - MultiDayView(5day): 中央日±2日の5日間
- * - MultiDayView: 中央日±floor(dayCount/2)日のN日間（2-9日）
+ * - MultiDayView: 中央日±floor(dayCount/2)日のN日間（2-7日）
  */
 export function useDateUtilities({
   referenceDate,

--- a/apps/product/src/features/calendar/domain/__tests__/view-range.test.ts
+++ b/apps/product/src/features/calendar/domain/__tests__/view-range.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import { calculateViewDateRange, getNextPeriod, getPreviousPeriod } from '../view-range';
 
+const multiDayViewTypes = ['2day', '3day', '4day', '5day', '6day', '7day'] as const;
+const weekendRoundTripCases = multiDayViewTypes.flatMap((viewType) =>
+  ['2026-01-17T12:00:00', '2026-01-18T12:00:00'].map((anchor) => [viewType, anchor] as const),
+);
+
 describe('calculateViewDateRange', () => {
   describe('day view', () => {
     it('1日分の範囲を返す', () => {
@@ -121,6 +126,28 @@ describe('getNextPeriod', () => {
       ),
     ).toBe(false);
   });
+
+  it('週末anchorの3dayは次期間から戻ると元の表示期間を復元する', () => {
+    const weekend = new Date('2026-01-17T12:00:00');
+    const current = calculateViewDateRange('3day', weekend, 1, false);
+    const nextDate = getNextPeriod('3day', weekend, false);
+    const next = calculateViewDateRange('3day', nextDate, 1, false);
+    const restoredDate = getPreviousPeriod('3day', nextDate, false);
+    const restored = calculateViewDateRange('3day', restoredDate, 1, false);
+
+    expect(nextDate.toISOString().slice(0, 10)).toBe('2026-01-22');
+    expect(next.days.map((day) => day.toISOString().slice(0, 10))).toEqual([
+      '2026-01-21',
+      '2026-01-22',
+      '2026-01-23',
+    ]);
+    expect(
+      next.days.some((day) =>
+        current.days.some((currentDay) => currentDay.getTime() === day.getTime()),
+      ),
+    ).toBe(false);
+    expect(restored.days).toEqual(current.days);
+  });
 });
 
 describe('getPreviousPeriod', () => {
@@ -164,4 +191,67 @@ describe('getPreviousPeriod', () => {
       ),
     ).toBe(false);
   });
+
+  it('週末anchorの3dayは前期間から進むと元の表示期間を復元する', () => {
+    const weekend = new Date('2026-01-17T12:00:00');
+    const current = calculateViewDateRange('3day', weekend, 1, false);
+    const previousDate = getPreviousPeriod('3day', weekend, false);
+    const previous = calculateViewDateRange('3day', previousDate, 1, false);
+    const restoredDate = getNextPeriod('3day', previousDate, false);
+    const restored = calculateViewDateRange('3day', restoredDate, 1, false);
+
+    expect(previousDate.toISOString().slice(0, 10)).toBe('2026-01-14');
+    expect(previous.days.map((day) => day.toISOString().slice(0, 10))).toEqual([
+      '2026-01-13',
+      '2026-01-14',
+      '2026-01-15',
+    ]);
+    expect(
+      previous.days.some((day) =>
+        current.days.some((currentDay) => currentDay.getTime() === day.getTime()),
+      ),
+    ).toBe(false);
+    expect(restored.days).toEqual(current.days);
+  });
+});
+
+describe('週末非表示multi-dayの期間移動', () => {
+  it.each(weekendRoundTripCases)(
+    '%sは週末anchor %sでも前後の期間と重複せず往復できる',
+    (viewType, anchor) => {
+      const weekend = new Date(anchor);
+      const current = calculateViewDateRange(viewType, weekend, 1, false);
+
+      const nextDate = getNextPeriod(viewType, weekend, false);
+      const next = calculateViewDateRange(viewType, nextDate, 1, false);
+      const restoredFromNext = calculateViewDateRange(
+        viewType,
+        getPreviousPeriod(viewType, nextDate, false),
+        1,
+        false,
+      );
+
+      const previousDate = getPreviousPeriod(viewType, weekend, false);
+      const previous = calculateViewDateRange(viewType, previousDate, 1, false);
+      const restoredFromPrevious = calculateViewDateRange(
+        viewType,
+        getNextPeriod(viewType, previousDate, false),
+        1,
+        false,
+      );
+
+      expect(
+        next.days.some((day) =>
+          current.days.some((currentDay) => currentDay.getTime() === day.getTime()),
+        ),
+      ).toBe(false);
+      expect(
+        previous.days.some((day) =>
+          current.days.some((currentDay) => currentDay.getTime() === day.getTime()),
+        ),
+      ).toBe(false);
+      expect(restoredFromNext.days).toEqual(current.days);
+      expect(restoredFromPrevious.days).toEqual(current.days);
+    },
+  );
 });

--- a/apps/product/src/features/calendar/domain/__tests__/view-range.test.ts
+++ b/apps/product/src/features/calendar/domain/__tests__/view-range.test.ts
@@ -98,6 +98,29 @@ describe('getNextPeriod', () => {
     const next = getNextPeriod('3day', date);
     expect(next.getDate()).toBe(18);
   });
+
+  it('週末非表示の7dayは7営業日進み、表示日が前期間と重複しない', () => {
+    const date = new Date('2026-01-15T12:00:00');
+    const current = calculateViewDateRange('7day', date, 1, false);
+    const nextDate = getNextPeriod('7day', date, false);
+    const next = calculateViewDateRange('7day', nextDate, 1, false);
+
+    expect(nextDate.toISOString().slice(0, 10)).toBe('2026-01-26');
+    expect(next.days.map((day) => day.toISOString().slice(0, 10))).toEqual([
+      '2026-01-21',
+      '2026-01-22',
+      '2026-01-23',
+      '2026-01-26',
+      '2026-01-27',
+      '2026-01-28',
+      '2026-01-29',
+    ]);
+    expect(
+      next.days.some((day) =>
+        current.days.some((currentDay) => currentDay.getTime() === day.getTime()),
+      ),
+    ).toBe(false);
+  });
 });
 
 describe('getPreviousPeriod', () => {
@@ -117,5 +140,28 @@ describe('getPreviousPeriod', () => {
     const date = new Date('2026-01-15');
     const prev = getPreviousPeriod('3day', date);
     expect(prev.getDate()).toBe(12);
+  });
+
+  it('週末非表示の7dayは7営業日戻り、表示日が次期間と重複しない', () => {
+    const date = new Date('2026-01-15T12:00:00');
+    const current = calculateViewDateRange('7day', date, 1, false);
+    const previousDate = getPreviousPeriod('7day', date, false);
+    const previous = calculateViewDateRange('7day', previousDate, 1, false);
+
+    expect(previousDate.toISOString().slice(0, 10)).toBe('2026-01-06');
+    expect(previous.days.map((day) => day.toISOString().slice(0, 10))).toEqual([
+      '2026-01-01',
+      '2026-01-02',
+      '2026-01-05',
+      '2026-01-06',
+      '2026-01-07',
+      '2026-01-08',
+      '2026-01-09',
+    ]);
+    expect(
+      previous.days.some((day) =>
+        current.days.some((currentDay) => currentDay.getTime() === day.getTime()),
+      ),
+    ).toBe(false);
   });
 });

--- a/apps/product/src/features/calendar/domain/view-range.ts
+++ b/apps/product/src/features/calendar/domain/view-range.ts
@@ -20,6 +20,15 @@ import { subDays } from '@/lib/date';
 import type { CalendarViewType, ViewDateRange } from '../types/calendar.types';
 import { getMultiDayCount, isMultiDayView } from '../types/calendar.types';
 
+/** 週末を、週末非表示の表示範囲が中央日として扱う次の平日へ揃える。 */
+function normalizeBusinessDayAnchor(referenceDate: Date): Date {
+  let anchor = referenceDate;
+  while (anchor.getDay() === 0 || anchor.getDay() === 6) {
+    anchor = addDays(anchor, 1);
+  }
+  return anchor;
+}
+
 /**
  * ビューの日付範囲を計算
  * @param viewType - カレンダーのビュータイプ
@@ -90,10 +99,7 @@ export function generateMultiDayDates(
   const offset = Math.floor(count / 2);
 
   if (!showWeekends) {
-    let centerDate = referenceDate;
-    while (centerDate.getDay() === 0 || centerDate.getDay() === 6) {
-      centerDate = addDays(centerDate, 1);
-    }
+    const centerDate = normalizeBusinessDayAnchor(referenceDate);
 
     const previousDates: Date[] = [];
     let candidate = subDays(centerDate, 1);
@@ -132,7 +138,9 @@ export function getNextPeriod(
 ): Date {
   if (isMultiDayView(viewType)) {
     const dayCount = getMultiDayCount(viewType);
-    return showWeekends ? addDays(currentDate, dayCount) : addBusinessDays(currentDate, dayCount);
+    return showWeekends
+      ? addDays(currentDate, dayCount)
+      : addBusinessDays(normalizeBusinessDayAnchor(currentDate), dayCount);
   }
   switch (viewType) {
     case 'day':
@@ -154,7 +162,9 @@ export function getPreviousPeriod(
 ): Date {
   if (isMultiDayView(viewType)) {
     const dayCount = getMultiDayCount(viewType);
-    return showWeekends ? subDays(currentDate, dayCount) : subBusinessDays(currentDate, dayCount);
+    return showWeekends
+      ? subDays(currentDate, dayCount)
+      : subBusinessDays(normalizeBusinessDayAnchor(currentDate), dayCount);
   }
   switch (viewType) {
     case 'day':

--- a/apps/product/src/features/calendar/domain/view-range.ts
+++ b/apps/product/src/features/calendar/domain/view-range.ts
@@ -4,7 +4,16 @@
  * ビューの日付範囲、ピリオド移動の計算を提供。
  */
 
-import { addDays, addWeeks, eachDayOfInterval, endOfWeek, startOfWeek, subWeeks } from 'date-fns';
+import {
+  addBusinessDays,
+  addDays,
+  addWeeks,
+  eachDayOfInterval,
+  endOfWeek,
+  startOfWeek,
+  subBusinessDays,
+  subWeeks,
+} from 'date-fns';
 
 import { subDays } from '@/lib/date';
 
@@ -116,9 +125,14 @@ export function generateMultiDayDates(
 /**
  * 次の期間を取得
  */
-export function getNextPeriod(viewType: CalendarViewType, currentDate: Date): Date {
+export function getNextPeriod(
+  viewType: CalendarViewType,
+  currentDate: Date,
+  showWeekends = true,
+): Date {
   if (isMultiDayView(viewType)) {
-    return addDays(currentDate, getMultiDayCount(viewType));
+    const dayCount = getMultiDayCount(viewType);
+    return showWeekends ? addDays(currentDate, dayCount) : addBusinessDays(currentDate, dayCount);
   }
   switch (viewType) {
     case 'day':
@@ -133,9 +147,14 @@ export function getNextPeriod(viewType: CalendarViewType, currentDate: Date): Da
 /**
  * 前の期間を取得
  */
-export function getPreviousPeriod(viewType: CalendarViewType, currentDate: Date): Date {
+export function getPreviousPeriod(
+  viewType: CalendarViewType,
+  currentDate: Date,
+  showWeekends = true,
+): Date {
   if (isMultiDayView(viewType)) {
-    return subDays(currentDate, getMultiDayCount(viewType));
+    const dayCount = getMultiDayCount(viewType);
+    return showWeekends ? subDays(currentDate, dayCount) : subBusinessDays(currentDate, dayCount);
   }
   switch (viewType) {
     case 'day':

--- a/apps/product/src/features/calendar/hooks/navigation/CalendarNavigationContext.tsx
+++ b/apps/product/src/features/calendar/hooks/navigation/CalendarNavigationContext.tsx
@@ -16,10 +16,11 @@ import { useCalendarNavigationStore } from '@/features/calendar/stores/useCalend
 import { MEDIA_QUERIES } from '@/lib/breakpoints';
 import { useMediaQuery } from '@/lib/hooks/useMediaQuery';
 
+import { getNextPeriod, getPreviousPeriod } from '../../domain/view-range';
 import { formatCalendarDateParam, parseCalendarDateParam } from '../../lib/date-param';
 import { isCalendarViewPath } from '../../lib/route-utils';
 import type { CalendarViewType } from '../../types/calendar.types';
-import { getMultiDayCount, isCalendarDiffView, isMultiDayView } from '../../types/calendar.types';
+import { isCalendarDiffView } from '../../types/calendar.types';
 
 type CalendarPanelKind = 'review' | 'diff' | 'analytics' | null;
 
@@ -30,12 +31,12 @@ function isValidViewType(view: string): view is CalendarViewType {
   const match = view.match(/^(\d+)day$/);
   if (match) {
     const n = parseInt(match[1]!);
-    return n >= 2 && n <= 9;
+    return n >= 2 && n <= 7;
   }
   return false;
 }
 
-/** モバイルで提供する表示。Weekはレーン切替で密度を確保し、2〜9日は対象外とする。 */
+/** モバイルで提供する表示。Weekはレーン切替で密度を確保し、2〜7日は対象外とする。 */
 function isMobileCalendarViewSupported(view: CalendarViewType): boolean {
   return view === 'day' || view === 'week';
 }
@@ -101,7 +102,7 @@ interface CalendarNavigationContextValue {
   isPending: boolean;
   navigateToDate: (date: Date, updateUrl?: boolean) => void;
   changeView: (view: CalendarViewType) => void;
-  navigateRelative: (direction: 'prev' | 'next' | 'today') => void;
+  navigateRelative: (direction: 'prev' | 'next' | 'today', showWeekends?: boolean) => void;
   setPanelKind: (panelKind: CalendarPanelKind | null, options?: { reviewTagId?: string }) => void;
   setReviewTagId: (reviewTagId: string | null) => void;
 }
@@ -200,7 +201,7 @@ export const CalendarNavigationProvider = ({ children }: { children: React.React
   );
 
   // モバイルで未対応の複数日ビューが設定された場合、dayへ切替
-  // （URL直アクセスやブラウザ戻る/進むで2〜9day URLに遷移した場合のガード）
+  // （URL直アクセスやブラウザ戻る/進むで2〜7day URLに遷移した場合のガード）
   React.useEffect(() => {
     if (isCalendarPage && isMobile && !isMobileCalendarViewSupported(viewType)) {
       startTransition(() => {
@@ -365,31 +366,16 @@ export const CalendarNavigationProvider = ({ children }: { children: React.React
   );
 
   const navigateRelative = useCallback(
-    (direction: 'prev' | 'next' | 'today') => {
+    (direction: 'prev' | 'next' | 'today', showWeekends = true) => {
       let newDate: Date;
 
       if (direction === 'today') {
         newDate = new Date();
       } else {
-        const multiplier = direction === 'next' ? 1 : -1;
-        newDate = new Date(currentDateRef.current);
-
-        if (isMultiDayView(viewTypeRef.current)) {
-          newDate.setDate(
-            currentDateRef.current.getDate() + getMultiDayCount(viewTypeRef.current) * multiplier,
-          );
-        } else {
-          switch (viewTypeRef.current) {
-            case 'day':
-              newDate.setDate(currentDateRef.current.getDate() + 1 * multiplier);
-              break;
-            case 'week':
-              newDate.setDate(currentDateRef.current.getDate() + 7 * multiplier);
-              break;
-            default:
-              newDate.setDate(currentDateRef.current.getDate() + 7 * multiplier);
-          }
-        }
+        newDate =
+          direction === 'next'
+            ? getNextPeriod(viewTypeRef.current, currentDateRef.current, showWeekends)
+            : getPreviousPeriod(viewTypeRef.current, currentDateRef.current, showWeekends);
       }
 
       navigateToDate(newDate, true);

--- a/apps/product/src/lib/tanstack-query/persist-storage.ts
+++ b/apps/product/src/lib/tanstack-query/persist-storage.ts
@@ -157,9 +157,9 @@ export const queryPersister: Persister = {
 export const PERSIST_MAX_AGE_MS = 2 * 60 * 60 * 1000; // 2時間
 
 /**
- * キャッシュバスターの文字列（デプロイ毎に変わる）
+ * キャッシュバスターの文字列（リリースversion変更時に変わる）
  *
- * next.config.mjs で NEXT_PUBLIC_APP_VERSION として npm_package_version を注入済み。
- * バージョンが変わるとキャッシュが自動的に破棄される。
+ * next.config.mjs でroot package.jsonのversionをNEXT_PUBLIC_APP_VERSIONとして注入済み。
+ * リリースversionが変わるとキャッシュが自動的に破棄される。
  */
 export const CACHE_BUSTER = process.env.NEXT_PUBLIC_APP_VERSION ?? 'dev';

--- a/docs/product/specs/calendar.md
+++ b/docs/product/specs/calendar.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_verified: 2026-07-16
+last_verified: 2026-07-17
 code: apps/product/src/features/calendar
 ---
 
@@ -12,6 +12,7 @@ Plan（予定）とRecord（記録）を同じ時間軸で配置・閲覧する�
 
 - Day / Week / Multi-Day（2〜7日）で、表示範囲と基準日をURLに保持する
 - Multi-Dayは選択した日数を表示列数として維持し、基準日を中央に配置する。週末非表示では土日を除いたN営業日を表示する。Weekは週境界を正とする別viewで、週末非表示時は平日の5日を表示する
+- Multi-Dayの前後移動は表示列数と同じN日単位とし、週末非表示ではN営業日単位で移動する。隣接する期間に同じ表示日を重複させない
 - 各日カラムをPlanレーンとRecordレーンに分ける。Planは控えめなoutline、Recordは塗りで表示する
 - モバイルはDay / Weekを提供する。Weekでは予定または記録を切り替えて日カラム全幅に表示し、最後に選んだ表示を端末へ保持する。既定は記録
 - モバイルの検索、作成、Inspector、tag / 日時picker、振り返りpanelは[Mobile overlays](./mobile-overlays.md)のmodal性とdismiss契約に従う

--- a/docs/product/specs/review.md
+++ b/docs/product/specs/review.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_verified: 2026-07-15
+last_verified: 2026-07-17
 code: apps/product/src/features/review
 ---
 
@@ -12,7 +12,7 @@ Calendarの右panelでPlanとRecordの差分を読み、次の計画に使うた
 
 - 独立したReview pageは持たず、Calendarのcontextual panelとして表示する
 - `panel=review`と`panel=diff`は、どちらもCalendarの表示範囲に対応する内容を表示する
-- day / week / 2〜9day multi-dayのviewを維持したままpanelを開閉できる
+- day / week / 2〜7day multi-dayのviewを維持したままpanelを開閉できる
 - 週末非表示時は、Calendarに実際に表示されている日だけをReview / Time P/Lの集計対象にする。先頭日と末尾日の間にある非表示の土日は含めない
 - Reflectionは表示日と、その直前の同じ表示日数を比較する。週末非表示時は比較期間も土日を飛ばす。既存の集計結果をrule-basedな純粋関数で要約し、LLMやin-app AIは使わない
 - DiffはCalendarが取得したPlan / Recordとその関連コンテキストから導出し、Review専用RPCは呼ばない

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dayopt",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "private": true,
   "engines": {
     "node": "24.x"


### PR DESCRIPTION
# Release v0.32.0

**リリース日**: 2026-07-17  
**バージョン**: 0.32.0

## 🎯 概要

v0.32.0では、時間データをPlan（予定）とRecord（記録）へ分離し、Calendar・Inspector・Review・統計・iCal・MCPを新モデルへ切り替えました。CalendarにはPlan / Recordの2レーン表示、予定と実績の差分、過去ブロック検索、Inspectorの自動保存・複製・重複エラー表示を追加しています。

あわせて、認証・OAuth・課金・Supabase RPCの権限境界を強化し、Product / WebのSentry監視を分離しました。chronotypeと充実度の契約、旧entries資産、互換用logs viewは撤去されています。

---

## 📋 変更内容

### ✨ 新機能 (Added)

- **Plan / RecordモデルとCalendar 2レーン表示** ([#1552](https://github.com/Dayopt/dayopt/pull/1552), [#1554](https://github.com/Dayopt/dayopt/pull/1554), [#1557](https://github.com/Dayopt/dayopt/pull/1557), [#1571](https://github.com/Dayopt/dayopt/pull/1571), [#1573](https://github.com/Dayopt/dayopt/pull/1573), [#1574](https://github.com/Dayopt/dayopt/pull/1574), [#1575](https://github.com/Dayopt/dayopt/pull/1575), [#1577](https://github.com/Dayopt/dayopt/pull/1577))
  - 予定と実績を独立したPlan / Recordとして保存し、Calendarで固定2レーン表示します。
  - PlanからRecordを作成し、未記録・予定外・skip・予定との差分をCalendarとReviewで確認できます。
  - 統計、iCal、MCP、Inspector、作成・編集・移動・削除を新モデルへ切り替えました。
- **ブロック検索と最新のタイムスロット操作** ([#1620](https://github.com/Dayopt/dayopt/pull/1620))
  - タグ名またはメモから過去のPlan / Recordを検索し、対象日のCalendarとInspectorへ移動できます。
  - Inspectorの自動保存、コピー・貼り付け、複製、Plan / Recordの関連表示、ショートカット一覧を統合しました。
  - 検索語はSentry、ログ、永続Query cacheへ保存しません。
- **Calendar Reviewの表示範囲連動** ([#1512](https://github.com/Dayopt/dayopt/pull/1512), [#1616](https://github.com/Dayopt/dayopt/pull/1616))
  - day / week / multi-dayの表示範囲に合わせ、右パネルで予定と記録の差分を確認できます。
  - 週末非表示時は、画面に表示している日だけを差分・集計対象にします。
- **Product / Webの監視分離と強化** ([#1641](https://github.com/Dayopt/dayopt/pull/1641), [#1643](https://github.com/Dayopt/dayopt/pull/1643), [#1644](https://github.com/Dayopt/dayopt/pull/1644))
  - ProductとWebを別のSentry projectへ分離し、Node / Edge / Browserの監視、source map、PII scrub、capture-once境界を整備しました。
  - Browser telemetryはanalytics同意後だけ有効になり、Session Replayは引き続き無効です。

### 🔄 変更 (Changed)

- **時間モデルの公開契約をPlan / Record / Timeblockへ統一** ([#1581](https://github.com/Dayopt/dayopt/pull/1581), [#1584](https://github.com/Dayopt/dayopt/pull/1584), [#1603](https://github.com/Dayopt/dayopt/pull/1603))
  - 旧Entry / Log命名を全層で置き換え、物理DBを`plans` / `records`へ統一しました。
  - `entries` table、互換`logs` view、旧名RPC aliasを削除しました。
- **CalendarとInspectorの操作を統一** ([#1546](https://github.com/Dayopt/dayopt/pull/1546), [#1616](https://github.com/Dayopt/dayopt/pull/1616), [#1647](https://github.com/Dayopt/dayopt/pull/1647))
  - モバイル検索をボトムシートへ統一し、7日表示は週末を除いた7営業日を表示します。
  - Plan / Recordの重複判定を共通化し、Inspectorの時間重複を入力欄直下へ表示します。
  - 複数日表示は2〜7日に整理し、表示列とデータ取得・Review範囲を一致させました。
- **Webのdocs / blogとローンチ導線を整理** ([#1442](https://github.com/Dayopt/dayopt/pull/1442), [#1614](https://github.com/Dayopt/dayopt/pull/1614))
  - docs / blogのナビゲーション、URL、カテゴリ、記事レイアウトを刷新しました。
  - ローンチ前表示と登録導線を認証画面へ接続しました。
- **共通基盤を更新** ([#1608](https://github.com/Dayopt/dayopt/pull/1608), [#1617](https://github.com/Dayopt/dayopt/pull/1617), [#1619](https://github.com/Dayopt/dayopt/pull/1619), [#1642](https://github.com/Dayopt/dayopt/pull/1642), [#1645](https://github.com/Dayopt/dayopt/pull/1645))
  - product / webのi18n基盤を共有化し、Node.js 24、React Email 6へ移行しました。
  - Settingsのfeature境界と日付・時刻フォーマッタを整理しました。

### 🐛 バグ修正 (Fixed)

- **本番DB migrationとschema driftを修復** ([#1583](https://github.com/Dayopt/dayopt/pull/1583), [#1632](https://github.com/Dayopt/dayopt/pull/1632))
  - 旧制約がtime-model migrationを停止させる順序問題をforward-only migrationで修復しました。
  - 欠落していた`user_settings.ical_feed_token`とpartial unique indexを冪等に復元しました。
- **本番ヘルスチェックの誤判定を修正** ([#1634](https://github.com/Dayopt/dayopt/pull/1634))
  - serverless環境で安定しないV8 heap比率をreadiness判定から除外し、DB probeを副作用のないSELECTへ変更しました。
- **フィードバック送信の消失を防止** ([#1509](https://github.com/Dayopt/dayopt/pull/1509))
  - GitHub Issue作成失敗時も送信内容を構造化ログとSentryへ保全し、送信処理をbest-effort化しました。
- **Calendar / Review / Inspectorの表示と操作を修正** ([#1546](https://github.com/Dayopt/dayopt/pull/1546), [#1556](https://github.com/Dayopt/dayopt/pull/1556), [#1616](https://github.com/Dayopt/dayopt/pull/1616), [#1620](https://github.com/Dayopt/dayopt/pull/1620), [#1647](https://github.com/Dayopt/dayopt/pull/1647))
  - モバイル週表示のちらつき、差分の二重計上、タイムゾーンを跨ぐコピー時刻、検索遷移の日付同期、連続ブロックの間隔累積を修正しました。
- **Multi-Dayのroutingと期間移動を整合** ([#1648](https://github.com/Dayopt/dayopt/pull/1648))
  - server / clientの対応範囲を2〜7日に統一し、`/8day`・`/9day`が別viewへfallbackする不整合を解消しました。
  - 週末非表示ではN営業日単位で前後移動し、隣接期間の日付が重複しないよう修正しました。
- **依存関係の脆弱性を解消** ([#1585](https://github.com/Dayopt/dayopt/pull/1585), [#1615](https://github.com/Dayopt/dayopt/pull/1615))
  - Dependabot security alerts 18件を解消しました。

### 🔒 セキュリティ (Security)

- **Supabase RPC / RLS境界** ([#1466](https://github.com/Dayopt/dayopt/pull/1466), [#1472](https://github.com/Dayopt/dayopt/pull/1472), [#1510](https://github.com/Dayopt/dayopt/pull/1510), [#1545](https://github.com/Dayopt/dayopt/pull/1545), [#1610](https://github.com/Dayopt/dayopt/pull/1610))
  - `SECURITY DEFINER` RPCのuser ID検証を追加し、通常RPCを`SECURITY INVOKER`へ移行しました。
  - billing column、tag ownership、soft-delete / restoreをRLS・column grant・triggerで制限しました。
  - privileged RPCはservice role専用に限定しました。
- **認証・OAuth・課金** ([#1468](https://github.com/Dayopt/dayopt/pull/1468), [#1485](https://github.com/Dayopt/dayopt/pull/1485), [#1501](https://github.com/Dayopt/dayopt/pull/1501))
  - Checkout価格をサーバー設定へ固定し、caller-controlledなprice IDを廃止しました。
  - OAuth redirect URIを完全一致allowlistへ変更しました。
  - OAuth bearer tokenのtRPC呼び出し、MFA AAL、auth redirectの認可境界を強化しました。
- **CSP・秘密情報・監視入力** ([#1547](https://github.com/Dayopt/dayopt/pull/1547), [#1641](https://github.com/Dayopt/dayopt/pull/1641), [#1643](https://github.com/Dayopt/dayopt/pull/1643), [#1644](https://github.com/Dayopt/dayopt/pull/1644))
  - Productのscript CSPをnonce方式へ移行し、Productionの`unsafe-inline`を削除しました。
  - CSP report、rate limit、contact、Sentryの入力境界をサイズ・origin・quota・PII scrubでfail-closed化しました。

### ⚠️ 破壊的変更 (Breaking Changes)

- **DBモデル**: `entries` tableを削除し、`logs`を`records`へ移行しました。互換用`logs` viewと旧Log名RPC aliasも削除済みです。DB objectを直接利用するクライアントは`plans` / `records`へ移行する必要があります。([#1584](https://github.com/Dayopt/dayopt/pull/1584), [#1603](https://github.com/Dayopt/dayopt/pull/1603))
- **レスポンス契約**: ChronotypeとFulfillmentScoreをRecord / Settings / exportの公開レスポンスから削除しました。([#1626](https://github.com/Dayopt/dayopt/pull/1626))
- **DB column**: `records.fulfillment_score`と`user_settings.chronotype_settings`を削除しました。([#1635](https://github.com/Dayopt/dayopt/pull/1635))
- **OAuth設定**: redirect URIはwildcardではなく完全なURIの登録が必要です。([#1485](https://github.com/Dayopt/dayopt/pull/1485))
- **Calendar URL**: Multi-Dayの対応範囲を2〜7日に統一し、旧`/8day`・`/9day` URLは404になります。([#1648](https://github.com/Dayopt/dayopt/pull/1648))

### 🗑️ 削除 (Removed)

- 旧`entries` runtime、table、互換`logs` view、旧RPC alias。([#1581](https://github.com/Dayopt/dayopt/pull/1581), [#1584](https://github.com/Dayopt/dayopt/pull/1584), [#1603](https://github.com/Dayopt/dayopt/pull/1603))
- Chronotype / FulfillmentScoreのruntime、設定、統計、export、DB列、Storybook / docs資産。([#1626](https://github.com/Dayopt/dayopt/pull/1626), [#1635](https://github.com/Dayopt/dayopt/pull/1635), [#1637](https://github.com/Dayopt/dayopt/pull/1637))
- 未使用のSettings API key UIと、本番のplayground route。([#1510](https://github.com/Dayopt/dayopt/pull/1510), [#1605](https://github.com/Dayopt/dayopt/pull/1605))
- Webのblog tag機能。([#1442](https://github.com/Dayopt/dayopt/pull/1442))

### ⚡ パフォーマンス (Performance)

- CIのlint laneを並列化し、キャッシュ・セットアップを共通化しました。([#1423](https://github.com/Dayopt/dayopt/pull/1423), [#1590](https://github.com/Dayopt/dayopt/pull/1590), [#1605](https://github.com/Dayopt/dayopt/pull/1605))
- Product runtimeの独立した性能改善値は、このリリースでは計測していません。

### 🗄️ データ移行・運用

- Plan / Recordへのbackfillは冪等・service-role専用で実装し、重複・所有者・件数をmigration内で検証します。([#1554](https://github.com/Dayopt/dayopt/pull/1554), [#1556](https://github.com/Dayopt/dayopt/pull/1556))
- destructive migrationは`CASCADE`を使わず、件数上限・catalog assertion・短いlock timeoutで未知の状態を拒否します。([#1584](https://github.com/Dayopt/dayopt/pull/1584), [#1635](https://github.com/Dayopt/dayopt/pull/1635))
- Stripe webhookへservice-role専用のclaim RPCとretry stateを追加しました。([#1639](https://github.com/Dayopt/dayopt/pull/1639))

---

## 🔗 Pull Requests

前回リリース v0.31.0 以降の全91 PRです。

- [#1419](https://github.com/Dayopt/dayopt/pull/1419) - docs(supabase): migration の GRANT 明示ルール追加 + CI checkout の SHA pin 統一
- [#1423](https://github.com/Dayopt/dayopt/pull/1423) - chore: 2026-06 エコシステム調査 + CI lint 並列化
- [#1429](https://github.com/Dayopt/dayopt/pull/1429) - chore(deps): actions/cache 5から6へ更新
- [#1430](https://github.com/Dayopt/dayopt/pull/1430) - chore(deps): production依存6件を更新
- [#1431](https://github.com/Dayopt/dayopt/pull/1431) - chore(deps-dev): development-testing依存4件を更新
- [#1432](https://github.com/Dayopt/dayopt/pull/1432) - chore(deps-dev): development-linting依存4件を更新
- [#1433](https://github.com/Dayopt/dayopt/pull/1433) - chore(deps-dev): @types/nodeを更新
- [#1434](https://github.com/Dayopt/dayopt/pull/1434) - chore(deps-dev): development-other依存6件を更新
- [#1435](https://github.com/Dayopt/dayopt/pull/1435) - chore(deps): Dependabot 5グループの更新を統合
- [#1437](https://github.com/Dayopt/dayopt/pull/1437) - fix(licenses): monorepoのproduction transitiveを反映
- [#1442](https://github.com/Dayopt/dayopt/pull/1442) - web: docs/blogのUI刷新とURL構造整理
- [#1443](https://github.com/Dayopt/dayopt/pull/1443) - chore(deps-dev): postcssを更新
- [#1451](https://github.com/Dayopt/dayopt/pull/1451) - docs: docs構造の再編と運用基盤の整備
- [#1456](https://github.com/Dayopt/dayopt/pull/1456) - docs: プロダクトコンセプト策定とdocs全面再編
- [#1458](https://github.com/Dayopt/dayopt/pull/1458) - chore(ai): AI協働テンプレート採用項目を反映
- [#1466](https://github.com/Dayopt/dayopt/pull/1466) - fix(security): SECURITY DEFINER RPCのuser_id検証を追加
- [#1468](https://github.com/Dayopt/dayopt/pull/1468) - fix(security): Checkout価格をサーバー設定に固定
- [#1472](https://github.com/Dayopt/dayopt/pull/1472) - fix(security): profilesの課金カラム更新権限を制限
- [#1485](https://github.com/Dayopt/dayopt/pull/1485) - fix: OAuth redirect URIを完全一致に制限
- [#1501](https://github.com/Dayopt/dayopt/pull/1501) - fix: auth APIの認可境界を強化
- [#1504](https://github.com/Dayopt/dayopt/pull/1504) - chore(deps): production依存27件を更新
- [#1505](https://github.com/Dayopt/dayopt/pull/1505) - chore(deps-dev): development-linting依存5件を更新
- [#1506](https://github.com/Dayopt/dayopt/pull/1506) - chore(deps-dev): development-other依存11件を更新
- [#1508](https://github.com/Dayopt/dayopt/pull/1508) - chore(deps): Dependabot更新を統合
- [#1509](https://github.com/Dayopt/dayopt/pull/1509) - fix(contact): フィードバック起票をbest-effort化
- [#1510](https://github.com/Dayopt/dayopt/pull/1510) - fix: セキュリティ監査指摘をまとめて修正
- [#1511](https://github.com/Dayopt/dayopt/pull/1511) - docs: 創業者監査ログとLPローンチ企画を追加
- [#1512](https://github.com/Dayopt/dayopt/pull/1512) - Review panelをCalendar右パネルへ整理
- [#1513](https://github.com/Dayopt/dayopt/pull/1513) - chore: AI設定の棚卸し
- [#1515](https://github.com/Dayopt/dayopt/pull/1515) - docs(architecture): package境界を現行構成へ同期
- [#1545](https://github.com/Dayopt/dayopt/pull/1545) - docs: Supabase grantとRealtime監査を明文化
- [#1546](https://github.com/Dayopt/dayopt/pull/1546) - fix: モバイル週表示と設定エラー表示を修正
- [#1547](https://github.com/Dayopt/dayopt/pull/1547) - fix: CSP nonceとsecrets docs監査
- [#1548](https://github.com/Dayopt/dayopt/pull/1548) - docs: Vercel pre-deploy/security readiness監査
- [#1549](https://github.com/Dayopt/dayopt/pull/1549) - docs: Supabase migration drift調査
- [#1550](https://github.com/Dayopt/dayopt/pull/1550) - feat: Storybook shared componentカタログとi18nを修正
- [#1551](https://github.com/Dayopt/dayopt/pull/1551) - docs: time-model-split統計RPC方針
- [#1552](https://github.com/Dayopt/dayopt/pull/1552) - feat: Plan / Log基盤テーブルを追加
- [#1553](https://github.com/Dayopt/dayopt/pull/1553) - docs: time-model-split Step 2-9設計
- [#1554](https://github.com/Dayopt/dayopt/pull/1554) - feat: entriesからPlan / Logへのbackfill
- [#1555](https://github.com/Dayopt/dayopt/pull/1555) - chore: リポジトリ整理 R-01〜R-04
- [#1556](https://github.com/Dayopt/dayopt/pull/1556) - fix: backfill重複解消の優先度を修正
- [#1557](https://github.com/Dayopt/dayopt/pull/1557) - feat: Plans / Logs server layer
- [#1563](https://github.com/Dayopt/dayopt/pull/1563) - docs: time-model-split後の次アクション確定
- [#1568](https://github.com/Dayopt/dayopt/pull/1568) - docs: 並行レーンorchestrationとrefactor凍結判断
- [#1570](https://github.com/Dayopt/dayopt/pull/1570) - feat: Plans / Logs統計TS service
- [#1571](https://github.com/Dayopt/dayopt/pull/1571) - feat: PlanとLogの作成編集フロー
- [#1573](https://github.com/Dayopt/dayopt/pull/1573) - feat: ReviewのPlan / Log差分
- [#1574](https://github.com/Dayopt/dayopt/pull/1574) - feat: Calendar 2レーン表示
- [#1575](https://github.com/Dayopt/dayopt/pull/1575) - feat: time modelの外部公開面を切替
- [#1577](https://github.com/Dayopt/dayopt/pull/1577) - feat: time-model-splitカットオーバー完了
- [#1581](https://github.com/Dayopt/dayopt/pull/1581) - refactor: Plan・Record・Timeblock契約を統一
- [#1583](https://github.com/Dayopt/dayopt/pull/1583) - fix: production migrationの制約順序を復旧
- [#1584](https://github.com/Dayopt/dayopt/pull/1584) - refactor: records物理テーブルへ移行しentriesを削除
- [#1585](https://github.com/Dayopt/dayopt/pull/1585) - fix: Dependabot security alerts 16件を解消
- [#1590](https://github.com/Dayopt/dayopt/pull/1590) - test: テスト自動化とCI品質ゲートを整備
- [#1600](https://github.com/Dayopt/dayopt/pull/1600) - chore: Dependabot依存更新を統合
- [#1603](https://github.com/Dayopt/dayopt/pull/1603) - refactor: time-model-split Step 9c完了
- [#1605](https://github.com/Dayopt/dayopt/pull/1605) - refactor: 非Web保守タスク4件を整理
- [#1606](https://github.com/Dayopt/dayopt/pull/1606) - docs: Upstash環境変数の障害記録
- [#1607](https://github.com/Dayopt/dayopt/pull/1607) - docs: Vercel運用監査と導入方針
- [#1608](https://github.com/Dayopt/dayopt/pull/1608) - refactor: product/webのi18n基盤を共有化
- [#1609](https://github.com/Dayopt/dayopt/pull/1609) - refactor: Zustandストア規約統一
- [#1610](https://github.com/Dayopt/dayopt/pull/1610) - fix: Supabase RPC権限を整理
- [#1611](https://github.com/Dayopt/dayopt/pull/1611) - docs: 内部ドキュメントの正本と検査契約を再構築
- [#1612](https://github.com/Dayopt/dayopt/pull/1612) - fix(docs): logのsupersede契約を厳密化
- [#1614](https://github.com/Dayopt/dayopt/pull/1614) - fix(lp): ローンチ前の表示と登録導線
- [#1615](https://github.com/Dayopt/dayopt/pull/1615) - fix(deps): 依存関係の脆弱性警告2件を解消
- [#1616](https://github.com/Dayopt/dayopt/pull/1616) - refactor(calendar): Calendar UIとReview体験を洗練
- [#1617](https://github.com/Dayopt/dayopt/pull/1617) - chore(node): Node.js 24へ統一
- [#1619](https://github.com/Dayopt/dayopt/pull/1619) - chore(email): React Email 6へ移行
- [#1620](https://github.com/Dayopt/dayopt/pull/1620) - feat(calendar): ブロック検索と最新タイムスロットUI
- [#1626](https://github.com/Dayopt/dayopt/pull/1626) - refactor: chronotypeとfulfillment契約を撤去
- [#1627](https://github.com/Dayopt/dayopt/pull/1627) - chore(deps): Dependabot更新を統合
- [#1628](https://github.com/Dayopt/dayopt/pull/1628) - refactor: tag / calendar / timeblock大型ファイル分割
- [#1629](https://github.com/Dayopt/dayopt/pull/1629) - chore(ai): Human–Agent Partnership導入
- [#1632](https://github.com/Dayopt/dayopt/pull/1632) - fix: productionのiCal schema driftを修復
- [#1633](https://github.com/Dayopt/dayopt/pull/1633) - chore(ai): ブラウザ視覚確認ルールを統一
- [#1634](https://github.com/Dayopt/dayopt/pull/1634) - fix: 本番ヘルスチェックの誤判定
- [#1635](https://github.com/Dayopt/dayopt/pull/1635) - refactor: chronotypeと充実度のDB列を削除
- [#1637](https://github.com/Dayopt/dayopt/pull/1637) - docs: chronotypeと充実度の撤去完了
- [#1638](https://github.com/Dayopt/dayopt/pull/1638) - refactor(calendar): 大型ファイル分割完了
- [#1639](https://github.com/Dayopt/dayopt/pull/1639) - chore: Stripe webhook migrationを先行適用
- [#1640](https://github.com/Dayopt/dayopt/pull/1640) - refactor(timeblock): 大型ファイル分割完了
- [#1641](https://github.com/Dayopt/dayopt/pull/1641) - feat: ProductのSentry監視を強化
- [#1642](https://github.com/Dayopt/dayopt/pull/1642) - refactor(settings): 命名・feature境界を整理
- [#1643](https://github.com/Dayopt/dayopt/pull/1643) - feat: WebのSentry監視を分離して強化
- [#1644](https://github.com/Dayopt/dayopt/pull/1644) - fix: Productの監視入力境界をfail-closed化
- [#1645](https://github.com/Dayopt/dayopt/pull/1645) - refactor: 日付/時刻フォーマッタを集約
- [#1647](https://github.com/Dayopt/dayopt/pull/1647) - fix: CalendarとInspectorの操作体験を改善
- [#1648](https://github.com/Dayopt/dayopt/pull/1648) - chore(release): v0.32.0へversion bump

---

**Full Changelog**: https://github.com/Dayopt/dayopt/compare/v0.31.0...v0.32.0

**Generated with Codex**
