### PR TITLE
fix(sentry): product node初期化を復旧する

### DIFF
--- a/apps/product/src/instrumentation.test.ts
+++ b/apps/product/src/instrumentation.test.ts
@@ -2,16 +2,26 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const sentry = vi.hoisted(() => ({
   captureRequestError: vi.fn(),
+  extraErrorDataIntegration: vi.fn(() => ({ name: 'extra-error-data' })),
+  init: vi.fn(),
   setTags: vi.fn(),
 }));
 
 vi.mock('@sentry/nextjs', () => ({
   captureRequestError: sentry.captureRequestError,
+  extraErrorDataIntegration: sentry.extraErrorDataIntegration,
+  init: sentry.init,
   withScope: (callback: (scope: { setTags: typeof sentry.setTags }) => void) =>
     callback({ setTags: sentry.setTags }),
 }));
+vi.mock('@/lib/sentry/scrub-pii', () => ({
+  scrubSentryBreadcrumb: vi.fn(),
+  scrubSentrySpan: vi.fn(),
+  scrubSentryTransaction: vi.fn(),
+  withPIIScrub: vi.fn(() => vi.fn()),
+}));
 
-import { onRequestError } from './instrumentation';
+import { onRequestError, register } from './instrumentation';
 
 const request = {
   path: '/day?query=private',
@@ -54,5 +64,19 @@ describe('Product onRequestError', () => {
     await onRequestError(new Error('preview failure'), request, context);
 
     expect(sentry.captureRequestError).not.toHaveBeenCalled();
+  });
+
+  it('loads the Node Sentry config from the src instrumentation convention', async () => {
+    vi.stubEnv('NEXT_RUNTIME', 'nodejs');
+
+    await register();
+
+    expect(sentry.init).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dsn: 'https://public@example.ingest.sentry.io/1',
+        enabled: true,
+        environment: 'production',
+      }),
+    );
   });
 });

--- a/apps/product/src/instrumentation.ts
+++ b/apps/product/src/instrumentation.ts
@@ -2,7 +2,7 @@
  * Next.js Instrumentation Hook
  * サーバー起動時にSentry SDKを初期化
  *
- * @see https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation
+ * @see https://nextjs.org/docs/app/guides/instrumentation
  * @see https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
  */
 
@@ -34,12 +34,12 @@ function resolveTechnicalRequestId(
 export async function register() {
   // Node.jsランタイム（サーバーサイド）
   if (process.env.NEXT_RUNTIME === 'nodejs') {
-    await import('./sentry.server.config');
+    await import('../sentry.server.config');
   }
 
   // Edgeランタイム（Middleware、Edge API Routes）
   if (process.env.NEXT_RUNTIME === 'edge') {
-    await import('./sentry.edge.config');
+    await import('../sentry.edge.config');
   }
 }
 

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -1,9 +1,9 @@
 ---
 status: current
-last_verified: 2026-07-16
+last_verified: 2026-07-22
 code:
   - packages/observability
-  - apps/product/instrumentation.ts
+  - apps/product/src/instrumentation.ts
   - apps/product/instrumentation-client.ts
   - apps/web/src/instrumentation.ts
   - apps/web/instrumentation-client.ts


### PR DESCRIPTION
## 概要

Product の Node runtime で Sentry client が初期化されず、operator smoke の server / tRPC が即時 503 になる不具合を修正します。

## 原因

Product は `apps/product/src/app` 構成ですが、Next.js instrumentation hook が `apps/product/instrumentation.ts` にあり、production build で検出されていませんでした。Next.js の `src` convention に合わせて `apps/product/src/instrumentation.ts` へ移動します。

## 変更

- Product instrumentation hook とunit testを `src/` 配下へ移動
- server / edge configの相対importを更新
- `register()` がNode Sentry configを読み込むregression testを追加
- monitoring docsのcanonical pathを更新
- browser consentとReplay無効設定には変更なし

## 検証

- `pnpm check`（Node 24.14.0）
  - Product: 233 files / 2,151 tests
  - Web: 42 files / 249 tests
  - observability: 4 files / 46 tests
- fresh Product production buildで `.next/server/instrumentation.js` の生成とserver config importを確認
- built instrumentation実行でSentry clientの `enabled: true` / `environment: production` を確認
- 最新main取り込み後:
  - focused 2 files / 7 tests
  - `pnpm typecheck`
  - `pnpm lint`
  - `pnpm lint:boundaries`

## 残る確認

merge後のProduction deployでProduct server / edge / tRPC smokeを再実行し、#1566へevent・release・symbolication・PII不在の証跡を記録します。

Refs #1566
