### PR TITLE
refactor: 生成型で表現可能なproduction as neverキャストを除去する

### DIFF
--- a/apps/product/src/app/api/v1/calendar/[token]/route.ts
+++ b/apps/product/src/app/api/v1/calendar/[token]/route.ts
@@ -23,11 +23,10 @@ import { createServiceRoleClient } from '@/lib/supabase/oauth';
 async function getUserIdByToken(token: string): Promise<string | null> {
   const supabase = createServiceRoleClient();
 
-  // ical_feed_tokenは生成型に未反映のため filter で直接クエリ
   const { data, error } = await supabase
     .from('user_settings')
     .select('user_id')
-    .eq('ical_feed_token' as never, token)
+    .eq('ical_feed_token', token)
     .maybeSingle();
 
   if (error) {
@@ -38,7 +37,7 @@ async function getUserIdByToken(token: string): Promise<string | null> {
     });
   }
   if (!data) return null;
-  return (data as Record<string, unknown>).user_id as string;
+  return data.user_id;
 }
 
 /**
@@ -85,8 +84,7 @@ async function getPlansForFeed(userId: string) {
 
   // tags リレーションからタグ名を抽出
   return (plans ?? []).map((plan) => {
-    const tags = plan.tags as unknown as { name: string } | null;
-    const tagName = tags?.name ?? null;
+    const tagName = plan.tags?.name ?? null;
     return {
       id: plan.id,
       title: plan.title,

--- a/apps/product/src/features/settings/server/settings-service.ts
+++ b/apps/product/src/features/settings/server/settings-service.ts
@@ -197,8 +197,7 @@ export class SettingsService {
       });
     }
 
-    const token = (data as Record<string, unknown> | null)?.ical_feed_token;
-    return { token: (token as string) ?? null };
+    return { token: data?.ical_feed_token ?? null };
   }
 
   async regenerateICalToken(userId: string) {
@@ -220,7 +219,7 @@ export class SettingsService {
 
     const { data: updated, error: updateError } = await this.supabase
       .from('user_settings')
-      .update({ ical_feed_token: newToken } as never)
+      .update({ ical_feed_token: newToken })
       .eq('user_id', userId)
       .select('ical_feed_token')
       .single();

--- a/apps/product/src/features/tags/server/tag-reorder-service.ts
+++ b/apps/product/src/features/tags/server/tag-reorder-service.ts
@@ -2,6 +2,7 @@ import 'server-only';
 
 import type { Database } from '@/lib/database';
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { toParentIdsRpcArg } from './tag-rpc-args';
 import { createTagDatabaseError, TagServiceError } from './tag-service-error';
 
 export interface ReorderTagUpdate {
@@ -59,7 +60,7 @@ export class TagReorderService {
       {
         p_user_id: userId,
         p_tag_ids: updates.map((update) => update.id),
-        p_parent_ids: updates.map((update) => update.parent_id) as never,
+        p_parent_ids: toParentIdsRpcArg(updates.map((update) => update.parent_id)),
         p_sort_orders: updates.map((update) => update.sort_order),
       },
     );

--- a/apps/product/src/features/tags/server/tag-rpc-args.ts
+++ b/apps/product/src/features/tags/server/tag-rpc-args.ts
@@ -1,0 +1,11 @@
+import 'server-only';
+
+/**
+ * batch_reorder_tags_hierarchy の p_parent_ids は Postgres 側で UUID[]（要素はNULL許容）だが、
+ * Supabase の型生成は配列引数の要素 nullability を表現できず string[] を生成する。
+ * root タグの parent_id=null を tag_ids/sort_orders と位置対応させたまま渡す必要があるため、
+ * ここでのみキャストして通す（既知 variance、generator を直しても解消しない）。
+ */
+export function toParentIdsRpcArg(parentIds: (string | null)[]): string[] {
+  return parentIds as unknown as string[];
+}

--- a/apps/product/src/features/tags/server/tag-rpc-args.ts
+++ b/apps/product/src/features/tags/server/tag-rpc-args.ts
@@ -4,8 +4,10 @@ import 'server-only';
  * batch_reorder_tags_hierarchy の p_parent_ids は Postgres 側で UUID[]（要素はNULL許容）だが、
  * Supabase の型生成は配列引数の要素 nullability を表現できず string[] を生成する。
  * root タグの parent_id=null を tag_ids/sort_orders と位置対応させたまま渡す必要があるため、
- * ここでのみキャストして通す（既知 variance、generator を直しても解消しない）。
+ * RPC呼び出し境界でのみ `as never`（既知 variance、generator を直しても解消しない）。
+ * 戻り値を never のままにして、null を含む配列を string[] として再利用できる値に
+ * 見せかけない（呼び出し側で null が無いと誤信させないため、string[] にはキャストしない）。
  */
-export function toParentIdsRpcArg(parentIds: (string | null)[]): string[] {
-  return parentIds as unknown as string[];
+export function toParentIdsRpcArg(parentIds: (string | null)[]): never {
+  return parentIds as never;
 }

--- a/apps/product/src/features/tags/server/tag-sort-order.ts
+++ b/apps/product/src/features/tags/server/tag-sort-order.ts
@@ -2,6 +2,7 @@ import 'server-only';
 
 import type { Database } from '@/lib/database';
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { toParentIdsRpcArg } from './tag-rpc-args';
 import { createTagDatabaseError } from './tag-service-error';
 
 /**
@@ -75,7 +76,7 @@ export async function makeRoomAtTop(
   const { error: reorderError } = await supabase.rpc('batch_reorder_tags_hierarchy', {
     p_user_id: userId,
     p_tag_ids: siblings.map((tag) => tag.id),
-    p_parent_ids: siblings.map(() => parentId) as never,
+    p_parent_ids: toParentIdsRpcArg(siblings.map(() => parentId)),
     p_sort_orders: siblings.map((tag) => tag.sort_order + 1),
   });
 

--- a/docs/engineering/log/2026-07-21-supabase-types-gen-status-quirk.md
+++ b/docs/engineering/log/2026-07-21-supabase-types-gen-status-quirk.md
@@ -1,0 +1,29 @@
+---
+status: frozen
+date: 2026-07-21
+code: apps/product/src/lib/database/generated/database.types.ts
+---
+
+# Supabase型生成がstripe_webhook_events.statusのCHECK制約リテラルユニオンを推論しない
+
+`pnpm types:generate`（`supabase gen types typescript --project-id ...`）を実行すると`stripe_webhook_events.status`の型がcommit済みの`'processing' | 'processed' | 'failed'`からstringへ緩む。本番のCHECK制約は正常に存在するため、schemaのdriftではなく生成側のquirk。
+
+---
+
+## 経緯
+
+issue #1541（生成型とas neverキャストの整合）の作業中、副産物として`database.types.ts`の軽微な差分に気づいた。当初は「graphql_publicスキーマの消失」と「status列のリテラルユニオン化（改善）」の2点として報告したが、詳しく検証すると両方とも報告内容が誤っていた。
+
+## 確認した事実
+
+- **graphql_public消失は検証ミスだった**: グローバルのHomebrew版CLIが古かった（2.78.1）。repoは`package.json`で`supabase: 2.109.1`をpinしており、`pnpm types:generate`は`node_modules/.bin/supabase`（2.109.1）を使う。pinされたバージョンで再生成するとcommit済みファイルと完全一致（差分ゼロ）。グローバルCLIは`brew upgrade supabase`で2.109.1へ更新済み
+- **status列は逆に、commit済みファイルの方が正しい**: 本番へ直接SQL照会し、`stripe_webhook_events_status_check: CHECK ((status = ANY (ARRAY['processing'::text, 'processed'::text, 'failed'::text])))`が存在し`convalidated: true`であることを確認した。にもかかわらず`supabase gen types typescript`（pin済み2.109.1でも再現）はこの列をstringへ生成する
+- CLIバージョンに依存しない現象（2.78.1でも2.109.1でも同じ結果）。Supabase側のhosted生成エンドポイントの挙動と推定されるが、原因は未特定（PostgRESTのschema cacheラグ等を疑ったが未検証）
+
+## 学び
+
+`pnpm types:generate`を実行して生成物をcommitする前に、`stripe_webhook_events.status`が`string`へregressionしていないか手動で確認すること。この列に限らず、CHECK制約由来のリテラルユニオンを持つ列を将来追加した場合も同様の確認が必要になりうる。
+
+## 再評価条件
+
+Supabase CLIの将来バージョンでこの列が正しく生成されるようになったら、本noteは役目を終える。他の列でも同様の欠落が見つかった場合は、影響列を洗い出した上でSupabaseへの問い合わせや代替の生成方法を検討する。


### PR DESCRIPTION
## Summary

- issue #1541（R-25）の実装。Supabase生成型と production code のギャップに起因する `as never` / `as unknown as` キャストを再検索し、生成型で表現可能なものを除去した
- `settings-service.ts` / calendar tokenルート — `user_settings.ical_feed_token` と `plans.tags(name)` は生成型に既出済みだったため、過剰キャストと stale コメントを除去
- `tag-reorder-service.ts` / `tag-sort-order.ts`（issue未記載のパターンを新規発見）— `batch_reorder_tags_hierarchy` の `p_parent_ids` はPostgres配列引数の要素nullabilityを生成型が表現できない既知varianceのため、`tag-rpc-args.ts` の狭いadapterへ理由コメント付きで統一
- 副産物として見つかった `database.types.ts` の見かけ上のdrift（graphql_public消失・`stripe_webhook_events.status`のリテラルユニオン化）を検証した結果、どちらも実ドリフトではなくローカルCLIバージョン起因の誤検知／Supabase型生成側の既知quirkと判明。次回 `pnpm types:generate` 実行時の注意点を調査ログとして記録（コード・生成型ファイルへの変更は無し）

## Test plan

- [x] `pnpm typecheck`（apps/product）
- [x] `pnpm lint` / `pnpm lint:boundaries`
- [x] `pnpm test:run`（全パッケージ、2139+224+54 tests）
- [x] `pnpm docs:check`

Closes #1541

🤖 Generated with [Claude Code](https://claude.com/claude-code)