### PR TITLE
packages/components への no-arbitrary-value 適用を判断（β+γ 併用）

### DIFF
--- a/docs/engineering/log/2026-07-23-packages-components-no-arbitrary-value.md
+++ b/docs/engineering/log/2026-07-23-packages-components-no-arbitrary-value.md
@@ -1,0 +1,37 @@
+---
+status: frozen
+date: 2026-07-23
+code: eslint.config.packages.mjs
+---
+
+# packages/components に tailwindcss/no-arbitrary-value を適用しない
+
+`packages/components` の Tailwind arbitrary value 32 マッチ（実クラス使用 30 箇所 / 16 ファイル、残り 2 はコメント内言及）を棚卸しした結果、`no-arbitrary-value` ルールは packages には適用せず、無傷で置換できる 3 箇所のみ Tailwind 数値スケールへ寄せる判断をした。
+
+## 背景・当時の前提
+
+R-05（#1520 / PR #1678）で `packages/*` を ESLint ゲートに載せた際、`packages/components` には `apps/product` が使っている `tailwindcss/no-arbitrary-value` を適用しなかった。同時に `badge.tsx` / `scroll-area.tsx` の `eslint-disable-next-line tailwindcss/no-arbitrary-value` 2 行を素のコメントへ置換した（plugin 未導入のため rule 未定義エラーになるため）。#1679 はこの残課題として、rule 適用可否の設計判断を求めていた。
+
+## 決定と理由
+
+- `min-w-[8rem]`（`select.tsx:100` / `dropdown-menu.tsx:188`）と `min-w-[12rem]`（`dropdown-menu.tsx:30`）の 3 箇所は Tailwind v4 デフォルト数値スケール（`--spacing: 0.25rem`）で `min-w-32` / `min-w-48` に置換した。描画値は完全一致（32 × 0.25rem = 8rem、48 × 0.25rem = 12rem）で UI 変更なし。`packages/foundations/src/tokens/spacing.css` のコメントが「component は数値スケールを使う」方針を明記しており、これが正規の書き方。
+- `tailwindcss/no-arbitrary-value` ルールは packages には適用しない。残り 27 箇所の arbitrary value は構造的に token 化不可:
+  - transition 対象プロパティの指定（`transition-[color,box-shadow]` 等、値ではなくプロパティ名の列挙）
+  - viewport / calc 単位（`max-h-[80vh]`, `max-w-[calc(100vw-2rem)]` — apps/product でも理由付き disable で運用中の同種パターン）
+  - pseudo-element content（`content-[""]`）
+  - grid template（`grid-rows-[0fr]`, `grid-cols-[1fr_auto]` — レイアウト構造の記述）
+  - radix CSS 変数（`min-w-[var(--radix-select-trigger-width)]` — radix が実行時に注入する値）
+- `rounded-[0.25rem]`（`logo.tsx:12`）と `translate-y-[-3px]`（`alert.tsx:7`）も対応 token が存在しないため置換しなかった。radius token 体系（`packages/foundations/src/tokens/radius.css`）は 0/8/16/full の 4 段階を意図的に採用しており 4px を含まない。`rounded-lg`（8px）へ寄せると `sm` サイズの見た目が変わるため不可。
+- `@dayopt/components` は shadcn/radix 由来の primitive 層であり、rule を有効化すると残り 27 箇所すべてに理由付き `eslint-disable-next-line` が必要になる。apps/product 側は既に同種パターンで 28 箇所の disable を運用しており、packages にも同程度の disable を積み増しても lint 上の signal が増えるわけではなく、primitive 層のコードを恒久的に汚すだけと判断した。
+
+## 却下した選択肢と、なぜ捨てたか
+
+- **rule を有効化し、token 化できる箇所を寄せ、残りへ disable を付ける**: apps/product と運用が揃う利点はあるが、disable が約 20〜22 行 primitive 層に恒久増加する。将来 upstream（shadcn）との同期時に diff ノイズが増えるだけで、arbitrary value を減らす効果は token 化 3 箇所以外に無い。
+- **無傷置換可能な min-w 3 箇所も含めて何もしない（適用外の追認のみ）**: `min-w-[8rem]` / `min-w-[12rem]` は Tailwind 標準スケールでそのまま書けるのに arbitrary 記法を残す理由がなく、コード品質として据え置く理由がない。
+
+## 影響・やること
+
+- `eslint.config.packages.mjs` に本判断をコメントとして明記済み（rule 追加は行わない）
+- `badge.tsx` / `scroll-area.tsx` の素コメントは現状維持（rule 未適用のため disable へ戻すと `reportUnusedDisableDirectives: 'error'` で fail する）
+- 将来 `packages/components` に新規 component を追加する際、arbitrary value の妥当性は lint ではなく code review で確認する
+- radius / spacing token 体系を拡張する（4px token の新設など）話が別途持ち上がった場合は、この判断を再評価する

--- a/eslint.config.packages.mjs
+++ b/eslint.config.packages.mjs
@@ -5,6 +5,15 @@
 // eslint.config.mjs から re-export して使う（base path を package 自身に置くため）。
 // @see apps/product/eslint.config.mjs — app 側の設定
 // @see docs/engineering/architecture.md#package-boundaries
+//
+// tailwindcss/no-arbitrary-value（apps/product のみ適用、eslint-plugin-tailwindcss 未導入）:
+// @dayopt/components は shadcn/radix 由来の primitive 層で、残存する arbitrary value
+// 30 箇所中 27 箇所が構造的に token 化不可（transition 対象プロパティ指定 / viewport・
+// calc 単位 / pseudo-element content / grid template / radix CSS 変数）。適用しても
+// 理由付き disable が primitive 層に恒久的に増えるだけで signal がないため、意図的に
+// packages には適用しない判断。
+// @see https://github.com/Dayopt/dayopt/issues/1679
+// @see docs/engineering/log/2026-07-23-packages-components-no-arbitrary-value.md
 
 import nextTs from 'eslint-config-next/typescript';
 import storybook from 'eslint-plugin-storybook';

--- a/packages/components/src/actions/dropdown-menu.tsx
+++ b/packages/components/src/actions/dropdown-menu.tsx
@@ -27,7 +27,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          'bg-card text-card-foreground border-border-subtle shadow-card data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-overlay-popover max-h-(--radix-dropdown-menu-content-available-height) min-w-[12rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto overscroll-contain rounded-lg border p-1 motion-reduce:animate-none',
+          'bg-card text-card-foreground border-border-subtle shadow-card data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-overlay-popover max-h-(--radix-dropdown-menu-content-available-height) min-w-48 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto overscroll-contain rounded-lg border p-1 motion-reduce:animate-none',
           className,
         )}
         {...props}
@@ -185,7 +185,7 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        'bg-card text-card-foreground border-border-subtle data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-overlay-popover shadow-card min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden overscroll-contain rounded-lg border p-1 motion-reduce:animate-none',
+        'bg-card text-card-foreground border-border-subtle data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-overlay-popover shadow-card min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden overscroll-contain rounded-lg border p-1 motion-reduce:animate-none',
         className,
       )}
       {...props}

--- a/packages/components/src/inputs/select.tsx
+++ b/packages/components/src/inputs/select.tsx
@@ -97,7 +97,7 @@ function SelectContent({
         data-slot="select-content"
         aria-label={ariaLabel}
         className={cn(
-          'bg-card text-card-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 border-border-subtle z-overlay-popover shadow-card relative max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto overscroll-contain rounded-lg border motion-reduce:animate-none',
+          'bg-card text-card-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 border-border-subtle z-overlay-popover shadow-card relative max-h-(--radix-select-content-available-height) min-w-32 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto overscroll-contain rounded-lg border motion-reduce:animate-none',
           position === 'popper' &&
             'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
           className,


### PR DESCRIPTION
## Summary
- `packages/components` の Tailwind arbitrary value 30箇所（16ファイル）を棚卸しし、`no-arbitrary-value` の扱いを判断した（issue #1679）
- 無傷で置換できる `min-w-[8rem]`（select.tsx / dropdown-menu.tsx 計2箇所）/ `min-w-[12rem]`（dropdown-menu.tsx）の3箇所を Tailwind 数値スケール（`min-w-32` / `min-w-48`）へ置換。描画値は完全一致（Storybook で computed `min-width: 128px` / `192px` を確認済み、UI変更なし）
- rule は packages には適用しない（Option β）。残り27箇所は shadcn/radix 由来 primitive として構造的に token 化不可（transition プロパティ指定・viewport/calc単位・pseudo-element content・grid template・radix CSS変数）と判明したため、有効化しても disable が恒久的に増えるだけと判断
- `rounded-[0.25rem]`（logo.tsx）/ `translate-y-[-3px]`（alert.tsx）は対応する design token が存在せず（radius体系は0/8/16/fullの4段階で4pxを意図的に除外）、置換すると見た目が変わるため据え置き
- 判断理由を `eslint.config.packages.mjs` のコメントと `docs/engineering/log/2026-07-23-packages-components-no-arbitrary-value.md` に明文化

## Test plan
- [x] `pnpm lint`（全workspace pass）
- [x] `pnpm check`（typecheck / lint / static / deadcode は pass。unit testの10ファイル失敗は本PRと無関係な既存環境問題であることを、変更前コミットで同一失敗を再現して確認済み）
- [x] `pnpm docs:check`（pass。既存のappend-onlyリンク切れ15件は無関係な既存warning）
- [x] Storybook で Select / DropdownMenu を開き、ドロップダウンの描画・computed min-width が置換前と同一であることを確認

Closes #1679

🤖 Generated with [Claude Code](https://claude.com/claude-code)