### PR TITLE
chore: 旧問い合わせcredentialの再設定をauditで常時拒否する

### DIFF
--- a/docs/operations/contact-email.md
+++ b/docs/operations/contact-email.md
@@ -92,7 +92,7 @@ DNS移管で到達性を失った場合は、Vercel Registrarのnameserverを元
 - `RESEND_API_KEY`と`RESEND_WEBHOOK_SECRET`がPreview / Developmentをtargetにしない
 - secretはVercelのSensitive typeを使う
 - Product / Webのwebhook URLと署名secretがResend側で別々に設定されている
-- 旧`GITHUB_TOKEN` / `GITHUB_CONTACT_REPO`はこの時点では削除しない
+- 旧`GITHUB_TOKEN` / `GITHUB_CONTACT_REPO`がどのtargetにも存在しない
 
 ```bash
 node scripts/production-config-audit.mjs
@@ -126,7 +126,7 @@ timeout後の再送やbounce / complaintを実在する第三者addressへ故意
 1. `v0.32.1`tagと詳細なGitHub Releaseを作る
 2. 両Vercel projectから旧`GITHUB_TOKEN` / `GITHUB_CONTACT_REPO`を削除して再deployする
 3. 旧contact専用PATを失効する
-4. `AUDIT_FORBID_LEGACY_CONTACT_ENV=true`でmetadata auditを実行する
+4. metadata auditを実行し、旧2 envがどのtargetにも無いことを確認する
 5. Issue #1646へPIIを含まない証跡を記録しcloseする
 6. release branchと作業worktreeを削除する
 

--- a/docs/operations/secrets.md
+++ b/docs/operations/secrets.md
@@ -154,7 +154,7 @@ Vercel Preview の Supabase env vars は Supabase Vercel integration が PR Prev
 
 Contact送信用の`RESEND_API_KEY` / `RESEND_FROM_EMAIL`とapp別`RESEND_WEBHOOK_SECRET`はProduct / WebのProductionだけへ同期する。送信credentialはPreview / Developmentへ置かない。Vercel metadataは`scripts/production-config-audit.mjs`でkey / target / typeだけを確認する。
 
-旧`GITHUB_TOKEN` / `GITHUB_CONTACT_REPO`のVercel replicaと専用PATは、Resendの両Production smokeと30分観察が終わるまで保持する。current schemaの新規作成対象からは外し、観察後に[問い合わせメール運用](./contact-email.md)の順で削除・失効する。
+旧`GITHUB_TOKEN` / `GITHUB_CONTACT_REPO`のVercel replicaは削除済みで、専用PATも失効済みである。current schemaの新規作成対象から外し、`Production Config Audit`が再設定を常時拒否する。経緯は[問い合わせメール運用](./contact-email.md)を参照する。
 
 ### GitHub Secrets
 

--- a/docs/operations/security/environment-secrets.md
+++ b/docs/operations/security/environment-secrets.md
@@ -88,15 +88,15 @@ Supabase integration 由来の production DB / key も `production` target の�
 
 2026-07-21にVercel APIで値を復号せずkey / target / typeだけを再確認した。Contact移行前の状態は次のとおりで、まだProduction契約を満たさない。
 
-| Project   | Metadata                                 | 確認結果                                                | Merge前の対応                               |
-| --------- | ---------------------------------------- | ------------------------------------------------------- | ------------------------------------------- |
-| `product` | `RESEND_API_KEY`                         | Production / PreviewはSensitive、DevelopmentはEncrypted | Productionだけへ限定する                    |
-| `product` | `RESEND_FROM_EMAIL`                      | Production / Preview / Developmentに存在                | Productionだけへ限定する                    |
-| `product` | `RESEND_WEBHOOK_SECRET`                  | Production Sensitive                                    | 維持する                                    |
-| `web`     | Resend 3変数                             | いずれも存在しない                                      | Productionへ追加する                        |
-| 両方      | Upstash 2変数                            | Productionに存在                                        | tokenをSensitiveのまま維持する              |
-| `web`     | Turnstile 2変数                          | Productionに存在                                        | secretをSensitiveのまま維持する             |
-| 両方      | 旧`GITHUB_TOKEN` / `GITHUB_CONTACT_REPO` | Production / Preview / Developmentに残存                | smokeと30分観察後まで保持し、その後削除する |
+| Project   | Metadata                                 | 確認結果                                                | Merge前の対応                   |
+| --------- | ---------------------------------------- | ------------------------------------------------------- | ------------------------------- |
+| `product` | `RESEND_API_KEY`                         | Production / PreviewはSensitive、DevelopmentはEncrypted | Productionだけへ限定する        |
+| `product` | `RESEND_FROM_EMAIL`                      | Production / Preview / Developmentに存在                | Productionだけへ限定する        |
+| `product` | `RESEND_WEBHOOK_SECRET`                  | Production Sensitive                                    | 維持する                        |
+| `web`     | Resend 3変数                             | いずれも存在しない                                      | Productionへ追加する            |
+| 両方      | Upstash 2変数                            | Productionに存在                                        | tokenをSensitiveのまま維持する  |
+| `web`     | Turnstile 2変数                          | Productionに存在                                        | secretをSensitiveのまま維持する |
+| 両方      | 旧`GITHUB_TOKEN` / `GITHUB_CONTACT_REPO` | 全scopeから削除済み                                     | 再設定をauditで常時拒否する     |
 
 Contactの目標契約:
 
@@ -104,7 +104,7 @@ Contactの目標契約:
 - `RESEND_API_KEY`と`RESEND_WEBHOOK_SECRET`はSensitive typeかつProduction targetだけにする
 - Product / Webのwebhook secretが異なることはmetadataでは証明できないため、Resend / Vercel dashboardで値を表示せず確認する
 - `RESEND_API_KEY`と`RESEND_WEBHOOK_SECRET`がPreview / Developmentにあれば`Production Config Audit`を失敗させる
-- 旧GitHub envの不在検査はProduction smoke後に`AUDIT_FORBID_LEGACY_CONTACT_ENV=true`で有効にする
+- 旧`GITHUB_TOKEN` / `GITHUB_CONTACT_REPO`がどのtargetにあっても`Production Config Audit`を失敗させる
 
 Previewは`RECOVERY_CODE_PEPPER`を維持する。production modeのenv validation / recovery code処理に必要なためである。その他のDevelopment secret cleanupは[#1558](https://github.com/Dayopt/dayopt/issues/1558)のscopeとし、Contact切替と混ぜない。
 

--- a/scripts/production-config-audit.mjs
+++ b/scripts/production-config-audit.mjs
@@ -40,7 +40,7 @@ function metadataOnlyEntries(response) {
   });
 }
 
-export function auditProjectMetadata(projectName, response, options = {}) {
+export function auditProjectMetadata(projectName, response) {
   const contract = PROJECT_CONTRACTS[projectName];
   if (!contract) throw new Error(`Unknown Vercel project contract: ${projectName}`);
 
@@ -76,11 +76,9 @@ export function auditProjectMetadata(projectName, response, options = {}) {
     }
   }
 
-  if (options.forbidLegacyContactEnv) {
-    for (const key of LEGACY_CONTACT_ENV) {
-      if (entries.some((entry) => entry.key === key)) {
-        errors.push(`${projectName}: legacy ${key} must be removed after contact smoke`);
-      }
+  for (const key of LEGACY_CONTACT_ENV) {
+    if (entries.some((entry) => entry.key === key)) {
+      errors.push(`${projectName}: legacy ${key} must not be configured`);
     }
   }
 
@@ -100,19 +98,14 @@ async function fetchProjectMetadata(projectName, token, teamId, fetchImpl) {
   return response.json();
 }
 
-export async function runProductionConfigAudit({
-  token,
-  teamId,
-  forbidLegacyContactEnv = false,
-  fetchImpl = fetch,
-}) {
+export async function runProductionConfigAudit({ token, teamId, fetchImpl = fetch }) {
   if (!token) throw new Error('VERCEL_TOKEN is required for Production Config Audit');
   if (!teamId) throw new Error('VERCEL_TEAM_ID is required for Production Config Audit');
 
   const allErrors = [];
   for (const projectName of Object.keys(PROJECT_CONTRACTS)) {
     const response = await fetchProjectMetadata(projectName, token, teamId, fetchImpl);
-    allErrors.push(...auditProjectMetadata(projectName, response, { forbidLegacyContactEnv }));
+    allErrors.push(...auditProjectMetadata(projectName, response));
   }
 
   if (allErrors.length > 0) {
@@ -126,7 +119,6 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   runProductionConfigAudit({
     token: process.env.VERCEL_TOKEN,
     teamId: process.env.VERCEL_TEAM_ID,
-    forbidLegacyContactEnv: process.env.AUDIT_FORBID_LEGACY_CONTACT_ENV === 'true',
   })
     .then(() => {
       console.log('Production Config Audit passed for product and web (metadata only).');

--- a/scripts/production-config-audit.test.ts
+++ b/scripts/production-config-audit.test.ts
@@ -68,13 +68,23 @@ describe('Production Config Audit', () => {
     expect(JSON.stringify(errors)).not.toContain('private-preview-value');
   });
 
-  it('defers legacy GitHub env removal until the post-smoke flag is enabled', () => {
+  it('rejects the legacy contact credentials in any environment', () => {
     const metadata = completeProductMetadata();
     metadata.envs.push(productionEntry('GITHUB_TOKEN', 'sensitive'));
+    metadata.envs.push({
+      key: 'GITHUB_CONTACT_REPO',
+      target: ['preview'],
+      type: 'plain',
+      value: 'must-not-appear',
+    });
 
-    expect(auditProjectMetadata('product', metadata)).toEqual([]);
-    expect(auditProjectMetadata('product', metadata, { forbidLegacyContactEnv: true })).toContain(
-      'product: legacy GITHUB_TOKEN must be removed after contact smoke',
-    );
+    const errors = auditProjectMetadata('product', metadata);
+
+    expect(errors).toContain('product: legacy GITHUB_TOKEN must not be configured');
+    expect(errors).toContain('product: legacy GITHUB_CONTACT_REPO must not be configured');
+  });
+
+  it('accepts metadata that no longer carries the legacy contact credentials', () => {
+    expect(auditProjectMetadata('product', completeProductMetadata())).toEqual([]);
   });
 });


### PR DESCRIPTION
Refs #1558（repo 側の残作業。token rotation と `.env.example` 整理は別途）。

## 背景

`300498b55` で `GITHUB_TOKEN` / `GITHUB_CONTACT_REPO` の不在検査を常時有効にしたが、直後の `e5f9f59cd`（「問い合わせcredential監査の変更を分離する」）で opt-in flag へ差し戻されていた。現行 main は `AUDIT_FORBID_LEGACY_CONTACT_ENV=true` を明示した時しか検査しない状態で、その flag はどの workflow からも渡されていない。

#1558 の 2026-07-22 時点の確認で、Vercel の Product / Web 全 scope から旧 2 env は削除済み、旧 contact PAT も 401 で失効済みとなっている。Resend 配送への移行（#1646 / v0.32.1）も完了している。保持理由がなくなったので、常時拒否へ戻す。

## 変更

- `scripts/production-config-audit.mjs`: `forbidLegacyContactEnv` option と `AUDIT_FORBID_LEGACY_CONTACT_ENV` env を削除し、どの target にあっても失敗させる
- `scripts/production-config-audit.test.ts`: 常時拒否と、旧 env を持たない metadata が通ることの 2 ケースへ更新
- docs 3 件を「観察後に削除する」という移行中の記述から現状（削除済み・再設定を常時拒否）へ更新

## この PR で `Production Config Audit` check が failure になるのは想定どおり

audit workflow は `scripts/production-config-audit.mjs` を変更する PR を検出すると、base revision の結果を head の証拠として使わないために意図的に failure にする（`Audit contract changed; trusted head audit is required`）。merge 後の trusted run が新 contract で成功することを確認する運用になっている。

その trusted run が失敗した場合は、旧 env がまだ Vercel に残っていることを意味する。Production への影響はなく（metadata の読取だけ）、該当 env を削除して再実行すればよい。

## 検証

- `scripts/production-config-audit.test.ts` 4 tests
- `pnpm typecheck` / `pnpm docs:check` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)