### PR TITLE
fix(ops): 1Password checkerのoptional契約を修正する

### DIFF
--- a/docs/operations/secrets.md
+++ b/docs/operations/secrets.md
@@ -136,7 +136,7 @@ pnpm 1password:check
 
 - `env:check` — required env を `OK / EMPTY / MISSING` だけで確認する
 - `secrets:check` — tracked files と untracked `.env*` を scan し、literal secret は `value: [redacted]` で報告する
-- `1password:check` — 1Password の vault / item / field / empty 状態だけを確認する。schemaで`required: true`のentryまたはoperational itemが不足・空の場合だけ失敗し、optional entryは`(optional)`付きで状態を表示して成功する。item の作成・変更・削除はしない
+- `1password:check` — 1Password の vault / item / field / empty 状態だけを確認する。schemaで`required: true`のentryまたはoperational itemが不足・空の場合だけ失敗し、optional entryは不足・空の状態を表示しても成功する。item の作成・変更・削除はしない
 
 `.op-env.local.example` の `op://` 参照は正規の local injection schema なので leak として扱わない。
 

--- a/docs/operations/secrets.md
+++ b/docs/operations/secrets.md
@@ -136,7 +136,7 @@ pnpm 1password:check
 
 - `env:check` — required env を `OK / EMPTY / MISSING` だけで確認する
 - `secrets:check` — tracked files と untracked `.env*` を scan し、literal secret は `value: [redacted]` で報告する
-- `1password:check` — 1Password の vault / item / field / empty 状態だけを確認する。item の作成・変更・削除はしない
+- `1password:check` — 1Password の vault / item / field / empty 状態だけを確認する。schemaで`required: true`のentryまたはoperational itemが不足・空の場合だけ失敗し、optional entryは`(optional)`付きで状態を表示して成功する。item の作成・変更・削除はしない
 
 `.op-env.local.example` の `op://` 参照は正規の local injection schema なので leak として扱わない。
 

--- a/scripts/__tests__/check-1password.test.ts
+++ b/scripts/__tests__/check-1password.test.ts
@@ -23,6 +23,9 @@ case "$1" in
     exit 0
     ;;
   item)
+    if [ -n "$FAKE_OP_MISSING_ITEM" ] && [ "$3" = "$FAKE_OP_MISSING_ITEM" ]; then
+      exit 1
+    fi
     case "$FAKE_OP_MODE" in
       error)
         printf '%s\n' "$FAKE_OP_SENTINEL" >&2
@@ -46,12 +49,18 @@ function createFakeOpDirectory(): string {
   return directory;
 }
 
-function runCheck(mode?: 'error' | 'invalid-json') {
+interface CheckOptions {
+  emptyField?: string;
+  missingItem?: string;
+  mode?: 'error' | 'invalid-json';
+}
+
+function runCheck(options: CheckOptions = {}) {
   const fakeOpDirectory = createFakeOpDirectory();
   const fields = [...new Set(onePasswordEnvSchema.map((entry) => entry.field))].map((field) => ({
     id: field,
     label: field,
-    value: sentinelSecret,
+    value: field === options.emptyField ? '' : sentinelSecret,
   }));
 
   return spawnSync('pnpm', ['exec', 'tsx', 'scripts/env/check-1password.ts'], {
@@ -60,7 +69,8 @@ function runCheck(mode?: 'error' | 'invalid-json') {
     env: {
       ...process.env,
       FAKE_OP_ITEM_JSON: JSON.stringify({ fields }),
-      FAKE_OP_MODE: mode ?? '',
+      FAKE_OP_MISSING_ITEM: options.missingItem ?? '',
+      FAKE_OP_MODE: options.mode ?? '',
       FAKE_OP_SENTINEL: sentinelSecret,
       PATH: `${fakeOpDirectory}:${process.env.PATH ?? ''}`,
     },
@@ -84,7 +94,7 @@ describe('check-1password.ts', () => {
   });
 
   it('op の失敗出力を引き継がない', () => {
-    const result = runCheck('error');
+    const result = runCheck({ mode: 'error' });
 
     expect(result.status).toBe(1);
     expect(result.stdout).toContain('MISSING_ITEM');
@@ -93,11 +103,50 @@ describe('check-1password.ts', () => {
   });
 
   it('不正な JSON の raw stdout を引き継がない', () => {
-    const result = runCheck('invalid-json');
+    const result = runCheck({ mode: 'invalid-json' });
 
     expect(result.status).toBe(1);
     expect(result.stdout).toContain('MISSING_ITEM');
     expect(result.stdout).not.toContain(sentinelSecret);
     expect(result.stderr).not.toContain(sentinelSecret);
+  });
+
+  it('optional item が未作成でも状態を表示して成功する', () => {
+    const result = runCheck({ missingItem: 'google' });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain(
+      'Dayopt-Shared / google / GOOGLE_SITE_VERIFICATION: MISSING_ITEM (optional)',
+    );
+  });
+
+  it('optional field が空でも状態を表示して成功する', () => {
+    const result = runCheck({ emptyField: 'GOOGLE_SITE_VERIFICATION' });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain(
+      'Dayopt-Shared / google / GOOGLE_SITE_VERIFICATION: EMPTY (optional)',
+    );
+  });
+
+  it('required item が未作成なら失敗する', () => {
+    const result = runCheck({ missingItem: 'sentry-web' });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('Dayopt-Production / sentry-web / SENTRY_DSN: MISSING_ITEM');
+  });
+
+  it('required field が空なら失敗する', () => {
+    const result = runCheck({ emptyField: 'SENTRY_DSN' });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('Dayopt-Production / sentry / SENTRY_DSN: EMPTY');
+  });
+
+  it('required operational item が未作成なら失敗する', () => {
+    const result = runCheck({ missingItem: 'recovery-codes' });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('Dayopt-Shared / recovery-codes: MISSING_ITEM');
   });
 });

--- a/scripts/__tests__/check-1password.test.ts
+++ b/scripts/__tests__/check-1password.test.ts
@@ -116,7 +116,7 @@ describe('check-1password.ts', () => {
 
     expect(result.status, result.stderr).toBe(0);
     expect(result.stdout).toContain(
-      'Dayopt-Shared / google / GOOGLE_SITE_VERIFICATION: MISSING_ITEM (optional)',
+      'Dayopt-Shared / google / GOOGLE_SITE_VERIFICATION: MISSING_ITEM',
     );
   });
 
@@ -124,9 +124,7 @@ describe('check-1password.ts', () => {
     const result = runCheck({ emptyField: 'GOOGLE_SITE_VERIFICATION' });
 
     expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toContain(
-      'Dayopt-Shared / google / GOOGLE_SITE_VERIFICATION: EMPTY (optional)',
-    );
+    expect(result.stdout).toContain('Dayopt-Shared / google / GOOGLE_SITE_VERIFICATION: EMPTY');
   });
 
   it('required item が未作成なら失敗する', () => {

--- a/scripts/env/check-1password.ts
+++ b/scripts/env/check-1password.ts
@@ -25,10 +25,6 @@ const vaultCache = new Map<string, boolean>();
 const itemCache = new Map<string, ItemResult>();
 const opTimeoutMs = 20_000;
 
-function formatStatus(status: string, required: boolean): string {
-  return required || status === 'OK' ? status : `${status} (optional)`;
-}
-
 function runOp(args: string[]): CommandResult {
   const result = spawnSync('op', args, {
     encoding: 'utf8',
@@ -142,9 +138,7 @@ for (const entry of onePasswordEnvSchema) {
     status = checkField(entry.vault, entry.item, entry.field);
   }
 
-  console.log(
-    `${entry.vault} / ${entry.item} / ${entry.field}: ${formatStatus(status, entry.required)}`,
-  );
+  console.log(`${entry.vault} / ${entry.item} / ${entry.field}: ${status}`);
   if (entry.required && status !== 'OK') hasFailure = true;
 }
 
@@ -161,7 +155,7 @@ for (const item of operationalItems) {
     status = itemResult.status === 'OK' ? 'OK' : 'MISSING_ITEM';
   }
 
-  console.log(`${item.vault} / ${item.item}: ${formatStatus(status, item.required)}`);
+  console.log(`${item.vault} / ${item.item}: ${status}`);
   if (item.required && status !== 'OK') hasFailure = true;
 }
 

--- a/scripts/env/check-1password.ts
+++ b/scripts/env/check-1password.ts
@@ -19,13 +19,15 @@ type OnePasswordItem = {
 };
 
 type ItemResult =
-  | { status: 'OK'; item: OnePasswordItem }
-  | { status: 'MISSING_ITEM' }
-  | { status: 'OP_TIMEOUT' };
+  { status: 'OK'; item: OnePasswordItem } | { status: 'MISSING_ITEM' } | { status: 'OP_TIMEOUT' };
 
 const vaultCache = new Map<string, boolean>();
 const itemCache = new Map<string, ItemResult>();
 const opTimeoutMs = 20_000;
+
+function formatStatus(status: string, required: boolean): string {
+  return required || status === 'OK' ? status : `${status} (optional)`;
+}
 
 function runOp(args: string[]): CommandResult {
   const result = spawnSync('op', args, {
@@ -140,8 +142,10 @@ for (const entry of onePasswordEnvSchema) {
     status = checkField(entry.vault, entry.item, entry.field);
   }
 
-  console.log(`${entry.vault} / ${entry.item} / ${entry.field}: ${status}`);
-  if (status !== 'OK') hasFailure = true;
+  console.log(
+    `${entry.vault} / ${entry.item} / ${entry.field}: ${formatStatus(status, entry.required)}`,
+  );
+  if (entry.required && status !== 'OK') hasFailure = true;
 }
 
 for (const item of operationalItems) {
@@ -157,8 +161,8 @@ for (const item of operationalItems) {
     status = itemResult.status === 'OK' ? 'OK' : 'MISSING_ITEM';
   }
 
-  console.log(`${item.vault} / ${item.item}: ${status}`);
-  if (status !== 'OK') hasFailure = true;
+  console.log(`${item.vault} / ${item.item}: ${formatStatus(status, item.required)}`);
+  if (item.required && status !== 'OK') hasFailure = true;
 }
 
 if (hasFailure) {

--- a/scripts/env/schema.ts
+++ b/scripts/env/schema.ts
@@ -14,6 +14,7 @@ export type EnvSchemaEntry = {
 export type OperationalItem = {
   vault: string;
   item: string;
+  required: boolean;
 };
 
 const staging = 'Dayopt-Staging';
@@ -107,11 +108,11 @@ export const productionEnvSchema: EnvSchemaEntry[] = [
 ];
 
 export const operationalItems: OperationalItem[] = [
-  { vault: shared, item: 'github-login' },
-  { vault: shared, item: 'github-ssh' },
-  { vault: shared, item: 'domain' },
-  { vault: shared, item: 'resend-support-replies' },
-  { vault: shared, item: 'recovery-codes' },
+  { vault: shared, item: 'github-login', required: true },
+  { vault: shared, item: 'github-ssh', required: true },
+  { vault: shared, item: 'domain', required: true },
+  { vault: shared, item: 'resend-support-replies', required: true },
+  { vault: shared, item: 'recovery-codes', required: true },
 ];
 
 export const onePasswordEnvSchema = [...envSchema, ...productionEnvSchema];


### PR DESCRIPTION
## 変更内容

- `pnpm 1password:check`のfailure判定をschemaの`required`へ合わせる
- optional entryの不足・空は状態を表示したままexit 0にする
- operational itemにもrequired契約を追加し、github login/SSH、domain、Resend support、recovery codesを必須として明示する
- optional/requiredのmissing・emptyとsecret非出力を8件の回帰テストで固定する
- 運用docsへchecker契約を反映する

## 原因

checkerが`EnvSchemaEntry.required`を参照せず、全entryを一律requiredとして扱っていました。このため未使用のoptional fieldにもdummy secretが必要になっていました。

## 影響

実行時アプリや1Password itemは変更しません。optional secretを埋めずにmaster監査できるようになり、本当に必要なProduction Sentry項目やrecovery codesの不足は引き続きfailureになります。

CodeQLがschema由来の`required`を表示用formatterへ渡す処理をclear-text loggingとして検出したため、状態表示は従来の固定値`OK / MISSING_* / EMPTY`だけとし、`required`は終了コード判定にのみ使用します。

## 検証

- `pnpm exec vitest run scripts/__tests__/check-1password.test.ts` — 8 tests pass
- `pnpm test:run` — Product 2,151 / Web 249 / observability 46 / scripts 66ほか全件pass
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:boundaries`
- `pnpm docs:check`
- `pnpm check`

Closes #1674
