### PR TITLE
fix: resend送信サブドメインを許可する

### DIFF
--- a/apps/product/production-build-gate.mjs
+++ b/apps/product/production-build-gate.mjs
@@ -9,8 +9,28 @@ export const REQUIRED_PRODUCT_OPERATIONAL_BUILD_ENV = [
 function isVerifiedDayoptSender(value) {
   if (typeof value !== 'string') return false;
   const normalized = value.trim().toLowerCase();
-  if (normalized === 'onboarding@resend.dev' || !normalized.endsWith('@dayopt.app')) return false;
-  return /^[^\s@]+@[^\s@]+$/u.test(normalized);
+  if (normalized.length > 254) return false;
+  if (normalized === 'onboarding@resend.dev') return false;
+
+  const parts = normalized.split('@');
+  if (parts.length !== 2) return false;
+  const [localPart, domain] = parts;
+  if (
+    !localPart ||
+    localPart.length > 64 ||
+    localPart.startsWith('.') ||
+    localPart.endsWith('.') ||
+    localPart.includes('..') ||
+    !/^[a-z0-9.!#$%&'*+/=?^_`{|}~-]+$/u.test(localPart)
+  ) {
+    return false;
+  }
+
+  if (domain !== 'dayopt.app' && !domain.endsWith('.dayopt.app')) return false;
+  return (
+    domain.length <= 253 &&
+    domain.split('.').every((label) => /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/u.test(label))
+  );
 }
 
 /** Prevent a Production deploy with unavailable delivery, monitoring, or abuse controls. */

--- a/apps/product/production-build-gate.test.mjs
+++ b/apps/product/production-build-gate.test.mjs
@@ -9,7 +9,7 @@ function completeProductionEnv() {
   return {
     VERCEL_ENV: 'production',
     RESEND_API_KEY: 'safe-dummy-key',
-    RESEND_FROM_EMAIL: 'contact-sender@dayopt.app',
+    RESEND_FROM_EMAIL: 'noreply@send.dayopt.app',
     RESEND_WEBHOOK_SECRET: 'safe-dummy-webhook-secret',
     UPSTASH_REDIS_REST_URL: 'https://example.upstash.io',
     UPSTASH_REDIS_REST_TOKEN: 'safe-dummy-token',
@@ -25,7 +25,9 @@ describe('Product operational production build gate', () => {
   it('does not let CI bypass a Vercel Production contract', () => {
     expect(() =>
       assertProductOperationalProductionBuildEnv({ VERCEL_ENV: 'production', CI: 'true' }),
-    ).toThrow(`Product production build requires: ${REQUIRED_PRODUCT_OPERATIONAL_BUILD_ENV.join(', ')}`);
+    ).toThrow(
+      `Product production build requires: ${REQUIRED_PRODUCT_OPERATIONAL_BUILD_ENV.join(', ')}`,
+    );
   });
 
   it('lists missing names without printing values', () => {
@@ -34,21 +36,44 @@ describe('Product operational production build gate', () => {
     );
   });
 
-  it('accepts a complete safe Production contract', () => {
-    expect(assertProductOperationalProductionBuildEnv(completeProductionEnv())).toBe(true);
-  });
-
-  it.each(['onboarding@resend.dev', 'sender@example.com', 'not-an-email'])(
-    'rejects an invalid Resend sender (%s)',
+  it.each(['contact-sender@dayopt.app', 'noreply@send.dayopt.app'])(
+    'accepts a verified Dayopt sender (%s)',
     (sender) => {
-      expect(() =>
+      expect(
         assertProductOperationalProductionBuildEnv({
           ...completeProductionEnv(),
           RESEND_FROM_EMAIL: sender,
         }),
-      ).toThrow('Product production build requires a verified Dayopt RESEND_FROM_EMAIL');
+      ).toBe(true);
     },
   );
+
+  it.each([
+    'onboarding@resend.dev',
+    'sender@example.com',
+    'sender@notdayopt.app',
+    'sender@dayopt.app.example.com',
+    'sender@.dayopt.app',
+    'not-an-email',
+  ])('rejects an invalid Resend sender (%s)', (sender) => {
+    expect(() =>
+      assertProductOperationalProductionBuildEnv({
+        ...completeProductionEnv(),
+        RESEND_FROM_EMAIL: sender,
+      }),
+    ).toThrow('Product production build requires a verified Dayopt RESEND_FROM_EMAIL');
+  });
+
+  it('rejects a Resend sender longer than 254 characters', () => {
+    const oversizedSender = `${'a'.repeat(64)}@${'b'.repeat(59)}.${'c'.repeat(59)}.${'d'.repeat(59)}.dayopt.app`;
+    expect(oversizedSender).toHaveLength(255);
+    expect(() =>
+      assertProductOperationalProductionBuildEnv({
+        ...completeProductionEnv(),
+        RESEND_FROM_EMAIL: oversizedSender,
+      }),
+    ).toThrow('Product production build requires a verified Dayopt RESEND_FROM_EMAIL');
+  });
 
   it('rejects a malformed Upstash URL before build work starts', () => {
     expect(() =>

--- a/apps/product/src/env.ts
+++ b/apps/product/src/env.ts
@@ -9,6 +9,12 @@ import 'server-only';
 
 import { z } from 'zod';
 
+function isDayoptEmailAddress(value: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  const domain = normalized.slice(normalized.lastIndexOf('@') + 1);
+  return domain === 'dayopt.app' || domain.endsWith('.dayopt.app');
+}
+
 function isRedirectUriList(value: string | undefined): boolean {
   if (!value) return true;
   return value
@@ -127,7 +133,7 @@ const serverSchema = z
         data.RESEND_WEBHOOK_SECRET?.trim() &&
         sender &&
         sender !== 'onboarding@resend.dev' &&
-        sender.endsWith('@dayopt.app'),
+        isDayoptEmailAddress(sender),
       );
     },
     {

--- a/apps/product/src/features/contact/server/__tests__/contact-service.test.ts
+++ b/apps/product/src/features/contact/server/__tests__/contact-service.test.ts
@@ -19,7 +19,7 @@ async function importService(envOverrides: Record<string, string> = {}) {
   vi.resetModules();
   vi.stubEnv('VERCEL_ENV', envOverrides.VERCEL_ENV ?? 'production');
   vi.stubEnv('RESEND_API_KEY', envOverrides.RESEND_API_KEY ?? 'resend-test-key');
-  vi.stubEnv('RESEND_FROM_EMAIL', envOverrides.RESEND_FROM_EMAIL ?? 'contact-sender@dayopt.app');
+  vi.stubEnv('RESEND_FROM_EMAIL', envOverrides.RESEND_FROM_EMAIL ?? 'noreply@send.dayopt.app');
   return import('../contact-service');
 }
 
@@ -72,7 +72,7 @@ describe('sendContactEmail', () => {
     });
     const body = JSON.parse(String(request.body)) as Record<string, unknown>;
     expect(body).toEqual({
-      from: 'Dayopt Contact <contact-sender@dayopt.app>',
+      from: 'Dayopt Contact <noreply@send.dayopt.app>',
       to: ['support@dayopt.app'],
       reply_to: 'test@example.com',
       subject: '[Dayopt Contact][Product][Bug]',
@@ -103,6 +103,18 @@ describe('sendContactEmail', () => {
     expect(body).not.toHaveProperty('attachments');
   });
 
+  it('also accepts a sender on the apex Dayopt domain', async () => {
+    const { sendContactEmail } = await importService({
+      RESEND_FROM_EMAIL: 'contact-sender@dayopt.app',
+    });
+
+    await sendContactEmail(defaultParams);
+
+    const request = mocks.fetch.mock.calls[0]?.[1] as RequestInit;
+    const body = JSON.parse(String(request.body)) as { from: string };
+    expect(body.from).toBe('Dayopt Contact <contact-sender@dayopt.app>');
+  });
+
   it.each(['preview', 'development', ''])(
     'refuses delivery outside Vercel Production even when credentials exist (%s)',
     async (vercelEnv) => {
@@ -117,10 +129,12 @@ describe('sendContactEmail', () => {
   );
 
   it.each([
-    { RESEND_API_KEY: '', RESEND_FROM_EMAIL: 'contact-sender@dayopt.app' },
+    { RESEND_API_KEY: '', RESEND_FROM_EMAIL: 'noreply@send.dayopt.app' },
     { RESEND_API_KEY: 'resend-test-key', RESEND_FROM_EMAIL: '' },
     { RESEND_API_KEY: 'resend-test-key', RESEND_FROM_EMAIL: 'onboarding@resend.dev' },
     { RESEND_API_KEY: 'resend-test-key', RESEND_FROM_EMAIL: 'sender@example.com' },
+    { RESEND_API_KEY: 'resend-test-key', RESEND_FROM_EMAIL: 'sender@notdayopt.app' },
+    { RESEND_API_KEY: 'resend-test-key', RESEND_FROM_EMAIL: 'sender@dayopt.app.example.com' },
   ])('fails closed when email configuration is invalid', async (envOverrides) => {
     const { sendContactEmail } = await importService(envOverrides);
 

--- a/apps/product/src/features/contact/server/contact-service.ts
+++ b/apps/product/src/features/contact/server/contact-service.ts
@@ -35,9 +35,11 @@ const emailAddressSchema = z
   .max(254)
   .email()
   .refine((value) => !/[\r\n,]/u.test(value));
-const senderEmailSchema = emailAddressSchema.refine((value) =>
-  value.toLowerCase().endsWith('@dayopt.app'),
-);
+const senderEmailSchema = emailAddressSchema.refine((value) => {
+  const normalized = value.toLowerCase();
+  const domain = normalized.slice(normalized.lastIndexOf('@') + 1);
+  return domain === 'dayopt.app' || domain.endsWith('.dayopt.app');
+});
 const resendSuccessSchema = z.object({ id: z.string().min(1) });
 
 interface ContactEmailParams {

--- a/apps/web/production-build-gate.mjs
+++ b/apps/web/production-build-gate.mjs
@@ -11,8 +11,28 @@ export const REQUIRED_WEB_OPERATIONAL_BUILD_ENV = [
 function isVerifiedDayoptSender(value) {
   if (typeof value !== 'string') return false;
   const normalized = value.trim().toLowerCase();
-  if (normalized === 'onboarding@resend.dev' || !normalized.endsWith('@dayopt.app')) return false;
-  return /^[^\s@]+@[^\s@]+$/u.test(normalized);
+  if (normalized.length > 254) return false;
+  if (normalized === 'onboarding@resend.dev') return false;
+
+  const parts = normalized.split('@');
+  if (parts.length !== 2) return false;
+  const [localPart, domain] = parts;
+  if (
+    !localPart ||
+    localPart.length > 64 ||
+    localPart.startsWith('.') ||
+    localPart.endsWith('.') ||
+    localPart.includes('..') ||
+    !/^[a-z0-9.!#$%&'*+/=?^_`{|}~-]+$/u.test(localPart)
+  ) {
+    return false;
+  }
+
+  if (domain !== 'dayopt.app' && !domain.endsWith('.dayopt.app')) return false;
+  return (
+    domain.length <= 253 &&
+    domain.split('.').every((label) => /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/u.test(label))
+  );
 }
 
 /** Fail a Vercel Production build before contact delivery can become partial. */

--- a/apps/web/production-build-gate.test.mjs
+++ b/apps/web/production-build-gate.test.mjs
@@ -9,7 +9,7 @@ function completeProductionEnv() {
   return {
     VERCEL_ENV: 'production',
     RESEND_API_KEY: 'safe-dummy-key',
-    RESEND_FROM_EMAIL: 'contact-sender@dayopt.app',
+    RESEND_FROM_EMAIL: 'noreply@send.dayopt.app',
     RESEND_WEBHOOK_SECRET: 'safe-dummy-webhook-secret',
     NEXT_PUBLIC_TURNSTILE_SITE_KEY: 'safe-dummy-site-key',
     TURNSTILE_SECRET_KEY: 'safe-dummy-turnstile-secret',
@@ -36,21 +36,44 @@ describe('Web operational production build gate', () => {
     );
   });
 
-  it('accepts a complete safe Production contract', () => {
-    expect(assertWebOperationalProductionBuildEnv(completeProductionEnv())).toBe(true);
-  });
-
-  it.each(['onboarding@resend.dev', 'sender@example.com', 'not-an-email'])(
-    'rejects an invalid Resend sender (%s)',
+  it.each(['contact-sender@dayopt.app', 'noreply@send.dayopt.app'])(
+    'accepts a verified Dayopt sender (%s)',
     (sender) => {
-      expect(() =>
+      expect(
         assertWebOperationalProductionBuildEnv({
           ...completeProductionEnv(),
           RESEND_FROM_EMAIL: sender,
         }),
-      ).toThrow('Web production build requires a verified Dayopt RESEND_FROM_EMAIL');
+      ).toBe(true);
     },
   );
+
+  it.each([
+    'onboarding@resend.dev',
+    'sender@example.com',
+    'sender@notdayopt.app',
+    'sender@dayopt.app.example.com',
+    'sender@.dayopt.app',
+    'not-an-email',
+  ])('rejects an invalid Resend sender (%s)', (sender) => {
+    expect(() =>
+      assertWebOperationalProductionBuildEnv({
+        ...completeProductionEnv(),
+        RESEND_FROM_EMAIL: sender,
+      }),
+    ).toThrow('Web production build requires a verified Dayopt RESEND_FROM_EMAIL');
+  });
+
+  it('rejects a Resend sender longer than 254 characters', () => {
+    const oversizedSender = `${'a'.repeat(64)}@${'b'.repeat(59)}.${'c'.repeat(59)}.${'d'.repeat(59)}.dayopt.app`;
+    expect(oversizedSender).toHaveLength(255);
+    expect(() =>
+      assertWebOperationalProductionBuildEnv({
+        ...completeProductionEnv(),
+        RESEND_FROM_EMAIL: oversizedSender,
+      }),
+    ).toThrow('Web production build requires a verified Dayopt RESEND_FROM_EMAIL');
+  });
 
   it('rejects a malformed Upstash URL before build work starts', () => {
     expect(() =>

--- a/apps/web/src/app/api/contact/contact-email.test.ts
+++ b/apps/web/src/app/api/contact/contact-email.test.ts
@@ -4,7 +4,7 @@ const mocks = vi.hoisted(() => ({
   env: {
     VERCEL_ENV: 'production' as string | undefined,
     RESEND_API_KEY: 'resend-test-key' as string | undefined,
-    RESEND_FROM_EMAIL: 'contact-sender@dayopt.app' as string | undefined,
+    RESEND_FROM_EMAIL: 'noreply@send.dayopt.app' as string | undefined,
   },
   fetch: vi.fn(),
 }));
@@ -27,7 +27,7 @@ describe('Web sendContactEmail', () => {
     vi.clearAllMocks();
     mocks.env.VERCEL_ENV = 'production';
     mocks.env.RESEND_API_KEY = 'resend-test-key';
-    mocks.env.RESEND_FROM_EMAIL = 'contact-sender@dayopt.app';
+    mocks.env.RESEND_FROM_EMAIL = 'noreply@send.dayopt.app';
     mocks.fetch.mockImplementation(async () => Response.json({ id: 'email-1' }));
     vi.stubGlobal('fetch', mocks.fetch);
   });
@@ -54,7 +54,7 @@ describe('Web sendContactEmail', () => {
     });
     const body = JSON.parse(String(request.body)) as Record<string, unknown>;
     expect(body).toEqual({
-      from: 'Dayopt Contact <contact-sender@dayopt.app>',
+      from: 'Dayopt Contact <noreply@send.dayopt.app>',
       to: ['support@dayopt.app'],
       reply_to: 'private@example.com',
       subject: '[Dayopt Contact][Web][Question]',
@@ -77,6 +77,16 @@ describe('Web sendContactEmail', () => {
     expect(body).not.toHaveProperty('attachments');
   });
 
+  it('also accepts a sender on the apex Dayopt domain', async () => {
+    mocks.env.RESEND_FROM_EMAIL = 'contact-sender@dayopt.app';
+
+    await sendContactEmail(input);
+
+    const request = mocks.fetch.mock.calls[0]?.[1] as RequestInit;
+    const body = JSON.parse(String(request.body)) as { from: string };
+    expect(body.from).toBe('Dayopt Contact <contact-sender@dayopt.app>');
+  });
+
   it.each(['preview', 'development', undefined])(
     'refuses non-Production delivery even with credentials (%s)',
     async (vercelEnv) => {
@@ -90,10 +100,12 @@ describe('Web sendContactEmail', () => {
   );
 
   it.each([
-    { key: undefined, from: 'contact-sender@dayopt.app' },
+    { key: undefined, from: 'noreply@send.dayopt.app' },
     { key: 'resend-test-key', from: undefined },
     { key: 'resend-test-key', from: 'onboarding@resend.dev' },
     { key: 'resend-test-key', from: 'sender@example.com' },
+    { key: 'resend-test-key', from: 'sender@notdayopt.app' },
+    { key: 'resend-test-key', from: 'sender@dayopt.app.example.com' },
   ])('fails closed for invalid email configuration', async ({ key, from }) => {
     mocks.env.RESEND_API_KEY = key;
     mocks.env.RESEND_FROM_EMAIL = from;

--- a/apps/web/src/app/api/contact/contact-email.ts
+++ b/apps/web/src/app/api/contact/contact-email.ts
@@ -20,9 +20,11 @@ const emailAddressSchema = z
   .max(254)
   .email()
   .refine((value) => !/[\r\n,]/u.test(value));
-const senderEmailSchema = emailAddressSchema.refine((value) =>
-  value.toLowerCase().endsWith('@dayopt.app'),
-);
+const senderEmailSchema = emailAddressSchema.refine((value) => {
+  const normalized = value.toLowerCase();
+  const domain = normalized.slice(normalized.lastIndexOf('@') + 1);
+  return domain === 'dayopt.app' || domain.endsWith('.dayopt.app');
+});
 const resendSuccessSchema = z.object({ id: z.string().min(1) });
 
 export type WebContactEmailInput = {

--- a/apps/web/src/platform/config/__tests__/env.test.ts
+++ b/apps/web/src/platform/config/__tests__/env.test.ts
@@ -8,7 +8,7 @@ function validProductionRuntimeEnv(): Partial<EnvConfig> {
     VERCEL_ENV: 'production',
     NEXT_PUBLIC_APP_URL: 'https://dayopt.app',
     RESEND_API_KEY: 'configured',
-    RESEND_FROM_EMAIL: 'contact-sender@dayopt.app',
+    RESEND_FROM_EMAIL: 'noreply@send.dayopt.app',
     RESEND_WEBHOOK_SECRET: 'configured',
     NEXT_PUBLIC_TURNSTILE_SITE_KEY: 'site-key',
     TURNSTILE_SECRET_KEY: 'secret-key',
@@ -27,6 +27,10 @@ afterEach(() => {
 describe('assertProductionRuntimeEnv', () => {
   it('完全な Vercel Production env を受け入れる', () => {
     expect(() => assertProductionRuntimeEnv(validProductionRuntimeEnv())).not.toThrow();
+
+    const apexSender = validProductionRuntimeEnv();
+    apexSender.RESEND_FROM_EMAIL = 'contact-sender@dayopt.app';
+    expect(() => assertProductionRuntimeEnv(apexSender)).not.toThrow();
   });
 
   it('CI と Preview では production secret を要求しない', () => {
@@ -74,7 +78,13 @@ describe('assertProductionRuntimeEnv', () => {
       'RESEND_API_KEY is required for the Production contact form',
     );
 
-    for (const sender of ['onboarding@resend.dev', 'not-an-email', 'contact@example.com']) {
+    for (const sender of [
+      'onboarding@resend.dev',
+      'not-an-email',
+      'contact@example.com',
+      'contact@notdayopt.app',
+      'contact@dayopt.app.example.com',
+    ]) {
       const invalidSender = validProductionRuntimeEnv();
       invalidSender.RESEND_FROM_EMAIL = sender;
       expect(() => assertProductionRuntimeEnv(invalidSender)).toThrow(

--- a/apps/web/src/platform/config/production-runtime-env.ts
+++ b/apps/web/src/platform/config/production-runtime-env.ts
@@ -3,6 +3,12 @@ import { z } from 'zod';
 import { EnvValidationError, type EnvConfig } from './env-types';
 import { loadEnv } from './load-env';
 
+function isDayoptEmailAddress(value: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  const domain = normalized.slice(normalized.lastIndexOf('@') + 1);
+  return domain === 'dayopt.app' || domain.endsWith('.dayopt.app');
+}
+
 export function assertProductionRuntimeEnv(env: Partial<EnvConfig> = loadEnv()): void {
   if (env.CI || env.VERCEL_ENV !== 'production') {
     return;
@@ -22,7 +28,7 @@ export function assertProductionRuntimeEnv(env: Partial<EnvConfig> = loadEnv()):
   if (
     !senderResult.success ||
     senderResult.data.toLowerCase() === 'onboarding@resend.dev' ||
-    !senderResult.data.toLowerCase().endsWith('@dayopt.app')
+    !isDayoptEmailAddress(senderResult.data)
   ) {
     errors.push('A verified RESEND_FROM_EMAIL is required for the Production contact form');
   }

--- a/docs/operations/log/2026-07-21-incident-resend-sender-subdomain.md
+++ b/docs/operations/log/2026-07-21-incident-resend-sender-subdomain.md
@@ -1,0 +1,38 @@
+---
+status: frozen
+date: 2026-07-21
+code:
+  - apps/product/production-build-gate.mjs
+  - apps/web/production-build-gate.mjs
+  - apps/product/src/env.ts
+  - apps/web/src/platform/config/production-runtime-env.ts
+---
+
+# Resend送信サブドメインをProduction gateが拒否した
+
+PR #1658のmain merge後、正本どおりに設定された`noreply@send.dayopt.app`をProduction build gateが無効な送信元として拒否し、Product / WebのProduction deploymentがbuild errorになった。PreviewではProduction限定gateを実行しないため検出されなかった。
+
+---
+
+## 起きた事実
+
+- 2026-07-21 11:28 JST、PR #1658をmerge commit`763617665`でmainへmergeした
+- merge前のVercel metadata auditはProduct / Webとも成功していた
+- Product / WebのProduction buildは、それぞれ検証済み`RESEND_FROM_EMAIL`を要求するgateで停止した
+- 1Passwordの正本値は`noreply@send.dayopt.app`で、Vercelへ同期された値と運用設計は正しかった
+- build gate、runtime env検証、送信serviceは`endsWith('@dayopt.app')`を使い、`dayopt.app`直下だけを許可していた
+- Resendで検証済みの送信domainは`send.dayopt.app`であり、正本値とcode契約が不一致だった
+
+## 影響範囲
+
+- 失敗したProduct / Web deploymentはProductionへ昇格せず、既存Production aliasは置き換わっていない
+- Product / Webを同一merge SHAでReadyにするrelease gateを満たせないため、実送信smoke、30分観察、tag、GitHub Releaseを停止した
+- Previewの表示と通常CIは成功していたが、Production限定の実値契約を証明していなかった
+- 問い合わせ本文、氏名、メールアドレスなどのPII漏えいは確認されていない
+
+## 学び
+
+- metadata auditのkey / target / type確認だけでは、値がcode contractを満たすことを証明できない
+- Production Contractのsafe dummyは、実運用のdomain構造を保つ代表値にする必要がある
+- 組織domainの検証は文字列suffix全体ではなく、メールアドレスのdomain partが`dayopt.app`またはそのサブドメインかを判定する
+- Preview成功後も、同一merge SHAのProduction buildと実送信をrelease前の独立gateとして維持する


### PR DESCRIPTION
## Summary

- Resendの検証済み送信元 `noreply@send.dayopt.app` をProduct/WebのProduction契約で許可
- apex `dayopt.app` と所有サブドメインだけを受理し、外部suffixや不正メールは拒否
- Production build failureのincident logと回帰テストを追加

## Root cause

#1658のProduction gateは文字列全体へ `endsWith('@dayopt.app')` を適用していたため、1Password正本とResend検証domainが使う `send.dayopt.app` を誤って拒否しました。PreviewではProduction限定gateを実行しないため、main merge後のProduction buildで初めて顕在化しました。

## Impact

この修正により、Product/Webは正本の送信元を使って同一SHAのProduction buildへ進めます。問い合わせの固定To、Reply-To、Production限定配送、webhook署名、PII非記録の契約は変更しません。

## Verification

- `pnpm check`
- `pnpm docs:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:boundaries`
- Product対象tests: 33 passed
- Web対象tests: 36 passed
- risk reviewer: blockerなし
- behavior verifier: blockerなし（追加指摘も反映済み）

Refs #1646
Follow-up to #1658