### PR TITLE
fix: 廃止済みsystem APIの404を固定する

### DIFF
--- a/apps/product/src/app/api/v1/system/[...retired]/__tests__/route.test.ts
+++ b/apps/product/src/app/api/v1/system/[...retired]/__tests__/route.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { GET, OPTIONS, POST } from '../route';
+
+describe('/api/v1/system retired endpoint fallback', () => {
+  it.each([
+    ['GET', GET],
+    ['POST', POST],
+    ['OPTIONS', OPTIONS],
+  ])('returns 404 for %s', (_method, handler) => {
+    expect(handler().status).toBe(404);
+  });
+});

--- a/apps/product/src/app/api/v1/system/[...retired]/route.ts
+++ b/apps/product/src/app/api/v1/system/[...retired]/route.ts
@@ -1,0 +1,7 @@
+function retiredSystemApiNotFound(): Response {
+  return new Response(null, { status: 404 });
+}
+
+export const GET = retiredSystemApiNotFound;
+export const POST = retiredSystemApiNotFound;
+export const OPTIONS = retiredSystemApiNotFound;

--- a/apps/web/src/app/api/v1/system/[...retired]/route.test.ts
+++ b/apps/web/src/app/api/v1/system/[...retired]/route.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { GET, OPTIONS, POST } from './route';
+
+describe('/api/v1/system retired endpoint fallback', () => {
+  it.each([
+    ['GET', GET],
+    ['POST', POST],
+    ['OPTIONS', OPTIONS],
+  ])('returns 404 for %s', (_method, handler) => {
+    expect(handler().status).toBe(404);
+  });
+});

--- a/apps/web/src/app/api/v1/system/[...retired]/route.ts
+++ b/apps/web/src/app/api/v1/system/[...retired]/route.ts
@@ -1,0 +1,7 @@
+function retiredSystemApiNotFound(): Response {
+  return new Response(null, { status: 404 });
+}
+
+export const GET = retiredSystemApiNotFound;
+export const POST = retiredSystemApiNotFound;
+export const OPTIONS = retiredSystemApiNotFound;


### PR DESCRIPTION
## 概要

Sentry smoke route削除後、Next.jsのsynthetic not-found fallbackにより、未定義pathのmethod別statusが次のように分かれていた。

- Product: GET 404 / POST・OPTIONS 200
- Web: GET・POST 404 / OPTIONS 204

両appの`/api/v1/system/*`へ汎用catch-all tombstoneを置き、GET/POST/OPTIONSを空bodyの404へ固定する。

## 安全性

- smoke固有route/auth/capture/browser global/sampling/env/rate limitは復元しない
- active sourceへsmoke識別子を追加しない
- 現在の顧客APIは別namespaceで、具体的な将来routeはcatch-allより優先される
- read-only explorerとbehavior-verifierでroute precedenceと既存API非干渉を確認済み

## 検証

- Product handler tests: 3 pass
- Web handler tests: 3 pass
- `pnpm check`（Product 2,133 / Web 254 / observability 47 / scripts 64 tests）
- `pnpm docs:check`
- merge前にProduct/Web Previewで全surfaceのGET/POST/OPTIONS 404を実測する

Refs #1566
