### PR TITLE
fix(security): Code Scanningアラート4件に対応する

### DIFF
--- a/apps/product/src/lib/auth/recovery-codes.ts
+++ b/apps/product/src/lib/auth/recovery-codes.ts
@@ -14,7 +14,7 @@ import 'server-only';
  * @see OWASP - Account Recovery
  */
 
-import { createHmac, randomBytes } from 'crypto';
+import { createHmac, randomInt } from 'crypto';
 
 import { env } from '@/env';
 
@@ -51,14 +51,10 @@ export function generateRecoveryCodes(): string[] {
   const charset = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // 紛らわしい文字を除外（I,O,0,1）
 
   for (let i = 0; i < RECOVERY_CODE_CONFIG.COUNT; i++) {
-    const bytes = randomBytes(RECOVERY_CODE_CONFIG.LENGTH);
     let code = '';
 
     for (let j = 0; j < RECOVERY_CODE_CONFIG.LENGTH; j++) {
-      const byte = bytes[j];
-      if (byte !== undefined) {
-        code += charset[byte % charset.length];
-      }
+      code += charset.charAt(randomInt(charset.length));
     }
 
     // フォーマット: XXXX-XXXX

--- a/apps/web/src/app/[locale]/(marketing)/releases/[version]/page.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/releases/[version]/page.tsx
@@ -110,7 +110,7 @@ const mdxComponents = createMDXComponents({
 
     return (
       <div
-        className={`my-6 rounded-r-lg border-l-4 p-4 ${changeType.color.replace('text-', 'border-').replace('bg-', 'bg-').replace('border-', 'border-l-')}`}
+        className={`my-6 rounded-r-lg border-l-4 p-4 ${changeType.color.replace('text-', 'border-').replace('border-', 'border-l-')}`}
       >
         <div className="mb-2 flex items-center gap-2">
           <span className="text-lg" role="img" aria-label={changeType.label}>

--- a/scripts/__tests__/check-1password.test.ts
+++ b/scripts/__tests__/check-1password.test.ts
@@ -1,0 +1,103 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { onePasswordEnvSchema } from '../env/schema';
+
+const rootDir = resolve(import.meta.dirname, '../..');
+const temporaryDirectories: string[] = [];
+const sentinelSecret = 'sentinel-secret-must-not-appear';
+
+const fakeOpScript = `#!/bin/sh
+case "$1" in
+  --version)
+    printf '%s\n' '2.0.0'
+    ;;
+  account)
+    printf '%s\n' '[]'
+    ;;
+  vault)
+    exit 0
+    ;;
+  item)
+    case "$FAKE_OP_MODE" in
+      error)
+        printf '%s\n' "$FAKE_OP_SENTINEL" >&2
+        exit 1
+        ;;
+      invalid-json)
+        printf '%s\n' "$FAKE_OP_SENTINEL"
+        ;;
+      *)
+        printf '%s\n' "$FAKE_OP_ITEM_JSON"
+        ;;
+    esac
+    ;;
+esac
+`;
+
+function createFakeOpDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), 'dayopt-fake-op-'));
+  temporaryDirectories.push(directory);
+  writeFileSync(join(directory, 'op'), fakeOpScript, { mode: 0o755 });
+  return directory;
+}
+
+function runCheck(mode?: 'error' | 'invalid-json') {
+  const fakeOpDirectory = createFakeOpDirectory();
+  const fields = [...new Set(onePasswordEnvSchema.map((entry) => entry.field))].map((field) => ({
+    id: field,
+    label: field,
+    value: sentinelSecret,
+  }));
+
+  return spawnSync('pnpm', ['exec', 'tsx', 'scripts/env/check-1password.ts'], {
+    cwd: rootDir,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      FAKE_OP_ITEM_JSON: JSON.stringify({ fields }),
+      FAKE_OP_MODE: mode ?? '',
+      FAKE_OP_SENTINEL: sentinelSecret,
+      PATH: `${fakeOpDirectory}:${process.env.PATH ?? ''}`,
+    },
+  });
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe('check-1password.ts', () => {
+  it('参照先と状態だけを表示し、取得した値を出力しない', () => {
+    const result = runCheck();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('Dayopt-Staging / supabase / SUPABASE_SERVICE_ROLE_KEY: OK');
+    expect(result.stdout).not.toContain(sentinelSecret);
+    expect(result.stderr).not.toContain(sentinelSecret);
+  });
+
+  it('op の失敗出力を引き継がない', () => {
+    const result = runCheck('error');
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('MISSING_ITEM');
+    expect(result.stdout).not.toContain(sentinelSecret);
+    expect(result.stderr).not.toContain(sentinelSecret);
+  });
+
+  it('不正な JSON の raw stdout を引き継がない', () => {
+    const result = runCheck('invalid-json');
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('MISSING_ITEM');
+    expect(result.stdout).not.toContain(sentinelSecret);
+    expect(result.stderr).not.toContain(sentinelSecret);
+  });
+});

--- a/scripts/generate-rls-snapshot.ts
+++ b/scripts/generate-rls-snapshot.ts
@@ -24,6 +24,8 @@ import { fileURLToPath } from 'url';
 
 import { format as formatWithPrettier } from 'prettier';
 
+import { escapeMarkdownTableCell as cell } from './lib/markdown-table';
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
 const OUTPUT_PATH = resolve(ROOT, 'docs/engineering/data/db/rls-snapshot.md');
@@ -166,11 +168,6 @@ function fetchRealtimePublication(): RealtimePublicationRow[] {
        ) t;`,
     ) ?? []
   );
-}
-
-/** markdown 1 セル用に改行・パイプを無害化 */
-function cell(value: string): string {
-  return value.replace(/\s+/g, ' ').replace(/\|/g, '\\|').trim() || '—';
 }
 
 function render(

--- a/scripts/lib/__tests__/markdown-table.test.ts
+++ b/scripts/lib/__tests__/markdown-table.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { escapeMarkdownTableCell } from '../markdown-table';
+
+describe('escapeMarkdownTableCell', () => {
+  it('pipe を Markdown の列区切りとして解釈されない形にする', () => {
+    expect(escapeMarkdownTableCell('a|b')).toBe(String.raw`a\|b`);
+    expect(escapeMarkdownTableCell('a|b|c')).toBe(String.raw`a\|b\|c`);
+  });
+
+  it('既存の backslash を保持したまま後続の pipe を escape する', () => {
+    expect(escapeMarkdownTableCell(String.raw`a\|b`)).toBe(String.raw`a\\\|b`);
+    expect(escapeMarkdownTableCell(String.raw`a\\|b`)).toBe(String.raw`a\\\\\|b`);
+  });
+
+  it('末尾の backslash を保持する', () => {
+    expect(escapeMarkdownTableCell('path\\')).toBe('path\\\\');
+  });
+
+  it('空白を正規化し、空なら em dash を返す', () => {
+    expect(escapeMarkdownTableCell('  hello\n\tworld  ')).toBe('hello world');
+    expect(escapeMarkdownTableCell(' \n\t ')).toBe('—');
+  });
+});

--- a/scripts/lib/markdown-table.ts
+++ b/scripts/lib/markdown-table.ts
@@ -1,0 +1,11 @@
+/** Markdown table のセル内容を、表示文字を保ったまま安全に埋め込める形へ変換する。 */
+export function escapeMarkdownTableCell(value: string): string {
+  return (
+    value
+      .replace(/\s+/g, ' ')
+      // 既存の backslash を先に escape し、後段で追加する pipe escape を壊さない。
+      .replace(/\\/g, '\\\\')
+      .replace(/\|/g, '\\|')
+      .trim() || '—'
+  );
+}


### PR DESCRIPTION
## 概要

Code Scanning の open alert 4件を確認し、実害のある指摘と静的解析上の誤検知を分けて対応します。

- recovery code生成を `randomInt` ベースに変更し、偏りのない選択をコード上でも明示
- RLS Markdown table生成のエスケープを専用helperへ切り出し、pipe・backslash・空白をテスト
- release pageの恒等的な `replace` を削除
- 1Password検査の失敗経路でsecret valueやchild process出力が親processへ漏れないことをsentinelテストで固定
- 最新 `main`（PR #1671まで）をmerge済み

## Code Scanning alertの扱い

- #1 Identity replacement: 恒等的な置換を削除
- #7 Biased random number generation: `randomInt` に変更
- #8 Incomplete multi-character sanitization: backslashを先にescapeするhelperと回帰テストを追加
- #6 Clear-text logging: 実装はvault/item/field名とbounded statusのみを出力し、secret value・stdout・stderrは出力しないことを再確認。sentinelテストを追加し、PR再解析後も残る場合はfalse positiveとしてdismissする

## 原因

一部は実際のno-op処理とエスケープ順序の曖昧さでした。残りは、charset長による数学的な安全性や、1Password CLIの出力をログへ渡していないデータフローをCodeQLが十分に証明できない形でした。

## 影響

- recovery codeの文字種・長さ・保存形式は変更なし
- release pageの表示結果は変更なし
- RLS snapshotのMarkdown出力は、pipe/backslashを含む値でも壊れにくくなる
- secret検査のログ契約をテストで明示

## 検証

- `pnpm check`
  - typecheck / lint / lint:boundaries / static checks / dead-code / unit tests
  - product: 233 files, 2150 tests
  - web: 42 files, 249 tests
  - scripts: 12 files, 61 tests
- `pnpm rls:snapshot:check`
