### PR TITLE
feat: mergeとProduction公開を分離するRelease Gateを追加する

### DIFF
--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -72,12 +72,12 @@ Phase 0: 準備（featureブランチにいる場合）
   └── 0.3 コード品質確認（lint, typecheck, test, build）
   → ユーザーにPRマージを促す
 
-Phase 1: タグ作成・リリース（mainブランチ）
+Phase 1: Production公開の確認とタグ作成（mainブランチ）
   ├── 1.1 mainブランチ最新取得
-  ├── 1.2 Gitタグ作成・プッシュ
-  └── 1.3 GitHub Actions 自動実行の確認
-       ├── 本番デプロイ
-       └── GitHub Release作成（auto-generated notes）
+  ├── 1.2 Production Release の promote 完了を待つ
+  ├── 1.3 Production を観察する（主要route / Sentry）
+  ├── 1.4 Gitタグ作成・プッシュ（promote成功の証跡）
+  └── 1.5 GitHub Release作成の確認（auto-generated notes）
 
 Phase 2: リリースノート反映
   ├── 2.1 前回リリース以降の全PRを取得

--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -37,7 +37,8 @@ Dayoptプロジェクトのリリース作業を安全かつ確実に実行す�
 │  └─ Phase 0 から: version bump → 品質チェック → PRマージを促す → タグ → リリースノート
 │
 ├─ mainにいてタグがまだ？
-│  └─ Phase 1 から: タグ作成・push → リリースノート
+│  └─ Phase 1 から: promote 完了確認 → 観察 → タグ作成・push → リリースノート
+│     （Production Release status が success になるまでタグを打たない）
 │
 ├─ タグはあるがReleaseがまだ？
 │  └─ Phase 2 から: GitHub Actions確認 → リリースノート
@@ -126,25 +127,48 @@ git checkout main
 git pull origin main
 ```
 
-### Phase 1.2: Gitタグ作成・プッシュ
+### Phase 1.2: Production promote の完了を待つ
+
+main への merge は Product / Web の Production build を作るだけで、Production domain は切り替わらない。`Production Release` workflow が同一 SHA の両 candidate を smoke・監査してから promote する。
+
+```bash
+# promote の実行状況を確認
+gh run list --workflow=release.yml --limit 1
+gh run watch --exit-status
+
+# 対象 SHA が Production に出たことを確認
+gh api "repos/Dayopt/dayopt/commits/$(git rev-parse HEAD)/status" \
+  --jq '.statuses[] | select(.context == "Production Release") | .state'
+```
+
+`success` にならないうちはタグを打たない。失敗時は `docs/operations/runbook.md` の Playbook 2 に従う。
+
+### Phase 1.3: Production を観察する
+
+promote 直後に主要 route と監視を確認する。異常があればタグを打たず、runbook の rollback 手順へ移る。
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" https://dayopt.app/
+curl -s -o /dev/null -w "%{http_code}\n" https://app.dayopt.app/api/health
+```
+
+Sentry の新規 issue と Vercel の runtime log も確認する。
+
+### Phase 1.4: Gitタグ作成・プッシュ
+
+観察まで終わってからタグを打つ。タグは deploy trigger ではなく、Production 公開が成功した証跡である。
 
 ```bash
 git tag v${VERSION}
 git push origin v${VERSION}
 ```
 
-タグpushにより GitHub Actions が自動で以下を実行：
+`create-release.yml` はタグ SHA の `Production Release` status が `success` であることを確認してから GitHub Release を作成する。未 promote の SHA にタグを打つと、この検証で止まる。
 
-- 本番デプロイ（Vercel）
-- GitHub Release作成（GitHub auto-generated notes）
-
-### Phase 1.3: 自動実行の確認
+### Phase 1.5: Release 作成の確認
 
 ```bash
-# ワークフローの実行状況を確認
 gh run list --workflow=create-release.yml --limit 1
-
-# リリースが作成されたことを確認
 gh release view v${VERSION}
 ```
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Verify Product and Web Production contracts with safe dummy values
         run: |
-          pnpm exec vitest run --config vitest.scripts.config.ts scripts/production-config-audit.test.ts scripts/production-release.test.ts
+          pnpm exec vitest run --config vitest.scripts.config.ts scripts/production-config-audit.test.ts scripts/production-release.test.ts scripts/__tests__/release-workflow-contract.test.ts
           pnpm --dir apps/product exec vitest --project unit run production-build-gate.test.mjs
           pnpm --dir apps/web exec vitest run production-build-gate.test.mjs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Verify Product and Web Production contracts with safe dummy values
         run: |
-          pnpm exec vitest run --config vitest.scripts.config.ts scripts/production-config-audit.test.ts
+          pnpm exec vitest run --config vitest.scripts.config.ts scripts/production-config-audit.test.ts scripts/production-release.test.ts
           pnpm --dir apps/product exec vitest --project unit run production-build-gate.test.mjs
           pnpm --dir apps/web exec vitest run production-build-gate.test.mjs
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -36,8 +36,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          state=$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/status" \
-            --jq '.statuses[] | select(.context == "Production Release") | .state' | head -n 1)
+          # 既定 shell は `bash -e` で pipefail が無い。gh が失敗しても head は 0 を
+          # 返すため、パイプをやめて 2 段に分ける。
+          set -o pipefail
+          statuses=$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/status" \
+            --jq '.statuses[] | select(.context == "Production Release") | .state')
+          state=$(printf '%s\n' "$statuses" | head -n 1)
           if [ "$state" != "success" ]; then
             echo "::error::Production Release has not succeeded for this commit (state: ${state:-missing})."
             echo "::error::Promote and observe Production first, then re-push the tag."

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -7,10 +7,11 @@ on:
 
 permissions:
   contents: write
+  statuses: read
 
-# デプロイはmainマージ時にVercelが自動実行するため、
+# Production公開はmainマージ後のProduction Release workflowがpromoteで行う。
 # このワークフローはGitHub Releaseの作成のみを担当する。
-# タグはバージョン記録用であり、デプロイトリガーではない。
+# タグはpromoteと観察が終わった後の証跡であり、デプロイトリガーではない。
 
 jobs:
   release:
@@ -29,6 +30,19 @@ jobs:
           VERSION=${GITHUB_REF#refs/tags/}
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "version_number=${VERSION#v}" >> $GITHUB_OUTPUT
+
+      # 未promoteのSHAへタグを打つと、Releaseだけが先行して証跡が実態とずれる。
+      - name: Verify the tagged commit is live in Production
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          state=$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/status" \
+            --jq '.statuses[] | select(.context == "Production Release") | .state' | head -n 1)
+          if [ "$state" != "success" ]; then
+            echo "::error::Production Release has not succeeded for this commit (state: ${state:-missing})."
+            echo "::error::Promote and observe Production first, then re-push the tag."
+            exit 1
+          fi
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,16 @@ jobs:
   release:
     name: Promote Production
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # この environment に deployment branch policy（main のみ）を設定すると、
+    # main 以外の ref からの dispatch は job 開始前に GitHub 側で拒否される。
+    # policy 未設定の間は素通りするため、設定するまで残存リスクは閉じない。
+    # 手順は docs/engineering/infra.md を参照。
+    environment: production-release
+    # scripts/production-release.mjs の WORST_CASE_RELEASE_MS を必ず上回ること。
+    # 下回ると rollback の途中で job が kill され、片方だけ promote された
+    # production が手動 rollback の手掛かりごと失われる。
+    # scripts/__tests__/release-workflow-contract.test.ts が不等式を守る。
+    timeout-minutes: 70
     steps:
       # 実行する workflow / script は常に dispatch した ref のものを使う。
       # inputs.sha は release 対象を指す data であって、実行するコードではない。

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,124 @@
+name: Production Release
+
+# main へ merge しても Production domain は自動で切り替わらない。
+# Auto-assign Custom Production Domains を無効化した Product / Web に対し、
+# このワークフローだけが「同一 SHA・両 project 成功」を確認して promote する。
+# タグと GitHub Release は promote と観察が終わった後の証跡であり、deploy trigger ではない。
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: 'Release target commit SHA (40 hex). Defaults to the current ref.'
+        required: false
+      force:
+        description: 'Break-glass Force Promote: skip smoke and Production Config Audit'
+        type: boolean
+        default: false
+      reason:
+        description: 'Required when force is enabled. Recorded in the commit status.'
+        required: false
+      simulate_failure:
+        description: 'Drill only: smoke:web | smoke:product | promote:web | promote:product'
+        required: false
+
+permissions:
+  contents: read
+  statuses: write
+
+concurrency:
+  # 実行中の release は中断しない。中断すると片方だけ promote された状態が残りうる。
+  group: production-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Promote Production
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      # push:main と workflow_dispatch はどちらも trusted ref。PR code は実行しない。
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.sha || github.sha }}
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
+      - name: Require a reason for Force Promote
+        if: inputs.force
+        env:
+          REASON: ${{ inputs.reason }}
+        run: |
+          if [ -z "$REASON" ]; then
+            echo "::error::Force Promote requires a reason. Record it here and in the ops log."
+            exit 1
+          fi
+
+      - name: Resolve release SHA
+        id: target
+        env:
+          INPUT_SHA: ${{ inputs.sha }}
+        run: |
+          sha="${INPUT_SHA:-$GITHUB_SHA}"
+          if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Release target must be a 40 character commit SHA"
+            exit 1
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Wait, smoke, and promote Production
+        id: release
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          # GitHub keeps the existing VERCEL_ORG_ID replica; the runtime contract
+          # uses the canonical 1Password/schema name VERCEL_TEAM_ID.
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_ORG_ID }}
+          # Deployment Protection guards candidate unique URLs, so smoke needs
+          # each project's Protection Bypass for Automation secret.
+          VERCEL_BYPASS_PRODUCT: ${{ secrets.VERCEL_AUTOMATION_BYPASS_PRODUCT }}
+          VERCEL_BYPASS_WEB: ${{ secrets.VERCEL_AUTOMATION_BYPASS_WEB }}
+          RELEASE_SHA: ${{ steps.target.outputs.sha }}
+          RELEASE_FORCE: ${{ inputs.force }}
+          RELEASE_SIMULATE_FAILURE: ${{ github.event_name == 'workflow_dispatch' && inputs.simulate_failure || '' }}
+        run: |
+          set +e
+          node scripts/production-release.mjs
+          release_exit=$?
+          set -e
+          echo "exit_code=$release_exit" >> "$GITHUB_OUTPUT"
+
+      - name: Publish Production Release status
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_EXIT: ${{ steps.release.outputs.exit_code || '1' }}
+          RELEASE_SHA: ${{ steps.target.outputs.sha }}
+          FORCED: ${{ inputs.force }}
+          REASON: ${{ inputs.reason }}
+        run: |
+          if [ "$RELEASE_EXIT" = "0" ]; then
+            state=success
+            description="Production serves this commit"
+          else
+            state=failure
+            description="Release gate stopped before or during promote; see the run summary"
+          fi
+          if [ "$FORCED" = "true" ]; then
+            description="Force Promote: $REASON"
+          fi
+
+          gh api --method POST "repos/$GITHUB_REPOSITORY/statuses/$RELEASE_SHA" \
+            -f state="$state" \
+            -f context="Production Release" \
+            -f description="${description:0:140}" \
+            -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            >/dev/null
+
+      - name: Enforce release result
+        if: always()
+        run: exit ${{ steps.release.outputs.exit_code || '1' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      # push:main と workflow_dispatch はどちらも trusted ref。PR code は実行しない。
+      # 実行する workflow / script は常に dispatch した ref のものを使う。
+      # inputs.sha は release 対象を指す data であって、実行するコードではない。
+      # ref に渡すと、未 merge の commit が持つ script を Production 権限で走らせられる。
+      #
+      # 残存リスク: main 以外の ref から dispatch すると、その ref の script が
+      # Production secret 付きで動く。これは YAML の if では塞げず、environment の
+      # deployment branch policy でしか閉じられない（infra.md に手順を記載）。
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ inputs.sha || github.sha }}
           persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -59,9 +64,10 @@ jobs:
             exit 1
           fi
 
-      - name: Resolve release SHA
+      - name: Resolve and validate release SHA
         id: target
         env:
+          GH_TOKEN: ${{ github.token }}
           INPUT_SHA: ${{ inputs.sha }}
         run: |
           sha="${INPUT_SHA:-$GITHUB_SHA}"
@@ -69,6 +75,21 @@ jobs:
             echo "::error::Release target must be a 40 character commit SHA"
             exit 1
           fi
+
+          # push:main の github.sha は GitHub 側が供給する main 上の commit なので
+          # 検証しない。人が渡した値のときだけ main 包含を確認し、GitHub API の
+          # 一時障害が通常の release を止めないようにする。
+          if [ -n "$INPUT_SHA" ]; then
+            # `main` という名の tag との曖昧さを避けるため heads/main で明示する。
+            # 404 なら gh が非 0 終了し、代入が set -e に拾われて fail closed になる
+            # （`export status=$(...)` にすると壊れるので前置しない）。
+            status=$(gh api "repos/$GITHUB_REPOSITORY/compare/heads/main...$sha" --jq '.status')
+            if [ "$status" != "identical" ] && [ "$status" != "behind" ]; then
+              echo "::error::Release target must already be merged into main (compare status: $status)"
+              exit 1
+            fi
+          fi
+
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
       - name: Wait, smoke, and promote Production
@@ -92,24 +113,40 @@ jobs:
           set -e
           echo "exit_code=$release_exit" >> "$GITHUB_OUTPUT"
 
+      # SHA が解決できていない場合は publish しない。空の SHA へ POST すると
+      # 404 で step が落ちるだけで、何の情報も残らない。
       - name: Publish Production Release status
-        if: always()
+        if: always() && steps.target.outputs.sha != ''
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_EXIT: ${{ steps.release.outputs.exit_code || '1' }}
+          RELEASE_STATUS: ${{ steps.release.outputs.release_status || 'failed' }}
           RELEASE_SHA: ${{ steps.target.outputs.sha }}
           FORCED: ${{ inputs.force }}
           REASON: ${{ inputs.reason }}
         run: |
-          if [ "$RELEASE_EXIT" = "0" ]; then
-            state=success
-            description="Production serves this commit"
-          else
+          if [[ ! "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Refusing to publish status for an invalid commit SHA"
+            exit 1
+          fi
+
+          if [ "$RELEASE_EXIT" != "0" ]; then
             state=failure
             description="Release gate stopped before or during promote; see the run summary"
-          fi
-          if [ "$FORCED" = "true" ]; then
-            description="Force Promote: $REASON"
+            if [ "$FORCED" = "true" ]; then
+              description="Force Promote failed: $REASON"
+            fi
+          elif [ "$RELEASE_STATUS" = "superseded" ]; then
+            # promote は 1 件も行われていない。この commit は live ではないので
+            # success を出すと create-release.yml の gate を素通りしてしまう。
+            state=failure
+            description="Superseded: a newer deployment already serves Production"
+          else
+            state=success
+            description="Production serves this commit"
+            if [ "$FORCED" = "true" ]; then
+              description="Force Promote: $REASON"
+            fi
           fi
 
           gh api --method POST "repos/$GITHUB_REPOSITORY/statuses/$RELEASE_SHA" \
@@ -121,4 +158,15 @@ jobs:
 
       - name: Enforce release result
         if: always()
-        run: exit ${{ steps.release.outputs.exit_code || '1' }}
+        env:
+          RELEASE_EXIT: ${{ steps.release.outputs.exit_code || '1' }}
+          RELEASE_STATUS: ${{ steps.release.outputs.release_status || 'failed' }}
+        run: |
+          if [ "$RELEASE_EXIT" != "0" ]; then
+            exit "$RELEASE_EXIT"
+          fi
+          if [ "$RELEASE_STATUS" = "superseded" ]; then
+            echo "::error::Target SHA is not live; a newer Production deployment already serves Production."
+            exit 1
+          fi
+          exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,10 @@ jobs:
           VERCEL_BYPASS_WEB: ${{ secrets.VERCEL_AUTOMATION_BYPASS_WEB }}
           RELEASE_SHA: ${{ steps.target.outputs.sha }}
           RELEASE_FORCE: ${{ inputs.force }}
+          # 段階適用が終わり Auto-assign Custom Production Domains を両 project で
+          # 無効化したら 'false' に変える。宣言するまでは「run 開始時点の値へ戻す」
+          # だけになり、前回 run から持ち越したドリフトを検出できない。
+          RELEASE_EXPECT_AUTO_ASSIGN: ''
           RELEASE_SIMULATE_FAILURE: ${{ github.event_name == 'workflow_dispatch' && inputs.simulate_failure || '' }}
         run: |
           set +e

--- a/docs/engineering/infra.md
+++ b/docs/engineering/infra.md
@@ -102,25 +102,45 @@ feature branch → PR
         ↓
 main merge
   ├── Supabase main deployment
-  └── Vercel Production
+  └── Vercel Production build（domain 未割当の candidate）
+        ↓
+      Production Release workflow（同一 SHA / smoke / audit）
+        ↓
+      promote → Production domain
 ```
 
 Vercel の正規 deployment source は `Dayopt/dayopt` の GitHub 連携だけとする。
-Preview は branch push / PR、Production は `main` merge から作成する。CLI、REST API、Deploy Hook、
-Marketplace integration、v0 から新規 Production deployment を作らない。緊急時は正常な既存 deployment の
-`Promote to Production` を rollback に使う。
+Preview は branch push / PR、Production build は `main` merge から作成する。CLI、REST API、Deploy Hook、
+Marketplace integration、v0 から新規 Production deployment を作らない。
 
-Deployment Policies による強制は [判断ログ](./log/2026-07-14-vercel-github-only-deployment-policy.md) のとおり、
-現在の Hobby plan では利用できない。Pro / Enterprise へ変更するまでは運用規約と既存の GitHub / Vercel 設定で統制する。
+### merge と Production 公開の分離
+
+Product / Web は Auto-assign Custom Production Domains を無効化してある。main への merge が作るのは
+domain 未割当の Production build だけで、Production domain の切り替えは `.github/workflows/release.yml`
+（`Production Release`）の promote だけが行う。workflow は次を満たした時だけ promote する。
+
+- Product / Web の Production build が **同一 merge SHA** で両方 `READY`
+- 各 candidate の unique URL への read-only smoke が成功（Deployment Protection があるため
+  Protection Bypass for Automation の secret が必須）
+- live な Vercel metadata に対する Production Config Audit が成功
+
+promote 順は web → product に固定し、2 つ目が失敗した場合は 1 つ目を直前 deployment へ自動 rollback する。
+片方だけ公開された状態は残さない。失敗時は Production domain が現行 SHA のまま維持される（fail-safe）。
+
+緊急時は正常な既存 deployment の `Instant Rollback` / `Promote to Production` を使う。手順は
+[runbook](../operations/runbook.md) の Playbook 2 を正とする。
+
+Deployment Policies による強制は [判断ログ](./log/2026-07-14-vercel-github-only-deployment-policy.md) を参照する。
 
 ### トラブルシューティング
 
-| 症状                                   | 対処                                                                           |
-| -------------------------------------- | ------------------------------------------------------------------------------ |
-| Supabase PR check が出ない             | Supabase GitHub integration / required check 設定を確認                        |
-| Vercel Preview が production DB を見る | Vercel Preview env から production Supabase vars を削除し integration を再同期 |
-| migration が Preview Branch で失敗     | Supabase deployment log を確認し、migration を修正して PR branch に push       |
-| Production に反映されない              | Supabase GitHub integration の production deployment log を確認                |
+| 症状                                    | 対処                                                                           |
+| --------------------------------------- | ------------------------------------------------------------------------------ |
+| Supabase PR check が出ない              | Supabase GitHub integration / required check 設定を確認                        |
+| Vercel Preview が production DB を見る  | Vercel Preview env から production Supabase vars を削除し integration を再同期 |
+| migration が Preview Branch で失敗      | Supabase deployment log を確認し、migration を修正して PR branch に push       |
+| Production に反映されない               | `gh run list --workflow=release.yml` で promote が成功しているか確認           |
+| Supabase 側が Production に反映されない | Supabase GitHub integration の production deployment log を確認                |
 
 ---
 
@@ -144,6 +164,22 @@ GitHub Code QualityはOrganization / Repositoryの両方で無効にし、PR品�
 - `Production Config Audit`はtrusted base revisionのscriptだけを実行し、Vercel APIからenvのkey / target / typeだけを検査する。secret値は取得・出力せず、PR codeへVercel tokenを渡さない
 - `RESEND_API_KEY`と`RESEND_WEBHOOK_SECRET`はProductionだけをtargetにし、Preview / Developmentへの設定をaudit failureにする
 - workflow導入PRでは`pull_request_target`がまだbaseにないため、同じscriptをmetadata-onlyで手動実行し、merge後の初回trusted run成功後にrequired statusへ昇格する
+
+### merge gate の required checks
+
+main ruleset の required status checks は `ci.yml` の 7 job に加えて次を含める。
+
+| context                   | 発行元            | 目的                                                       |
+| ------------------------- | ----------------- | ---------------------------------------------------------- |
+| `Production Config Audit` | GitHub Actions    | live な Vercel env metadata が Production 契約を満たすこと |
+| `Vercel – product`        | Vercel GitHub App | Product の Preview build が成功すること                    |
+| `Vercel – web`            | Vercel GitHub App | Web の Preview build が成功すること                        |
+
+- `Vercel – product` / `Vercel – web` の区切り文字は en dash（U+2013）で、hyphen ではない
+- Vercel の check context は **project 名に由来する**。project を rename すると required check が一致しなくなり、
+  全 PR が merge 不能になる。rename する場合は ruleset を先に更新する
+- 同じ理由で、Ignored Build Step を設定すると status 自体が付かなくなる。設定しない
+- `Production Release` は merge 後の証跡であり、required check にはしない
 
 段階的導入案と当時の計測値は履歴であり、現行構成として複製しない。経緯は [ADR-016](./log/2026-03-19-ci-quality-gates-roadmap.md) に残す。
 

--- a/docs/engineering/infra.md
+++ b/docs/engineering/infra.md
@@ -115,9 +115,18 @@ Marketplace integration、v0 から新規 Production deployment を作らない�
 
 ### merge と Production 公開の分離
 
-Product / Web は Auto-assign Custom Production Domains を無効化してある。main への merge が作るのは
-domain 未割当の Production build だけで、Production domain の切り替えは `.github/workflows/release.yml`
-（`Production Release`）の promote だけが行う。workflow は次を満たした時だけ promote する。
+gate が機能する前提は **Product / Web の Auto-assign Custom Production Domains が無効**であること。
+これを無効化するまで main merge は従来どおり直接公開され、release workflow は素通りする。
+
+1. Vercel Dashboard → product / web → Settings → Git
+2. Auto-assign Custom Production Domains を OFF にする（web を先に、動作確認後 product）
+3. 両方 OFF にしたら `.github/workflows/release.yml` の `RELEASE_EXPECT_AUTO_ASSIGN` を `'false'` にする
+
+Production 設定の変更なので、実施はユーザーの明示承認下で行う。
+
+無効化後は、main への merge が作るのは domain 未割当の Production build だけになり、Production domain の
+切り替えは `.github/workflows/release.yml`（`Production Release`）の promote だけが行う。
+workflow は次を満たした時だけ promote する。
 
 - Product / Web の Production build が **同一 merge SHA** で両方 `READY`
 - 各 candidate の unique URL への read-only smoke が成功（Deployment Protection があるため
@@ -153,12 +162,18 @@ release job は `environment: production-release` を宣言済みなので、閉
 
 1. Settings → Environments → `production-release` を開く（初回 run で自動作成される）
 2. Deployment branch policy を Selected branches にし、`main` だけを許可する
-3. `VERCEL_TOKEN` / `VERCEL_ORG_ID` / `VERCEL_AUTOMATION_BYPASS_PRODUCT` /
-   `VERCEL_AUTOMATION_BYPASS_WEB` を repository secret から environment secret へ移す
+3. `VERCEL_AUTOMATION_BYPASS_PRODUCT` / `VERCEL_AUTOMATION_BYPASS_WEB` だけを repository secret から
+   environment secret へ移す
 
-2 だけでも main 以外からの dispatch は job 開始前に拒否される。3 は secret の露出範囲を
-この job に限定するための追加措置。いずれも Production 経路に触る設定変更なので、
-実施はユーザーの明示承認下で行う。
+2 だけでも main 以外からの dispatch は job 開始前に拒否される。3 は secret の露出範囲をこの job に
+限定するための追加措置で、対象は release.yml しか読まない bypass secret 2 つに限る。
+
+**`VERCEL_TOKEN` と `VERCEL_ORG_ID` は repository secret のまま残す。** `production-config-audit.yml` の
+audit job は `pull_request_target` と `push: main` で走るため `environment:` を宣言できず、repository
+scope でこの 2 つを読む。environment secret へ移すと Production Config Audit が起動直後に落ちる。
+このため手順 3 の目的（露出範囲の限定）は bypass secret のみの部分達成になる。
+
+いずれも Production 経路に触る設定変更なので、実施はユーザーの明示承認下で行う。
 
 緊急時は正常な既存 deployment の `Instant Rollback` / `Promote to Production` を使う。手順は
 [runbook](../operations/runbook.md) の Playbook 2 を正とする。

--- a/docs/engineering/infra.md
+++ b/docs/engineering/infra.md
@@ -127,6 +127,24 @@ domain 未割当の Production build だけで、Production domain の切り替�
 promote 順は web → product に固定し、2 つ目が失敗した場合は 1 つ目を直前 deployment へ自動 rollback する。
 片方だけ公開された状態は残さない。失敗時は Production domain が現行 SHA のまま維持される（fail-safe）。
 
+対象 SHA より新しい Production deployment が既に live の場合は promote せず、`Production Release` status
+を failure にする。live でない commit に tag を打てないようにするためで、run 自体も失敗として扱う。
+
+### release workflow の信頼境界
+
+`release.yml` は Vercel の promote / rollback 権限を持つ token を扱う。実行する script は常に
+**workflow を dispatch した ref のもの**を使い、`sha` 入力は release 対象を指す data としてだけ扱う。
+`actions/checkout` の `ref` に入力 SHA を渡すと、未 merge の commit が持つ script が Production 権限で
+動く。この制約は `scripts/__tests__/release-workflow-contract.test.ts` が回帰から守る。
+
+手動 dispatch の `sha` は main に merge 済みであることを compare API で確認する。ただしこれは
+「merge 済みか」の確認であって、コード実行の防御ではない。
+
+**未解決の残存リスク**: `actions: write` を持つ主体が main 以外の ref から dispatch すると、その ref の
+script が Production secret 付きで動く。YAML の条件では塞げない。閉じるには release job へ専用の
+environment（deployment branch policy を `main` に限定）を作り、Vercel 系 secret を repository secret から
+environment secret へ移す必要がある。GitHub 設定の変更なので、実施はユーザーの明示承認下で行う。
+
 緊急時は正常な既存 deployment の `Instant Rollback` / `Promote to Production` を使う。手順は
 [runbook](../operations/runbook.md) の Playbook 2 を正とする。
 

--- a/docs/engineering/infra.md
+++ b/docs/engineering/infra.md
@@ -146,9 +146,19 @@ promote 順は web → product に固定し、2 つ目が失敗した場合は 1
 「merge 済みか」の確認であって、コード実行の防御ではない。
 
 **未解決の残存リスク**: `actions: write` を持つ主体が main 以外の ref から dispatch すると、その ref の
-script が Production secret 付きで動く。YAML の条件では塞げない。閉じるには release job へ専用の
-environment（deployment branch policy を `main` に限定）を作り、Vercel 系 secret を repository secret から
-environment secret へ移す必要がある。GitHub 設定の変更なので、実施はユーザーの明示承認下で行う。
+script が Production secret 付きで動く。YAML の条件では塞げない（攻撃者の branch では条件ごと消せる）。
+
+release job は `environment: production-release` を宣言済みなので、閉じるのに必要なのは GitHub 設定だけ。
+**設定するまでこのリスクは開いたまま**である点に注意する。
+
+1. Settings → Environments → `production-release` を開く（初回 run で自動作成される）
+2. Deployment branch policy を Selected branches にし、`main` だけを許可する
+3. `VERCEL_TOKEN` / `VERCEL_ORG_ID` / `VERCEL_AUTOMATION_BYPASS_PRODUCT` /
+   `VERCEL_AUTOMATION_BYPASS_WEB` を repository secret から environment secret へ移す
+
+2 だけでも main 以外からの dispatch は job 開始前に拒否される。3 は secret の露出範囲を
+この job に限定するための追加措置。いずれも Production 経路に触る設定変更なので、
+実施はユーザーの明示承認下で行う。
 
 緊急時は正常な既存 deployment の `Instant Rollback` / `Promote to Production` を使う。手順は
 [runbook](../operations/runbook.md) の Playbook 2 を正とする。

--- a/docs/engineering/infra.md
+++ b/docs/engineering/infra.md
@@ -130,6 +130,11 @@ promote 順は web → product に固定し、2 つ目が失敗した場合は 1
 対象 SHA より新しい Production deployment が既に live の場合は promote せず、`Production Release` status
 を failure にする。live でない commit に tag を打てないようにするためで、run 自体も失敗として扱う。
 
+**Vercel 側の既知バグへの対処**: promote endpoint は project 設定の `autoAssignCustomDomains` を
+`true` へ戻す（[vercel/vercel#15095](https://github.com/vercel/vercel/issues/15095)、未修正）。放置すると
+次の main merge が gate を通らず直接公開される。release script は promote / rollback の直前に観測した値を
+そのまま復元する。無効化していれば無効のまま、段階適用中で有効なら有効のままになる。
+
 ### release workflow の信頼境界
 
 `release.yml` は Vercel の promote / rollback 権限を持つ token を扱う。実行する script は常に

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -111,17 +111,47 @@ supabase functions deploy --use-api
 
 ## Playbook 2: Vercelデプロイ失敗（P1）
 
+### 前提: mergeとProduction公開は分離されている
+
+main へ merge しても Production domain は切り替わらない。Product / Web は Auto-assign Custom Production Domains を無効化してあり、merge が作るのは **domain 未割当の Production build（candidate）** だけである。`Production Release` workflow が同一 merge SHA の両 candidate を READY まで待ち、smoke と Production Config Audit を通してから promote する。
+
+このため「本番が新しくならない」ことは、それ自体では障害ではない。**現行 Production は既知の正常 deployment のまま応答し続けている**。復旧の緊急度は「本番が壊れたか」ではなく「本番が古いままか」で判断する。
+
 ### 検知
 
-- [ ] GitHub Actions / Vercel Dashboardでデプロイ失敗通知
+- [ ] GitHub Actions で `Production Release` が failure
+- [ ] Vercel Dashboardでビルド失敗通知
 - [ ] 本番サイトが古いバージョンのまま（新機能が反映されない）
 
 ### 初動
 
-- [ ] Vercel Dashboard → Deployments → 失敗デプロイのログを開く
-- [ ] 失敗フェーズを特定: lint / typecheck / build のどれか
+- [ ] `gh run list --workflow=release.yml --limit 3` で直近の release run を確認
+- [ ] run summary で「どこで止まったか」を特定: candidate build / smoke / audit / promote
+- [ ] 本番 domain が正常応答しているか確認
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" https://dayopt.app/
+curl -s -o /dev/null -w "%{http_code}\n" https://app.dayopt.app/api/health
+```
 
 ### 復旧
+
+#### ケース0: candidate build / smoke / audit の失敗（promote 前）
+
+promote は行われていないので、**Production domain は現行 SHA のまま無傷**。緊急操作は不要。
+
+- [ ] run summary のエラーを確認し、原因に応じてケースA / B を実施
+- [ ] 修正を main へ merge すると、新しい SHA で release gate が再実行される
+- [ ] 同じ SHA を再試行するだけなら `gh workflow run release.yml -f sha=<SHA>`
+- [ ] smoke が Deployment Protection で止まった場合は、対象 project の Protection Bypass for Automation と repository secret（`VERCEL_AUTOMATION_BYPASS_PRODUCT` / `VERCEL_AUTOMATION_BYPASS_WEB`）を確認する
+
+#### ケース0-B: 片方だけ promote された（部分リリース）
+
+release workflow は promote 順を web → product に固定し、2 つ目が失敗した場合は 1 つ目を直前 deployment へ自動 rollback する。
+
+- [ ] run log で `rolled back to <deployment id>` を確認する
+- [ ] `MANUAL ROLLBACK REQUIRED` が出ている場合は自動 rollback も失敗している。メッセージ中の deployment id へ手動で戻す（ケースC の手順）
+- [ ] run summary の `previous` deployment id が手動 rollback の戻し先になる
 
 #### ケースA: CI失敗（lint / typecheck）
 
@@ -148,21 +178,39 @@ npm run lint:boundaries  # feature境界違反
 
 #### ケースC: 緊急ロールバック（本番が壊れている場合）
 
+promote 済みの deployment に問題があった場合だけ使う。
+
 - [ ] Vercel Dashboard → Deployments
-- [ ] 正常に動作していた直前のデプロイを見つける
-- [ ] **"..." → "Promote to Production"** で2クリックロールバック
+- [ ] 正常に動作していた直前のデプロイを見つける（release run summary の `previous` deployment id が最も確実）
+- [ ] **"..." → "Instant Rollback"（または "Promote to Production"）** で2クリックロールバック
 - [ ] CLI / REST API / Redeploy で新しいProduction buildを作らない
+- [ ] Product / Web の片方だけ戻すと SHA が食い違う。**両方を同じ SHA へ揃える**
 - [ ] ロールバック後: 本番サイトで動作確認
 - [ ] 落ち着いて原因調査 → 修正 → 再デプロイ
 
-通常のProduction deployは `Dayopt/dayopt` の `main` mergeだけを使う。
-`Promote to Production` は正常な既存deploymentへ戻す緊急操作で、新規buildの作成経路ではない。
+Vercel の rollback はビルド成果物だけを戻す。**DB migration と変更済み環境変数は戻らない**。migration を含むリリースでは、直前 deployment がそのまま動く後方互換期間（expand/contract）を事前に確保しておく。
+
+通常のProduction公開は `main` merge → `Production Release` workflow の promote だけを使う。
+`Instant Rollback` / `Promote to Production` は正常な既存deploymentへ戻す緊急操作で、新規buildの作成経路ではない。
+
+#### ケースD: Force Promote（break-glass）
+
+release gate 自体が壊れていて、かつ Production を今すぐ前進させる必要がある時だけ使う。smoke と Production Config Audit をスキップするため、通常運用では使わない。
+
+```bash
+gh workflow run release.yml -f sha=<SHA> -f force=true -f reason="<なぜ gate を飛ばすか>"
+```
+
+- [ ] reason は必須。空だと workflow が停止する
+- [ ] 実行後、`docs/operations/log/YYYY-MM-DD-incident-*.md` に使用理由と結果を記録する
+- [ ] gate の障害そのものを issue 化して、break-glass を常用しない
 
 ### 振り返り
 
 - [ ] pre-commitフック（typecheck/lint）がスキップされていなかったか
 - [ ] `.env.example` に新しい環境変数が追加されているか
 - [ ] ビルドエラーの場合: ローカルで `npm run build` を実行してから push するフローに
+- [ ] Force Promote を使った場合: gate 側の欠陥が issue 化されているか
 
 ## Playbook 3: Stripe Webhook停止（P1）
 
@@ -1070,13 +1118,14 @@ npm run analytics:stats
 
 #### 2. ロールバック実行
 
-```bash
-# Vercelで前のデプロイに戻す
-npm run deploy:rollback
+Vercel Dashboard から Product / Web **両方**を同じ SHA の deployment へ戻す。戻し先は `Production Release` run summary の `previous` deployment id が最も確実。
 
-# または Vercel UI から前のデプロイをPromote
-# https://vercel.com/Dayopt/dayopt/deployments
-```
+- https://vercel.com/dayopt/product/deployments
+- https://vercel.com/dayopt/web/deployments
+
+対象 deployment の "..." → **Instant Rollback**（または Promote to Production）。新しい Production build は作らない。
+
+戻るのはビルド成果物だけで、**DB migration と変更済み環境変数は戻らない**。migration を含むリリースでは、戻し先の deployment が現在のスキーマで動くことを先に確認する。
 
 #### 3. GitHub Releaseの対応
 
@@ -1097,7 +1146,10 @@ gh issue create \
 # （通常のリリースフローと同じ: Phase 0 → 4）
 #   npm version patch --no-git-tag-version → commit → PR → merge（merge commit, ブランチ削除）
 
-# main 取り込み後、main 上でタグを打って push（Release は自動作成される）
+# main 取り込み後、Production Release の promote 完了を待つ
+gh run watch --exit-status
+
+# promote と観察が終わってからタグを打つ（Release は自動作成される）
 git checkout main && git pull origin main
 git tag v${VERSION_PATCH}
 git push origin v${VERSION_PATCH}

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -117,6 +117,10 @@ main へ merge しても Production domain は切り替わらない。Product / 
 
 このため「本番が新しくならない」ことは、それ自体では障害ではない。**現行 Production は既知の正常 deployment のまま応答し続けている**。復旧の緊急度は「本番が壊れたか」ではなく「本番が古いままか」で判断する。
 
+ただしこれは **Auto-assign Custom Production Domains を無効化した後**の話。無効化前は main merge が
+そのまま公開されるため、release run が赤くても本番が無傷とは限らない。ケース0 へ進む前に、現在の
+production deployment がどの SHA かを Vercel Dashboard で確認する（HTTP status だけでは判別できない）。
+
 ### 検知
 
 - [ ] GitHub Actions で `Production Release` が failure
@@ -537,7 +541,7 @@ ORDER BY created_at DESC;
 
 タグpushにより以下が自動実行される：
 
-- [ ] **本番デプロイ（Vercel）が成功**
+- [ ] **`Production Release` の promote が成功**（`gh run list --workflow=release.yml --limit 1`）
 
   ```bash
   gh run list --workflow=create-release.yml --limit 1
@@ -934,7 +938,7 @@ git log -5 --oneline
 node -p "require('./package.json').version"  # → ${VERSION} になっているはず
 ```
 
-> main マージ時点で Vercel が本番へ自動デプロイする（タグはデプロイトリガーではなくバージョン記録用）。
+> main マージは domain 未割当の Production build を作るだけで、公開は `Production Release` workflow の promote が行う。タグはデプロイトリガーではなく、promote と観察が終わった後の証跡。
 
 ### Phase 2: リリースノート作成
 
@@ -1010,7 +1014,7 @@ git tag --list | tail -5
 git push origin v${VERSION}
 ```
 
-タグ push により GitHub Actions（`.github/workflows/create-release.yml`）が **GitHub Release を自動作成**する（auto-generated notes 付き）。本番デプロイは main マージ時点で Vercel が既に実行済み。
+タグ push により GitHub Actions（`.github/workflows/create-release.yml`）が **GitHub Release を自動作成**する（auto-generated notes 付き）。この workflow はデプロイしない。公開は main マージ後の `Production Release` workflow が promote 済みで、create-release はタグ SHA の `Production Release` status が success であることを確認してから Release を作る。
 
 #### 4.2 プッシュ確認
 
@@ -1377,7 +1381,7 @@ git commit -am "chore(release): v${VERSION} へ version bump"
    ↓
 3. CI・品質チェック (Quality Gate)
    ↓
-4. PR マージ (merge commit / ブランチ削除) → Vercel 自動デプロイ
+4. PR マージ (merge commit / ブランチ削除) → Vercel が Production build → `Production Release` が promote
    ↓
 5. main でタグ作成 & push
    ↓

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -142,7 +142,7 @@ promote は行われていないので、**Production domain は現行 SHA の�
 
 - [ ] run summary のエラーを確認し、原因に応じてケースA / B を実施
 - [ ] 修正を main へ merge すると、新しい SHA で release gate が再実行される
-- [ ] 同じ SHA を再試行するだけなら `gh workflow run release.yml -f sha=<SHA>`
+- [ ] 同じ SHA を再試行するだけなら `gh workflow run release.yml -f sha=<SHA>` - `sha` は main に merge 済みの commit だけを受け付ける - `--ref` は付けない。付けるとその ref の script が Production 権限で動く
 - [ ] smoke が Deployment Protection で止まった場合は、対象 project の Protection Bypass for Automation と repository secret（`VERCEL_AUTOMATION_BYPASS_PRODUCT` / `VERCEL_AUTOMATION_BYPASS_WEB`）を確認する
 
 #### ケース0-B: 片方だけ promote された（部分リリース）
@@ -200,6 +200,8 @@ release gate 自体が壊れていて、かつ Production を今すぐ前進さ�
 ```bash
 gh workflow run release.yml -f sha=<SHA> -f force=true -f reason="<なぜ gate を飛ばすか>"
 ```
+
+`--ref` は付けない。release script は常に main のものを使う。
 
 - [ ] reason は必須。空だと workflow が停止する
 - [ ] 実行後、`docs/operations/log/YYYY-MM-DD-incident-*.md` に使用理由と結果を記録する

--- a/docs/operations/secrets.md
+++ b/docs/operations/secrets.md
@@ -89,21 +89,21 @@ field 名は可能な限り current code の env 名と一致させる。`.op-en
 
 ### `Dayopt-Shared`
 
-| Item                     | Fields                                                                                        | 用途                                                |
-| ------------------------ | --------------------------------------------------------------------------------------------- | --------------------------------------------------- |
-| `turnstile`              | `NEXT_PUBLIC_TURNSTILE_SITE_KEY`, `TURNSTILE_SECRET_KEY`                                      | Cloudflare Turnstile                                |
-| `anthropic`              | `ANTHROPIC_API_KEY`                                                                           | optional / legacy key。現行runtime consumerなし     |
-| `resend`                 | `RESEND_API_KEY`, `RESEND_FROM_EMAIL`                                                         | Product / WebのProduction email sending master      |
-| `resend-support-replies` | `RESEND_SMTP_API_KEY`                                                                         | Gmail Send mail as専用。Sending access / domain限定 |
-| `sentry`                 | `SENTRY_AUTH_TOKEN`                                                                           | Product / Web の Production release upload          |
-| `github-login`           | password, TOTP, recovery codes                                                                | GitHub account login                                |
-| `github-ssh`             | SSH private key                                                                               | GitHub SSH Agent                                    |
-| `vercel`                 | `VERCEL_TOKEN`, `VERCEL_TEAM_ID`, `VERCEL_PROJECT_ID_STAGING`, `VERCEL_PROJECT_ID_PRODUCTION` | Production Config Audit / project metadata          |
-| `google`                 | `GOOGLE_SITE_VERIFICATION`, `YANDEX_VERIFICATION`, `YAHOO_VERIFICATION`                       | Webmaster verification                              |
-| `domain`                 | registrar login, TOTP, recovery codes                                                         | dayopt.app 管理                                     |
-| `recovery-codes`         | service-specific recovery code index                                                          | 横断確認用。正本は各 Login item 側                  |
+| Item                     | Fields                                                                                        | 用途                                                            |
+| ------------------------ | --------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `turnstile`              | `NEXT_PUBLIC_TURNSTILE_SITE_KEY`, `TURNSTILE_SECRET_KEY`                                      | Cloudflare Turnstile                                            |
+| `anthropic`              | `ANTHROPIC_API_KEY`                                                                           | optional / legacy key。現行runtime consumerなし                 |
+| `resend`                 | `RESEND_API_KEY`, `RESEND_FROM_EMAIL`                                                         | Product / WebのProduction email sending master                  |
+| `resend-support-replies` | `RESEND_SMTP_API_KEY`                                                                         | Gmail Send mail as専用。Sending access / domain限定             |
+| `sentry`                 | `SENTRY_AUTH_TOKEN`                                                                           | Product / Web の Production release upload                      |
+| `github-login`           | password, TOTP, recovery codes                                                                | GitHub account login                                            |
+| `github-ssh`             | SSH private key                                                                               | GitHub SSH Agent                                                |
+| `vercel`                 | `VERCEL_TOKEN`, `VERCEL_TEAM_ID`, `VERCEL_PROJECT_ID_STAGING`, `VERCEL_PROJECT_ID_PRODUCTION` | Production Config Audit / Production Release / project metadata |
+| `google`                 | `GOOGLE_SITE_VERIFICATION`, `YANDEX_VERIFICATION`, `YAHOO_VERIFICATION`                       | Webmaster verification                                          |
+| `domain`                 | registrar login, TOTP, recovery codes                                                         | dayopt.app 管理                                                 |
+| `recovery-codes`         | service-specific recovery code index                                                          | 横断確認用。正本は各 Login item 側                              |
 
-`VERCEL_TOKEN`はautomation専用とし、local CLIのloginや`--token`引数には使わない。Production Config Auditが環境変数からprocess内で読み、Authorization headerにだけ設定する。localの確認方法とrotation順序は[Environment Secrets](./security/environment-secrets.md)を正とする。
+`VERCEL_TOKEN`はautomation専用とし、local CLIのloginや`--token`引数には使わない。Production Config AuditとProduction Releaseが環境変数からprocess内で読み、Authorization headerにだけ設定する。Production Releaseはenv metadataの読取に加えて、Production deploymentのpromoteとrollbackを行う。localの確認方法とrotation順序は[Environment Secrets](./security/environment-secrets.md)を正とする。
 
 ---
 

--- a/docs/operations/security/environment-secrets.md
+++ b/docs/operations/security/environment-secrets.md
@@ -23,19 +23,21 @@ Supabase migration の production 適用は GitHub Actions ではなく Supabase
 
 GitHub branch protection では、通常の CI check に加えて Supabase integration の Preview Branch check を required にする。
 
-| Secret                  | 用途                         | 方針                                       |
-| ----------------------- | ---------------------------- | ------------------------------------------ |
-| `CODECOV_TOKEN`         | coverage upload              | CI 用 replica                              |
-| `LHCI_GITHUB_APP_TOKEN` | Lighthouse CI                | CI 用 replica                              |
-| `SUPABASE_ACCESS_TOKEN` | emergency / manual operation | 通常 migration flow では使わない           |
-| `VERCEL_TOKEN`          | Production Config Audit      | env metadata読取に限定                     |
-| `VERCEL_ORG_ID`         | Production Config Audit      | 1Password `VERCEL_TEAM_ID`のGitHub replica |
+| Secret                             | 用途                                         | 方針                                                  |
+| ---------------------------------- | -------------------------------------------- | ----------------------------------------------------- |
+| `CODECOV_TOKEN`                    | coverage upload                              | CI 用 replica                                         |
+| `LHCI_GITHUB_APP_TOKEN`            | Lighthouse CI                                | CI 用 replica                                         |
+| `SUPABASE_ACCESS_TOKEN`            | emergency / manual operation                 | 通常 migration flow では使わない                      |
+| `VERCEL_TOKEN`                     | Production Config Audit / Production Release | env metadata読取とProduction promote / rollbackに限定 |
+| `VERCEL_ORG_ID`                    | Production Config Audit / Production Release | 1Password `VERCEL_TEAM_ID`のGitHub replica            |
+| `VERCEL_AUTOMATION_BYPASS_PRODUCT` | Production Release smoke                     | Product の Protection Bypass for Automation           |
+| `VERCEL_AUTOMATION_BYPASS_WEB`     | Production Release smoke                     | Web の Protection Bypass for Automation               |
 
 GitHub Actions の通常 build は release / source map upload を行わないため、Sentry metadata と `SENTRY_AUTH_TOKEN` を渡さない。
 
-`VERCEL_TOKEN`をlocal CLIの`--token`引数へ渡さない。Vercel CLIはpaginationなどの再実行案内に引数値を含める場合がある。localのmetadata確認はconnector、Dashboard、または対話login済みCLIを使う。Production Config Auditは1Password masterから同期したGitHub replicaを環境変数で受け取り、process内でAuthorization headerにだけ設定する。
+`VERCEL_TOKEN`をlocal CLIの`--token`引数へ渡さない。Vercel CLIはpaginationなどの再実行案内に引数値を含める場合がある。localのmetadata確認はconnector、Dashboard、または対話login済みCLIを使う。Production Config AuditとProduction Releaseは1Password masterから同期したGitHub replicaを環境変数で受け取り、process内でAuthorization headerにだけ設定する。Protection Bypass secretも同様に、smoke requestのheaderにだけ設定してlogやerror messageへ出さない。
 
-露出が疑われる場合は値を表示・比較せず、replacement作成 → 1Password master更新 → GitHub replica更新 → trusted branchでProduction Config Audit成功確認 → 旧token revokeの順でrotateする。事故記録は[Vercel CLI token出力 incident](../log/2026-07-22-incident-vercel-cli-token-output.md)を参照する。
+露出が疑われる場合は値を表示・比較せず、replacement作成 → 1Password master更新 → GitHub replica更新 → trusted branchでProduction Config Audit成功確認 → 旧token revokeの順でrotateする。旧tokenを先にrevokeするとauditとProduction Releaseの両方が止まるため、この順序を崩さない。事故記録は[Vercel CLI token出力 incident](../log/2026-07-22-incident-vercel-cli-token-output.md)を参照する。
 
 ## Vercel
 

--- a/docs/operations/security/environment-secrets.md
+++ b/docs/operations/security/environment-secrets.md
@@ -23,15 +23,15 @@ Supabase migration の production 適用は GitHub Actions ではなく Supabase
 
 GitHub branch protection では、通常の CI check に加えて Supabase integration の Preview Branch check を required にする。
 
-| Secret                             | 用途                                         | 方針                                                  |
-| ---------------------------------- | -------------------------------------------- | ----------------------------------------------------- |
-| `CODECOV_TOKEN`                    | coverage upload                              | CI 用 replica                                         |
-| `LHCI_GITHUB_APP_TOKEN`            | Lighthouse CI                                | CI 用 replica                                         |
-| `SUPABASE_ACCESS_TOKEN`            | emergency / manual operation                 | 通常 migration flow では使わない                      |
-| `VERCEL_TOKEN`                     | Production Config Audit / Production Release | env metadata読取とProduction promote / rollbackに限定 |
-| `VERCEL_ORG_ID`                    | Production Config Audit / Production Release | 1Password `VERCEL_TEAM_ID`のGitHub replica            |
-| `VERCEL_AUTOMATION_BYPASS_PRODUCT` | Production Release smoke                     | Product の Protection Bypass for Automation           |
-| `VERCEL_AUTOMATION_BYPASS_WEB`     | Production Release smoke                     | Web の Protection Bypass for Automation               |
+| Secret                             | 用途                                         | 方針                                                                                          |
+| ---------------------------------- | -------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `CODECOV_TOKEN`                    | coverage upload                              | CI 用 replica                                                                                 |
+| `LHCI_GITHUB_APP_TOKEN`            | Lighthouse CI                                | CI 用 replica                                                                                 |
+| `SUPABASE_ACCESS_TOKEN`            | emergency / manual operation                 | 通常 migration flow では使わない                                                              |
+| `VERCEL_TOKEN`                     | Production Config Audit / Production Release | env metadata読取、Production promote / rollback、promoteの副作用で戻るproject設定の復元に限定 |
+| `VERCEL_ORG_ID`                    | Production Config Audit / Production Release | 1Password `VERCEL_TEAM_ID`のGitHub replica                                                    |
+| `VERCEL_AUTOMATION_BYPASS_PRODUCT` | Production Release smoke                     | Product の Protection Bypass for Automation                                                   |
+| `VERCEL_AUTOMATION_BYPASS_WEB`     | Production Release smoke                     | Web の Protection Bypass for Automation                                                       |
 
 GitHub Actions の通常 build は release / source map upload を行わないため、Sentry metadata と `SENTRY_AUTH_TOKEN` を渡さない。
 

--- a/scripts/__tests__/release-workflow-contract.test.ts
+++ b/scripts/__tests__/release-workflow-contract.test.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Production Release workflow は Vercel の promote / rollback 権限を持つ token を
+ * 扱うため、信頼境界を YAML の形で固定する。bash step は unit test できないので、
+ * 壊れたら Production に影響する制御だけを contract として検査する。
+ */
+const WORKFLOWS = join(process.cwd(), '.github/workflows');
+
+function workflow(name: string) {
+  return readFileSync(join(WORKFLOWS, name), 'utf8');
+}
+
+describe('release workflow contract', () => {
+  const release = workflow('release.yml');
+
+  it('never checks out a caller-supplied ref', () => {
+    // ref に inputs.sha を渡すと、未 merge の commit が持つ script が
+    // Production secret 付きで実行される。これが唯一の実効的な防御。
+    const checkoutBlock = release.slice(
+      release.indexOf('actions/checkout'),
+      release.indexOf('actions/setup-node'),
+    );
+    expect(checkoutBlock).toContain('persist-credentials: false');
+    expect(checkoutBlock).not.toMatch(/^\s*ref:/m);
+  });
+
+  it('validates the SHA shape before using it in an API path', () => {
+    const shapeCheck = release.indexOf('40 character commit SHA');
+    const compareCall = release.indexOf('compare/heads/main');
+    expect(shapeCheck).toBeGreaterThan(-1);
+    expect(compareCall).toBeGreaterThan(shapeCheck);
+  });
+
+  it('accepts only commits already merged into main', () => {
+    expect(release).toContain('compare/heads/main...$sha');
+    expect(release).toContain('"$status" != "identical" ] && [ "$status" != "behind"');
+    // ahead / diverged を許可に足すと未 merge の commit が Production へ出る。
+    expect(release).not.toMatch(/status" = "(ahead|diverged)"/);
+  });
+
+  it('keeps the compare check fail-closed', () => {
+    // export / local を前置すると command substitution の終了ステータスが
+    // 代入文に伝わらず、gh の失敗が握り潰される。
+    expect(release).not.toMatch(/^\s*(export|local|declare)\s+status=\$\(/m);
+  });
+
+  it('publishes the commit status only for a resolved SHA', () => {
+    expect(release).toContain("if: always() && steps.target.outputs.sha != ''");
+    expect(release).toContain('statuses/$RELEASE_SHA');
+    // caller の入力を status API のパスへ直接入れない。
+    expect(release).not.toContain('statuses/${{ inputs.sha }}');
+  });
+
+  it('refuses to call a superseded commit live', () => {
+    // superseded は promote 0 件。success を publish すると create-release.yml の
+    // gate を素通りし、live でない commit に Release が作られる。
+    expect(release).toContain('steps.release.outputs.release_status');
+    const publishStep = release.slice(release.indexOf('Publish Production Release status'));
+    expect(publishStep).toMatch(/RELEASE_STATUS" = "superseded"[\s\S]{0,200}state=failure/);
+  });
+
+  it('gates GitHub Release creation on a live Production Release status', () => {
+    const createRelease = workflow('create-release.yml');
+    expect(createRelease).toContain('Production Release');
+    expect(createRelease).toContain('"$state" != "success"');
+  });
+
+  it('keeps the audit workflow pinned to its trusted base revision', () => {
+    // release.yml と対称に「掃除」されないよう固定する。pull_request_target で
+    // PR head を checkout すると、PR code が Vercel token を読める。
+    const audit = workflow('production-config-audit.yml');
+    expect(audit).toContain('ref: ${{ github.event.pull_request.base.sha || github.sha }}');
+  });
+});

--- a/scripts/__tests__/release-workflow-contract.test.ts
+++ b/scripts/__tests__/release-workflow-contract.test.ts
@@ -3,6 +3,8 @@ import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+import { WORST_CASE_RELEASE_MS } from '../production-release.mjs';
+
 /**
  * Production Release workflow は Vercel の promote / rollback 権限を持つ token を
  * 扱うため、信頼境界を YAML の形で固定する。bash step は unit test できないので、
@@ -61,6 +63,20 @@ describe('release workflow contract', () => {
     expect(release).toContain('steps.release.outputs.release_status');
     const publishStep = release.slice(release.indexOf('Publish Production Release status'));
     expect(publishStep).toMatch(/RELEASE_STATUS" = "superseded"[\s\S]{0,200}state=failure/);
+  });
+
+  it('allows more wall clock than the script can consume', () => {
+    // job が先に kill されると、rollback 途中の片系 promote が
+    // 手動 rollback の手掛かり（run summary の previous id）ごと消える。
+    const timeoutMinutes = Number(release.match(/timeout-minutes:\s*(\d+)/)?.[1]);
+    expect(timeoutMinutes).toBeGreaterThan(0);
+    expect(timeoutMinutes * 60_000).toBeGreaterThan(WORST_CASE_RELEASE_MS);
+    // checkout / setup / API 往復のぶんの余裕も残す。
+    expect(timeoutMinutes * 60_000 - WORST_CASE_RELEASE_MS).toBeGreaterThanOrEqual(10 * 60_000);
+  });
+
+  it('attaches the job to an environment that can gate non-main dispatches', () => {
+    expect(release).toMatch(/^\s*environment:\s*production-release\s*$/m);
   });
 
   it('gates GitHub Release creation on a live Production Release status', () => {

--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -691,6 +691,7 @@ export async function runProductionRelease({
         logger.log(`${project.name}: another actor already promoted ${deployment.id}; skipping`);
         continue;
       }
+
       if (live?.id !== current.get(project.name)?.id) {
         throw new ReleaseError(
           `${project.name}: production moved to ${live?.id ?? 'none'} while the gate was ` +
@@ -770,6 +771,24 @@ export async function runProductionRelease({
       preexistingDrift: driftedProjects,
     });
     throw Object.assign(error, { rolledBack });
+  }
+
+  // promote しなかった project も掃く。pending から除外された側や、外部の promote で
+  // skip した側も、その promote の副作用で設定が飛んでいることがある。
+  // ループ内の復元は「窓を作らない」ため、この掃きは「取りこぼさない」ためにある。
+  const swept = await restoreAll({
+    entries: projects.map((project) => ({
+      project,
+      projectId: projectIds.get(project.name),
+      autoAssignCustomDomains: expectedFor(project.name),
+    })),
+    token,
+    teamId,
+    fetchImpl,
+    logger,
+  });
+  for (const name of swept) {
+    if (!driftedProjects.includes(name)) driftedProjects.push(name);
   }
 
   // production は正しい SHA を配信している。設定復元の失敗で巻き戻す理由はないが、

--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -633,13 +633,15 @@ export async function runProductionRelease({
     );
   }
 
+  // 以降の判定はすべて待機後の実状態を使う。movedElsewhere を抜けている時点で
+  // current は before か candidate のどちらかに一致している。
   const superseded = candidates.filter(({ project, deployment }) => {
-    const current = before.get(project.name);
+    const live = current.get(project.name);
     return (
-      current !== null &&
-      current.createdAt !== null &&
+      live !== null &&
+      live.createdAt !== null &&
       deployment.createdAt !== null &&
-      current.createdAt > deployment.createdAt
+      live.createdAt > deployment.createdAt
     );
   });
   if (superseded.length > 0) {
@@ -649,8 +651,9 @@ export async function runProductionRelease({
   }
 
   // 既に production へ出ている build は公開済みなので、gate の対象から外す。
+  // 待機中に人が同じ candidate を promote していた場合もここで除外される。
   const pending = candidates.filter(
-    ({ project, deployment }) => before.get(project.name)?.id !== deployment.id,
+    ({ project, deployment }) => current.get(project.name)?.id !== deployment.id,
   );
 
   if (force) {
@@ -683,7 +686,8 @@ export async function runProductionRelease({
         projectId: projectIds.get(project.name),
         autoAssignCustomDomains: expectedFor(project.name),
         deployment,
-        previous: before.get(project.name),
+        // rollback 先は待機後の実状態。待機中に人が動かしていたらそちらを尊重する。
+        previous: current.get(project.name),
       };
       logger.log(
         `${project.name}: promoting ${deployment.id} over ${entry.previous?.id ?? 'none'}`,

--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -7,21 +7,36 @@ const API_ORIGIN = 'https://api.vercel.com';
 /**
  * promote 順序 = 配列順。web を先に promote するため、2 つ目(product)が失敗した時に
  * rollback 対象になるのは web 側だけになる。
+ *
+ * smoke は status だけでは足りない。product は未知 path でも 200 を返し
+ * （`/[locale]/[nday]` が任意の 1 segment に一致する）、Next.js は streaming 中の
+ * 失敗も 200 のまま返す。そこで Next.js が返す `x-matched-path` で
+ * 「どの route が応答したか」を確定させ、内容が意味を持つ endpoint だけ本文も見る。
  */
 export const RELEASE_PROJECTS = [
   {
     name: 'web',
     bypassEnv: 'VERCEL_BYPASS_WEB',
-    productionOrigin: 'https://dayopt.app',
-    smokePaths: ['/', '/ja'],
+    smokeChecks: [
+      { path: '/', matchedPath: '/en' },
+      { path: '/ja', matchedPath: '/ja' },
+    ],
   },
   {
     name: 'product',
     bypassEnv: 'VERCEL_BYPASS_PRODUCT',
-    productionOrigin: 'https://app.dayopt.app',
-    smokePaths: ['/api/health', '/login'],
+    smokeChecks: [
+      // health は degraded でも 200 を返すので、本文で healthy を確認する。
+      { path: '/api/health', matchedPath: '/api/health', contains: '"status":"healthy"' },
+      { path: '/auth/login', matchedPath: '/[locale]/auth/login' },
+      // ja message bundle のロードまで通す。namespace 欠落は既知の事故モード。
+      { path: '/ja/auth/login', matchedPath: '/[locale]/auth/login' },
+    ],
   },
 ];
+
+/** 200 のまま streaming 中に失敗した Next.js response の目印。 */
+const STREAMED_FAILURE_MARKERS = ['NEXT_HTTP_ERROR_FALLBACK', 'NEXT_REDIRECT'];
 
 const READY_TIMEOUT_MS = 25 * 60 * 1000;
 const READY_POLL_MS = 15 * 1000;
@@ -48,16 +63,22 @@ function apiUrl(path, teamId, params = {}) {
   return url;
 }
 
-async function callVercel(url, { token, fetchImpl, method = 'GET', label }) {
-  const response = await fetchImpl(url, {
-    method,
-    headers: { Authorization: `Bearer ${token}` },
-  });
+async function callVercel(url, { token, fetchImpl, method = 'GET', label, parseJson = true }) {
+  const headers = { Authorization: `Bearer ${token}` };
+  const init = { method, headers };
+  if (method === 'POST') {
+    // 公式 client は promote / rollback に空の JSON body を送る。
+    headers['Content-Type'] = 'application/json';
+    init.body = '{}';
+  }
+
+  const response = await fetchImpl(url, init);
   if (!response.ok) {
     // Response body may echo request context; report the status only.
     throw new ReleaseError(`Vercel API ${label} failed with status ${response.status}`);
   }
-  return response.json();
+  // promote / rollback answer 201 / 202 and may carry an empty body.
+  return parseJson ? response.json() : null;
 }
 
 function normalizeDeployment(raw) {
@@ -69,15 +90,19 @@ function normalizeDeployment(raw) {
     url: typeof raw.url === 'string' ? raw.url : null,
     state: raw.readyState ?? raw.state ?? null,
     createdAt: raw.createdAt ?? raw.created ?? null,
+    target: raw.target ?? null,
+    // GitHub 連携以外（CLI / API）の deployment はこの値を持たない。
+    // 正規経路の build だけを release 対象にするため、これを必須にする。
     sha: raw.meta?.githubCommitSha ?? null,
   };
 }
 
 /** target SHA の production deployment を 1 件返す。無ければ null。 */
 export async function findDeploymentForSha({ projectName, sha, token, teamId, fetchImpl }) {
-  const url = apiUrl('/v6/deployments', teamId, {
+  const url = apiUrl('/v7/deployments', teamId, {
     projectId: projectName,
     target: 'production',
+    sha,
     limit: '20',
   });
   const body = await callVercel(url, {
@@ -87,23 +112,39 @@ export async function findDeploymentForSha({ projectName, sha, token, teamId, fe
   });
 
   const deployments = Array.isArray(body?.deployments) ? body.deployments : [];
+  // server 側の filter を信用しきらず、SHA と target を手元で再確認する。
   const matches = deployments
     .map(normalizeDeployment)
-    .filter((deployment) => deployment !== null && deployment.sha === sha)
+    .filter(
+      (deployment) =>
+        deployment !== null && deployment.sha === sha && deployment.target === 'production',
+    )
     .sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0));
 
   return matches[0] ?? null;
 }
 
-/** 現在 production domain に割り当てられている deployment。未割当なら null。 */
-export async function getCurrentProduction({ projectName, token, teamId, fetchImpl }) {
+/**
+ * project の現在状態を 1 回の呼び出しで取る。
+ *
+ * `/v9/projects/{idOrName}` は名前で引けるが、promote / rollback の path は
+ * `prj_` ID を要求する。ここで得た ID を以降の書き込みに使い、名前解決の
+ * 曖昧さを release 経路から外す。
+ */
+export async function getProjectState({ projectName, token, teamId, fetchImpl }) {
   const url = apiUrl(`/v9/projects/${encodeURIComponent(projectName)}`, teamId);
   const body = await callVercel(url, {
     token,
     fetchImpl,
     label: `project(${projectName})`,
   });
-  return normalizeDeployment(body?.targets?.production);
+  if (typeof body?.id !== 'string') {
+    throw new ReleaseError(`${projectName}: could not resolve the Vercel project id`);
+  }
+  return {
+    projectId: body.id,
+    production: normalizeDeployment(body?.targets?.production),
+  };
 }
 
 /**
@@ -186,7 +227,7 @@ function isProtectionRedirect(response) {
 export async function smokeDeployment({
   projectName,
   deploymentUrl,
-  paths,
+  checks,
   bypassSecret,
   fetchImpl,
   sleepImpl,
@@ -194,9 +235,13 @@ export async function smokeDeployment({
   attempts = SMOKE_ATTEMPTS,
   timeoutMs = SMOKE_TIMEOUT_MS,
 }) {
-  const headers = bypassSecret ? { 'x-vercel-protection-bypass': bypassSecret } : {};
+  const headers = {
+    // 明示しないと locale 検出でトップページが別 locale へ redirect されうる。
+    'accept-language': 'en',
+    ...(bypassSecret ? { 'x-vercel-protection-bypass': bypassSecret } : {}),
+  };
 
-  for (const path of paths) {
+  for (const { path, matchedPath, contains } of checks) {
     let lastError = null;
 
     for (let attempt = 1; attempt <= attempts; attempt += 1) {
@@ -215,6 +260,28 @@ export async function smokeDeployment({
           );
         }
         if (response.status === 200) {
+          // 以下の不一致は routing / render の問題なので retry しても変わらない。
+          const matched = response.headers?.get?.('x-matched-path');
+          if (matchedPath && matched !== matchedPath) {
+            throw new ReleaseError(
+              `${projectName}: smoke ${path} was served by ${matched ?? 'an unknown route'} ` +
+                `(expected ${matchedPath})`,
+            );
+          }
+
+          const body = await response.text();
+          const streamedFailure = STREAMED_FAILURE_MARKERS.find((marker) => body.includes(marker));
+          if (streamedFailure) {
+            throw new ReleaseError(
+              `${projectName}: smoke ${path} returned 200 but streamed ${streamedFailure}`,
+            );
+          }
+          if (contains && !body.includes(contains)) {
+            throw new ReleaseError(
+              `${projectName}: smoke ${path} returned 200 without the expected content`,
+            );
+          }
+
           lastError = null;
           break;
         }
@@ -252,8 +319,8 @@ async function waitForProductionAssignment({
   const deadline = nowImpl() + timeoutMs;
 
   for (;;) {
-    const current = await getCurrentProduction({ projectName, token, teamId, fetchImpl });
-    if (current?.id === deploymentId) return current;
+    const { production } = await getProjectState({ projectName, token, teamId, fetchImpl });
+    if (production?.id === deploymentId) return production;
 
     if (nowImpl() >= deadline) {
       throw new ReleaseError(
@@ -264,25 +331,36 @@ async function waitForProductionAssignment({
   }
 }
 
-/** deployment を production domain へ昇格し、反映を確認する。 */
-export async function promoteDeployment({
+/**
+ * production domain を指定 deployment へ向け、反映を確認する。
+ *
+ * promote と rollback で同じ endpoint を使う。REST API には rollback 専用の
+ * `/v1/projects/{id}/rollback/{deploymentId}` もあるが、対象が
+ * `isRollbackCandidate` に限られる。promote は「任意の deployment へ production
+ * traffic を向ける」ことが明記されており、復旧経路では同じ run の中で先に
+ * 成功実績を作る呼び出しを再利用する方が失敗確率が低い。
+ */
+async function pointProductionTo({
   projectName,
+  projectId,
   deploymentId,
   token,
   teamId,
   fetchImpl,
   sleepImpl,
   nowImpl,
+  action,
 }) {
   const url = apiUrl(
-    `/v10/projects/${encodeURIComponent(projectName)}/promote/${encodeURIComponent(deploymentId)}`,
+    `/v10/projects/${encodeURIComponent(projectId)}/promote/${encodeURIComponent(deploymentId)}`,
     teamId,
   );
   await callVercel(url, {
     token,
     fetchImpl,
     method: 'POST',
-    label: `promote(${projectName})`,
+    label: `${action}(${projectName})`,
+    parseJson: false,
   });
   return waitForProductionAssignment({
     projectName,
@@ -292,40 +370,18 @@ export async function promoteDeployment({
     fetchImpl,
     sleepImpl,
     nowImpl,
-    action: 'promote',
+    action,
   });
 }
 
-/** production domain を既知の正常 deployment へ戻し、反映を確認する。 */
-export async function rollbackDeployment({
-  projectName,
-  deploymentId,
-  token,
-  teamId,
-  fetchImpl,
-  sleepImpl,
-  nowImpl,
-}) {
-  const url = apiUrl(
-    `/v1/projects/${encodeURIComponent(projectName)}/rollback/${encodeURIComponent(deploymentId)}`,
-    teamId,
-  );
-  await callVercel(url, {
-    token,
-    fetchImpl,
-    method: 'POST',
-    label: `rollback(${projectName})`,
-  });
-  return waitForProductionAssignment({
-    projectName,
-    deploymentId,
-    token,
-    teamId,
-    fetchImpl,
-    sleepImpl,
-    nowImpl,
-    action: 'rollback',
-  });
+/** candidate を production domain へ昇格する。 */
+export async function promoteDeployment(options) {
+  return pointProductionTo({ ...options, action: 'promote' });
+}
+
+/** production domain を既知の正常 deployment へ戻す。 */
+export async function rollbackDeployment(options) {
+  return pointProductionTo({ ...options, action: 'rollback' });
 }
 
 function assertSimulationPoint(simulateFailure, point) {
@@ -357,12 +413,12 @@ export async function runProductionRelease({
     throw new ReleaseError('RELEASE_SHA must be a 40 character commit SHA');
   }
 
+  const projectIds = new Map();
   const before = new Map();
   for (const project of projects) {
-    before.set(
-      project.name,
-      await getCurrentProduction({ projectName: project.name, token, teamId, fetchImpl }),
-    );
+    const state = await getProjectState({ projectName: project.name, token, teamId, fetchImpl });
+    projectIds.set(project.name, state.projectId);
+    before.set(project.name, state.production);
   }
 
   if (projects.every((project) => before.get(project.name)?.sha === sha)) {
@@ -409,7 +465,7 @@ export async function runProductionRelease({
       await smokeDeployment({
         projectName: project.name,
         deploymentUrl: deployment.url,
-        paths: project.smokePaths,
+        checks: project.smokeChecks,
         bypassSecret: bypassSecrets[project.name],
         fetchImpl,
         sleepImpl,
@@ -427,6 +483,7 @@ export async function runProductionRelease({
       assertSimulationPoint(simulateFailure, `promote:${project.name}`);
       await promoteDeployment({
         projectName: project.name,
+        projectId: projectIds.get(project.name),
         deploymentId: deployment.id,
         token,
         teamId,
@@ -435,7 +492,12 @@ export async function runProductionRelease({
         nowImpl,
       });
       logger.log(`${project.name}: promoted ${deployment.id}`);
-      promoted.push({ project, deployment, previous: before.get(project.name) });
+      promoted.push({
+        project,
+        projectId: projectIds.get(project.name),
+        deployment,
+        previous: before.get(project.name),
+      });
     }
   } catch (error) {
     const rolledBack = await rollbackPromoted({
@@ -475,6 +537,7 @@ async function rollbackPromoted({
     try {
       await rollbackDeployment({
         projectName: entry.project.name,
+        projectId: entry.projectId,
         deploymentId: entry.previous.id,
         token,
         teamId,
@@ -506,6 +569,16 @@ function writeStepSummary(lines) {
   appendFileSync(path, `${lines.join('\n')}\n`);
 }
 
+/** workflow が status publish と run の合否を別々に決められるようにする。 */
+export const RELEASE_STATUSES = new Set(['already-released', 'promoted', 'superseded', 'failed']);
+
+export function writeReleaseStatus(status, { env = process.env } = {}) {
+  const path = env.GITHUB_OUTPUT;
+  // 固定集合以外は書かない。任意文字列を GITHUB_OUTPUT へ流さない。
+  if (!path || !RELEASE_STATUSES.has(status)) return;
+  appendFileSync(path, `release_status=${status}\n`);
+}
+
 function summarize(result) {
   const lines = [
     '## Production Release',
@@ -521,6 +594,13 @@ function summarize(result) {
   }
   if (result.promoted.length > 0) {
     lines.push('', 'Manual rollback targets are the `previous` deployment ids above.');
+  }
+  if (result.status === 'superseded') {
+    lines.push(
+      '',
+      'A newer Production deployment already serves Production. Nothing was promoted,',
+      'and this commit is **not** live. Do not tag it.',
+    );
   }
   return lines;
 }
@@ -540,11 +620,13 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   })
     .then((result) => {
       writeStepSummary(summarize(result));
+      writeReleaseStatus(result.status);
       console.log(`Production Release finished: ${result.status}`);
     })
     .catch((error) => {
       const message = error instanceof Error ? error.message : 'Production Release failed';
       writeStepSummary(['## Production Release', '', `- Failed: ${message}`]);
+      writeReleaseStatus('failed');
       console.error(message);
       process.exitCode = 1;
     });

--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -681,13 +681,29 @@ export async function runProductionRelease({
   try {
     for (const { project, deployment } of pending) {
       assertSimulationPoint(simulateFailure, `promote:${project.name}`);
+
+      // smoke と audit で数分経っている。その間に人が Instant Rollback や手動
+      // promote を行いうるので、rollback 先は promote の直前に取り直す。
+      const live = (await getProjectState({ projectName: project.name, token, teamId, fetchImpl }))
+        .production;
+
+      if (live?.id === deployment.id) {
+        logger.log(`${project.name}: another actor already promoted ${deployment.id}; skipping`);
+        continue;
+      }
+      if (live?.id !== current.get(project.name)?.id) {
+        throw new ReleaseError(
+          `${project.name}: production moved to ${live?.id ?? 'none'} while the gate was ` +
+            `running; refusing to promote ${deployment.id} over it`,
+        );
+      }
+
       const entry = {
         project,
         projectId: projectIds.get(project.name),
         autoAssignCustomDomains: expectedFor(project.name),
         deployment,
-        // rollback 先は待機後の実状態。待機中に人が動かしていたらそちらを尊重する。
-        previous: current.get(project.name),
+        previous: live,
       };
       logger.log(
         `${project.name}: promoting ${deployment.id} over ${entry.previous?.id ?? 'none'}`,

--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -182,7 +182,11 @@ async function restoreAutoAssignCustomDomains({
   fetchImpl,
   logger,
 }) {
-  if (typeof expected !== 'boolean') return false;
+  if (typeof expected !== 'boolean') {
+    // gate の前提は「Auto-assign が無効であること」なので、観測できなかった事実は残す。
+    logger.log(`${projectName}: autoAssignCustomDomains was not observable; skipping restore`);
+    return false;
+  }
 
   const current = await getProjectState({ projectName, token, teamId, fetchImpl });
   if (current.autoAssignCustomDomains === expected) return false;
@@ -449,16 +453,52 @@ async function rollbackDeployment({
     nowImpl,
     action: 'rollback',
   });
-  await restoreAutoAssignCustomDomains({
-    projectName,
-    projectId,
-    expected: autoAssignCustomDomains,
-    token,
-    teamId,
-    fetchImpl,
-    logger,
-  });
-  return production;
+  // production pointer は戻っている。設定復元の失敗をここで throw すると
+  // 「rollback 自体が失敗した」と誤報し、既に戻っている先への手動 rollback を
+  // 指示することになる。両者を分けて返す。
+  let autoAssignDrifted = false;
+  try {
+    await restoreAutoAssignCustomDomains({
+      projectName,
+      projectId,
+      expected: autoAssignCustomDomains,
+      token,
+      teamId,
+      fetchImpl,
+      logger,
+    });
+  } catch {
+    autoAssignDrifted = true;
+  }
+  return { production, autoAssignDrifted };
+}
+
+/** 復元をまとめて試し、失敗した project 名だけを返す。個別失敗は throw しない。 */
+async function restoreAll({ entries, token, teamId, fetchImpl, logger }) {
+  const drifted = [];
+  for (const entry of entries) {
+    try {
+      await restoreAutoAssignCustomDomains({
+        projectName: entry.project.name,
+        projectId: entry.projectId,
+        expected: entry.autoAssignCustomDomains,
+        token,
+        teamId,
+        fetchImpl,
+        logger,
+      });
+    } catch {
+      drifted.push(entry.project.name);
+    }
+  }
+  return drifted;
+}
+
+function driftError(sha, drifted) {
+  return new ReleaseError(
+    `Production serves ${sha}, but autoAssignCustomDomains could not be restored for ` +
+      `${drifted.join(', ')}. Set it back before the next merge or the release gate is bypassed.`,
+  );
 }
 
 function assertSimulationPoint(simulateFailure, point) {
@@ -476,6 +516,10 @@ export async function runProductionRelease({
   token,
   teamId,
   force = false,
+  // gate が有効な運用（Auto-assign 無効化済み）では false を宣言する。
+  // null の間は「run 開始時点の値へ戻す」だけになり、前回 run から持ち越した
+  // ドリフトは検出できない。段階適用が終わったら宣言する。
+  expectedAutoAssign = null,
   bypassSecrets = {},
   projects = RELEASE_PROJECTS,
   simulateFailure = '',
@@ -500,9 +544,53 @@ export async function runProductionRelease({
     before.set(project.name, state.production);
   }
 
-  if (projects.every((project) => before.get(project.name)?.sha === sha)) {
+  // job が任意の時点で消えても手動 rollback 先が run に残るよう、先に書き出す。
+  const openingLines = ['## Production Release', '', `- Commit: \`${sha}\``];
+  for (const project of projects) {
+    const current = before.get(project.name);
+    const line =
+      `- ${project.name}: current production \`${current?.id ?? 'none'}\`` +
+      ` (sha \`${current?.sha ?? 'unknown'}\`, autoAssign ${autoAssign.get(project.name)})`;
+    openingLines.push(line);
+    logger.log(line.slice(2));
+  }
+  writeStepSummary(openingLines);
+
+  const expectedFor = (name) =>
+    typeof expectedAutoAssign === 'boolean' ? expectedAutoAssign : autoAssign.get(name);
+
+  const alreadyServing = projects.filter((project) => before.get(project.name)?.sha === sha);
+
+  // 前回 run が中断して片側だけ公開された状態。既に配信中の側は戻し先を持たないので
+  // 自動 rollback の対象にはできない。せめて名指しして人が判断できるようにする。
+  const preexistingSplit =
+    alreadyServing.length > 0 && alreadyServing.length < projects.length
+      ? alreadyServing.map((project) => project.name)
+      : [];
+  if (preexistingSplit.length > 0) {
+    const message =
+      `Pre-existing split: ${preexistingSplit.join(', ')} already serve ${sha} from an earlier run. ` +
+      `They are outside this run's rollback scope; check them by hand if this run fails.`;
+    logger.log(message);
+    writeStepSummary(['', `> ${message}`]);
+  }
+
+  if (alreadyServing.length === projects.length) {
     logger.log(`All projects already serve ${sha}; nothing to promote.`);
-    return { status: 'already-released', sha, promoted: [], rolledBack: [] };
+    // 前回 run が復元に失敗して終わっている可能性があるため、設定だけは見に行く。
+    const drifted = await restoreAll({
+      entries: projects.map((project) => ({
+        project,
+        projectId: projectIds.get(project.name),
+        autoAssignCustomDomains: expectedFor(project.name),
+      })),
+      token,
+      teamId,
+      fetchImpl,
+      logger,
+    });
+    if (drifted.length > 0) throw driftError(sha, drifted);
+    return { status: 'already-released', sha, promoted: [], rolledBack: [], preexistingSplit };
   }
 
   const candidates = await waitForReadyCandidates({
@@ -516,6 +604,35 @@ export async function runProductionRelease({
     logger,
   });
 
+  // 待機は最大 25 分ブロックする。その間に人が Instant Rollback や手動 promote を
+  // 行いうるため、判定は待機後の実状態で行う。
+  const current = new Map();
+  for (const project of projects) {
+    const state = await getProjectState({ projectName: project.name, token, teamId, fetchImpl });
+    current.set(project.name, state.production);
+  }
+
+  const movedElsewhere = candidates.filter(({ project, deployment }) => {
+    const now = current.get(project.name);
+    const wasId = before.get(project.name)?.id ?? null;
+    // 同じ candidate を人が先に promote した場合は競合ではない。
+    return now?.id !== wasId && now?.id !== deployment.id;
+  });
+  if (movedElsewhere.length > 0) {
+    const detail = movedElsewhere
+      .map(({ project, deployment }) => {
+        const now = current.get(project.name);
+        return (
+          `${project.name}: was ${before.get(project.name)?.id ?? 'none'}, ` +
+          `now ${now?.id ?? 'none'}, candidate ${deployment.id}`
+        );
+      })
+      .join('; ');
+    throw new ReleaseError(
+      `Production moved while waiting for candidates; refusing to promote over it (${detail})`,
+    );
+  }
+
   const superseded = candidates.filter(({ project, deployment }) => {
     const current = before.get(project.name);
     return (
@@ -528,7 +645,7 @@ export async function runProductionRelease({
   if (superseded.length > 0) {
     const names = superseded.map(({ project }) => project.name).join(', ');
     logger.log(`Skipping promote: a newer production deployment already serves ${names}.`);
-    return { status: 'superseded', sha, promoted: [], rolledBack: [] };
+    return { status: 'superseded', sha, promoted: [], rolledBack: [], preexistingSplit };
   }
 
   // 既に production へ出ている build は公開済みなので、gate の対象から外す。
@@ -557,28 +674,48 @@ export async function runProductionRelease({
   }
 
   const promoted = [];
+  const driftedProjects = [];
   try {
     for (const { project, deployment } of pending) {
       assertSimulationPoint(simulateFailure, `promote:${project.name}`);
-      await requestProductionPointer({
-        projectName: project.name,
+      const entry = {
+        project,
         projectId: projectIds.get(project.name),
-        deploymentId: deployment.id,
-        token,
-        teamId,
-        fetchImpl,
-        action: 'promote',
-      });
+        autoAssignCustomDomains: expectedFor(project.name),
+        deployment,
+        previous: before.get(project.name),
+      };
+      logger.log(
+        `${project.name}: promoting ${deployment.id} over ${entry.previous?.id ?? 'none'}`,
+      );
+
+      try {
+        await requestProductionPointer({
+          projectName: project.name,
+          projectId: entry.projectId,
+          deploymentId: deployment.id,
+          token,
+          teamId,
+          fetchImpl,
+          action: 'promote',
+        });
+      } catch (error) {
+        // POST が届いたかどうか分からない。実状態を 1 回だけ見て、実際に動いて
+        // いた時だけ rollback 対象へ入れる。無条件に入れると、何も起きていない
+        // project へ rollback promote を撃ってしまい auto-assign を壊す。
+        const state = await getProjectState({
+          projectName: project.name,
+          token,
+          teamId,
+          fetchImpl,
+        }).catch(() => null);
+        if (state?.production?.id === deployment.id) promoted.push(entry);
+        throw error;
+      }
 
       // POST が受理された時点で production は動きうる。反映確認が timeout しても
       // rollback 対象から漏らさないよう、確認を待つ前に記録する。
-      promoted.push({
-        project,
-        projectId: projectIds.get(project.name),
-        autoAssignCustomDomains: autoAssign.get(project.name),
-        deployment,
-        previous: before.get(project.name),
-      });
+      promoted.push(entry);
 
       await waitForProductionAssignment({
         projectName: project.name,
@@ -590,10 +727,16 @@ export async function runProductionRelease({
         nowImpl,
         action: 'promote',
       });
+
+      // promote は auto-assign を true に戻す。次の project の確認を待つ間ずっと
+      // 片側だけ auto-assign が有効な窓を作らないよう、ここで即座に戻す。
+      // 復元の失敗は rollback を誘発させず、drifted に積んで最後に報告する。
+      driftedProjects.push(
+        ...(await restoreAll({ entries: [entry], token, teamId, fetchImpl, logger })),
+      );
       logger.log(`${project.name}: promoted ${deployment.id}`);
     }
   } catch (error) {
-    // rollback も promote endpoint を使うため、設定の復元は rollback の後に行う。
     const rolledBack = await rollbackPromoted({
       promoted,
       token,
@@ -603,37 +746,17 @@ export async function runProductionRelease({
       nowImpl,
       logger,
       cause: error,
+      preexistingSplit,
+      preexistingDrift: driftedProjects,
     });
     throw Object.assign(error, { rolledBack });
   }
 
-  // 設定の復元は promote の try/catch から外す。ここで失敗しても production は
-  // 正しい SHA を配信しており、正常なリリースを rollback する理由にならない。
-  // ただし放置すると次の merge が gate を迂回するため、run は失敗させる。
-  const drifted = [];
-  for (const entry of promoted) {
-    try {
-      await restoreAutoAssignCustomDomains({
-        projectName: entry.project.name,
-        projectId: entry.projectId,
-        expected: entry.autoAssignCustomDomains,
-        token,
-        teamId,
-        fetchImpl,
-        logger,
-      });
-    } catch {
-      drifted.push(entry.project.name);
-    }
-  }
-  if (drifted.length > 0) {
-    throw new ReleaseError(
-      `Production serves ${sha}, but autoAssignCustomDomains could not be restored for ` +
-        `${drifted.join(', ')}. Set it back before the next merge or the release gate is bypassed.`,
-    );
-  }
+  // production は正しい SHA を配信している。設定復元の失敗で巻き戻す理由はないが、
+  // 放置すると次の merge が gate を迂回するため run は失敗させる。
+  if (driftedProjects.length > 0) throw driftError(sha, driftedProjects);
 
-  return { status: 'promoted', sha, promoted, rolledBack: [] };
+  return { status: 'promoted', sha, promoted, rolledBack: [], preexistingSplit };
 }
 
 async function rollbackPromoted({
@@ -645,9 +768,12 @@ async function rollbackPromoted({
   nowImpl,
   logger,
   cause,
+  preexistingSplit = [],
+  preexistingDrift = [],
 }) {
   const rolledBack = [];
   const stranded = [];
+  const drifted = [...preexistingDrift];
 
   for (const entry of [...promoted].reverse()) {
     if (!entry.previous?.id) {
@@ -655,7 +781,7 @@ async function rollbackPromoted({
       continue;
     }
     try {
-      await rollbackDeployment({
+      const { autoAssignDrifted } = await rollbackDeployment({
         projectName: entry.project.name,
         projectId: entry.projectId,
         autoAssignCustomDomains: entry.autoAssignCustomDomains,
@@ -667,6 +793,7 @@ async function rollbackPromoted({
         sleepImpl,
         nowImpl,
       });
+      if (autoAssignDrifted) drifted.push(entry.project.name);
       logger.log(`${entry.project.name}: rolled back to ${entry.previous.id}`);
       rolledBack.push(entry);
     } catch {
@@ -674,12 +801,25 @@ async function rollbackPromoted({
     }
   }
 
-  if (stranded.length > 0) {
-    throw new ReleaseError(
-      `MANUAL ROLLBACK REQUIRED after "${cause.message}". ` +
-        `Point production back to: ${stranded.join('; ')}`,
-      { manualRollback: stranded },
-    );
+  if (stranded.length > 0 || drifted.length > 0 || preexistingSplit.length > 0) {
+    const lines = [`Rollback after "${cause.message}" did not fully clean up.`];
+    if (stranded.length > 0) {
+      lines.push(`MANUAL ROLLBACK REQUIRED. Point production back to: ${stranded.join('; ')}`);
+    }
+    if (preexistingSplit.length > 0) {
+      lines.push(
+        `Outside this run's rollback scope: ${preexistingSplit.join(', ')} already served the ` +
+          `target SHA before it started. Check them by hand.`,
+      );
+    }
+    if (drifted.length > 0) {
+      lines.push(
+        `Production is restored, but autoAssignCustomDomains could not be restored for ` +
+          `${drifted.join(', ')}. Set it back before the next merge or the gate is bypassed.`,
+      );
+    }
+    // manualRollback は「production pointer が動かせていない」ものだけを指す。
+    throw new ReleaseError(lines.join(' '), { manualRollback: stranded });
   }
 
   return rolledBack;
@@ -717,6 +857,12 @@ function summarize(result) {
   if (result.promoted.length > 0) {
     lines.push('', 'Manual rollback targets are the `previous` deployment ids above.');
   }
+  if (result.preexistingSplit?.length > 0) {
+    lines.push(
+      '',
+      `Pre-existing split from an earlier run: ${result.preexistingSplit.join(', ')}.`,
+    );
+  }
   if (result.status === 'superseded') {
     lines.push(
       '',
@@ -737,6 +883,12 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     token: process.env.VERCEL_TOKEN,
     teamId: process.env.VERCEL_TEAM_ID,
     force: process.env.RELEASE_FORCE === 'true',
+    expectedAutoAssign:
+      process.env.RELEASE_EXPECT_AUTO_ASSIGN === 'false'
+        ? false
+        : process.env.RELEASE_EXPECT_AUTO_ASSIGN === 'true'
+          ? true
+          : null,
     simulateFailure: process.env.RELEASE_SIMULATE_FAILURE ?? '',
     bypassSecrets,
   })

--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -332,23 +332,24 @@ async function waitForProductionAssignment({
 }
 
 /**
- * production domain を指定 deployment へ向け、反映を確認する。
+ * production domain を指定 deployment へ向けるよう要求する。反映確認はしない。
  *
  * promote と rollback で同じ endpoint を使う。REST API には rollback 専用の
  * `/v1/projects/{id}/rollback/{deploymentId}` もあるが、対象が
  * `isRollbackCandidate` に限られる。promote は「任意の deployment へ production
  * traffic を向ける」ことが明記されており、復旧経路では同じ run の中で先に
  * 成功実績を作る呼び出しを再利用する方が失敗確率が低い。
+ *
+ * 要求と確認を分けているのは、POST が受理された時点で production が動きうるため。
+ * 呼び出し側は確認を待つ前に rollback 対象として記録する。
  */
-async function pointProductionTo({
+async function requestProductionPointer({
   projectName,
   projectId,
   deploymentId,
   token,
   teamId,
   fetchImpl,
-  sleepImpl,
-  nowImpl,
   action,
 }) {
   const url = apiUrl(
@@ -362,6 +363,28 @@ async function pointProductionTo({
     label: `${action}(${projectName})`,
     parseJson: false,
   });
+}
+
+/** production domain を既知の正常 deployment へ戻し、反映まで確認する。 */
+async function rollbackDeployment({
+  projectName,
+  projectId,
+  deploymentId,
+  token,
+  teamId,
+  fetchImpl,
+  sleepImpl,
+  nowImpl,
+}) {
+  await requestProductionPointer({
+    projectName,
+    projectId,
+    deploymentId,
+    token,
+    teamId,
+    fetchImpl,
+    action: 'rollback',
+  });
   return waitForProductionAssignment({
     projectName,
     deploymentId,
@@ -370,18 +393,8 @@ async function pointProductionTo({
     fetchImpl,
     sleepImpl,
     nowImpl,
-    action,
+    action: 'rollback',
   });
-}
-
-/** candidate を production domain へ昇格する。 */
-export async function promoteDeployment(options) {
-  return pointProductionTo({ ...options, action: 'promote' });
-}
-
-/** production domain を既知の正常 deployment へ戻す。 */
-export async function rollbackDeployment(options) {
-  return pointProductionTo({ ...options, action: 'rollback' });
 }
 
 function assertSimulationPoint(simulateFailure, point) {
@@ -481,23 +494,36 @@ export async function runProductionRelease({
   try {
     for (const { project, deployment } of pending) {
       assertSimulationPoint(simulateFailure, `promote:${project.name}`);
-      await promoteDeployment({
+      await requestProductionPointer({
         projectName: project.name,
         projectId: projectIds.get(project.name),
         deploymentId: deployment.id,
         token,
         teamId,
         fetchImpl,
-        sleepImpl,
-        nowImpl,
+        action: 'promote',
       });
-      logger.log(`${project.name}: promoted ${deployment.id}`);
+
+      // POST が受理された時点で production は動きうる。反映確認が timeout しても
+      // rollback 対象から漏らさないよう、確認を待つ前に記録する。
       promoted.push({
         project,
         projectId: projectIds.get(project.name),
         deployment,
         previous: before.get(project.name),
       });
+
+      await waitForProductionAssignment({
+        projectName: project.name,
+        deploymentId: deployment.id,
+        token,
+        teamId,
+        fetchImpl,
+        sleepImpl,
+        nowImpl,
+        action: 'promote',
+      });
+      logger.log(`${project.name}: promoted ${deployment.id}`);
     }
   } catch (error) {
     const rolledBack = await rollbackPromoted({

--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -44,7 +44,20 @@ const ASSIGN_TIMEOUT_MS = 5 * 60 * 1000;
 const ASSIGN_POLL_MS = 5 * 1000;
 const SMOKE_ATTEMPTS = 3;
 const SMOKE_TIMEOUT_MS = 15 * 1000;
+const SMOKE_RETRY_DELAY_MS = 2 * 1000;
 const TERMINAL_FAILURE_STATES = new Set(['ERROR', 'CANCELED', 'DELETED']);
+
+/**
+ * この script が費やしうる最悪時間。workflow の `timeout-minutes` がこれを
+ * 下回ると、rollback の途中で job が kill され、片方だけ promote された
+ * production が手動 rollback の手掛かりごと失われる。
+ * 内訳: candidate 待機 + 全 smoke の retry + promote 反映待ち + rollback 反映待ち。
+ */
+export const WORST_CASE_RELEASE_MS =
+  READY_TIMEOUT_MS +
+  RELEASE_PROJECTS.reduce((total, project) => total + project.smokeChecks.length, 0) *
+    (SMOKE_ATTEMPTS * SMOKE_TIMEOUT_MS + (SMOKE_ATTEMPTS - 1) * SMOKE_RETRY_DELAY_MS) +
+  RELEASE_PROJECTS.length * ASSIGN_TIMEOUT_MS * 2;
 
 export class ReleaseError extends Error {
   constructor(message, { manualRollback } = {}) {
@@ -335,7 +348,7 @@ export async function smokeDeployment({
         );
       }
 
-      if (attempt < attempts) await sleepImpl(2000);
+      if (attempt < attempts) await sleepImpl(SMOKE_RETRY_DELAY_MS);
     }
 
     if (lastError) throw lastError;

--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -577,18 +577,10 @@ export async function runProductionRelease({
         nowImpl,
         action: 'promote',
       });
-      await restoreAutoAssignCustomDomains({
-        projectName: project.name,
-        projectId: projectIds.get(project.name),
-        expected: autoAssign.get(project.name),
-        token,
-        teamId,
-        fetchImpl,
-        logger,
-      });
       logger.log(`${project.name}: promoted ${deployment.id}`);
     }
   } catch (error) {
+    // rollback も promote endpoint を使うため、設定の復元は rollback の後に行う。
     const rolledBack = await rollbackPromoted({
       promoted,
       token,
@@ -600,6 +592,32 @@ export async function runProductionRelease({
       cause: error,
     });
     throw Object.assign(error, { rolledBack });
+  }
+
+  // 設定の復元は promote の try/catch から外す。ここで失敗しても production は
+  // 正しい SHA を配信しており、正常なリリースを rollback する理由にならない。
+  // ただし放置すると次の merge が gate を迂回するため、run は失敗させる。
+  const drifted = [];
+  for (const entry of promoted) {
+    try {
+      await restoreAutoAssignCustomDomains({
+        projectName: entry.project.name,
+        projectId: entry.projectId,
+        expected: entry.autoAssignCustomDomains,
+        token,
+        teamId,
+        fetchImpl,
+        logger,
+      });
+    } catch {
+      drifted.push(entry.project.name);
+    }
+  }
+  if (drifted.length > 0) {
+    throw new ReleaseError(
+      `Production serves ${sha}, but autoAssignCustomDomains could not be restored for ` +
+        `${drifted.join(', ')}. Set it back before the next merge or the release gate is bypassed.`,
+    );
   }
 
   return { status: 'promoted', sha, promoted, rolledBack: [] };

--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -169,8 +169,14 @@ export async function waitForReadyCandidates({
 
 function isProtectionRedirect(response) {
   if (response.status < 300 || response.status >= 400) return false;
-  const location = response.headers?.get?.('location') ?? '';
-  return location.includes('vercel.com/sso-api');
+  const location = response.headers?.get?.('location');
+  if (!location) return false;
+  try {
+    const url = new URL(location);
+    return url.host === 'vercel.com' && url.pathname === '/sso-api';
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -63,13 +63,16 @@ function apiUrl(path, teamId, params = {}) {
   return url;
 }
 
-async function callVercel(url, { token, fetchImpl, method = 'GET', label, parseJson = true }) {
+async function callVercel(
+  url,
+  { token, fetchImpl, method = 'GET', label, body, parseJson = true },
+) {
   const headers = { Authorization: `Bearer ${token}` };
   const init = { method, headers };
-  if (method === 'POST') {
+  if (method !== 'GET') {
     // 公式 client は promote / rollback に空の JSON body を送る。
     headers['Content-Type'] = 'application/json';
-    init.body = '{}';
+    init.body = JSON.stringify(body ?? {});
   }
 
   const response = await fetchImpl(url, init);
@@ -144,7 +147,43 @@ export async function getProjectState({ projectName, token, teamId, fetchImpl })
   return {
     projectId: body.id,
     production: normalizeDeployment(body?.targets?.production),
+    // promote endpoint がこの設定を書き換えるため、事前値を控えて後で戻す。
+    autoAssignCustomDomains: body.autoAssignCustomDomains ?? null,
   };
+}
+
+/**
+ * promote / rollback の副作用で書き換わった Auto-assign Custom Domains を戻す。
+ *
+ * `POST /v10/projects/{id}/promote/{deploymentId}` は project 設定の
+ * `autoAssignCustomDomains` を `true` に戻す（vercel/vercel#15095、未修正）。
+ * 放置すると次の main merge が gate を通らず直接公開されるため、
+ * release の直前に観測した値へ必ず戻す。
+ */
+async function restoreAutoAssignCustomDomains({
+  projectName,
+  projectId,
+  expected,
+  token,
+  teamId,
+  fetchImpl,
+  logger,
+}) {
+  if (typeof expected !== 'boolean') return false;
+
+  const current = await getProjectState({ projectName, token, teamId, fetchImpl });
+  if (current.autoAssignCustomDomains === expected) return false;
+
+  await callVercel(apiUrl(`/v9/projects/${encodeURIComponent(projectId)}`, teamId), {
+    token,
+    fetchImpl,
+    method: 'PATCH',
+    label: `restore-auto-assign(${projectName})`,
+    body: { autoAssignCustomDomains: expected },
+    parseJson: false,
+  });
+  logger.log(`${projectName}: restored autoAssignCustomDomains to ${expected}`);
+  return true;
 }
 
 /**
@@ -370,11 +409,13 @@ async function rollbackDeployment({
   projectName,
   projectId,
   deploymentId,
+  autoAssignCustomDomains,
   token,
   teamId,
   fetchImpl,
   sleepImpl,
   nowImpl,
+  logger,
 }) {
   await requestProductionPointer({
     projectName,
@@ -385,7 +426,7 @@ async function rollbackDeployment({
     fetchImpl,
     action: 'rollback',
   });
-  return waitForProductionAssignment({
+  const production = await waitForProductionAssignment({
     projectName,
     deploymentId,
     token,
@@ -395,6 +436,16 @@ async function rollbackDeployment({
     nowImpl,
     action: 'rollback',
   });
+  await restoreAutoAssignCustomDomains({
+    projectName,
+    projectId,
+    expected: autoAssignCustomDomains,
+    token,
+    teamId,
+    fetchImpl,
+    logger,
+  });
+  return production;
 }
 
 function assertSimulationPoint(simulateFailure, point) {
@@ -427,10 +478,12 @@ export async function runProductionRelease({
   }
 
   const projectIds = new Map();
+  const autoAssign = new Map();
   const before = new Map();
   for (const project of projects) {
     const state = await getProjectState({ projectName: project.name, token, teamId, fetchImpl });
     projectIds.set(project.name, state.projectId);
+    autoAssign.set(project.name, state.autoAssignCustomDomains);
     before.set(project.name, state.production);
   }
 
@@ -509,6 +562,7 @@ export async function runProductionRelease({
       promoted.push({
         project,
         projectId: projectIds.get(project.name),
+        autoAssignCustomDomains: autoAssign.get(project.name),
         deployment,
         previous: before.get(project.name),
       });
@@ -522,6 +576,15 @@ export async function runProductionRelease({
         sleepImpl,
         nowImpl,
         action: 'promote',
+      });
+      await restoreAutoAssignCustomDomains({
+        projectName: project.name,
+        projectId: projectIds.get(project.name),
+        expected: autoAssign.get(project.name),
+        token,
+        teamId,
+        fetchImpl,
+        logger,
       });
       logger.log(`${project.name}: promoted ${deployment.id}`);
     }
@@ -564,6 +627,8 @@ async function rollbackPromoted({
       await rollbackDeployment({
         projectName: entry.project.name,
         projectId: entry.projectId,
+        autoAssignCustomDomains: entry.autoAssignCustomDomains,
+        logger,
         deploymentId: entry.previous.id,
         token,
         teamId,

--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -1,0 +1,545 @@
+import { appendFileSync } from 'node:fs';
+
+import { runProductionConfigAudit } from './production-config-audit.mjs';
+
+const API_ORIGIN = 'https://api.vercel.com';
+
+/**
+ * promote 順序 = 配列順。web を先に promote するため、2 つ目(product)が失敗した時に
+ * rollback 対象になるのは web 側だけになる。
+ */
+export const RELEASE_PROJECTS = [
+  {
+    name: 'web',
+    bypassEnv: 'VERCEL_BYPASS_WEB',
+    productionOrigin: 'https://dayopt.app',
+    smokePaths: ['/', '/ja'],
+  },
+  {
+    name: 'product',
+    bypassEnv: 'VERCEL_BYPASS_PRODUCT',
+    productionOrigin: 'https://app.dayopt.app',
+    smokePaths: ['/api/health', '/login'],
+  },
+];
+
+const READY_TIMEOUT_MS = 25 * 60 * 1000;
+const READY_POLL_MS = 15 * 1000;
+const ASSIGN_TIMEOUT_MS = 5 * 60 * 1000;
+const ASSIGN_POLL_MS = 5 * 1000;
+const SMOKE_ATTEMPTS = 3;
+const SMOKE_TIMEOUT_MS = 15 * 1000;
+const TERMINAL_FAILURE_STATES = new Set(['ERROR', 'CANCELED', 'DELETED']);
+
+export class ReleaseError extends Error {
+  constructor(message, { manualRollback } = {}) {
+    super(message);
+    this.name = 'ReleaseError';
+    this.manualRollback = manualRollback ?? null;
+  }
+}
+
+function apiUrl(path, teamId, params = {}) {
+  const url = new URL(`${API_ORIGIN}${path}`);
+  url.searchParams.set('teamId', teamId);
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return url;
+}
+
+async function callVercel(url, { token, fetchImpl, method = 'GET', label }) {
+  const response = await fetchImpl(url, {
+    method,
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!response.ok) {
+    // Response body may echo request context; report the status only.
+    throw new ReleaseError(`Vercel API ${label} failed with status ${response.status}`);
+  }
+  return response.json();
+}
+
+function normalizeDeployment(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const id = raw.uid ?? raw.id;
+  if (typeof id !== 'string') return null;
+  return {
+    id,
+    url: typeof raw.url === 'string' ? raw.url : null,
+    state: raw.readyState ?? raw.state ?? null,
+    createdAt: raw.createdAt ?? raw.created ?? null,
+    sha: raw.meta?.githubCommitSha ?? null,
+  };
+}
+
+/** target SHA の production deployment を 1 件返す。無ければ null。 */
+export async function findDeploymentForSha({ projectName, sha, token, teamId, fetchImpl }) {
+  const url = apiUrl('/v6/deployments', teamId, {
+    projectId: projectName,
+    target: 'production',
+    limit: '20',
+  });
+  const body = await callVercel(url, {
+    token,
+    fetchImpl,
+    label: `deployments(${projectName})`,
+  });
+
+  const deployments = Array.isArray(body?.deployments) ? body.deployments : [];
+  const matches = deployments
+    .map(normalizeDeployment)
+    .filter((deployment) => deployment !== null && deployment.sha === sha)
+    .sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0));
+
+  return matches[0] ?? null;
+}
+
+/** 現在 production domain に割り当てられている deployment。未割当なら null。 */
+export async function getCurrentProduction({ projectName, token, teamId, fetchImpl }) {
+  const url = apiUrl(`/v9/projects/${encodeURIComponent(projectName)}`, teamId);
+  const body = await callVercel(url, {
+    token,
+    fetchImpl,
+    label: `project(${projectName})`,
+  });
+  return normalizeDeployment(body?.targets?.production);
+}
+
+/**
+ * 全 project の candidate が READY になるまで待つ。
+ * ERROR / CANCELED は復帰しないので即座に失敗させる。
+ */
+export async function waitForReadyCandidates({
+  projects,
+  sha,
+  token,
+  teamId,
+  fetchImpl,
+  sleepImpl,
+  nowImpl,
+  logger,
+  timeoutMs = READY_TIMEOUT_MS,
+  pollMs = READY_POLL_MS,
+}) {
+  const deadline = nowImpl() + timeoutMs;
+  const ready = new Map();
+
+  for (;;) {
+    for (const project of projects) {
+      if (ready.has(project.name)) continue;
+
+      const deployment = await findDeploymentForSha({
+        projectName: project.name,
+        sha,
+        token,
+        teamId,
+        fetchImpl,
+      });
+      if (!deployment) continue;
+
+      if (TERMINAL_FAILURE_STATES.has(deployment.state)) {
+        throw new ReleaseError(
+          `${project.name}: production build for ${sha} ended in ${deployment.state}`,
+        );
+      }
+      if (deployment.state === 'READY') {
+        logger.log(`${project.name}: candidate ${deployment.id} is READY`);
+        ready.set(project.name, deployment);
+      }
+    }
+
+    if (ready.size === projects.length) {
+      return projects.map((project) => ({ project, deployment: ready.get(project.name) }));
+    }
+
+    if (nowImpl() >= deadline) {
+      const pending = projects
+        .filter((project) => !ready.has(project.name))
+        .map((project) => project.name)
+        .join(', ');
+      throw new ReleaseError(
+        `Timed out waiting for READY production builds of ${sha} (pending: ${pending})`,
+      );
+    }
+
+    await sleepImpl(pollMs);
+  }
+}
+
+function isProtectionRedirect(response) {
+  if (response.status < 300 || response.status >= 400) return false;
+  const location = response.headers?.get?.('location') ?? '';
+  return location.includes('vercel.com/sso-api');
+}
+
+/**
+ * candidate deployment の unique URL を read-only で検証する。
+ * Deployment Protection が有効なため bypass secret が必須。
+ */
+export async function smokeDeployment({
+  projectName,
+  deploymentUrl,
+  paths,
+  bypassSecret,
+  fetchImpl,
+  sleepImpl,
+  logger,
+  attempts = SMOKE_ATTEMPTS,
+  timeoutMs = SMOKE_TIMEOUT_MS,
+}) {
+  const headers = bypassSecret ? { 'x-vercel-protection-bypass': bypassSecret } : {};
+
+  for (const path of paths) {
+    let lastError = null;
+
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+      try {
+        const response = await fetchImpl(`https://${deploymentUrl}${path}`, {
+          headers,
+          redirect: 'manual',
+          signal: AbortSignal.timeout(timeoutMs),
+        });
+
+        if (isProtectionRedirect(response)) {
+          // Retrying cannot fix a missing bypass secret.
+          throw new ReleaseError(
+            `${projectName}: Deployment Protection blocked ${path}. ` +
+              `Enable Protection Bypass for Automation and set the matching repository secret.`,
+          );
+        }
+        if (response.status === 200) {
+          lastError = null;
+          break;
+        }
+        lastError = new ReleaseError(
+          `${projectName}: smoke ${path} returned ${response.status} (expected 200)`,
+        );
+      } catch (error) {
+        if (error instanceof ReleaseError) throw error;
+        // Network/timeout failures carry no response body; keep only the reason name.
+        lastError = new ReleaseError(
+          `${projectName}: smoke ${path} failed (${error?.name ?? 'RequestFailed'})`,
+        );
+      }
+
+      if (attempt < attempts) await sleepImpl(2000);
+    }
+
+    if (lastError) throw lastError;
+    logger.log(`${projectName}: smoke ${path} ok`);
+  }
+}
+
+async function waitForProductionAssignment({
+  projectName,
+  deploymentId,
+  token,
+  teamId,
+  fetchImpl,
+  sleepImpl,
+  nowImpl,
+  action,
+  timeoutMs = ASSIGN_TIMEOUT_MS,
+  pollMs = ASSIGN_POLL_MS,
+}) {
+  const deadline = nowImpl() + timeoutMs;
+
+  for (;;) {
+    const current = await getCurrentProduction({ projectName, token, teamId, fetchImpl });
+    if (current?.id === deploymentId) return current;
+
+    if (nowImpl() >= deadline) {
+      throw new ReleaseError(
+        `${projectName}: ${action} did not take effect for deployment ${deploymentId}`,
+      );
+    }
+    await sleepImpl(pollMs);
+  }
+}
+
+/** deployment を production domain へ昇格し、反映を確認する。 */
+export async function promoteDeployment({
+  projectName,
+  deploymentId,
+  token,
+  teamId,
+  fetchImpl,
+  sleepImpl,
+  nowImpl,
+}) {
+  const url = apiUrl(
+    `/v10/projects/${encodeURIComponent(projectName)}/promote/${encodeURIComponent(deploymentId)}`,
+    teamId,
+  );
+  await callVercel(url, {
+    token,
+    fetchImpl,
+    method: 'POST',
+    label: `promote(${projectName})`,
+  });
+  return waitForProductionAssignment({
+    projectName,
+    deploymentId,
+    token,
+    teamId,
+    fetchImpl,
+    sleepImpl,
+    nowImpl,
+    action: 'promote',
+  });
+}
+
+/** production domain を既知の正常 deployment へ戻し、反映を確認する。 */
+export async function rollbackDeployment({
+  projectName,
+  deploymentId,
+  token,
+  teamId,
+  fetchImpl,
+  sleepImpl,
+  nowImpl,
+}) {
+  const url = apiUrl(
+    `/v1/projects/${encodeURIComponent(projectName)}/rollback/${encodeURIComponent(deploymentId)}`,
+    teamId,
+  );
+  await callVercel(url, {
+    token,
+    fetchImpl,
+    method: 'POST',
+    label: `rollback(${projectName})`,
+  });
+  return waitForProductionAssignment({
+    projectName,
+    deploymentId,
+    token,
+    teamId,
+    fetchImpl,
+    sleepImpl,
+    nowImpl,
+    action: 'rollback',
+  });
+}
+
+function assertSimulationPoint(simulateFailure, point) {
+  if (simulateFailure === point) {
+    throw new ReleaseError(`Simulated failure at ${point} (release drill)`);
+  }
+}
+
+/**
+ * merge 済み SHA を両 project の production domain へ公開する。
+ * 片方だけ promote された状態は残さない。
+ */
+export async function runProductionRelease({
+  sha,
+  token,
+  teamId,
+  force = false,
+  bypassSecrets = {},
+  projects = RELEASE_PROJECTS,
+  simulateFailure = '',
+  fetchImpl = fetch,
+  sleepImpl = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  nowImpl = () => Date.now(),
+  logger = console,
+}) {
+  if (!token) throw new ReleaseError('VERCEL_TOKEN is required for Production Release');
+  if (!teamId) throw new ReleaseError('VERCEL_TEAM_ID is required for Production Release');
+  if (!/^[0-9a-f]{40}$/.test(sha ?? '')) {
+    throw new ReleaseError('RELEASE_SHA must be a 40 character commit SHA');
+  }
+
+  const before = new Map();
+  for (const project of projects) {
+    before.set(
+      project.name,
+      await getCurrentProduction({ projectName: project.name, token, teamId, fetchImpl }),
+    );
+  }
+
+  if (projects.every((project) => before.get(project.name)?.sha === sha)) {
+    logger.log(`All projects already serve ${sha}; nothing to promote.`);
+    return { status: 'already-released', sha, promoted: [], rolledBack: [] };
+  }
+
+  const candidates = await waitForReadyCandidates({
+    projects,
+    sha,
+    token,
+    teamId,
+    fetchImpl,
+    sleepImpl,
+    nowImpl,
+    logger,
+  });
+
+  const superseded = candidates.filter(({ project, deployment }) => {
+    const current = before.get(project.name);
+    return (
+      current !== null &&
+      current.createdAt !== null &&
+      deployment.createdAt !== null &&
+      current.createdAt > deployment.createdAt
+    );
+  });
+  if (superseded.length > 0) {
+    const names = superseded.map(({ project }) => project.name).join(', ');
+    logger.log(`Skipping promote: a newer production deployment already serves ${names}.`);
+    return { status: 'superseded', sha, promoted: [], rolledBack: [] };
+  }
+
+  // 既に production へ出ている build は公開済みなので、gate の対象から外す。
+  const pending = candidates.filter(
+    ({ project, deployment }) => before.get(project.name)?.id !== deployment.id,
+  );
+
+  if (force) {
+    logger.log('Force Promote: skipping smoke and Production Config Audit.');
+  } else {
+    for (const { project, deployment } of pending) {
+      assertSimulationPoint(simulateFailure, `smoke:${project.name}`);
+      await smokeDeployment({
+        projectName: project.name,
+        deploymentUrl: deployment.url,
+        paths: project.smokePaths,
+        bypassSecret: bypassSecrets[project.name],
+        fetchImpl,
+        sleepImpl,
+        logger,
+      });
+    }
+
+    await runProductionConfigAudit({ token, teamId, fetchImpl });
+    logger.log('Production Config Audit passed against live Vercel metadata.');
+  }
+
+  const promoted = [];
+  try {
+    for (const { project, deployment } of pending) {
+      assertSimulationPoint(simulateFailure, `promote:${project.name}`);
+      await promoteDeployment({
+        projectName: project.name,
+        deploymentId: deployment.id,
+        token,
+        teamId,
+        fetchImpl,
+        sleepImpl,
+        nowImpl,
+      });
+      logger.log(`${project.name}: promoted ${deployment.id}`);
+      promoted.push({ project, deployment, previous: before.get(project.name) });
+    }
+  } catch (error) {
+    const rolledBack = await rollbackPromoted({
+      promoted,
+      token,
+      teamId,
+      fetchImpl,
+      sleepImpl,
+      nowImpl,
+      logger,
+      cause: error,
+    });
+    throw Object.assign(error, { rolledBack });
+  }
+
+  return { status: 'promoted', sha, promoted, rolledBack: [] };
+}
+
+async function rollbackPromoted({
+  promoted,
+  token,
+  teamId,
+  fetchImpl,
+  sleepImpl,
+  nowImpl,
+  logger,
+  cause,
+}) {
+  const rolledBack = [];
+  const stranded = [];
+
+  for (const entry of [...promoted].reverse()) {
+    if (!entry.previous?.id) {
+      stranded.push(`${entry.project.name} (no previous production deployment recorded)`);
+      continue;
+    }
+    try {
+      await rollbackDeployment({
+        projectName: entry.project.name,
+        deploymentId: entry.previous.id,
+        token,
+        teamId,
+        fetchImpl,
+        sleepImpl,
+        nowImpl,
+      });
+      logger.log(`${entry.project.name}: rolled back to ${entry.previous.id}`);
+      rolledBack.push(entry);
+    } catch {
+      stranded.push(`${entry.project.name} -> ${entry.previous.id}`);
+    }
+  }
+
+  if (stranded.length > 0) {
+    throw new ReleaseError(
+      `MANUAL ROLLBACK REQUIRED after "${cause.message}". ` +
+        `Point production back to: ${stranded.join('; ')}`,
+      { manualRollback: stranded },
+    );
+  }
+
+  return rolledBack;
+}
+
+function writeStepSummary(lines) {
+  const path = process.env.GITHUB_STEP_SUMMARY;
+  if (!path) return;
+  appendFileSync(path, `${lines.join('\n')}\n`);
+}
+
+function summarize(result) {
+  const lines = [
+    '## Production Release',
+    '',
+    `- Commit: \`${result.sha}\``,
+    `- Status: ${result.status}`,
+  ];
+  for (const entry of result.promoted) {
+    lines.push(
+      `- ${entry.project.name}: promoted \`${entry.deployment.id}\`` +
+        ` (previous \`${entry.previous?.id ?? 'none'}\`)`,
+    );
+  }
+  if (result.promoted.length > 0) {
+    lines.push('', 'Manual rollback targets are the `previous` deployment ids above.');
+  }
+  return lines;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const bypassSecrets = Object.fromEntries(
+    RELEASE_PROJECTS.map((project) => [project.name, process.env[project.bypassEnv]]),
+  );
+
+  runProductionRelease({
+    sha: process.env.RELEASE_SHA,
+    token: process.env.VERCEL_TOKEN,
+    teamId: process.env.VERCEL_TEAM_ID,
+    force: process.env.RELEASE_FORCE === 'true',
+    simulateFailure: process.env.RELEASE_SIMULATE_FAILURE ?? '',
+    bypassSecrets,
+  })
+    .then((result) => {
+      writeStepSummary(summarize(result));
+      console.log(`Production Release finished: ${result.status}`);
+    })
+    .catch((error) => {
+      const message = error instanceof Error ? error.message : 'Production Release failed';
+      writeStepSummary(['## Production Release', '', `- Failed: ${message}`]);
+      console.error(message);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/production-release.test.ts
+++ b/scripts/production-release.test.ts
@@ -714,6 +714,37 @@ describe('runProductionRelease', () => {
     expect(world.promoted()).toEqual(['product']);
   });
 
+  it('refuses to promote when production moves during smoke and audit', async () => {
+    // 待機後の再取得と promote の間には smoke と audit があり数分かかる。
+    // その窓で人が動かしていたら上書きしない。
+    const world = createReleaseWorld();
+    let webReads = 0;
+    const fetchImpl = vi.fn(async (input: URL | string, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/v9/projects/web') && (init?.method ?? 'GET') === 'GET') {
+        webReads += 1;
+        // 1回目=before, 2回目=待機後。3回目（promote 直前）で第三の deployment に。
+        if (webReads > 2) {
+          return Response.json({
+            id: 'prj_web',
+            autoAssignCustomDomains: false,
+            targets: {
+              production: {
+                id: 'dpl_web_hotfix',
+                createdAt: 1500,
+                meta: { githubCommitSha: OLD_SHA },
+              },
+            },
+          });
+        }
+      }
+      return world.fetchImpl(input, init);
+    });
+
+    await expect(release({ fetchImpl })).rejects.toThrow(/production moved to dpl_web_hotfix/);
+    expect(world.promoted()).toEqual([]);
+  });
+
   it('skips smoke and audit under Force Promote', async () => {
     const world = createReleaseWorld();
     const fetchImpl = vi.fn(async (input: URL | string, init?: RequestInit) => {

--- a/scripts/production-release.test.ts
+++ b/scripts/production-release.test.ts
@@ -745,6 +745,42 @@ describe('runProductionRelease', () => {
     expect(world.promoted()).toEqual([]);
   });
 
+  it('restores the setting for a project it skipped promoting', async () => {
+    // 外部が同じ candidate を promote した場合、その promote も auto-assign を
+    // true に戻す。promote を飛ばした project も設定は揃えて終える。
+    const world = createReleaseWorld();
+    let webReads = 0;
+    let webAutoAssign = false;
+    const fetchImpl = vi.fn(async (input: URL | string, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/v9/projects/prj_web') && (init?.method ?? 'GET') === 'PATCH') {
+        webAutoAssign = JSON.parse(String(init?.body ?? '{}')).autoAssignCustomDomains;
+        return new Response(null, { status: 200 });
+      }
+      if (url.includes('/v9/projects/web')) {
+        webReads += 1;
+        // promote 直前（3回目）で外部 promote 済み + 副作用で auto-assign が true。
+        if (webReads > 2) {
+          webAutoAssign = webReads === 3 ? true : webAutoAssign;
+          return Response.json({
+            id: 'prj_web',
+            autoAssignCustomDomains: webAutoAssign,
+            targets: {
+              production: { id: 'dpl_web_new', createdAt: 2000, meta: { githubCommitSha: SHA } },
+            },
+          });
+        }
+      }
+      return world.fetchImpl(input, init);
+    });
+
+    const result = await release({ fetchImpl });
+
+    expect(result.status).toBe('promoted');
+    // web は promote していないが、設定は false へ戻っている。
+    expect(webAutoAssign).toBe(false);
+  });
+
   it('skips smoke and audit under Force Promote', async () => {
     const world = createReleaseWorld();
     const fetchImpl = vi.fn(async (input: URL | string, init?: RequestInit) => {

--- a/scripts/production-release.test.ts
+++ b/scripts/production-release.test.ts
@@ -603,6 +603,24 @@ describe('runProductionRelease', () => {
     expect(world.autoAssign).toEqual({ web: true, product: true });
   });
 
+  it('fails the run without rolling back when the setting cannot be restored', async () => {
+    // 設定復元の失敗で正常なリリースを巻き戻すと、production が理由なく旧 SHA へ戻る。
+    // production はそのままにし、run だけ失敗させて次の merge 前の対処を促す。
+    const world = createReleaseWorld();
+    const fetchImpl = vi.fn(async (input: URL | string, init?: RequestInit) => {
+      if ((init?.method ?? 'GET') === 'PATCH') {
+        return new Response(null, { status: 500 });
+      }
+      return world.fetchImpl(input, init);
+    });
+
+    const error = await release({ fetchImpl }).catch((thrown: Error) => thrown);
+
+    expect(error.message).toMatch(/autoAssignCustomDomains could not be restored/);
+    expect(world.promoted()).toEqual(['web', 'product']);
+    expect(world.rolledBack()).toEqual([]);
+  });
+
   it('skips smoke and audit under Force Promote', async () => {
     const world = createReleaseWorld();
     const fetchImpl = vi.fn(async (input: URL | string, init?: RequestInit) => {

--- a/scripts/production-release.test.ts
+++ b/scripts/production-release.test.ts
@@ -95,8 +95,17 @@ function auditMetadata(project: 'product' | 'web') {
  * 両 project が candidate を持つ既定シナリオ。
  * promote と rollback は同じ endpoint を使うので、対象 deployment id で区別する。
  */
-function createReleaseWorld(options: { productionSha?: string; smokeBody?: string } = {}) {
+function createReleaseWorld(
+  options: { productionSha?: string; smokeBody?: string; autoAssign?: boolean | null } = {},
+) {
   const previous = { web: 'dpl_web_old', product: 'dpl_product_old' };
+  // Vercel の promote endpoint は autoAssignCustomDomains を true に戻す
+  // （vercel/vercel#15095）。その副作用を再現する。
+  const autoAssign: Record<string, boolean | null> = {
+    web: options.autoAssign === undefined ? false : options.autoAssign,
+    product: options.autoAssign === undefined ? false : options.autoAssign,
+  };
+  const patches: { project: string; value: unknown }[] = [];
   const production: Record<string, { id: string; sha: string; createdAt: number }> = {
     web: { id: previous.web, sha: options.productionSha ?? OLD_SHA, createdAt: 1000 },
     product: { id: previous.product, sha: options.productionSha ?? OLD_SHA, createdAt: 1000 },
@@ -117,11 +126,19 @@ function createReleaseWorld(options: { productionSha?: string; smokeBody?: strin
 
     const project = url.includes('web') ? 'web' : 'product';
 
+    if (method === 'PATCH' && url.includes('/v9/projects/')) {
+      const value = JSON.parse(String(init?.body ?? '{}')).autoAssignCustomDomains;
+      patches.push({ project, value });
+      autoAssign[project] = value;
+      return new Response(null, { status: 200 });
+    }
     if (method === 'POST' && url.includes('/promote/')) {
       const deploymentId = url.split('/promote/')[1]!.split('?')[0]!;
       // promote / rollback は project 名ではなく prj_ ID を使う。
       expect(url).toContain(`/projects/prj_${project}/promote/`);
       pointCalls.push({ project, deploymentId });
+      // 副作用: 設定が true へ戻る。
+      if (autoAssign[project] !== null) autoAssign[project] = true;
       const isRollback = deploymentId === previous[project as 'web' | 'product'];
       production[project] = isRollback
         ? { id: deploymentId, sha: OLD_SHA, createdAt: 1000 }
@@ -138,6 +155,7 @@ function createReleaseWorld(options: { productionSha?: string; smokeBody?: strin
       const current = production[project]!;
       return Response.json({
         id: `prj_${project}`,
+        autoAssignCustomDomains: autoAssign[project],
         targets: {
           production: {
             id: current.id,
@@ -155,7 +173,7 @@ function createReleaseWorld(options: { productionSha?: string; smokeBody?: strin
   const rolledBack = () =>
     pointCalls.filter((call) => call.deploymentId.endsWith('_old')).map((call) => call.project);
 
-  return { fetchImpl, pointCalls, promoted, rolledBack };
+  return { fetchImpl, pointCalls, promoted, rolledBack, patches, autoAssign };
 }
 
 function release(overrides: Record<string, unknown> = {}) {
@@ -556,6 +574,33 @@ describe('runProductionRelease', () => {
     expect(error.message).toContain('MANUAL ROLLBACK REQUIRED');
     expect(error.message).toContain('dpl_web_old');
     expect(error.message).not.toContain(TOKEN);
+  });
+
+  it('restores autoAssignCustomDomains that promote flips back on', async () => {
+    // vercel/vercel#15095: promote endpoint が project 設定を書き換える。
+    // 放置すると次の main merge が gate を通らず直接公開される。
+    const world = createReleaseWorld();
+
+    await expect(release({ fetchImpl: world.fetchImpl })).resolves.toMatchObject({
+      status: 'promoted',
+    });
+
+    expect(world.patches).toEqual([
+      { project: 'web', value: false },
+      { project: 'product', value: false },
+    ]);
+    expect(world.autoAssign).toEqual({ web: false, product: false });
+  });
+
+  it('leaves autoAssignCustomDomains alone while it is intentionally enabled', async () => {
+    // 段階適用の Phase A では Auto-assign が ON のままでよい。
+    // 事前値へ戻すだけなので、勝手に無効化しない。
+    const world = createReleaseWorld({ autoAssign: true });
+
+    await release({ fetchImpl: world.fetchImpl });
+
+    expect(world.patches).toEqual([]);
+    expect(world.autoAssign).toEqual({ web: true, product: true });
   });
 
   it('skips smoke and audit under Force Promote', async () => {

--- a/scripts/production-release.test.ts
+++ b/scripts/production-release.test.ts
@@ -96,7 +96,12 @@ function auditMetadata(project: 'product' | 'web') {
  * promote と rollback は同じ endpoint を使うので、対象 deployment id で区別する。
  */
 function createReleaseWorld(
-  options: { productionSha?: string; smokeBody?: string; autoAssign?: boolean | null } = {},
+  options: {
+    productionSha?: string;
+    smokeBody?: string;
+    autoAssign?: boolean | null;
+    webAlreadyAtTarget?: boolean;
+  } = {},
 ) {
   const previous = { web: 'dpl_web_old', product: 'dpl_product_old' };
   // Vercel の promote endpoint は autoAssignCustomDomains を true に戻す
@@ -107,7 +112,9 @@ function createReleaseWorld(
   };
   const patches: { project: string; value: unknown }[] = [];
   const production: Record<string, { id: string; sha: string; createdAt: number }> = {
-    web: { id: previous.web, sha: options.productionSha ?? OLD_SHA, createdAt: 1000 },
+    web: options.webAlreadyAtTarget
+      ? { id: 'dpl_web_new', sha: SHA, createdAt: 2000 }
+      : { id: previous.web, sha: options.productionSha ?? OLD_SHA, createdAt: 1000 },
     product: { id: previous.product, sha: options.productionSha ?? OLD_SHA, createdAt: 1000 },
   };
   const candidates = {
@@ -619,6 +626,63 @@ describe('runProductionRelease', () => {
     expect(error.message).toMatch(/autoAssignCustomDomains could not be restored/);
     expect(world.promoted()).toEqual(['web', 'product']);
     expect(world.rolledBack()).toEqual([]);
+  });
+
+  it('names a pre-existing split it cannot roll back', async () => {
+    // 前回 run が中断して web だけ公開された状態。web は戻し先を持たないので
+    // 自動 rollback の対象にできない。名指しだけはする。
+    const world = createReleaseWorld({ webAlreadyAtTarget: true });
+
+    const result = await release({ fetchImpl: world.fetchImpl });
+
+    expect(result.status).toBe('promoted');
+    expect(result.preexistingSplit).toEqual(['web']);
+    // web は既に対象 SHA を配信しているので promote しない。
+    expect(world.promoted()).toEqual(['product']);
+  });
+
+  it('refuses to promote over production that moved while waiting', async () => {
+    // 待機中にオペレータが Instant Rollback した場合、その判断を上書きしない。
+    const world = createReleaseWorld();
+    let projectReads = 0;
+    const fetchImpl = vi.fn(async (input: URL | string, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/v9/projects/web') && (init?.method ?? 'GET') === 'GET') {
+        projectReads += 1;
+        // 1 回目（before snapshot）は通常、2 回目（待機後）は別 deployment。
+        if (projectReads > 1) {
+          return Response.json({
+            id: 'prj_web',
+            autoAssignCustomDomains: false,
+            targets: {
+              production: {
+                id: 'dpl_web_hotfix',
+                createdAt: 1500,
+                meta: { githubCommitSha: OLD_SHA },
+              },
+            },
+          });
+        }
+      }
+      return world.fetchImpl(input, init);
+    });
+
+    await expect(release({ fetchImpl })).rejects.toThrow(/Production moved while waiting/);
+    expect(world.promoted()).toEqual([]);
+  });
+
+  it('still checks the setting when both projects already serve the SHA', async () => {
+    // 前回 run が復元に失敗して終わった後の再実行。ここで success を返すと
+    // auto-assign が true のまま tag gate を通ってしまう。
+    const world = createReleaseWorld({ productionSha: SHA, autoAssign: true });
+    const fetchImpl = vi.fn(async (input: URL | string, init?: RequestInit) => {
+      if ((init?.method ?? 'GET') === 'PATCH') return new Response(null, { status: 500 });
+      return world.fetchImpl(input, init);
+    });
+
+    await expect(release({ fetchImpl, expectedAutoAssign: false })).rejects.toThrow(
+      /could not be restored/,
+    );
   });
 
   it('skips smoke and audit under Force Promote', async () => {

--- a/scripts/production-release.test.ts
+++ b/scripts/production-release.test.ts
@@ -685,6 +685,35 @@ describe('runProductionRelease', () => {
     );
   });
 
+  it('respects a manual promote of the same candidate during the wait', async () => {
+    // 待機中に人が同じ candidate を Dashboard から promote した場合は競合ではない。
+    // 止めず、かつ二重 promote もしない。
+    const world = createReleaseWorld();
+    let webReads = 0;
+    const fetchImpl = vi.fn(async (input: URL | string, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/v9/projects/web') && (init?.method ?? 'GET') === 'GET') {
+        webReads += 1;
+        if (webReads > 1) {
+          return Response.json({
+            id: 'prj_web',
+            autoAssignCustomDomains: false,
+            targets: {
+              production: { id: 'dpl_web_new', createdAt: 2000, meta: { githubCommitSha: SHA } },
+            },
+          });
+        }
+      }
+      return world.fetchImpl(input, init);
+    });
+
+    const result = await release({ fetchImpl });
+
+    expect(result.status).toBe('promoted');
+    // web は既に candidate を配信しているので promote しない。
+    expect(world.promoted()).toEqual(['product']);
+  });
+
   it('skips smoke and audit under Force Promote', async () => {
     const world = createReleaseWorld();
     const fetchImpl = vi.fn(async (input: URL | string, init?: RequestInit) => {

--- a/scripts/production-release.test.ts
+++ b/scripts/production-release.test.ts
@@ -514,6 +514,30 @@ describe('runProductionRelease', () => {
     expect(world.pointCalls).toEqual([]);
   });
 
+  it('rolls back a promote whose confirmation never lands', async () => {
+    // POST は受理されたが production 割当の反映が確認できない場合。
+    // 確認待ちで諦めると web だけ新 SHA という部分公開が残る。
+    const world = createReleaseWorld();
+    let clock = 0;
+    const fetchImpl = vi.fn(async (input: URL | string, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/promote/dpl_web_new')) {
+        // 受理はするが production 割当は動かさない。
+        world.pointCalls.push({ project: 'web', deploymentId: 'dpl_web_new' });
+        return new Response(null, { status: 202 });
+      }
+      return world.fetchImpl(input, init);
+    });
+
+    const error = await release({
+      fetchImpl,
+      nowImpl: () => (clock += 60_000),
+    }).catch((thrown: Error) => thrown);
+
+    expect(error.message).toMatch(/promote did not take effect/);
+    expect(world.rolledBack()).toEqual(['web']);
+  });
+
   it('demands a manual rollback when the automatic rollback also fails', async () => {
     const world = createReleaseWorld();
     const fetchImpl = vi.fn(async (input: URL | string, init?: RequestInit) => {

--- a/scripts/production-release.test.ts
+++ b/scripts/production-release.test.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -5,6 +9,7 @@ import {
   runProductionRelease,
   smokeDeployment,
   waitForReadyCandidates,
+  writeReleaseStatus,
 } from './production-release.mjs';
 
 const SHA = 'a'.repeat(40);
@@ -12,40 +17,59 @@ const OLD_SHA = 'b'.repeat(40);
 const TOKEN = 'vercel-token-must-not-appear';
 const BYPASS = 'bypass-secret-must-not-appear';
 
-type Deployment = {
-  uid: string;
-  url: string;
-  readyState: string;
-  created: number;
-  meta: { githubCommitSha: string };
+/** 実際の smoke marker をすべて含む body。個別テストで上書きする。 */
+const SMOKE_BODY = '<html lang="en">{"status":"healthy"}</html>';
+
+/** RELEASE_PROJECTS が期待する x-matched-path を返す smoke response。 */
+const MATCHED_PATHS: Record<string, string> = {
+  '/': '/en',
+  '/ja': '/ja',
+  '/api/health': '/api/health',
+  '/auth/login': '/[locale]/auth/login',
+  '/ja/auth/login': '/[locale]/auth/login',
 };
 
-function deployment(uid: string, sha: string, readyState = 'READY', created = 2000): Deployment {
-  return { uid, url: `${uid}.vercel.app`, readyState, created, meta: { githubCommitSha: sha } };
+function smokeResponse(url: string, body = SMOKE_BODY) {
+  const path = new URL(url).pathname;
+  return new Response(body, {
+    status: 200,
+    headers: { 'x-matched-path': MATCHED_PATHS[path] ?? path },
+  });
+}
+
+function deployment(uid: string, sha: string, readyState = 'READY', created = 2000) {
+  return {
+    uid,
+    url: `${uid}.vercel.app`,
+    readyState,
+    created,
+    target: 'production',
+    meta: { githubCommitSha: sha },
+  };
 }
 
 function projectTarget(id: string, sha: string, createdAt = 1000) {
-  return { targets: { production: { id, createdAt, meta: { githubCommitSha: sha } } } };
+  return {
+    id: 'prj_test',
+    targets: { production: { id, createdAt, meta: { githubCommitSha: sha } } },
+  };
 }
 
 const noop = { log: () => {} };
 const noSleep = () => Promise.resolve();
 
-/**
- * URL ごとに応答を返す fetch mock。呼び出し履歴を calls に記録する。
- */
+/** URL ごとに応答を返す fetch mock。Vercel API 以外は smoke とみなす。 */
 function createVercelMock(handlers: Record<string, () => unknown>) {
-  const calls: { url: string; method: string }[] = [];
-  const fetchImpl = vi.fn(async (input: URL | string, init?: RequestInit) => {
+  const fetchImpl = vi.fn(async (input: URL | string) => {
     const url = String(input);
-    const method = init?.method ?? 'GET';
-    calls.push({ url, method });
-
+    if (new URL(url).origin !== 'https://api.vercel.com') {
+      return smokeResponse(url);
+    }
     const key = Object.keys(handlers).find((pattern) => url.includes(pattern));
     if (!key) throw new Error(`Unhandled request: ${url}`);
     return Response.json(handlers[key]!());
   });
-  return { fetchImpl, calls };
+  return { fetchImpl };
 }
 
 /** production env 契約を満たす metadata（audit を通過させるため） */
@@ -69,52 +93,51 @@ function auditMetadata(project: 'product' | 'web') {
 
 /**
  * 両 project が candidate を持つ既定シナリオ。
- * production target は promote が成功するたびに進む。
+ * promote と rollback は同じ endpoint を使うので、対象 deployment id で区別する。
  */
-function createReleaseWorld(options: { productionSha?: string } = {}) {
-  const production = {
-    web: { id: 'dpl_web_old', sha: options.productionSha ?? OLD_SHA, createdAt: 1000 },
-    product: { id: 'dpl_product_old', sha: options.productionSha ?? OLD_SHA, createdAt: 1000 },
+function createReleaseWorld(options: { productionSha?: string; smokeBody?: string } = {}) {
+  const previous = { web: 'dpl_web_old', product: 'dpl_product_old' };
+  const production: Record<string, { id: string; sha: string; createdAt: number }> = {
+    web: { id: previous.web, sha: options.productionSha ?? OLD_SHA, createdAt: 1000 },
+    product: { id: previous.product, sha: options.productionSha ?? OLD_SHA, createdAt: 1000 },
   };
   const candidates = {
     web: deployment('dpl_web_new', SHA),
     product: deployment('dpl_product_new', SHA),
   };
-  const promoteCalls: string[] = [];
-  const rollbackCalls: string[] = [];
+  const pointCalls: { project: string; deploymentId: string }[] = [];
 
   const fetchImpl = vi.fn(async (input: URL | string, init?: RequestInit) => {
     const url = String(input);
     const method = init?.method ?? 'GET';
+
+    if (new URL(url).origin !== 'https://api.vercel.com') {
+      return smokeResponse(url, options.smokeBody);
+    }
+
     const project = url.includes('web') ? 'web' : 'product';
 
-    // smoke は deployment の unique URL を叩く。Vercel API 以外は 200 を返す。
-    if (new URL(url).origin !== 'https://api.vercel.com') {
-      return new Response(null, { status: 200 });
-    }
     if (method === 'POST' && url.includes('/promote/')) {
-      promoteCalls.push(project);
-      production[project] = {
-        ...candidates[project],
-        id: candidates[project].uid,
-        createdAt: 2000,
-      };
-      return Response.json({});
+      const deploymentId = url.split('/promote/')[1]!.split('?')[0]!;
+      // promote / rollback は project 名ではなく prj_ ID を使う。
+      expect(url).toContain(`/projects/prj_${project}/promote/`);
+      pointCalls.push({ project, deploymentId });
+      const isRollback = deploymentId === previous[project as 'web' | 'product'];
+      production[project] = isRollback
+        ? { id: deploymentId, sha: OLD_SHA, createdAt: 1000 }
+        : { id: deploymentId, sha: SHA, createdAt: 2000 };
+      return new Response(null, { status: 202 });
     }
-    if (method === 'POST' && url.includes('/rollback/')) {
-      rollbackCalls.push(project);
-      production[project] = { id: 'dpl_' + project + '_old', sha: OLD_SHA, createdAt: 1000 };
-      return Response.json({});
-    }
-    if (url.includes('/v6/deployments')) {
-      return Response.json({ deployments: [candidates[project]] });
+    if (url.includes('/v7/deployments')) {
+      return Response.json({ deployments: [candidates[project as 'web' | 'product']] });
     }
     if (url.includes('/env')) {
-      return Response.json(auditMetadata(project));
+      return Response.json(auditMetadata(project as 'product' | 'web'));
     }
     if (url.includes('/v9/projects/')) {
-      const current = production[project];
+      const current = production[project]!;
       return Response.json({
+        id: `prj_${project}`,
         targets: {
           production: {
             id: current.id,
@@ -127,7 +150,12 @@ function createReleaseWorld(options: { productionSha?: string } = {}) {
     throw new Error(`Unhandled request: ${url}`);
   });
 
-  return { fetchImpl, promoteCalls, rollbackCalls, production };
+  const promoted = () =>
+    pointCalls.filter((call) => call.deploymentId.endsWith('_new')).map((call) => call.project);
+  const rolledBack = () =>
+    pointCalls.filter((call) => call.deploymentId.endsWith('_old')).map((call) => call.project);
+
+  return { fetchImpl, pointCalls, promoted, rolledBack };
 }
 
 function release(overrides: Record<string, unknown> = {}) {
@@ -144,9 +172,9 @@ function release(overrides: Record<string, unknown> = {}) {
 }
 
 describe('findDeploymentForSha', () => {
-  it('returns only the deployment whose commit SHA matches', async () => {
+  it('returns only the production deployment whose commit SHA matches', async () => {
     const { fetchImpl } = createVercelMock({
-      '/v6/deployments': () => ({
+      '/v7/deployments': () => ({
         deployments: [deployment('dpl_other', OLD_SHA), deployment('dpl_match', SHA)],
       }),
     });
@@ -160,11 +188,37 @@ describe('findDeploymentForSha', () => {
     });
 
     expect(found?.id).toBe('dpl_match');
+    expect(String(fetchImpl.mock.calls[0]?.[0])).toContain(`sha=${SHA}`);
   });
 
-  it('returns null when no deployment exists for the SHA', async () => {
+  it('ignores deployments created outside the GitHub integration', async () => {
+    const cliDeployment = {
+      uid: 'dpl_cli',
+      url: 'dpl_cli.vercel.app',
+      readyState: 'ERROR',
+      created: 3000,
+      target: 'production',
+      meta: { gitCommitSha: SHA },
+    };
     const { fetchImpl } = createVercelMock({
-      '/v6/deployments': () => ({ deployments: [deployment('dpl_other', OLD_SHA)] }),
+      '/v7/deployments': () => ({ deployments: [cliDeployment, deployment('dpl_match', SHA)] }),
+    });
+
+    const found = await findDeploymentForSha({
+      projectName: 'web',
+      sha: SHA,
+      token: TOKEN,
+      teamId: 'team',
+      fetchImpl,
+    });
+
+    expect(found?.id).toBe('dpl_match');
+  });
+
+  it('ignores preview deployments that share the commit SHA', async () => {
+    const preview = { ...deployment('dpl_preview', SHA), target: null };
+    const { fetchImpl } = createVercelMock({
+      '/v7/deployments': () => ({ deployments: [preview] }),
     });
 
     await expect(
@@ -207,7 +261,7 @@ describe('waitForReadyCandidates', () => {
 
   it('fails fast when a build ends in ERROR', async () => {
     const { fetchImpl } = createVercelMock({
-      '/v6/deployments': () => ({ deployments: [deployment('dpl_web', SHA, 'ERROR')] }),
+      '/v7/deployments': () => ({ deployments: [deployment('dpl_web', SHA, 'ERROR')] }),
     });
 
     await expect(
@@ -226,7 +280,7 @@ describe('waitForReadyCandidates', () => {
 
   it('times out when a candidate never becomes READY', async () => {
     const { fetchImpl } = createVercelMock({
-      '/v6/deployments': () => ({ deployments: [deployment('dpl_web', SHA, 'BUILDING')] }),
+      '/v7/deployments': () => ({ deployments: [deployment('dpl_web', SHA, 'BUILDING')] }),
     });
     let clock = 0;
 
@@ -247,12 +301,14 @@ describe('waitForReadyCandidates', () => {
 });
 
 describe('smokeDeployment', () => {
+  const okBody = () => smokeResponse('https://dpl.vercel.app/');
+
   it('sends the bypass header only when a secret is configured', async () => {
-    const withSecret = vi.fn(async () => new Response(null, { status: 200 }));
+    const withSecret = vi.fn(okBody);
     await smokeDeployment({
       projectName: 'web',
       deploymentUrl: 'dpl.vercel.app',
-      paths: ['/'],
+      checks: [{ path: '/' }],
       bypassSecret: BYPASS,
       fetchImpl: withSecret,
       sleepImpl: noSleep,
@@ -260,17 +316,19 @@ describe('smokeDeployment', () => {
     });
     expect(withSecret.mock.calls[0]?.[1]?.headers).toHaveProperty('x-vercel-protection-bypass');
 
-    const withoutSecret = vi.fn(async () => new Response(null, { status: 200 }));
+    const withoutSecret = vi.fn(okBody);
     await smokeDeployment({
       projectName: 'web',
       deploymentUrl: 'dpl.vercel.app',
-      paths: ['/'],
+      checks: [{ path: '/' }],
       bypassSecret: undefined,
       fetchImpl: withoutSecret,
       sleepImpl: noSleep,
       logger: noop,
     });
-    expect(withoutSecret.mock.calls[0]?.[1]?.headers).toEqual({});
+    expect(withoutSecret.mock.calls[0]?.[1]?.headers).not.toHaveProperty(
+      'x-vercel-protection-bypass',
+    );
   });
 
   it('reports a missing Protection Bypass instead of retrying the SSO redirect', async () => {
@@ -286,7 +344,7 @@ describe('smokeDeployment', () => {
       smokeDeployment({
         projectName: 'web',
         deploymentUrl: 'dpl.vercel.app',
-        paths: ['/'],
+        checks: [{ path: '/' }],
         bypassSecret: BYPASS,
         fetchImpl,
         sleepImpl: noSleep,
@@ -296,17 +354,78 @@ describe('smokeDeployment', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
-  it('retries transient failures and never leaks the bypass secret or response body', async () => {
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValueOnce(new Response('internal detail', { status: 500 }))
-      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+  it('rejects a 200 that was served by a different route', async () => {
+    // product は未知 path でも 200 を返すため、status だけでは不足する。
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response('<title>Calendar</title>', {
+          status: 200,
+          headers: { 'x-matched-path': '/[locale]/[nday]' },
+        }),
+    );
+
+    await expect(
+      smokeDeployment({
+        projectName: 'product',
+        deploymentUrl: 'dpl.vercel.app',
+        checks: [{ path: '/auth/login', matchedPath: '/[locale]/auth/login' }],
+        bypassSecret: BYPASS,
+        fetchImpl,
+        sleepImpl: noSleep,
+        logger: noop,
+      }),
+    ).rejects.toThrow(/was served by \/\[locale\]\/\[nday\]/);
+    // route の不一致は retry しても変わらない。
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a 200 that streamed a Next.js failure', async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response('<html>NEXT_HTTP_ERROR_FALLBACK;404</html>', {
+          status: 200,
+          headers: { 'x-matched-path': '/en' },
+        }),
+    );
 
     await expect(
       smokeDeployment({
         projectName: 'web',
         deploymentUrl: 'dpl.vercel.app',
-        paths: ['/'],
+        checks: [{ path: '/', matchedPath: '/en' }],
+        bypassSecret: BYPASS,
+        fetchImpl,
+        sleepImpl: noSleep,
+        logger: noop,
+      }),
+    ).rejects.toThrow(/streamed NEXT_HTTP_ERROR_FALLBACK/);
+  });
+
+  it('sends an explicit Accept-Language so locale detection cannot redirect', async () => {
+    const fetchImpl = vi.fn(okBody);
+    await smokeDeployment({
+      projectName: 'web',
+      deploymentUrl: 'dpl.vercel.app',
+      checks: [{ path: '/' }],
+      bypassSecret: undefined,
+      fetchImpl,
+      sleepImpl: noSleep,
+      logger: noop,
+    });
+    expect(fetchImpl.mock.calls[0]?.[1]?.headers).toMatchObject({ 'accept-language': 'en' });
+  });
+
+  it('retries transient failures and never leaks the bypass secret or response body', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('internal detail', { status: 500 }))
+      .mockResolvedValueOnce(smokeResponse('https://dpl.vercel.app/'));
+
+    await expect(
+      smokeDeployment({
+        projectName: 'web',
+        deploymentUrl: 'dpl.vercel.app',
+        checks: [{ path: '/', matchedPath: '/en' }],
         bypassSecret: BYPASS,
         fetchImpl,
         sleepImpl: noSleep,
@@ -317,9 +436,9 @@ describe('smokeDeployment', () => {
 
     const failing = vi.fn(async () => new Response('internal detail', { status: 503 }));
     const error = await smokeDeployment({
-      projectName: 'web',
+      projectName: 'product',
       deploymentUrl: 'dpl.vercel.app',
-      paths: ['/api/health'],
+      checks: [{ path: '/api/health', contains: '"status":"healthy"' }],
       bypassSecret: BYPASS,
       fetchImpl: failing,
       sleepImpl: noSleep,
@@ -338,15 +457,17 @@ describe('runProductionRelease', () => {
   });
 
   it('is a no-op when both projects already serve the SHA', async () => {
-    const { fetchImpl, promoteCalls } = createReleaseWorld({ productionSha: SHA });
+    const world = createReleaseWorld({ productionSha: SHA });
 
-    await expect(release({ fetchImpl })).resolves.toMatchObject({ status: 'already-released' });
-    expect(promoteCalls).toEqual([]);
+    await expect(release({ fetchImpl: world.fetchImpl })).resolves.toMatchObject({
+      status: 'already-released',
+    });
+    expect(world.pointCalls).toEqual([]);
   });
 
   it('skips promote when a newer production deployment already exists', async () => {
     const { fetchImpl } = createVercelMock({
-      '/v6/deployments': () => ({ deployments: [deployment('dpl_new', SHA, 'READY', 1000)] }),
+      '/v7/deployments': () => ({ deployments: [deployment('dpl_new', SHA, 'READY', 1000)] }),
       '/v9/projects/': () => projectTarget('dpl_newer', OLD_SHA, 5000),
     });
 
@@ -354,43 +475,53 @@ describe('runProductionRelease', () => {
   });
 
   it('promotes web before product after smoke and audit succeed', async () => {
-    const { fetchImpl, promoteCalls, rollbackCalls } = createReleaseWorld();
+    const world = createReleaseWorld();
 
-    const result = await release({ fetchImpl });
+    const result = await release({ fetchImpl: world.fetchImpl });
 
     expect(result.status).toBe('promoted');
-    expect(promoteCalls).toEqual(['web', 'product']);
-    expect(rollbackCalls).toEqual([]);
+    expect(world.promoted()).toEqual(['web', 'product']);
+    expect(world.rolledBack()).toEqual([]);
   });
 
   it('rolls web back to its previous deployment when product fails to promote', async () => {
-    const { fetchImpl, promoteCalls, rollbackCalls } = createReleaseWorld();
+    const world = createReleaseWorld();
 
-    await expect(release({ fetchImpl, simulateFailure: 'promote:product' })).rejects.toThrow(
-      /Simulated failure at promote:product/,
-    );
+    await expect(
+      release({ fetchImpl: world.fetchImpl, simulateFailure: 'promote:product' }),
+    ).rejects.toThrow(/Simulated failure at promote:product/);
 
-    expect(promoteCalls).toEqual(['web']);
-    expect(rollbackCalls).toEqual(['web']);
+    expect(world.promoted()).toEqual(['web']);
+    expect(world.rolledBack()).toEqual(['web']);
   });
 
   it('leaves production untouched when smoke fails before any promote', async () => {
-    const { fetchImpl, promoteCalls, rollbackCalls } = createReleaseWorld();
+    const world = createReleaseWorld();
 
-    await expect(release({ fetchImpl, simulateFailure: 'smoke:web' })).rejects.toThrow(
-      /Simulated failure at smoke:web/,
+    await expect(
+      release({ fetchImpl: world.fetchImpl, simulateFailure: 'smoke:web' }),
+    ).rejects.toThrow(/Simulated failure at smoke:web/);
+
+    expect(world.pointCalls).toEqual([]);
+  });
+
+  it('stops before promote when a candidate serves an unhealthy /api/health', async () => {
+    const world = createReleaseWorld({ smokeBody: '{"status":"degraded"}' });
+
+    await expect(release({ fetchImpl: world.fetchImpl })).rejects.toThrow(
+      /without the expected content/,
     );
-
-    expect(promoteCalls).toEqual([]);
-    expect(rollbackCalls).toEqual([]);
+    expect(world.pointCalls).toEqual([]);
   });
 
   it('demands a manual rollback when the automatic rollback also fails', async () => {
     const world = createReleaseWorld();
     const fetchImpl = vi.fn(async (input: URL | string, init?: RequestInit) => {
-      if (String(input).includes('/rollback/')) {
+      const url = String(input);
+      if (url.includes('/promote/dpl_web_old')) {
         return new Response(null, { status: 500 });
       }
+      // 以降は既定の world mock に委ねる。
       return world.fetchImpl(input, init);
     });
 
@@ -413,6 +544,26 @@ describe('runProductionRelease', () => {
     await expect(release({ fetchImpl, force: true })).resolves.toMatchObject({
       status: 'promoted',
     });
-    expect(world.promoteCalls).toEqual(['web', 'product']);
+    expect(world.promoted()).toEqual(['web', 'product']);
+  });
+});
+
+describe('writeReleaseStatus', () => {
+  function outputFile() {
+    return join(mkdtempSync(join(tmpdir(), 'release-status-')), 'output.txt');
+  }
+
+  it('writes each known status for the workflow to branch on', () => {
+    for (const status of ['already-released', 'promoted', 'superseded', 'failed']) {
+      const path = outputFile();
+      writeReleaseStatus(status, { env: { GITHUB_OUTPUT: path } });
+      expect(readFileSync(path, 'utf8')).toBe(`release_status=${status}\n`);
+    }
+  });
+
+  it('refuses to write a status outside the known set', () => {
+    const path = outputFile();
+    writeReleaseStatus('promoted\nmalicious=1', { env: { GITHUB_OUTPUT: path } });
+    expect(() => readFileSync(path, 'utf8')).toThrow();
   });
 });

--- a/scripts/production-release.test.ts
+++ b/scripts/production-release.test.ts
@@ -88,7 +88,8 @@ function createReleaseWorld(options: { productionSha?: string } = {}) {
     const method = init?.method ?? 'GET';
     const project = url.includes('web') ? 'web' : 'product';
 
-    if (!url.startsWith('https://api.vercel.com')) {
+    // smoke は deployment の unique URL を叩く。Vercel API 以外は 200 を返す。
+    if (new URL(url).origin !== 'https://api.vercel.com') {
       return new Response(null, { status: 200 });
     }
     if (method === 'POST' && url.includes('/promote/')) {

--- a/scripts/production-release.test.ts
+++ b/scripts/production-release.test.ts
@@ -1,0 +1,417 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  findDeploymentForSha,
+  runProductionRelease,
+  smokeDeployment,
+  waitForReadyCandidates,
+} from './production-release.mjs';
+
+const SHA = 'a'.repeat(40);
+const OLD_SHA = 'b'.repeat(40);
+const TOKEN = 'vercel-token-must-not-appear';
+const BYPASS = 'bypass-secret-must-not-appear';
+
+type Deployment = {
+  uid: string;
+  url: string;
+  readyState: string;
+  created: number;
+  meta: { githubCommitSha: string };
+};
+
+function deployment(uid: string, sha: string, readyState = 'READY', created = 2000): Deployment {
+  return { uid, url: `${uid}.vercel.app`, readyState, created, meta: { githubCommitSha: sha } };
+}
+
+function projectTarget(id: string, sha: string, createdAt = 1000) {
+  return { targets: { production: { id, createdAt, meta: { githubCommitSha: sha } } } };
+}
+
+const noop = { log: () => {} };
+const noSleep = () => Promise.resolve();
+
+/**
+ * URL ごとに応答を返す fetch mock。呼び出し履歴を calls に記録する。
+ */
+function createVercelMock(handlers: Record<string, () => unknown>) {
+  const calls: { url: string; method: string }[] = [];
+  const fetchImpl = vi.fn(async (input: URL | string, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? 'GET';
+    calls.push({ url, method });
+
+    const key = Object.keys(handlers).find((pattern) => url.includes(pattern));
+    if (!key) throw new Error(`Unhandled request: ${url}`);
+    return Response.json(handlers[key]!());
+  });
+  return { fetchImpl, calls };
+}
+
+/** production env 契約を満たす metadata（audit を通過させるため） */
+function auditMetadata(project: 'product' | 'web') {
+  const sensitive = (key: string) => ({ key, target: ['production'], type: 'sensitive' });
+  const plain = (key: string) => ({ key, target: ['production'], type: 'plain' });
+  const shared = [
+    sensitive('RESEND_API_KEY'),
+    plain('RESEND_FROM_EMAIL'),
+    sensitive('RESEND_WEBHOOK_SECRET'),
+    plain('UPSTASH_REDIS_REST_URL'),
+    sensitive('UPSTASH_REDIS_REST_TOKEN'),
+  ];
+  return {
+    envs:
+      project === 'web'
+        ? [...shared, plain('NEXT_PUBLIC_TURNSTILE_SITE_KEY'), sensitive('TURNSTILE_SECRET_KEY')]
+        : shared,
+  };
+}
+
+/**
+ * 両 project が candidate を持つ既定シナリオ。
+ * production target は promote が成功するたびに進む。
+ */
+function createReleaseWorld(options: { productionSha?: string } = {}) {
+  const production = {
+    web: { id: 'dpl_web_old', sha: options.productionSha ?? OLD_SHA, createdAt: 1000 },
+    product: { id: 'dpl_product_old', sha: options.productionSha ?? OLD_SHA, createdAt: 1000 },
+  };
+  const candidates = {
+    web: deployment('dpl_web_new', SHA),
+    product: deployment('dpl_product_new', SHA),
+  };
+  const promoteCalls: string[] = [];
+  const rollbackCalls: string[] = [];
+
+  const fetchImpl = vi.fn(async (input: URL | string, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? 'GET';
+    const project = url.includes('web') ? 'web' : 'product';
+
+    if (!url.startsWith('https://api.vercel.com')) {
+      return new Response(null, { status: 200 });
+    }
+    if (method === 'POST' && url.includes('/promote/')) {
+      promoteCalls.push(project);
+      production[project] = {
+        ...candidates[project],
+        id: candidates[project].uid,
+        createdAt: 2000,
+      };
+      return Response.json({});
+    }
+    if (method === 'POST' && url.includes('/rollback/')) {
+      rollbackCalls.push(project);
+      production[project] = { id: 'dpl_' + project + '_old', sha: OLD_SHA, createdAt: 1000 };
+      return Response.json({});
+    }
+    if (url.includes('/v6/deployments')) {
+      return Response.json({ deployments: [candidates[project]] });
+    }
+    if (url.includes('/env')) {
+      return Response.json(auditMetadata(project));
+    }
+    if (url.includes('/v9/projects/')) {
+      const current = production[project];
+      return Response.json({
+        targets: {
+          production: {
+            id: current.id,
+            createdAt: current.createdAt,
+            meta: { githubCommitSha: current.sha },
+          },
+        },
+      });
+    }
+    throw new Error(`Unhandled request: ${url}`);
+  });
+
+  return { fetchImpl, promoteCalls, rollbackCalls, production };
+}
+
+function release(overrides: Record<string, unknown> = {}) {
+  return runProductionRelease({
+    sha: SHA,
+    token: TOKEN,
+    teamId: 'team',
+    sleepImpl: noSleep,
+    nowImpl: () => 0,
+    logger: noop,
+    bypassSecrets: { web: BYPASS, product: BYPASS },
+    ...overrides,
+  });
+}
+
+describe('findDeploymentForSha', () => {
+  it('returns only the deployment whose commit SHA matches', async () => {
+    const { fetchImpl } = createVercelMock({
+      '/v6/deployments': () => ({
+        deployments: [deployment('dpl_other', OLD_SHA), deployment('dpl_match', SHA)],
+      }),
+    });
+
+    const found = await findDeploymentForSha({
+      projectName: 'web',
+      sha: SHA,
+      token: TOKEN,
+      teamId: 'team',
+      fetchImpl,
+    });
+
+    expect(found?.id).toBe('dpl_match');
+  });
+
+  it('returns null when no deployment exists for the SHA', async () => {
+    const { fetchImpl } = createVercelMock({
+      '/v6/deployments': () => ({ deployments: [deployment('dpl_other', OLD_SHA)] }),
+    });
+
+    await expect(
+      findDeploymentForSha({
+        projectName: 'web',
+        sha: SHA,
+        token: TOKEN,
+        teamId: 'team',
+        fetchImpl,
+      }),
+    ).resolves.toBeNull();
+  });
+});
+
+describe('waitForReadyCandidates', () => {
+  const projects = [{ name: 'web' }, { name: 'product' }];
+
+  it('resolves once every project reports READY', async () => {
+    let round = 0;
+    const fetchImpl = vi.fn(async (input: URL | string) => {
+      const project = String(input).includes('web') ? 'web' : 'product';
+      round += 1;
+      const state = project === 'web' || round > 2 ? 'READY' : 'BUILDING';
+      return Response.json({ deployments: [deployment(`dpl_${project}`, SHA, state)] });
+    });
+
+    const ready = await waitForReadyCandidates({
+      projects,
+      sha: SHA,
+      token: TOKEN,
+      teamId: 'team',
+      fetchImpl,
+      sleepImpl: noSleep,
+      nowImpl: () => 0,
+      logger: noop,
+    });
+
+    expect(ready.map((entry) => entry.deployment.id)).toEqual(['dpl_web', 'dpl_product']);
+  });
+
+  it('fails fast when a build ends in ERROR', async () => {
+    const { fetchImpl } = createVercelMock({
+      '/v6/deployments': () => ({ deployments: [deployment('dpl_web', SHA, 'ERROR')] }),
+    });
+
+    await expect(
+      waitForReadyCandidates({
+        projects,
+        sha: SHA,
+        token: TOKEN,
+        teamId: 'team',
+        fetchImpl,
+        sleepImpl: noSleep,
+        nowImpl: () => 0,
+        logger: noop,
+      }),
+    ).rejects.toThrow(/ended in ERROR/);
+  });
+
+  it('times out when a candidate never becomes READY', async () => {
+    const { fetchImpl } = createVercelMock({
+      '/v6/deployments': () => ({ deployments: [deployment('dpl_web', SHA, 'BUILDING')] }),
+    });
+    let clock = 0;
+
+    await expect(
+      waitForReadyCandidates({
+        projects,
+        sha: SHA,
+        token: TOKEN,
+        teamId: 'team',
+        fetchImpl,
+        sleepImpl: noSleep,
+        nowImpl: () => (clock += 60_000),
+        logger: noop,
+        timeoutMs: 120_000,
+      }),
+    ).rejects.toThrow(/Timed out waiting for READY/);
+  });
+});
+
+describe('smokeDeployment', () => {
+  it('sends the bypass header only when a secret is configured', async () => {
+    const withSecret = vi.fn(async () => new Response(null, { status: 200 }));
+    await smokeDeployment({
+      projectName: 'web',
+      deploymentUrl: 'dpl.vercel.app',
+      paths: ['/'],
+      bypassSecret: BYPASS,
+      fetchImpl: withSecret,
+      sleepImpl: noSleep,
+      logger: noop,
+    });
+    expect(withSecret.mock.calls[0]?.[1]?.headers).toHaveProperty('x-vercel-protection-bypass');
+
+    const withoutSecret = vi.fn(async () => new Response(null, { status: 200 }));
+    await smokeDeployment({
+      projectName: 'web',
+      deploymentUrl: 'dpl.vercel.app',
+      paths: ['/'],
+      bypassSecret: undefined,
+      fetchImpl: withoutSecret,
+      sleepImpl: noSleep,
+      logger: noop,
+    });
+    expect(withoutSecret.mock.calls[0]?.[1]?.headers).toEqual({});
+  });
+
+  it('reports a missing Protection Bypass instead of retrying the SSO redirect', async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(null, {
+          status: 302,
+          headers: { location: 'https://vercel.com/sso-api?url=x' },
+        }),
+    );
+
+    await expect(
+      smokeDeployment({
+        projectName: 'web',
+        deploymentUrl: 'dpl.vercel.app',
+        paths: ['/'],
+        bypassSecret: BYPASS,
+        fetchImpl,
+        sleepImpl: noSleep,
+        logger: noop,
+      }),
+    ).rejects.toThrow(/Protection Bypass for Automation/);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries transient failures and never leaks the bypass secret or response body', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('internal detail', { status: 500 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    await expect(
+      smokeDeployment({
+        projectName: 'web',
+        deploymentUrl: 'dpl.vercel.app',
+        paths: ['/'],
+        bypassSecret: BYPASS,
+        fetchImpl,
+        sleepImpl: noSleep,
+        logger: noop,
+      }),
+    ).resolves.toBeUndefined();
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+
+    const failing = vi.fn(async () => new Response('internal detail', { status: 503 }));
+    const error = await smokeDeployment({
+      projectName: 'web',
+      deploymentUrl: 'dpl.vercel.app',
+      paths: ['/api/health'],
+      bypassSecret: BYPASS,
+      fetchImpl: failing,
+      sleepImpl: noSleep,
+      logger: noop,
+    }).catch((thrown: Error) => thrown);
+
+    expect(error.message).toContain('503');
+    expect(error.message).not.toContain(BYPASS);
+    expect(error.message).not.toContain('internal detail');
+  });
+});
+
+describe('runProductionRelease', () => {
+  it('rejects a SHA that is not a full commit hash', async () => {
+    await expect(release({ sha: 'main' })).rejects.toThrow(/40 character commit SHA/);
+  });
+
+  it('is a no-op when both projects already serve the SHA', async () => {
+    const { fetchImpl, promoteCalls } = createReleaseWorld({ productionSha: SHA });
+
+    await expect(release({ fetchImpl })).resolves.toMatchObject({ status: 'already-released' });
+    expect(promoteCalls).toEqual([]);
+  });
+
+  it('skips promote when a newer production deployment already exists', async () => {
+    const { fetchImpl } = createVercelMock({
+      '/v6/deployments': () => ({ deployments: [deployment('dpl_new', SHA, 'READY', 1000)] }),
+      '/v9/projects/': () => projectTarget('dpl_newer', OLD_SHA, 5000),
+    });
+
+    await expect(release({ fetchImpl })).resolves.toMatchObject({ status: 'superseded' });
+  });
+
+  it('promotes web before product after smoke and audit succeed', async () => {
+    const { fetchImpl, promoteCalls, rollbackCalls } = createReleaseWorld();
+
+    const result = await release({ fetchImpl });
+
+    expect(result.status).toBe('promoted');
+    expect(promoteCalls).toEqual(['web', 'product']);
+    expect(rollbackCalls).toEqual([]);
+  });
+
+  it('rolls web back to its previous deployment when product fails to promote', async () => {
+    const { fetchImpl, promoteCalls, rollbackCalls } = createReleaseWorld();
+
+    await expect(release({ fetchImpl, simulateFailure: 'promote:product' })).rejects.toThrow(
+      /Simulated failure at promote:product/,
+    );
+
+    expect(promoteCalls).toEqual(['web']);
+    expect(rollbackCalls).toEqual(['web']);
+  });
+
+  it('leaves production untouched when smoke fails before any promote', async () => {
+    const { fetchImpl, promoteCalls, rollbackCalls } = createReleaseWorld();
+
+    await expect(release({ fetchImpl, simulateFailure: 'smoke:web' })).rejects.toThrow(
+      /Simulated failure at smoke:web/,
+    );
+
+    expect(promoteCalls).toEqual([]);
+    expect(rollbackCalls).toEqual([]);
+  });
+
+  it('demands a manual rollback when the automatic rollback also fails', async () => {
+    const world = createReleaseWorld();
+    const fetchImpl = vi.fn(async (input: URL | string, init?: RequestInit) => {
+      if (String(input).includes('/rollback/')) {
+        return new Response(null, { status: 500 });
+      }
+      return world.fetchImpl(input, init);
+    });
+
+    const error = await release({ fetchImpl, simulateFailure: 'promote:product' }).catch(
+      (thrown: Error) => thrown,
+    );
+
+    expect(error.message).toContain('MANUAL ROLLBACK REQUIRED');
+    expect(error.message).toContain('dpl_web_old');
+    expect(error.message).not.toContain(TOKEN);
+  });
+
+  it('skips smoke and audit under Force Promote', async () => {
+    const world = createReleaseWorld();
+    const fetchImpl = vi.fn(async (input: URL | string, init?: RequestInit) => {
+      if (String(input).includes('/env')) throw new Error('audit must not run under force');
+      return world.fetchImpl(input, init);
+    });
+
+    await expect(release({ fetchImpl, force: true })).resolves.toMatchObject({
+      status: 'promoted',
+    });
+    expect(world.promoteCalls).toEqual(['web', 'product']);
+  });
+});


### PR DESCRIPTION
Closes #1667 の baseline scope（Rolling Releases は follow-up として分離）。

## 何を変えるか

main への merge が Production domain を切り替えるのをやめ、`Production Release` workflow の promote だけが公開を行うようにする。

```
main merge → Vercel が両 project を Production build（domain 未割当 = candidate）
           → release.yml: 同一SHAでREADY待機 → candidate smoke → live metadata audit
           → web → product の順に promote（2つ目失敗時は1つ目を自動 rollback）
           → commit status "Production Release" を証跡として publish
tag push（promote + 観察後）→ GitHub Release
```

## 主要な設計判断

- **promote 順は web → product 固定**。2 つ目が失敗した時に rollback されるのが web 側になり、クリティカルな product が部分状態になる確率を下げる
- **smoke は candidate の unique URL に対して行う**。「検証した build = promote する build」が URL レベルで保証される。両 project とも Deployment Protection が有効なため Protection Bypass for Automation の secret が必須
- **smoke は status だけを見ない**。product は未知 path でも 200 を返し（`/[locale]/[nday]` が任意の 1 segment に一致）、Next.js は streaming 中の `notFound()` / `redirect()` も 200 のまま返す。`x-matched-path` で route 同一性を確定し、`NEXT_HTTP_ERROR_FALLBACK` / `NEXT_REDIRECT` の streamed 失敗を検出する。`/api/health` は degraded でも 200 なので本文で `"status":"healthy"` を確認する
- **promote / rollback は `prj_` ID を使う**。`/v9/projects/{idOrName}` の応答から追加 API 呼び出しなしで取得する
- **rollback も promote endpoint に統一**。専用 rollback endpoint は対象が `isRollbackCandidate` に限られる一方、promote は任意 deployment を対象にでき、同じ run で先に成功実績を作る呼び出しなので復旧経路の失敗確率が低い
- **promote の副作用で戻る project 設定を復元する**。Vercel の promote endpoint は `autoAssignCustomDomains` を `true` へ戻す（[vercel/vercel#15095](https://github.com/vercel/vercel/issues/15095)、未修正）。放置すると初回リリース後に gate 自身が無効化されるため、promote / rollback の直前に観測した値をそのまま復元する（`false` 固定にはしない。段階適用中に意図しない設定変更を起こさないため）
- **promote は要求と反映確認を分離**し、POST が受理された時点で rollback 対象へ記録する。反映確認が timeout しても部分公開を残さない
- **audit は in-process で再実行**する。cross-workflow の status polling をしないので鮮度が高く race がない
- **idempotency / supersede guard**: current production が既に対象 SHA なら no-op、candidate より新しい production がいるなら promote せず `Production Release` を failure にする（live でない commit に tag を打てないようにするため）
- **concurrency は `cancel-in-progress: false`**。実行中の release を中断すると片方だけ promote された状態が残りうる
- 失敗モードは常に「Production が既知の正常 deployment のまま更新されない」に閉じる（fail-safe）

## 信頼境界

`release.yml` は Vercel の promote / rollback 権限を持つ token を扱う。

- 実行する script は常に **workflow を dispatch した ref** のもの。`inputs.sha` は release 対象を指す data で、`actions/checkout` の `ref` には渡さない
- 手動 dispatch の SHA は `compare/heads/main...<sha>` で main 包含を確認する（`identical` / `behind` のみ）。これは「merge 済みか」の確認であり、コード実行の防御ではない
- `scripts/__tests__/release-workflow-contract.test.ts` が `ref:` の不在・SHA 検証の順序・compare の許可集合・fail-closed な代入形を固定する

**未解決の残存リスク**: `actions: write` を持つ主体が main 以外の ref から dispatch すると、その ref の script が Production secret 付きで動く。YAML の条件では塞げない。

release job は `environment: production-release` を宣言済みなので、閉じるのに必要なのは GitHub 設定だけ。**設定するまでリスクは開いたまま**である点に注意（手順は infra.md）。

1. Settings → Environments → `production-release`（初回 run で自動作成）
2. Deployment branch policy を Selected branches にし `main` のみ許可 ← これだけで dispatch は拒否される
3. Vercel 系 secret 4 つを repository secret から environment secret へ移す

なお、この PR が新しい露出を作っているわけではない。同じ `VERCEL_TOKEN` を使う `production-config-audit.yml` が既に `workflow_dispatch` を持って main 上で動いており、repository secret が write 権限保持者から到達可能なのは GitHub Actions の既存の性質。

## merge 前に必要な外部設定

- [ ] Product / Web で **Protection Bypass for Automation** を有効化し、secret を発行
- [ ] `VERCEL_AUTOMATION_BYPASS_PRODUCT` / `VERCEL_AUTOMATION_BYPASS_WEB` を repository secret へ登録

これらが無いと smoke が Deployment Protection の SSO redirect で止まる（Production への影響はなし。promote 前に停止する）。

## merge 後の段階適用（本 PR には含まない）

1. Phase A 観察: Auto-assign は ON のまま 2-3 merge を流し、wait/smoke/audit を副作用ゼロで実地検証
2. required checks 追加: `Production Config Audit` / `Vercel – product` / `Vercel – web`
3. web の Auto-assign OFF → 片系失敗 drill（`simulate_failure=smoke:web`）で domain 不変を確認
4. product も OFF → 自動 rollback drill（`simulate_failure=promote:product`）
5. Instant Rollback drill で runbook の実効性を確認
6. `production-release` environment に main 限定の branch policy を設定し、secret を移す（残存リスクを閉じる）

## 検証

- `scripts/production-release.test.ts` 27 tests + `scripts/__tests__/release-workflow-contract.test.ts` 10 tests（`ref:` の不在、compare の許可集合、superseded の status、job timeout > script の最悪時間、environment 宣言を固定）
- `pnpm typecheck` / `pnpm lint` / `pnpm docs:check` 通過
- 本番 domain に対する実測で smoke 契約を確認（`/login` が 200 で Calendar を返すこと、`/auth/login` の `x-matched-path`、`Accept-Language: ja` での 307、`/api/health` の body）

## 副産物として見つかった別件

- `apps/product` が未知 path に 404 ではなく 200 を返す（soft 404）
- `apps/web/src/app/layout.tsx:32` が `lang="en"` 固定で、`/ja` でも `en` を配信する
- canonical URL が deployment URL / 別 origin を指している箇所がある

いずれも本 PR の scope 外。別 issue として扱う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


