### PR TITLE
fix(sentry): Production smokeの空POSTを許可

### DIFF
--- a/apps/product/src/lib/sentry/__tests__/operator-smoke-auth.test.ts
+++ b/apps/product/src/lib/sentry/__tests__/operator-smoke-auth.test.ts
@@ -65,6 +65,31 @@ describe('authorizeProductOperatorSmoke', () => {
     expect(checkRateLimit.mock.calls.map(([stage]) => stage)).toEqual(['per-ip', 'global']);
   });
 
+  it('accepts an empty POST normalized by the runtime to Content-Length 0', async () => {
+    const normalizedRequest = new Request(
+      'https://app.dayopt.app/api/v1/system/sentry-smoke/server',
+      {
+        method: 'POST',
+        body: '',
+        headers: {
+          Authorization: `Bearer ${TOKEN}`,
+          'Content-Length': '0',
+          Origin: 'https://app.dayopt.app',
+          'Sec-Fetch-Site': 'same-origin',
+        },
+      },
+    );
+    expect(normalizedRequest.body).not.toBeNull();
+
+    const result = await authorizeProductOperatorSmoke(normalizedRequest, {
+      env: activeEnvironment(),
+      now: NOW,
+      checkRateLimit,
+    });
+
+    expect(result).toEqual({ authorized: true });
+  });
+
   it.each([
     ['preview', { VERCEL_ENV: 'preview' }],
     ['disabled', { SENTRY_OPERATOR_SMOKE_ENABLED: 'false' }],
@@ -136,6 +161,27 @@ describe('authorizeProductOperatorSmoke', () => {
           Authorization: `Bearer ${TOKEN}`,
           Origin: 'https://app.dayopt.app',
           'Sec-Fetch-Site': 'same-origin',
+        },
+      }),
+      { env: activeEnvironment(), now: NOW, checkRateLimit },
+    );
+
+    expect(result.authorized).toBe(false);
+    expect(checkRateLimit).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['positive content length', { 'Content-Length': '2' }],
+    ['streamed transfer', { 'Transfer-Encoding': 'chunked' }],
+  ])('rejects %s before rate limiting', async (_label, headers) => {
+    const result = await authorizeProductOperatorSmoke(
+      new Request('https://app.dayopt.app/api/v1/system/sentry-smoke/server', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${TOKEN}`,
+          Origin: 'https://app.dayopt.app',
+          'Sec-Fetch-Site': 'same-origin',
+          ...headers,
         },
       }),
       { env: activeEnvironment(), now: NOW, checkRateLimit },

--- a/apps/product/src/lib/sentry/operator-smoke-auth.ts
+++ b/apps/product/src/lib/sentry/operator-smoke-auth.ts
@@ -75,6 +75,15 @@ function hasSameOriginBrowserRequest(request: Request): boolean {
   );
 }
 
+function hasNoDeclaredRequestBody(request: Request): boolean {
+  if (request.headers.has('transfer-encoding')) return false;
+
+  const contentLength = request.headers.get('content-length');
+  if (contentLength !== null) return contentLength.trim() === '0';
+
+  return request.body === null;
+}
+
 function bytesToHex(bytes: Uint8Array): string {
   return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
 }
@@ -156,7 +165,7 @@ export async function authorizeProductOperatorSmoke(
   if (
     !hasActiveConfiguration(env, now) ||
     !hasSameOriginBrowserRequest(request) ||
-    request.body !== null
+    !hasNoDeclaredRequestBody(request)
   ) {
     return { authorized: false, response: operatorSmokeUnavailableResponse() };
   }

--- a/apps/web/src/platform/observability/operator-smoke-auth.test.ts
+++ b/apps/web/src/platform/observability/operator-smoke-auth.test.ts
@@ -50,6 +50,28 @@ describe('authorizeWebOperatorSmoke', () => {
     expect(checkRateLimit.mock.calls.map(([stage]) => stage)).toEqual(['per-ip', 'global']);
   });
 
+  it('accepts an empty POST normalized by the runtime to Content-Length 0', async () => {
+    const normalizedRequest = new Request('https://dayopt.app/api/v1/system/sentry-smoke/server', {
+      method: 'POST',
+      body: '',
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        'Content-Length': '0',
+        Origin: 'https://dayopt.app',
+        'Sec-Fetch-Site': 'same-origin',
+      },
+    });
+    expect(normalizedRequest.body).not.toBeNull();
+
+    const result = await authorizeWebOperatorSmoke(normalizedRequest, {
+      env: activeEnvironment(),
+      now: NOW,
+      checkRateLimit,
+    });
+
+    expect(result).toEqual({ authorized: true });
+  });
+
   it.each([
     ['preview', { VERCEL_ENV: 'preview' }],
     ['disabled', { SENTRY_OPERATOR_SMOKE_ENABLED: 'false' }],
@@ -87,6 +109,27 @@ describe('authorizeWebOperatorSmoke', () => {
 
     expect(crossOrigin.authorized).toBe(false);
     expect(bodyBearing.authorized).toBe(false);
+    expect(checkRateLimit).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['positive content length', { 'Content-Length': '2' }],
+    ['streamed transfer', { 'Transfer-Encoding': 'chunked' }],
+  ])('rejects %s before rate limiting', async (_label, headers) => {
+    const result = await authorizeWebOperatorSmoke(
+      new Request('https://dayopt.app/api/v1/system/sentry-smoke/server', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${TOKEN}`,
+          Origin: 'https://dayopt.app',
+          'Sec-Fetch-Site': 'same-origin',
+          ...headers,
+        },
+      }),
+      { env: activeEnvironment(), now: NOW, checkRateLimit },
+    );
+
+    expect(result.authorized).toBe(false);
     expect(checkRateLimit).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/platform/observability/operator-smoke-auth.ts
+++ b/apps/web/src/platform/observability/operator-smoke-auth.ts
@@ -66,6 +66,15 @@ function hasSameOriginBrowserRequest(request: Request): boolean {
   );
 }
 
+function hasNoDeclaredRequestBody(request: Request): boolean {
+  if (request.headers.has('transfer-encoding')) return false;
+
+  const contentLength = request.headers.get('content-length');
+  if (contentLength !== null) return contentLength.trim() === '0';
+
+  return request.body === null;
+}
+
 async function sha256(value: string): Promise<Uint8Array> {
   return new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value)));
 }
@@ -118,7 +127,7 @@ export async function authorizeWebOperatorSmoke(
   if (
     !hasActiveConfiguration(env, now) ||
     !hasSameOriginBrowserRequest(request) ||
-    request.body !== null
+    !hasNoDeclaredRequestBody(request)
   ) {
     return { authorized: false, response: operatorSmokeUnavailableResponse() };
   }


### PR DESCRIPTION
## 概要

Product/Webの一時operator smoke endpointが、Vercelで空POSTをnon-null body streamとして正規化された際に404となる問題を修正します。`Content-Length: 0`のみを空bodyとして許可し、`Transfer-Encoding`または正のContent-Lengthはfail-closedで拒否します。

## Productionで確認した症状

- Product server/edge/tRPC: 認可前に404
- Web server: 認可前に404
- Production envのflag・token digest・expiryは期待値と一致

## 検証

- `pnpm check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:boundaries`
- Product: 233 files / 2146 tests
- Web: 42 files / 244 tests
- behavior review: PASS
- security review: PASS（P0-P2なし）

マージ後にProduct/WebをProductionへdeployし、実際のVercel正規化でserver/edge/tRPC smokeを再確認します。#1566 の一時検証surfaceであり、証跡取得後にcode/envを削除します。