### PR TITLE
docs(ops): Vercel token出力事故を記録する

### DIFF
--- a/docs/operations/log/2026-07-22-incident-vercel-cli-token-output.md
+++ b/docs/operations/log/2026-07-22-incident-vercel-cli-token-output.md
@@ -1,0 +1,41 @@
+---
+status: frozen
+date: 2026-07-22
+last_verified: 2026-07-22
+issue: 1558
+code:
+  - .github/workflows/production-config-audit.yml
+  - scripts/production-config-audit.mjs
+---
+
+# Vercel CLI の一覧出力に認証 token が含まれた
+
+2026-07-22、Sentry 運用確認中に Vercel CLI の一覧 command を実行したところ、pagination の案内に command line 引数として渡した認証 token の全値が含まれた。値は repository、GitHub Issue、PR、公開ログへ転記していないが、露出したものとして扱い、利用を停止した。
+
+## 起きた事実
+
+- Vercel CLI の一覧結果に続く pagination の案内が、認証用の `--token` 引数を値ごと再構成した。
+- 出力先は private な Codex tool session だった。
+- token の値、断片、長さ、hash は repository、docs、GitHub Issue、PRへ記録していない。
+- 出力を確認した時点で、その token を使う Vercel CLI command を停止した。以後の確認は値を扱わない connector と GitHub の secret metadata に限定した。
+- GitHub repository には `VERCEL_TOKEN` secret が存在し、trusted branch の Production Config Audit が利用している。
+- 1Password CLI は未認証で、1Password master と GitHub replica が同じ値かどうかは比較していない。
+- 現時点で、この出力を起点とする不正利用の証拠は確認していない。
+
+## 影響範囲
+
+- token は露出したものとして扱う。実際の権限 scope は値を再利用せず確認できないため未確認で、付与権限の範囲では Vercel team / project metadata へのアクセスに使われる可能性がある。
+- 顧客向け deployment、domain、environment variable、Sentry event を変更した証拠はない。
+- token を先に revoke すると Production Config Audit を停止させるため、replacement を master と replica へ同期し、trusted branch で audit 成功を確認してから旧 token を revoke する必要がある。
+
+## 学び
+
+- Vercel CLI の `--token` に長寿命 token を渡すと、CLI が生成する再実行・pagination 案内に値が含まれる場合がある。
+- local の metadata 確認は connector、Dashboard、または対話 login 済み CLI を使い、長寿命 token を command line 引数へ渡さない。
+- automation は token を環境変数から process 内で読み、Authorization header にだけ設定する。値を command、例外、構造化ログへ含めない。
+- rotation は replacement 作成、1Password master 更新、GitHub replica 更新、trusted audit 成功確認、旧 token revoke の順で行う。
+
+## 関連
+
+- GitHub Issue #1558
+- GitHub Issue #1566

--- a/docs/operations/secrets.md
+++ b/docs/operations/secrets.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_verified: 2026-07-21
+last_verified: 2026-07-22
 code: scripts/env/schema.ts
 ---
 
@@ -98,10 +98,12 @@ field 名は可能な限り current code の env 名と一致させる。`.op-en
 | `sentry`                 | `SENTRY_AUTH_TOKEN`                                                                           | Product / Web の Production release upload          |
 | `github-login`           | password, TOTP, recovery codes                                                                | GitHub account login                                |
 | `github-ssh`             | SSH private key                                                                               | GitHub SSH Agent                                    |
-| `vercel`                 | `VERCEL_TOKEN`, `VERCEL_TEAM_ID`, `VERCEL_PROJECT_ID_STAGING`, `VERCEL_PROJECT_ID_PRODUCTION` | Vercel CLI / future automation                      |
+| `vercel`                 | `VERCEL_TOKEN`, `VERCEL_TEAM_ID`, `VERCEL_PROJECT_ID_STAGING`, `VERCEL_PROJECT_ID_PRODUCTION` | Production Config Audit / project metadata          |
 | `google`                 | `GOOGLE_SITE_VERIFICATION`, `YANDEX_VERIFICATION`, `YAHOO_VERIFICATION`                       | Webmaster verification                              |
 | `domain`                 | registrar login, TOTP, recovery codes                                                         | dayopt.app 管理                                     |
 | `recovery-codes`         | service-specific recovery code index                                                          | 横断確認用。正本は各 Login item 側                  |
+
+`VERCEL_TOKEN`はautomation専用とし、local CLIのloginや`--token`引数には使わない。Production Config Auditが環境変数からprocess内で読み、Authorization headerにだけ設定する。localの確認方法とrotation順序は[Environment Secrets](./security/environment-secrets.md)を正とする。
 
 ---
 

--- a/docs/operations/security/environment-secrets.md
+++ b/docs/operations/security/environment-secrets.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_verified: 2026-07-21
+last_verified: 2026-07-22
 ---
 
 # Environment Secrets
@@ -32,6 +32,10 @@ GitHub branch protection では、通常の CI check に加えて Supabase integ
 | `VERCEL_ORG_ID`         | Production Config Audit      | 1Password `VERCEL_TEAM_ID`のGitHub replica |
 
 GitHub Actions の通常 build は release / source map upload を行わないため、Sentry metadata と `SENTRY_AUTH_TOKEN` を渡さない。
+
+`VERCEL_TOKEN`をlocal CLIの`--token`引数へ渡さない。Vercel CLIはpaginationなどの再実行案内に引数値を含める場合がある。localのmetadata確認はconnector、Dashboard、または対話login済みCLIを使う。Production Config Auditは1Password masterから同期したGitHub replicaを環境変数で受け取り、process内でAuthorization headerにだけ設定する。
+
+露出が疑われる場合は値を表示・比較せず、replacement作成 → 1Password master更新 → GitHub replica更新 → trusted branchでProduction Config Audit成功確認 → 旧token revokeの順でrotateする。事故記録は[Vercel CLI token出力 incident](../log/2026-07-22-incident-vercel-cli-token-output.md)を参照する。
 
 ## Vercel
 


### PR DESCRIPTION
## 概要

Sentry運用確認中にVercel CLIのpagination案内へ認証tokenが含まれた事実を、値を一切含めずincident logへ記録します。あわせて、長寿命tokenをCLI引数へ渡さない恒久ルールと安全なrotation順序をEnvironment Secretsへ追加します。

## 影響

- tokenは露出したものとして扱う
- 顧客向けdeploymentやenv変更の証拠はない
- #1558 は1Password CLI未認証のためblockedを維持
- replacement同期とtrusted audit成功前に旧tokenをrevokeしない

## 検証

- pnpm docs:check
- commit hook / Prettier
- pnpm secrets:check は既存の scripts/__tests__/dev-with-op.test.ts:39 のfixture検出で失敗（本差分にsecret値なし）

Related to #1558
Related to #1566