### PR TITLE
fix(sentry): Node smokeの空body検証を修正

### DIFF
--- a/apps/product/src/lib/sentry/__tests__/operator-smoke-auth.test.ts
+++ b/apps/product/src/lib/sentry/__tests__/operator-smoke-auth.test.ts
@@ -88,6 +88,34 @@ describe('authorizeProductOperatorSmoke', () => {
     });
 
     expect(result).toEqual({ authorized: true });
+    expect(normalizedRequest.bodyUsed).toBe(false);
+  });
+
+  it('accepts an empty POST stream after the Node runtime removes Content-Length 0', async () => {
+    const normalizedRequest = new Request(
+      'https://app.dayopt.app/api/v1/system/sentry-smoke/server',
+      {
+        method: 'POST',
+        body: '',
+        headers: {
+          Authorization: `Bearer ${TOKEN}`,
+          Origin: 'https://app.dayopt.app',
+          'Sec-Fetch-Site': 'same-origin',
+        },
+      },
+    );
+    expect(normalizedRequest.body).not.toBeNull();
+    expect(normalizedRequest.headers.has('content-length')).toBe(false);
+
+    const result = await authorizeProductOperatorSmoke(normalizedRequest, {
+      env: activeEnvironment(),
+      now: NOW,
+      checkRateLimit,
+    });
+
+    expect(result).toEqual({ authorized: true });
+    expect(normalizedRequest.bodyUsed).toBe(false);
+    expect(checkRateLimit.mock.calls.map(([stage]) => stage)).toEqual(['per-ip', 'global']);
   });
 
   it.each([
@@ -152,7 +180,10 @@ describe('authorizeProductOperatorSmoke', () => {
     expect(checkRateLimit).not.toHaveBeenCalled();
   });
 
-  it('rejects any request body before rate limiting', async () => {
+  it.each([
+    ['without a framing header', {}],
+    ['despite Content-Length 0', { 'Content-Length': '0' }],
+  ])('rejects a non-empty body %s after token verification', async (_label, headers) => {
     const result = await authorizeProductOperatorSmoke(
       new Request('https://app.dayopt.app/api/v1/system/sentry-smoke/server', {
         method: 'POST',
@@ -161,13 +192,76 @@ describe('authorizeProductOperatorSmoke', () => {
           Authorization: `Bearer ${TOKEN}`,
           Origin: 'https://app.dayopt.app',
           'Sec-Fetch-Site': 'same-origin',
+          ...headers,
         },
       }),
       { env: activeEnvironment(), now: NOW, checkRateLimit },
     );
 
     expect(result.authorized).toBe(false);
-    expect(checkRateLimit).not.toHaveBeenCalled();
+    expect(checkRateLimit.mock.calls.map(([stage]) => stage)).toEqual(['per-ip', 'global']);
+  });
+
+  it('applies global limiting before reading one non-empty chunk and cancels the clone', async () => {
+    const events: string[] = [];
+    const read = vi.fn(async () => {
+      events.push('read');
+      return { done: false, value: new Uint8Array([1]) };
+    });
+    const cancel = vi.fn(async () => undefined);
+    const smokeRequest = request();
+    vi.spyOn(smokeRequest, 'clone').mockImplementation(() => {
+      events.push('clone');
+      return { body: { getReader: () => ({ read, cancel }) } } as never;
+    });
+
+    const result = await authorizeProductOperatorSmoke(smokeRequest, {
+      env: activeEnvironment(),
+      now: NOW,
+      checkRateLimit: async (stage) => {
+        events.push(stage);
+        return 'allowed';
+      },
+    });
+
+    expect(result.authorized).toBe(false);
+    expect(events).toEqual(['per-ip', 'global', 'clone', 'read']);
+    expect(read).toHaveBeenCalledOnce();
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it('fails closed and cancels the cloned stream when the body probe times out', async () => {
+    vi.useFakeTimers();
+    try {
+      let markReadStarted: (() => void) | undefined;
+      const readStarted = new Promise<void>((resolve) => {
+        markReadStarted = resolve;
+      });
+      const read = vi.fn(() => {
+        markReadStarted?.();
+        return new Promise<never>(() => undefined);
+      });
+      const cancel = vi.fn(async () => undefined);
+      const smokeRequest = request();
+      vi.spyOn(smokeRequest, 'clone').mockReturnValue({
+        body: { getReader: () => ({ read, cancel }) },
+      } as never);
+
+      const resultPromise = authorizeProductOperatorSmoke(smokeRequest, {
+        env: activeEnvironment(),
+        now: NOW,
+        checkRateLimit,
+      });
+      await readStarted;
+      await vi.advanceTimersByTimeAsync(1_000);
+      const result = await resultPromise;
+
+      expect(result.authorized).toBe(false);
+      if (!result.authorized) expect(result.response.status).toBe(404);
+      expect(cancel).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it.each([
@@ -193,7 +287,9 @@ describe('authorizeProductOperatorSmoke', () => {
 
   it('counts and rejects an invalid token without returning it', async () => {
     const invalidToken = 'B'.repeat(43);
-    const result = await authorizeProductOperatorSmoke(request(invalidToken), {
+    const invalidRequest = request(invalidToken);
+    const cloneSpy = vi.spyOn(invalidRequest, 'clone');
+    const result = await authorizeProductOperatorSmoke(invalidRequest, {
       env: activeEnvironment(),
       now: NOW,
       checkRateLimit,
@@ -202,6 +298,7 @@ describe('authorizeProductOperatorSmoke', () => {
     expect(result.authorized).toBe(false);
     expect(checkRateLimit).toHaveBeenCalledOnce();
     expect(checkRateLimit).toHaveBeenCalledWith('per-ip', expect.any(Request), expect.any(Object));
+    expect(cloneSpy).not.toHaveBeenCalled();
     if (!result.authorized) {
       expect(result.response.status).toBe(404);
       expect(result.response.headers.get('cache-control')).toContain('no-store');

--- a/apps/product/src/lib/sentry/operator-smoke-auth.ts
+++ b/apps/product/src/lib/sentry/operator-smoke-auth.ts
@@ -8,6 +8,7 @@ const TOKEN_PATTERN = /^Bearer ([A-Za-z0-9_-]{43})$/u;
 const DIGEST_PATTERN = /^[a-f0-9]{64}$/u;
 const ABSOLUTE_ACTIVE_FROM_MS = Date.parse('2026-07-21T23:00:00.000Z');
 const ABSOLUTE_DEADLINE_MS = Date.parse('2026-07-22T12:00:00.000Z');
+const BODY_PROBE_TIMEOUT_MS = 1_000;
 const SMOKE_RATE_LIMIT_TIMEOUT_MS = 2_000;
 
 type SmokeEnvironment = Record<string, string | undefined>;
@@ -75,13 +76,34 @@ function hasSameOriginBrowserRequest(request: Request): boolean {
   );
 }
 
-function hasNoDeclaredRequestBody(request: Request): boolean {
+function hasAllowedRequestBodyFraming(request: Request): boolean {
   if (request.headers.has('transfer-encoding')) return false;
 
   const contentLength = request.headers.get('content-length');
-  if (contentLength !== null) return contentLength.trim() === '0';
+  return contentLength === null || contentLength.trim() === '0';
+}
 
-  return request.body === null;
+async function hasEmptyRequestBody(request: Request): Promise<boolean> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    const reader = request.clone().body?.getReader();
+    if (!reader) return true;
+
+    const outcome = await Promise.race([
+      reader.read().then((result) => ({ kind: 'read' as const, result })),
+      new Promise<{ kind: 'timeout' }>((resolve) => {
+        timeoutId = setTimeout(() => resolve({ kind: 'timeout' }), BODY_PROBE_TIMEOUT_MS);
+      }),
+    ]);
+    void reader.cancel().catch(() => undefined);
+
+    return outcome.kind === 'read' && outcome.result.done === true;
+  } catch {
+    return false;
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  }
 }
 
 function bytesToHex(bytes: Uint8Array): string {
@@ -165,7 +187,7 @@ export async function authorizeProductOperatorSmoke(
   if (
     !hasActiveConfiguration(env, now) ||
     !hasSameOriginBrowserRequest(request) ||
-    !hasNoDeclaredRequestBody(request)
+    !hasAllowedRequestBodyFraming(request)
   ) {
     return { authorized: false, response: operatorSmokeUnavailableResponse() };
   }
@@ -190,6 +212,10 @@ export async function authorizeProductOperatorSmoke(
       authorized: false,
       response: operatorSmokeUnavailableResponse(globalRateLimit === 'limited' ? 429 : 503),
     };
+  }
+
+  if (!(await hasEmptyRequestBody(request))) {
+    return { authorized: false, response: operatorSmokeUnavailableResponse() };
   }
 
   return { authorized: true };

--- a/apps/web/src/platform/observability/operator-smoke-auth.test.ts
+++ b/apps/web/src/platform/observability/operator-smoke-auth.test.ts
@@ -70,6 +70,31 @@ describe('authorizeWebOperatorSmoke', () => {
     });
 
     expect(result).toEqual({ authorized: true });
+    expect(normalizedRequest.bodyUsed).toBe(false);
+  });
+
+  it('accepts an empty POST stream after the Node runtime removes Content-Length 0', async () => {
+    const normalizedRequest = new Request('https://dayopt.app/api/v1/system/sentry-smoke/server', {
+      method: 'POST',
+      body: '',
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        Origin: 'https://dayopt.app',
+        'Sec-Fetch-Site': 'same-origin',
+      },
+    });
+    expect(normalizedRequest.body).not.toBeNull();
+    expect(normalizedRequest.headers.has('content-length')).toBe(false);
+
+    const result = await authorizeWebOperatorSmoke(normalizedRequest, {
+      env: activeEnvironment(),
+      now: NOW,
+      checkRateLimit,
+    });
+
+    expect(result).toEqual({ authorized: true });
+    expect(normalizedRequest.bodyUsed).toBe(false);
+    expect(checkRateLimit.mock.calls.map(([stage]) => stage)).toEqual(['per-ip', 'global']);
   });
 
   it.each([
@@ -89,12 +114,21 @@ describe('authorizeWebOperatorSmoke', () => {
     expect(checkRateLimit).not.toHaveBeenCalled();
   });
 
-  it('rejects cross-origin and body-bearing requests before rate limiting', async () => {
+  it('rejects cross-origin requests before rate limiting', async () => {
     const crossOrigin = await authorizeWebOperatorSmoke(
       request(TOKEN, 'https://attacker.example'),
       { env: activeEnvironment(), now: NOW, checkRateLimit },
     );
-    const bodyBearing = await authorizeWebOperatorSmoke(
+
+    expect(crossOrigin.authorized).toBe(false);
+    expect(checkRateLimit).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['without a framing header', {}],
+    ['despite Content-Length 0', { 'Content-Length': '0' }],
+  ])('rejects a non-empty body %s after token verification', async (_label, headers) => {
+    const result = await authorizeWebOperatorSmoke(
       new Request('https://dayopt.app/api/v1/system/sentry-smoke/server', {
         method: 'POST',
         body: '{}',
@@ -102,14 +136,76 @@ describe('authorizeWebOperatorSmoke', () => {
           Authorization: `Bearer ${TOKEN}`,
           Origin: 'https://dayopt.app',
           'Sec-Fetch-Site': 'same-origin',
+          ...headers,
         },
       }),
       { env: activeEnvironment(), now: NOW, checkRateLimit },
     );
 
-    expect(crossOrigin.authorized).toBe(false);
-    expect(bodyBearing.authorized).toBe(false);
-    expect(checkRateLimit).not.toHaveBeenCalled();
+    expect(result.authorized).toBe(false);
+    expect(checkRateLimit.mock.calls.map(([stage]) => stage)).toEqual(['per-ip', 'global']);
+  });
+
+  it('applies global limiting before reading one non-empty chunk and cancels the clone', async () => {
+    const events: string[] = [];
+    const read = vi.fn(async () => {
+      events.push('read');
+      return { done: false, value: new Uint8Array([1]) };
+    });
+    const cancel = vi.fn(async () => undefined);
+    const smokeRequest = request();
+    vi.spyOn(smokeRequest, 'clone').mockImplementation(() => {
+      events.push('clone');
+      return { body: { getReader: () => ({ read, cancel }) } } as never;
+    });
+
+    const result = await authorizeWebOperatorSmoke(smokeRequest, {
+      env: activeEnvironment(),
+      now: NOW,
+      checkRateLimit: async (stage) => {
+        events.push(stage);
+        return 'allowed';
+      },
+    });
+
+    expect(result.authorized).toBe(false);
+    expect(events).toEqual(['per-ip', 'global', 'clone', 'read']);
+    expect(read).toHaveBeenCalledOnce();
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it('fails closed and cancels the cloned stream when the body probe times out', async () => {
+    vi.useFakeTimers();
+    try {
+      let markReadStarted: (() => void) | undefined;
+      const readStarted = new Promise<void>((resolve) => {
+        markReadStarted = resolve;
+      });
+      const read = vi.fn(() => {
+        markReadStarted?.();
+        return new Promise<never>(() => undefined);
+      });
+      const cancel = vi.fn(async () => undefined);
+      const smokeRequest = request();
+      vi.spyOn(smokeRequest, 'clone').mockReturnValue({
+        body: { getReader: () => ({ read, cancel }) },
+      } as never);
+
+      const resultPromise = authorizeWebOperatorSmoke(smokeRequest, {
+        env: activeEnvironment(),
+        now: NOW,
+        checkRateLimit,
+      });
+      await readStarted;
+      await vi.advanceTimersByTimeAsync(1_000);
+      const result = await resultPromise;
+
+      expect(result.authorized).toBe(false);
+      if (!result.authorized) expect(result.response.status).toBe(404);
+      expect(cancel).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it.each([
@@ -151,13 +247,16 @@ describe('authorizeWebOperatorSmoke', () => {
   });
 
   it('counts an invalid token and fails closed when rate limiting is unavailable', async () => {
-    const invalid = await authorizeWebOperatorSmoke(request('B'.repeat(43)), {
+    const invalidRequest = request('B'.repeat(43));
+    const cloneSpy = vi.spyOn(invalidRequest, 'clone');
+    const invalid = await authorizeWebOperatorSmoke(invalidRequest, {
       env: activeEnvironment(),
       now: NOW,
       checkRateLimit,
     });
     expect(invalid.authorized).toBe(false);
     expect(checkRateLimit).toHaveBeenCalledOnce();
+    expect(cloneSpy).not.toHaveBeenCalled();
 
     const unavailable = await authorizeWebOperatorSmoke(request(), {
       env: activeEnvironment(),

--- a/apps/web/src/platform/observability/operator-smoke-auth.ts
+++ b/apps/web/src/platform/observability/operator-smoke-auth.ts
@@ -12,6 +12,7 @@ const TOKEN_PATTERN = /^Bearer ([A-Za-z0-9_-]{43})$/u;
 const DIGEST_PATTERN = /^[a-f0-9]{64}$/u;
 const ABSOLUTE_ACTIVE_FROM_MS = Date.parse('2026-07-21T23:00:00.000Z');
 const ABSOLUTE_DEADLINE_MS = Date.parse('2026-07-22T12:00:00.000Z');
+const BODY_PROBE_TIMEOUT_MS = 1_000;
 
 type SmokeEnvironment = Record<string, string | undefined>;
 type RateLimitResult = 'allowed' | 'limited' | 'unavailable';
@@ -66,13 +67,34 @@ function hasSameOriginBrowserRequest(request: Request): boolean {
   );
 }
 
-function hasNoDeclaredRequestBody(request: Request): boolean {
+function hasAllowedRequestBodyFraming(request: Request): boolean {
   if (request.headers.has('transfer-encoding')) return false;
 
   const contentLength = request.headers.get('content-length');
-  if (contentLength !== null) return contentLength.trim() === '0';
+  return contentLength === null || contentLength.trim() === '0';
+}
 
-  return request.body === null;
+async function hasEmptyRequestBody(request: Request): Promise<boolean> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    const reader = request.clone().body?.getReader();
+    if (!reader) return true;
+
+    const outcome = await Promise.race([
+      reader.read().then((result) => ({ kind: 'read' as const, result })),
+      new Promise<{ kind: 'timeout' }>((resolve) => {
+        timeoutId = setTimeout(() => resolve({ kind: 'timeout' }), BODY_PROBE_TIMEOUT_MS);
+      }),
+    ]);
+    void reader.cancel().catch(() => undefined);
+
+    return outcome.kind === 'read' && outcome.result.done === true;
+  } catch {
+    return false;
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  }
 }
 
 async function sha256(value: string): Promise<Uint8Array> {
@@ -127,7 +149,7 @@ export async function authorizeWebOperatorSmoke(
   if (
     !hasActiveConfiguration(env, now) ||
     !hasSameOriginBrowserRequest(request) ||
-    !hasNoDeclaredRequestBody(request)
+    !hasAllowedRequestBodyFraming(request)
   ) {
     return { authorized: false, response: operatorSmokeUnavailableResponse() };
   }
@@ -152,6 +174,10 @@ export async function authorizeWebOperatorSmoke(
       authorized: false,
       response: operatorSmokeUnavailableResponse(globalRateLimit === 'limited' ? 429 : 503),
     };
+  }
+
+  if (!(await hasEmptyRequestBody(request))) {
+    return { authorized: false, response: operatorSmokeUnavailableResponse() };
   }
 
   return { authorized: true };


### PR DESCRIPTION
## 概要

PR #1670のProduction smokeで、Edgeは202で送信できた一方、Vercel Node runtimeが`Content-Length: 0`を除去して空body streamを渡すためProduct/Web serverとtRPCが404になりました。

Node正規化後も、token・per-IP/global rate limitを通過したrequestだけを1秒上限のfirst readで検査し、`done === true`の空streamだけを許可します。non-empty、timeout、clone/read errorはfail-closedです。元Requestはclone側だけを読むためtRPCへ未消費で渡ります。

## セキュリティ境界

- `Transfer-Encoding` / positive `Content-Length`はrate limit前に拒否
- active/origin/framing → per-IP → token → global → clone/read
- bodyは全量buffer化せずfirst readのみ、1秒timeout
- invalid tokenではbodyをcloneしない
- immutable deadline `2026-07-22T12:00:00Z`は維持

## 検証

- `pnpm check`
- `pnpm test:run`
- Product: 233 files / 2150 tests
- Web: 42 files / 249 tests
- focused: Product 21 / Web 17
- behavior review: PASS（P0-P2なし）
- risk review: PASS（P0-P2なし）

マージ後、Product/Web Productionへdeployしてserver/edge/tRPC smokeを再実行します。#1566の証跡取得後に一時surface/envは削除します。