### PR TITLE
feat(external-calendar): Step 1 — calendar_connections migration（RLS/GRANT/複合FK 一式）

### DIFF
--- a/apps/product/src/lib/database/generated/database.types.ts
+++ b/apps/product/src/lib/database/generated/database.types.ts
@@ -33,6 +33,95 @@ export type Database = {
   };
   public: {
     Tables: {
+      calendar_connection_calendars: {
+        Row: {
+          calendar_name: string | null;
+          connection_id: string;
+          created_at: string;
+          id: string;
+          last_synced_at: string | null;
+          provider_calendar_id: string;
+          sync_token: string | null;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          calendar_name?: string | null;
+          connection_id: string;
+          created_at?: string;
+          id?: string;
+          last_synced_at?: string | null;
+          provider_calendar_id: string;
+          sync_token?: string | null;
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          calendar_name?: string | null;
+          connection_id?: string;
+          created_at?: string;
+          id?: string;
+          last_synced_at?: string | null;
+          provider_calendar_id?: string;
+          sync_token?: string | null;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'calendar_connection_calendars_connection_owner_fkey';
+            columns: ['connection_id', 'user_id'];
+            isOneToOne: false;
+            referencedRelation: 'calendar_connections';
+            referencedColumns: ['id', 'user_id'];
+          },
+        ];
+      };
+      calendar_connections: {
+        Row: {
+          created_at: string;
+          granted_scopes: string[];
+          id: string;
+          last_sync_error: string | null;
+          last_synced_at: string | null;
+          provider: string;
+          provider_account_email: string | null;
+          provider_account_id: string;
+          refresh_token_enc: string;
+          status: string;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          granted_scopes: string[];
+          id?: string;
+          last_sync_error?: string | null;
+          last_synced_at?: string | null;
+          provider: string;
+          provider_account_email?: string | null;
+          provider_account_id: string;
+          refresh_token_enc: string;
+          status: string;
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          created_at?: string;
+          granted_scopes?: string[];
+          id?: string;
+          last_sync_error?: string | null;
+          last_synced_at?: string | null;
+          provider?: string;
+          provider_account_email?: string | null;
+          provider_account_id?: string;
+          refresh_token_enc?: string;
+          status?: string;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [];
+      };
       email_suppressions: {
         Row: {
           created_at: string;
@@ -60,6 +149,7 @@ export type Database = {
       external_calendar_events: {
         Row: {
           calendar_name: string | null;
+          connection_id: string | null;
           created_at: string;
           description: string | null;
           dismissed_at: string | null;
@@ -77,6 +167,7 @@ export type Database = {
         };
         Insert: {
           calendar_name?: string | null;
+          connection_id?: string | null;
           created_at?: string;
           description?: string | null;
           dismissed_at?: string | null;
@@ -94,6 +185,7 @@ export type Database = {
         };
         Update: {
           calendar_name?: string | null;
+          connection_id?: string | null;
           created_at?: string;
           description?: string | null;
           dismissed_at?: string | null;
@@ -109,7 +201,15 @@ export type Database = {
           updated_at?: string;
           user_id?: string;
         };
-        Relationships: [];
+        Relationships: [
+          {
+            foreignKeyName: 'external_calendar_events_connection_id_fkey';
+            columns: ['connection_id'];
+            isOneToOne: false;
+            referencedRelation: 'calendar_connections';
+            referencedColumns: ['id'];
+          },
+        ];
       };
       mfa_recovery_codes: {
         Row: {
@@ -600,14 +700,6 @@ export type Database = {
       [_ in never]: never;
     };
     Functions: {
-      claim_stripe_webhook_event: {
-        Args: {
-          p_event_id: string;
-          p_event_type: string;
-          p_stale_before: string;
-        };
-        Returns: string;
-      };
       batch_rename_tags: {
         Args: { p_new_names: string[]; p_tag_ids: string[]; p_user_id: string };
         Returns: number;
@@ -628,6 +720,14 @@ export type Database = {
           p_user_id: string;
         };
         Returns: number;
+      };
+      claim_stripe_webhook_event: {
+        Args: {
+          p_event_id: string;
+          p_event_type: string;
+          p_stale_before: string;
+        };
+        Returns: string;
       };
       confirm_day_plans_to_records: {
         Args: {

--- a/apps/product/src/lib/database/generated/database.types.ts
+++ b/apps/product/src/lib/database/generated/database.types.ts
@@ -203,11 +203,11 @@ export type Database = {
         };
         Relationships: [
           {
-            foreignKeyName: 'external_calendar_events_connection_id_fkey';
-            columns: ['connection_id'];
+            foreignKeyName: 'external_calendar_events_connection_owner_fkey';
+            columns: ['connection_id', 'user_id'];
             isOneToOne: false;
             referencedRelation: 'calendar_connections';
-            referencedColumns: ['id'];
+            referencedColumns: ['id', 'user_id'];
           },
         ];
       };

--- a/apps/product/src/lib/test/integration/rls-access.integration.test.ts
+++ b/apps/product/src/lib/test/integration/rls-access.integration.test.ts
@@ -583,6 +583,75 @@ describe.skipIf(SKIP_INTEGRATION)('RLS access matrix', () => {
       expect(error?.code).toBe('42501');
     });
 
+    // 複合 FK (connection_id, user_id) -> calendar_connections (id, user_id) の回帰テスト。
+    // service_role は RLS を bypass するので、cross-user の取り違えを止めるのは FK だけ。
+    // これが無いと Step 3 の sync / Step 7 の切断が他ユーザーのミラー行を巻き込む
+    it('ミラー行に他ユーザーのconnectionをぶら下げられない', async () => {
+      const { error } = await adminSupabase.from('external_calendar_events').insert({
+        user_id: TEST_USER_A_ID,
+        connection_id: CALENDAR_CONNECTION_ID, // user B の接続
+        provider: 'google',
+        provider_calendar_id: 'primary',
+        provider_event_id: `evt-cross-${crypto.randomUUID()}`,
+        title: 'cross-user link',
+        start_at: '2026-06-20T09:00:00.000Z',
+        end_at: '2026-06-20T10:00:00.000Z',
+        status: 'confirmed',
+        last_synced_at: new Date().toISOString(),
+      });
+
+      expect(error?.code).toBe('23503');
+    });
+
+    it('切断でミラー行のconnection_idだけがNULLになりuser_idは残る', async () => {
+      const connectionId = crypto.randomUUID();
+      const eventId = crypto.randomUUID();
+
+      const { error: connectionError } = await adminSupabase.from('calendar_connections').insert({
+        id: connectionId,
+        user_id: TEST_USER_B_ID,
+        provider: 'google',
+        provider_account_id: `sub-${connectionId}`,
+        granted_scopes: ['https://www.googleapis.com/auth/calendar.readonly'],
+        refresh_token_enc: 'disconnect-ciphertext',
+        status: 'active',
+      });
+      expect(connectionError).toBeNull();
+
+      const { error: eventError } = await adminSupabase.from('external_calendar_events').insert({
+        id: eventId,
+        user_id: TEST_USER_B_ID,
+        connection_id: connectionId,
+        provider: 'google',
+        provider_calendar_id: 'primary',
+        provider_event_id: `evt-disconnect-${eventId}`,
+        title: 'survives disconnect',
+        start_at: '2026-06-21T09:00:00.000Z',
+        end_at: '2026-06-21T10:00:00.000Z',
+        status: 'confirmed',
+        last_synced_at: new Date().toISOString(),
+      });
+      expect(eventError).toBeNull();
+
+      const { error: deleteError } = await adminSupabase
+        .from('calendar_connections')
+        .delete()
+        .eq('id', connectionId);
+      expect(deleteError).toBeNull();
+
+      const { data, error } = await adminSupabase
+        .from('external_calendar_events')
+        .select('connection_id, user_id')
+        .eq('id', eventId)
+        .single();
+
+      expect(error).toBeNull();
+      expect(data?.connection_id).toBeNull();
+      expect(data?.user_id).toBe(TEST_USER_B_ID);
+
+      await adminSupabase.from('external_calendar_events').delete().eq('id', eventId);
+    });
+
     // service_role は rolbypassrls = t なので、これは policy ではなく GRANT の証明
     it('service_roleはtoken列を読める', async () => {
       const { data, error } = await adminSupabase

--- a/apps/product/src/lib/test/integration/rls-access.integration.test.ts
+++ b/apps/product/src/lib/test/integration/rls-access.integration.test.ts
@@ -38,6 +38,26 @@ const RPC_COUNT_CODE_ID = crypto.randomUUID();
 const RPC_USE_CODE_ID = crypto.randomUUID();
 const RPC_COUNT_CODE_HASH = `rpc-count-${crypto.randomUUID()}`;
 const RPC_USE_CODE_HASH = `rpc-use-${crypto.randomUUID()}`;
+const CALENDAR_CONNECTION_ID = crypto.randomUUID();
+const CALENDAR_CONNECTION_CALENDAR_ID = crypto.randomUUID();
+/** calendar_connections で authenticated に GRANT SELECT されている列（migration 20260723233814 と対応） */
+const CALENDAR_CONNECTION_GRANTED_COLUMNS = [
+  'id',
+  'user_id',
+  'provider',
+  'provider_account_email',
+  'status',
+  'last_synced_at',
+  'last_sync_error',
+  'created_at',
+  'updated_at',
+] as const;
+/** authenticated から読めてはいけない列 */
+const CALENDAR_CONNECTION_WITHHELD_COLUMNS = [
+  'refresh_token_enc',
+  'granted_scopes',
+  'provider_account_id',
+] as const;
 const TEST_EMAIL_A = `test-rls-a-${TEST_USER_A_ID}@example.com`;
 const TEST_EMAIL_B = `test-rls-b-${TEST_USER_B_ID}@example.com`;
 const TEST_PASSWORD = 'test-password-123';
@@ -413,6 +433,166 @@ describe.skipIf(SKIP_INTEGRATION)('RLS access matrix', () => {
         .eq('id', TEST_USER_B_ID);
 
       expect(resetError).toBeNull();
+    });
+  });
+
+  // calendar_connections は repo 初の column-scoped SELECT。userOwnedCases /
+  // serviceRoleCases のどちらの共通ブロックにも当てはまらないため独立させる
+  // （前者は select('*') と update/delete が error null を期待し、後者は
+  // "No browser client access" policy の件数と結びついている）。
+  //
+  // production の pg_default_acl は新規 public テーブルに anon/authenticated へ
+  // arwdDxtm を撒くが local は Dxtm しか撒かない。REVOKE 漏れは local 由来の
+  // rls:snapshot では検出できないので、ここと migration 内の invariant が gate になる。
+  describe('calendar connection column grants', () => {
+    beforeAll(async () => {
+      const { error: connectionError } = await adminSupabase.from('calendar_connections').insert({
+        id: CALENDAR_CONNECTION_ID,
+        user_id: TEST_USER_B_ID,
+        provider: 'google',
+        provider_account_id: `sub-${CALENDAR_CONNECTION_ID}`,
+        provider_account_email: TEST_EMAIL_B,
+        granted_scopes: ['https://www.googleapis.com/auth/calendar.readonly'],
+        refresh_token_enc: 'rls-ciphertext',
+        status: 'active',
+      });
+      if (connectionError) throw connectionError;
+
+      const { error: calendarError } = await adminSupabase
+        .from('calendar_connection_calendars')
+        .insert({
+          id: CALENDAR_CONNECTION_CALENDAR_ID,
+          connection_id: CALENDAR_CONNECTION_ID,
+          user_id: TEST_USER_B_ID,
+          provider_calendar_id: 'primary',
+          calendar_name: 'RLS calendar',
+          sync_token: 'rls-sync-token',
+        });
+      if (calendarError) throw calendarError;
+    });
+
+    afterAll(async () => {
+      // 子は複合 FK の ON DELETE CASCADE で消える
+      await adminSupabase.from('calendar_connections').delete().eq('id', CALENDAR_CONNECTION_ID);
+    });
+
+    it('ownerはgrant済みの列だけを明示指定して自分の接続を読める', async () => {
+      const { data, error } = await supabaseB
+        .from('calendar_connections')
+        .select(CALENDAR_CONNECTION_GRANTED_COLUMNS.join(', '))
+        .eq('id', CALENDAR_CONNECTION_ID);
+
+      expect(error).toBeNull();
+      expect(data).toHaveLength(1);
+    });
+
+    it("ownerでもselect('*')は列権限で拒否される", async () => {
+      const { error } = await supabaseB
+        .from('calendar_connections')
+        .select('*')
+        .eq('id', CALENDAR_CONNECTION_ID);
+
+      expect(error?.code).toBe('42501');
+    });
+
+    it.each(CALENDAR_CONNECTION_WITHHELD_COLUMNS)('ownerでも%s列は読めない', async (column) => {
+      const { error } = await supabaseB
+        .from('calendar_connections')
+        .select(column)
+        .eq('id', CALENDAR_CONNECTION_ID);
+
+      expect(error?.code).toBe('42501');
+    });
+
+    it('未grant列をfilterに使うクエリも拒否される', async () => {
+      const { error } = await supabaseB
+        .from('calendar_connections')
+        .select('id')
+        .eq('provider_account_id', `sub-${CALENDAR_CONNECTION_ID}`);
+
+      expect(error?.code).toBe('42501');
+    });
+
+    it('他ユーザーの接続はRLSで0件になる', async () => {
+      const { data, error } = await supabaseA
+        .from('calendar_connections')
+        .select('id')
+        .eq('id', CALENDAR_CONNECTION_ID);
+
+      expect(error).toBeNull();
+      expect(data).toEqual([]);
+    });
+
+    it.each(['insert', 'update', 'delete'] as const)(
+      'authenticated clientの%sを拒否する',
+      async (operation) => {
+        if (operation === 'insert') {
+          const { error } = await supabaseB.from('calendar_connections').insert({
+            user_id: TEST_USER_B_ID,
+            provider: 'google',
+            provider_account_id: `sub-forbidden-${crypto.randomUUID()}`,
+            granted_scopes: ['https://www.googleapis.com/auth/calendar.readonly'],
+            refresh_token_enc: 'forbidden',
+            status: 'active',
+          });
+          expect(error?.code).toBe('42501');
+          return;
+        }
+
+        const { error } =
+          operation === 'update'
+            ? await supabaseB
+                .from('calendar_connections')
+                .update({ status: 'reauth_required' })
+                .eq('id', CALENDAR_CONNECTION_ID)
+            : await supabaseB
+                .from('calendar_connections')
+                .delete()
+                .eq('id', CALENDAR_CONNECTION_ID);
+
+        expect(error?.code).toBe('42501');
+      },
+    );
+
+    it('ownerは選択カレンダーをtable単位のSELECTで読める', async () => {
+      const { data, error } = await supabaseB
+        .from('calendar_connection_calendars')
+        .select('*')
+        .eq('id', CALENDAR_CONNECTION_CALENDAR_ID);
+
+      expect(error).toBeNull();
+      expect(data).toHaveLength(1);
+    });
+
+    it('他ユーザーの選択カレンダーはRLSで0件になる', async () => {
+      const { data, error } = await supabaseA
+        .from('calendar_connection_calendars')
+        .select('id')
+        .eq('id', CALENDAR_CONNECTION_CALENDAR_ID);
+
+      expect(error).toBeNull();
+      expect(data).toEqual([]);
+    });
+
+    it('authenticated clientは選択カレンダーを変更できない', async () => {
+      const { error } = await supabaseB
+        .from('calendar_connection_calendars')
+        .update({ sync_token: 'forbidden' })
+        .eq('id', CALENDAR_CONNECTION_CALENDAR_ID);
+
+      expect(error?.code).toBe('42501');
+    });
+
+    // service_role は rolbypassrls = t なので、これは policy ではなく GRANT の証明
+    it('service_roleはtoken列を読める', async () => {
+      const { data, error } = await adminSupabase
+        .from('calendar_connections')
+        .select('refresh_token_enc, granted_scopes, provider_account_id')
+        .eq('id', CALENDAR_CONNECTION_ID)
+        .single();
+
+      expect(error).toBeNull();
+      expect(data?.refresh_token_enc).toBe('rls-ciphertext');
     });
   });
 
@@ -981,5 +1161,28 @@ describe.skipIf(SKIP_INTEGRATION)('RLS access matrix', () => {
     ).toHaveLength(serviceRoleCases.length);
     expect(snapshot).not.toContain('### user_badges');
     expect(snapshot).not.toContain('### api_keys');
+  });
+
+  it('I-16 snapshotがcalendar_connectionsのcolumn grantを列単位で記録する', () => {
+    const snapshot = readFileSync(
+      resolve(process.cwd(), '../../docs/engineering/data/db/rls-snapshot.md'),
+      'utf8',
+    );
+
+    expect(snapshot).toContain('### calendar_connections');
+    expect(snapshot).toContain('### calendar_connection_calendars');
+
+    for (const column of CALENDAR_CONNECTION_GRANTED_COLUMNS) {
+      expect(snapshot).toContain(`public.calendar_connections.${column}`);
+    }
+    for (const column of CALENDAR_CONNECTION_WITHHELD_COLUMNS) {
+      expect(snapshot).not.toContain(`public.calendar_connections.${column}`);
+    }
+
+    // table 単位の SELECT を authenticated に与えていないことの記録。
+    // 与えてしまうと列単位の grant が意味を失う
+    expect(snapshot).not.toMatch(
+      /\| table\s+\| public\.calendar_connections\s+\| authenticated\s+\|/,
+    );
   });
 });

--- a/docs/engineering/architecture.md
+++ b/docs/engineering/architecture.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_verified: 2026-07-14
+last_verified: 2026-07-24
 code: apps/product/src
 ---
 
@@ -354,7 +354,7 @@ USING (auth.uid() = user_id);
 
 ## Database Architecture
 
-> **RLS 対象 public テーブル数**: 13 | **PostgreSQL**: v17
+> **RLS 対象 public テーブル数**: 15 | **PostgreSQL**: v17
 
 Dayopt は Supabase（PostgreSQL）を使用する。本番は Pro organization の `dayopt` project、PR ごとの検証は ephemeral Preview Branches を使い、永続 Staging project は置かない。
 RLS の正確な対象・policy・grant は自動生成の [`data/db/rls-snapshot.md`](./data/db/rls-snapshot.md) を正とする。
@@ -363,12 +363,23 @@ RLS の正確な対象・policy・grant は自動生成の [`data/db/rls-snapsho
 
 #### コアビジネス（4テーブル）
 
-| テーブル                     | 役割                                                             | 主要カラム                                                                                                |
-| ---------------------------- | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| **plans**                    | Plan（予定）。これからやる時間の宣言                             | title, tag_id, start_at, end_at, skipped_at, source, external_calendar_event_id                           |
-| **records**                  | Record（記録）。`plan_id` で 1 Plan : N Record                   | title, tag_id, plan_id, start_at, end_at, source, external_calendar_event_id                              |
-| **external_calendar_events** | 外部カレンダー同期ミラー（テーブルのみ存在。同期実装は Phase 2） | provider, provider_calendar_id, provider_event_id, start_at, end_at, status, dismissed_at, last_synced_at |
-| **tags**                     | 階層タグ（親子1階層）                                            | name, color, parent_id, sort_order, is_active                                                             |
+| テーブル                     | 役割                                                             | 主要カラム                                                                                                               |
+| ---------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| **plans**                    | Plan（予定）。これからやる時間の宣言                             | title, tag_id, start_at, end_at, skipped_at, source, external_calendar_event_id                                          |
+| **records**                  | Record（記録）。`plan_id` で 1 Plan : N Record                   | title, tag_id, plan_id, start_at, end_at, source, external_calendar_event_id                                             |
+| **external_calendar_events** | 外部カレンダー同期ミラー（テーブルのみ存在。同期実装は Phase 2） | connection_id, provider, provider_calendar_id, provider_event_id, start_at, end_at, status, dismissed_at, last_synced_at |
+| **tags**                     | 階層タグ（親子1階層）                                            | name, color, parent_id, sort_order, is_active                                                                            |
+
+#### 外部カレンダー連携（2テーブル）
+
+Phase 2（external-calendar-import）で追加。OAuth / 同期 / UI は Step 2 以降。
+
+| テーブル                          | 役割                                                              | 主要カラム                                                                                       |
+| --------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| **calendar_connections**          | provider アカウント接続。同一 provider の複数アカウントを許容     | provider, provider_account_id, provider_account_email, granted_scopes, refresh_token_enc, status |
+| **calendar_connection_calendars** | 取り込み対象として選択されたカレンダーと per-calendar sync cursor | connection_id, provider_calendar_id, calendar_name, sync_token, last_synced_at                   |
+
+`calendar_connections.refresh_token_enc` / `granted_scopes` / `provider_account_id` は authenticated へ GRANT しない（column-scoped SELECT）。詳細は [`data/db/rls-snapshot.md`](./data/db/rls-snapshot.md)。
 
 #### ユーザー設定（2テーブル）
 
@@ -431,10 +442,36 @@ RLS の正確な対象・policy・grant は自動生成の [`data/db/rls-snapsho
                               │───────────────────────────│
                               │ id (PK)                    │
                               │ user_id (FK)                │
+                              │ connection_id (FK, NULL)    │
                               │ provider, provider_calendar_ │
                               │  id, provider_event_id      │
                               │ start_at/end_at, status     │
                               │ dismissed_at, last_synced_at │
+                              └─────────────┬─────────────┘
+                                            │ connection_id (ON DELETE SET NULL)
+                                            ▼
+                              ┌───────────────────────────┐
+                              │   calendar_connections     │
+                              │  (provider アカウント接続) │
+                              │───────────────────────────│
+                              │ id (PK)                    │
+                              │ user_id (FK)                │
+                              │ provider, provider_account_ │
+                              │  id, provider_account_email │
+                              │ granted_scopes              │
+                              │ refresh_token_enc           │
+                              │ status, last_synced_at      │
+                              └─────────────┬─────────────┘
+                                            │ (id, user_id) 複合 FK
+                                            ▼
+                              ┌───────────────────────────┐
+                              │ calendar_connection_       │
+                              │   calendars (選択カレンダー)│
+                              │───────────────────────────│
+                              │ id (PK)                    │
+                              │ connection_id, user_id (FK) │
+                              │ provider_calendar_id        │
+                              │ calendar_name, sync_token   │
                               └───────────────────────────┘
 
 === セキュリティ/監査 ===

--- a/docs/engineering/data/db/rls-snapshot.md
+++ b/docs/engineering/data/db/rls-snapshot.md
@@ -5,27 +5,43 @@
 > **手で編集しない**。migration 変更時は CI（`pnpm rls:snapshot:check`）が drift を検出する。
 > 再生成で更新すること。
 >
-> 集計: public スキーマの policy 38 件 / RLS 対象テーブル 13 件 / GRANT 85 件 / Realtime publication 0 件。
+> 集計: public スキーマの policy 42 件 / RLS 対象テーブル 15 件 / GRANT 97 件 / Realtime publication 0 件。
 
 ## RLS 有効状態（public テーブル）
 
-| table                     | RLS enabled | forced |
-| ------------------------- | ----------- | ------ |
-| email_suppressions        | ✅          | —      |
-| external_calendar_events  | ✅          | —      |
-| mfa_recovery_codes        | ✅          | —      |
-| oauth_audit_log           | ✅          | —      |
-| oauth_authorization_codes | ✅          | —      |
-| oauth_tokens              | ✅          | —      |
-| plans                     | ✅          | —      |
-| profiles                  | ✅          | —      |
-| records                   | ✅          | —      |
-| reports                   | ✅          | —      |
-| stripe_webhook_events     | ✅          | —      |
-| tags                      | ✅          | —      |
-| user_settings             | ✅          | —      |
+| table                         | RLS enabled | forced |
+| ----------------------------- | ----------- | ------ |
+| calendar_connection_calendars | ✅          | —      |
+| calendar_connections          | ✅          | —      |
+| email_suppressions            | ✅          | —      |
+| external_calendar_events      | ✅          | —      |
+| mfa_recovery_codes            | ✅          | —      |
+| oauth_audit_log               | ✅          | —      |
+| oauth_authorization_codes     | ✅          | —      |
+| oauth_tokens                  | ✅          | —      |
+| plans                         | ✅          | —      |
+| profiles                      | ✅          | —      |
+| records                       | ✅          | —      |
+| reports                       | ✅          | —      |
+| stripe_webhook_events         | ✅          | —      |
+| tags                          | ✅          | —      |
+| user_settings                 | ✅          | —      |
 
 ## ポリシー一覧（table 別）
+
+### calendar_connection_calendars
+
+| policy                                                        | cmd    | permissive | roles           | USING                                   | WITH CHECK |
+| ------------------------------------------------------------- | ------ | ---------- | --------------- | --------------------------------------- | ---------- |
+| Service role has full access to calendar connection calendars | ALL    | PERMISSIVE | {service_role}  | true                                    | true       |
+| Users can view own calendar connection calendars              | SELECT | PERMISSIVE | {authenticated} | (( SELECT auth.uid() AS uid) = user_id) | —          |
+
+### calendar_connections
+
+| policy                                               | cmd    | permissive | roles           | USING                                   | WITH CHECK |
+| ---------------------------------------------------- | ------ | ---------- | --------------- | --------------------------------------- | ---------- |
+| Service role has full access to calendar connections | ALL    | PERMISSIVE | {service_role}  | true                                    | true       |
+| Users can view own calendar connections              | SELECT | PERMISSIVE | {authenticated} | (( SELECT auth.uid() AS uid) = user_id) | —          |
 
 ### email_suppressions
 
@@ -134,6 +150,15 @@
 
 | object type | object                                                                                                                                                                                                                                           | grantee             | privileges                     |
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------- | ------------------------------ |
+| column      | public.calendar_connections.created_at                                                                                                                                                                                                           | authenticated       | SELECT                         |
+| column      | public.calendar_connections.id                                                                                                                                                                                                                   | authenticated       | SELECT                         |
+| column      | public.calendar_connections.last_sync_error                                                                                                                                                                                                      | authenticated       | SELECT                         |
+| column      | public.calendar_connections.last_synced_at                                                                                                                                                                                                       | authenticated       | SELECT                         |
+| column      | public.calendar_connections.provider                                                                                                                                                                                                             | authenticated       | SELECT                         |
+| column      | public.calendar_connections.provider_account_email                                                                                                                                                                                               | authenticated       | SELECT                         |
+| column      | public.calendar_connections.status                                                                                                                                                                                                               | authenticated       | SELECT                         |
+| column      | public.calendar_connections.updated_at                                                                                                                                                                                                           | authenticated       | SELECT                         |
+| column      | public.calendar_connections.user_id                                                                                                                                                                                                              | authenticated       | SELECT                         |
 | column      | public.external_calendar_events.dismissed_at                                                                                                                                                                                                     | authenticated       | UPDATE                         |
 | column      | public.profiles.avatar_url                                                                                                                                                                                                                       | authenticated       | INSERT, UPDATE                 |
 | column      | public.profiles.email                                                                                                                                                                                                                            | authenticated       | INSERT                         |
@@ -183,6 +208,9 @@
 | routine     | public.update_updated_at()                                                                                                                                                                                                                       | service_role        | EXECUTE                        |
 | routine     | public.use_recovery_code(p_user_id uuid, p_code_hash text)                                                                                                                                                                                       | service_role        | EXECUTE                        |
 | routine     | public.vault_secret_exists(p_name text)                                                                                                                                                                                                          | service_role        | EXECUTE                        |
+| table       | public.calendar_connection_calendars                                                                                                                                                                                                             | authenticated       | SELECT                         |
+| table       | public.calendar_connection_calendars                                                                                                                                                                                                             | service_role        | DELETE, INSERT, SELECT, UPDATE |
+| table       | public.calendar_connections                                                                                                                                                                                                                      | service_role        | DELETE, INSERT, SELECT, UPDATE |
 | table       | public.email_suppressions                                                                                                                                                                                                                        | anon                | DELETE, INSERT, SELECT, UPDATE |
 | table       | public.email_suppressions                                                                                                                                                                                                                        | authenticated       | DELETE, INSERT, SELECT, UPDATE |
 | table       | public.email_suppressions                                                                                                                                                                                                                        | service_role        | DELETE, INSERT, SELECT, UPDATE |

--- a/docs/projects/external-calendar-import/overview.md
+++ b/docs/projects/external-calendar-import/overview.md
@@ -1,7 +1,7 @@
 ---
 status: active
 last_verified: 2026-07-24
-code: supabase/migrations/20260723233814_add_calendar_connection_tables.sql
+code: supabase/migrations/20260724000416_enforce_external_event_connection_owner.sql
 ---
 
 # external-calendar-import — 外部カレンダーを one-way で取り込む
@@ -96,10 +96,12 @@ owner 整合は **複合 FK** で担保する（Step 1 実装時の変更。当�
 
 ### 4-2b. ミラーへの connection_id 追加（Step 1 実装時の追加）
 
-`external_calendar_events` に `connection_id uuid REFERENCES calendar_connections(id) ON DELETE SET NULL` を追加し、upsert key を `(user_id, provider, connection_id, provider_calendar_id, provider_event_id)` に張り替えた。
+`external_calendar_events` に `connection_id` を追加し、upsert key を `(user_id, provider, connection_id, provider_calendar_id, provider_event_id)` に張り替えた。
 
 - **理由**: §4-1 が同一 provider の複数アカウントを許容するため、2 つの Google アカウントが同じ共有カレンダーを購読すると旧 4 列キーで行を奪い合い、切断時の prune も connection 単位に絞れない
-- **`ON DELETE SET NULL` である理由**: §8 は plans / records から参照済みのミラー行を残す。それらの FK は NO ACTION なので、CASCADE にすると切断が `23503` で丸ごと失敗する。孤立した行は §8 の言う歴史的アンカーとして `connection_id IS NULL` で残る
+- **owner 整合も複合 FK で担保する**: `FOREIGN KEY (connection_id, user_id) REFERENCES calendar_connections (id, user_id) ON DELETE SET NULL (connection_id)`。単一列 FK だと「その connection が存在する」ことしか保証せず、service_role の書き手（Step 3 の sync、Step 7 の切断）が user A のミラー行に user B の connection をぶら下げられてしまう。そうなると (a) connection 単位の prune が他ユーザーの行を巻き込み、(b) B の切断が A の行を書き換え、(c) `external_calendar_events` は table 単位 SELECT なので A が他人の connection UUID を読める。子テーブルと同じ規則を適用する（PR #1714 のレビュー指摘）
+- **`ON DELETE SET NULL (connection_id)` の列リストは必須**: 列を指定しないと `user_id` まで NULL 化しようとして `23502` になる（PG15+ の構文。local / production とも 17.6）
+- **`ON DELETE SET NULL` である理由**: §8 は plans / records から参照済みのミラー行を残す。それらの FK は NO ACTION なので、CASCADE にすると切断が `23503` で丸ごと失敗する。孤立した行は §8 の言う歴史的アンカーとして `connection_id IS NULL` で残る。`MATCH SIMPLE` なので `connection_id IS NULL` の行は FK 検査の対象外になり、孤立行は正当なまま
 - unique index は既定の `NULLS DISTINCT` のまま。孤立行は二度と upsert に参加しないので、distinct 扱いが切断を阻むことはない
 - production・local とも空テーブルの段階で入れたので backfill はゼロ
 

--- a/docs/projects/external-calendar-import/overview.md
+++ b/docs/projects/external-calendar-import/overview.md
@@ -1,7 +1,7 @@
 ---
 status: active
-last_verified: 2026-07-23
-code: supabase/migrations/20260708232500_add_time_model_tables.sql
+last_verified: 2026-07-24
+code: supabase/migrations/20260723233814_add_calendar_connection_tables.sql
 ---
 
 # external-calendar-import — 外部カレンダーを one-way で取り込む
@@ -69,23 +69,39 @@ Phase 1 から継承する拘束（本書で再決定しない）:
 
 - UNIQUE `(user_id, provider, provider_account_id)` — **同一 provider の複数アカウントを最初から許容する**。schema コストはゼロで、UI は接続一覧表示で吸収する
 - access token は**保存しない**。1h TTL の一時値であり、保存すると secret 面が増えるだけ（同期のたびに refresh token から mint する。§5-3）
+- Step 1 実装時の追加（migration `20260723233814`）:
+  - `status` は `CHECK (status IN ('active','reauth_required'))`。provider 由来の値ではなくアプリが決める閉じた集合なので、ミラーの not-blank ではなく `plans_source_check` と同型にした。3 つ目の状態を足す時は migration が要る
+  - `granted_scopes` に `cardinality > 0 かつ NULL 要素なし` の CHECK。`NOT NULL` だけでは `'{}'` を通してしまい、監査用途を満たさない
+  - `refresh_token_enc` / `provider_account_id` に not-blank CHECK（ミラーの書式踏襲）
+  - 子テーブルの複合 FK 参照先として `UNIQUE (id, user_id)`
 
 ### 4-2. calendar_connection_calendars
 
 **選択済みカレンダーのみ**永続化する。選択可能な一覧は接続時・設定画面表示時にオンデマンドで provider API から取得し、保存しない。
 
-| カラム                  | 型                   | 制約                                                        |
-| ----------------------- | -------------------- | ----------------------------------------------------------- |
-| id                      | uuid PK              |                                                             |
-| connection_id           | uuid NOT NULL        | FK → calendar_connections, ON DELETE CASCADE                |
-| user_id                 | uuid NOT NULL        | RLS 簡素化のための非正規化。owner 整合は constraint trigger |
-| provider_calendar_id    | text NOT NULL        | UNIQUE `(connection_id, provider_calendar_id)`              |
-| calendar_name           | text NULL            |                                                             |
-| sync_token              | text NULL            | **per-calendar cursor**（§6-3。NULL = 次回 full sync）      |
-| last_synced_at          | timestamptz NULL     |                                                             |
-| created_at / updated_at | timestamptz NOT NULL |                                                             |
+| カラム                  | 型                   | 制約                                                    |
+| ----------------------- | -------------------- | ------------------------------------------------------- |
+| id                      | uuid PK              |                                                         |
+| connection_id           | uuid NOT NULL        | 複合 FK の一部（下記）                                  |
+| user_id                 | uuid NOT NULL        | RLS 簡素化のための非正規化。owner 整合は複合 FK（下記） |
+| provider_calendar_id    | text NOT NULL        | UNIQUE `(connection_id, provider_calendar_id)`          |
+| calendar_name           | text NULL            |                                                         |
+| sync_token              | text NULL            | **per-calendar cursor**（§6-3。NULL = 次回 full sync）  |
+| last_synced_at          | timestamptz NULL     |                                                         |
+| created_at / updated_at | timestamptz NOT NULL |                                                         |
 
 sync cursor を connection ではなく calendar 行に置く理由: Google の `syncToken` は events collection（= カレンダー）単位で発行される。connection 単位に置くと複数カレンダー選択で破綻する。Microsoft Graph の deltaLink も resource 単位なので同じ形に収まる。
+
+owner 整合は **複合 FK** で担保する（Step 1 実装時の変更。当初案は constraint trigger）。親に `UNIQUE (id, user_id)` を置き、子は `FOREIGN KEY (connection_id, user_id) REFERENCES calendar_connections (id, user_id) ON DELETE CASCADE` を持つ。constraint trigger は子側の `AFTER INSERT OR UPDATE` しか見ないため、親の `UPDATE calendar_connections SET user_id` を素通りさせる（repo はこの穴の backfill を [`20260706120100_backfill_entry_tag_owner_mismatch.sql`](../../../supabase/migrations/20260706120100_backfill_entry_tag_owner_mismatch.sql) で実際に払っている）。加えて trigger の存在確認 SELECT は lock を取らないが、RI は参照行に `FOR KEY SHARE` を取る。コストは冗長 index 1 本で、trigger 関数と REVOKE / GRANT EXECUTE の定型が不要になる。
+
+### 4-2b. ミラーへの connection_id 追加（Step 1 実装時の追加）
+
+`external_calendar_events` に `connection_id uuid REFERENCES calendar_connections(id) ON DELETE SET NULL` を追加し、upsert key を `(user_id, provider, connection_id, provider_calendar_id, provider_event_id)` に張り替えた。
+
+- **理由**: §4-1 が同一 provider の複数アカウントを許容するため、2 つの Google アカウントが同じ共有カレンダーを購読すると旧 4 列キーで行を奪い合い、切断時の prune も connection 単位に絞れない
+- **`ON DELETE SET NULL` である理由**: §8 は plans / records から参照済みのミラー行を残す。それらの FK は NO ACTION なので、CASCADE にすると切断が `23503` で丸ごと失敗する。孤立した行は §8 の言う歴史的アンカーとして `connection_id IS NULL` で残る
+- unique index は既定の `NULLS DISTINCT` のまま。孤立行は二度と upsert に参加しないので、distinct 扱いが切断を阻むことはない
+- production・local とも空テーブルの段階で入れたので backfill はゼロ
 
 ### 4-3. Token 保護（相談事項 → 採用: Option α + γ の組み合わせ）
 
@@ -95,15 +111,17 @@ sync cursor を connection ではなく calendar 行に置く理由: Google の 
 
 ### 4-4. RLS / GRANT（migration に 1 セットで書く）
 
-| ロール        | calendar_connections                                                                                                                                                                                                  | calendar_connection_calendars |
-| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
-| authenticated | column-scoped SELECT のみ（`id, provider, provider_account_email, status, last_synced_at, last_sync_error, created_at`。**`refresh_token_enc` / `granted_scopes` は grant から除外**）+ `auth.uid() = user_id` policy | SELECT のみ + 同 policy       |
-| service_role  | ALL                                                                                                                                                                                                                   | ALL                           |
-| anon          | なし                                                                                                                                                                                                                  | なし                          |
+| ロール        | calendar_connections                                                                                                                                                                                                                                               | calendar_connection_calendars |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------- |
+| authenticated | column-scoped SELECT のみ（`id, user_id, provider, provider_account_email, status, last_synced_at, last_sync_error, created_at, updated_at`。**`refresh_token_enc` / `granted_scopes` / `provider_account_id` は grant から除外**）+ `auth.uid() = user_id` policy | SELECT のみ + 同 policy       |
+| service_role  | ALL                                                                                                                                                                                                                                                                | ALL                           |
+| anon          | なし                                                                                                                                                                                                                                                               | なし                          |
 
 - 全 mutation（接続作成・カレンダー選択・切断）は tRPC service が `createServiceRoleClient` + 明示的な `user_id` 一致ガードで実行する。ミラーテーブルと同じ「書き込みは service_role 責務」の構図
-- 注意: column-scoped grant の下では `select('*')` が permission denied になる。service 層は明示カラム指定を徹底する
-- `pnpm rls:snapshot` を再生成し、drift を CI で検出する
+- 注意: column-scoped grant の下では `select('*')` だけでなく、**未 grant 列を `WHERE` / `ORDER BY` / `EXPLAIN` に含むクエリもすべて 42501 になる**。エラーは列名を出さず `permission denied for table` としか言わない。service 層は明示カラム指定を徹底する
+- `user_id` を grant に含めた理由（Step 1 実装時の変更）: JWT で既に既知なので開示はゼロ。除外すると repo 内で 81 箇所使われている `.eq('user_id', …)` idiom が 42501 になる。ローカル検証で「RLS の `USING` 句は呼び出し側の列権限チェックを受けない」ことは実証済み（未 grant の `user_id` を参照する policy が正しく行を絞った）ため grant は必須ではないが、次に触る人の地雷を消すために含める
+- §4-3 が挙げる「前例 2 件」はいずれも書き込み側の grant であり、**column-scoped SELECT は本 project が repo 初**
+- `pnpm rls:snapshot` を再生成し、drift を CI で検出する。ただし snapshot は SELECT / INSERT / UPDATE / DELETE しか記録せず、しかも生成元は local DB である。production の `pg_default_acl` は新規 public テーブルに anon / authenticated へ `arwdDxtm` を撒く（local は `Dxtm` のみ）ため、**REVOKE 漏れは snapshot でも CI でも検出できない**。migration 自身に `has_table_privilege` / `has_column_privilege` の invariant を書き、production 適用時に落ちるようにする
 - 2026-07-16 の [iCal schema drift incident](../../operations/log/2026-07-16-incident-production-ical-schema-drift.md) の規律に従う: 明示 transaction + `lock_timeout = '5s'`、local reset → Supabase Preview Branch 検証 → merge の経路のみ。Dashboard SQL Editor と手動 `db push` は使わない
 
 ## 5. OAuth フロー（Google）

--- a/supabase/migrations/20260723233814_add_calendar_connection_tables.sql
+++ b/supabase/migrations/20260723233814_add_calendar_connection_tables.sql
@@ -1,0 +1,334 @@
+-- external-calendar-import Step 1 (issue #1703).
+-- Connection model for one-way external calendar import: account connections and
+-- the calendars selected under them. No OAuth, sync, or UI lands here.
+--
+-- Design: docs/projects/external-calendar-import/overview.md §4.
+-- Format follows 20260708232500_add_time_model_tables.sql.
+--
+-- Token protection (§4-3): `refresh_token_enc` holds AES-256-GCM ciphertext AND is
+-- withheld from `authenticated` by a column-scoped SELECT grant. This is the first
+-- column-scoped SELECT in this repo -- the two precedents cited by §4-3
+-- (GRANT UPDATE(dismissed_at), 20260705070000) are both write-side grants.
+--
+-- Why the grants are verified inside this migration (section 6): production and
+-- local disagree on `pg_default_acl` for new public tables. Production grants
+-- anon/authenticated `arwdDxtm` (full DML); a clean local/Preview database grants
+-- only `Dxtm`. A missing REVOKE would therefore expose `refresh_token_enc` in
+-- production while looking clean locally, and `pnpm rls:snapshot` cannot catch it
+-- (it reports only SELECT/INSERT/UPDATE/DELETE, so TRUNCATE is invisible too).
+-- The invariant block below is the only gate that runs where it matters.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+-- =============================================================================
+-- 1. Tables
+-- =============================================================================
+
+CREATE TABLE public.calendar_connections (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  provider TEXT NOT NULL,
+  provider_account_id TEXT NOT NULL,
+  provider_account_email TEXT,
+  granted_scopes TEXT[] NOT NULL,
+  refresh_token_enc TEXT NOT NULL,
+  status TEXT NOT NULL,
+  last_synced_at TIMESTAMPTZ,
+  last_sync_error TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- Free text + not-blank, matching the mirror table (§4-1 "enum 不使用").
+  CONSTRAINT calendar_connections_provider_not_blank CHECK (length(btrim(provider)) > 0),
+  CONSTRAINT calendar_connections_provider_account_id_not_blank
+    CHECK (length(btrim(provider_account_id)) > 0),
+  CONSTRAINT calendar_connections_refresh_token_enc_not_blank
+    CHECK (length(btrim(refresh_token_enc)) > 0),
+  -- `status` is app-controlled (unlike the provider-supplied mirror status), so the
+  -- closed value set is enforced like plans_source_check. This subsumes not-blank.
+  CONSTRAINT calendar_connections_status_check CHECK (status IN ('active', 'reauth_required')),
+  -- NOT NULL alone admits '{}' and '{NULL}', which defeats the audit / scope-drift
+  -- purpose the column exists for (§4-1).
+  CONSTRAINT calendar_connections_granted_scopes_not_empty CHECK (
+    cardinality(granted_scopes) > 0 AND array_position(granted_scopes, NULL::TEXT) IS NULL
+  ),
+  -- Referenced by the child's composite FK below.
+  CONSTRAINT calendar_connections_id_user_id_unique UNIQUE (id, user_id)
+);
+
+-- Only selected calendars are persisted. The selectable list is fetched on demand
+-- from the provider and never stored (§4-2).
+CREATE TABLE public.calendar_connection_calendars (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  connection_id UUID NOT NULL,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  provider_calendar_id TEXT NOT NULL,
+  calendar_name TEXT,
+  -- Per-calendar sync cursor (Google syncToken / Graph deltaLink). NULL = full sync
+  -- next run. A cursor is not a credential, so it stays inside the table-level
+  -- SELECT grant the design assigns to this table (§4-4).
+  sync_token TEXT,
+  last_synced_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT calendar_connection_calendars_provider_calendar_id_not_blank
+    CHECK (length(btrim(provider_calendar_id)) > 0),
+  -- Owner integrity as a composite FK rather than a constraint trigger. A child-side
+  -- AFTER INSERT OR UPDATE trigger cannot see `UPDATE calendar_connections SET user_id`
+  -- (the gap 20260706120100_backfill_entry_tag_owner_mismatch.sql had to backfill), and
+  -- its unlocked existence probe is racy. RI takes FOR KEY SHARE on the referenced row.
+  CONSTRAINT calendar_connection_calendars_connection_owner_fkey
+    FOREIGN KEY (connection_id, user_id)
+    REFERENCES public.calendar_connections (id, user_id)
+    ON DELETE CASCADE
+);
+
+-- The mirror was created in Phase 1 as an FK receptacle only, without a link to the
+-- connection that produced each row. §4-1 allows several accounts of the same provider,
+-- so two connections subscribed to the same shared calendar would collide on the
+-- upsert key and disconnect could not scope its prune. Both environments are still
+-- empty, so this costs no backfill.
+--
+-- ON DELETE SET NULL, not CASCADE: §8 keeps mirror rows that plans / records already
+-- reference. Those FKs are NO ACTION, so a cascading delete would raise 23503 and abort
+-- the whole disconnect. Orphaned rows stay as the historical anchor §8 describes.
+ALTER TABLE public.external_calendar_events
+  ADD COLUMN connection_id UUID REFERENCES public.calendar_connections(id) ON DELETE SET NULL;
+
+-- =============================================================================
+-- 2. Constraints / indexes
+-- =============================================================================
+
+-- Several accounts of the same provider are allowed from the start (§4-1).
+CREATE UNIQUE INDEX calendar_connections_provider_account_unique
+  ON public.calendar_connections(user_id, provider, provider_account_id);
+
+-- Declared as an index rather than an inline UNIQUE: the auto-generated constraint name
+-- would be 68 characters and Postgres would silently truncate it to 63.
+CREATE UNIQUE INDEX calendar_connection_calendars_provider_calendar_unique
+  ON public.calendar_connection_calendars(connection_id, provider_calendar_id);
+
+-- The unique index above starts at connection_id, so it does not serve user_id lookups
+-- or the auth.users cascade. calendar_connections needs no equivalent: its
+-- (user_id, provider, provider_account_id) index already supplies the user_id prefix.
+CREATE INDEX calendar_connection_calendars_user_id_idx
+  ON public.calendar_connection_calendars(user_id);
+
+-- Rebuild the mirror's upsert key to include connection_id. NULLS DISTINCT (the default)
+-- is intentional: rows orphaned by disconnect carry connection_id IS NULL and never
+-- participate in an upsert again, so treating them as distinct can never block a
+-- disconnect, while live rows always carry a connection_id and dedupe normally.
+DROP INDEX public.external_calendar_events_provider_event_unique;
+
+CREATE UNIQUE INDEX external_calendar_events_provider_event_unique
+  ON public.external_calendar_events(
+    user_id, provider, connection_id, provider_calendar_id, provider_event_id
+  );
+
+CREATE INDEX external_calendar_events_connection_id_idx
+  ON public.external_calendar_events(connection_id)
+  WHERE connection_id IS NOT NULL;
+
+-- =============================================================================
+-- 3. Triggers
+-- =============================================================================
+
+-- public.update_updated_at() already exists; only the triggers are new.
+CREATE TRIGGER trigger_update_calendar_connections_updated_at
+  BEFORE UPDATE ON public.calendar_connections
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at();
+
+CREATE TRIGGER trigger_update_calendar_connection_calendars_updated_at
+  BEFORE UPDATE ON public.calendar_connection_calendars
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at();
+
+-- =============================================================================
+-- 4. RLS / GRANT
+-- =============================================================================
+--
+-- Order matters. Revoking a table-level privilege also drops the column privileges on
+-- every column, so REVOKE must precede the column-scoped GRANT.
+
+ALTER TABLE public.calendar_connections ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.calendar_connection_calendars ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON public.calendar_connections FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON public.calendar_connection_calendars FROM PUBLIC, anon, authenticated;
+
+-- Column-scoped: refresh_token_enc / granted_scopes / provider_account_id are never
+-- readable by a browser client. user_id and updated_at are granted on purpose --
+-- user_id is already in the caller's JWT so it discloses nothing, and withholding it
+-- would make `.eq('user_id', ...)` and `ORDER BY updated_at` fail with 42501, which is
+-- the dominant query idiom in this codebase.
+--
+-- Any query touching a non-granted column fails with 42501 -- including select('*'),
+-- WHERE, ORDER BY, and EXPLAIN. The error names the table, never the column, so the
+-- service layer must list columns explicitly.
+GRANT SELECT (
+  id,
+  user_id,
+  provider,
+  provider_account_email,
+  status,
+  last_synced_at,
+  last_sync_error,
+  created_at,
+  updated_at
+) ON public.calendar_connections TO authenticated;
+
+GRANT SELECT ON public.calendar_connection_calendars TO authenticated;
+
+-- All mutations run through the tRPC service with createServiceRoleClient and an
+-- explicit user_id guard, matching the mirror table.
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.calendar_connections TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.calendar_connection_calendars TO service_role;
+
+CREATE POLICY "Users can view own calendar connections"
+  ON public.calendar_connections
+  FOR SELECT TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+CREATE POLICY "Service role has full access to calendar connections"
+  ON public.calendar_connections
+  FOR ALL TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY "Users can view own calendar connection calendars"
+  ON public.calendar_connection_calendars
+  FOR SELECT TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+CREATE POLICY "Service role has full access to calendar connection calendars"
+  ON public.calendar_connection_calendars
+  FOR ALL TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- =============================================================================
+-- 5. Schema invariants
+-- =============================================================================
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_attribute
+    WHERE attrelid = 'public.external_calendar_events'::regclass
+      AND attname = 'connection_id'
+      AND attnum > 0
+      AND NOT attisdropped
+  ) THEN
+    RAISE EXCEPTION 'public.external_calendar_events.connection_id was not created';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_index index_metadata
+    JOIN pg_class index_relation ON index_relation.oid = index_metadata.indexrelid
+    WHERE index_metadata.indrelid = 'public.external_calendar_events'::regclass
+      AND index_relation.relname = 'external_calendar_events_provider_event_unique'
+      AND index_metadata.indisunique
+      AND index_metadata.indnkeyatts = 5
+  ) THEN
+    RAISE EXCEPTION 'external_calendar_events_provider_event_unique is not the 5-column key';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.calendar_connection_calendars'::regclass
+      AND conname = 'calendar_connection_calendars_connection_owner_fkey'
+      AND contype = 'f'
+      AND confdeltype = 'c'
+  ) THEN
+    RAISE EXCEPTION 'the composite owner FK on calendar_connection_calendars is missing';
+  END IF;
+END;
+$$;
+
+-- =============================================================================
+-- 6. Privilege invariants
+-- =============================================================================
+--
+-- These run on every environment the migration is applied to, which is the point:
+-- production seeds new public tables with anon/authenticated = arwdDxtm, local with
+-- Dxtm. Only an in-migration assertion catches a REVOKE that failed to do its job
+-- where it actually matters. TRUNCATE is asserted explicitly because RLS does not
+-- restrict it and pnpm rls:snapshot does not report it.
+
+DO $$
+DECLARE
+  connection_tables TEXT[] := ARRAY[
+    'public.calendar_connections',
+    'public.calendar_connection_calendars'
+  ];
+  hidden_columns TEXT[] := ARRAY['refresh_token_enc', 'granted_scopes', 'provider_account_id'];
+  visible_columns TEXT[] := ARRAY[
+    'id',
+    'user_id',
+    'provider',
+    'provider_account_email',
+    'status',
+    'last_synced_at',
+    'last_sync_error',
+    'created_at',
+    'updated_at'
+  ];
+  target_table TEXT;
+  target_column TEXT;
+  browser_role TEXT;
+BEGIN
+  FOREACH target_table IN ARRAY connection_tables LOOP
+    FOREACH browser_role IN ARRAY ARRAY['anon', 'authenticated'] LOOP
+      IF has_table_privilege(browser_role, target_table, 'INSERT')
+        OR has_table_privilege(browser_role, target_table, 'UPDATE')
+        OR has_table_privilege(browser_role, target_table, 'DELETE')
+        OR has_table_privilege(browser_role, target_table, 'TRUNCATE')
+      THEN
+        RAISE EXCEPTION '% must not hold write privileges on %', browser_role, target_table;
+      END IF;
+    END LOOP;
+
+    IF has_table_privilege('anon', target_table, 'SELECT') THEN
+      RAISE EXCEPTION 'anon must not hold SELECT on %', target_table;
+    END IF;
+
+    IF NOT has_table_privilege('service_role', target_table, 'SELECT, INSERT, UPDATE, DELETE') THEN
+      RAISE EXCEPTION 'service_role is missing DML privileges on %', target_table;
+    END IF;
+  END LOOP;
+
+  -- calendar_connections is column-scoped: no table-level SELECT at all.
+  IF has_table_privilege('authenticated', 'public.calendar_connections', 'SELECT') THEN
+    RAISE EXCEPTION 'authenticated must not hold table-level SELECT on calendar_connections';
+  END IF;
+
+  FOREACH target_column IN ARRAY hidden_columns LOOP
+    IF has_column_privilege(
+      'authenticated', 'public.calendar_connections', target_column, 'SELECT'
+    ) THEN
+      RAISE EXCEPTION 'authenticated must not read calendar_connections.%', target_column;
+    END IF;
+  END LOOP;
+
+  FOREACH target_column IN ARRAY visible_columns LOOP
+    IF NOT has_column_privilege(
+      'authenticated', 'public.calendar_connections', target_column, 'SELECT'
+    ) THEN
+      RAISE EXCEPTION 'authenticated is missing SELECT on calendar_connections.%', target_column;
+    END IF;
+  END LOOP;
+
+  -- The child keeps table-level SELECT (§4-4).
+  IF NOT has_table_privilege('authenticated', 'public.calendar_connection_calendars', 'SELECT') THEN
+    RAISE EXCEPTION 'authenticated is missing SELECT on calendar_connection_calendars';
+  END IF;
+END;
+$$;
+
+COMMIT;

--- a/supabase/migrations/20260724000416_enforce_external_event_connection_owner.sql
+++ b/supabase/migrations/20260724000416_enforce_external_event_connection_owner.sql
@@ -1,0 +1,90 @@
+-- Follow-up to 20260723233814 (external-calendar-import Step 1, issue #1703).
+--
+-- That migration linked the mirror to a connection with a single-column FK:
+--   connection_id UUID REFERENCES calendar_connections(id) ON DELETE SET NULL
+-- which proves only that the connection exists, not that it belongs to the row's
+-- own user. A service_role writer (the Step 3 sync engine, the Step 7 disconnect
+-- path) could therefore attach user A's mirror row to user B's connection. Three
+-- consequences, none of them theoretical once Step 3 lands:
+--
+--   1. connection-scoped prune / disconnect would mutate the wrong user's rows
+--   2. `ON DELETE SET NULL` would silently blank a foreign user's connection_id
+--      when the owner of that connection disconnects
+--   3. external_calendar_events grants table-level SELECT to authenticated, so the
+--      row owner could read a connection UUID belonging to someone else
+--
+-- calendar_connection_calendars already enforces owner integrity with the composite
+-- FK pattern. The mirror link needs the same rule. Found in review of PR #1714.
+--
+-- ON DELETE SET NULL (connection_id) — the column list is required here (PG15+, both
+-- local and production run 17.6): a bare SET NULL would null every referencing column
+-- including user_id, which is NOT NULL, so disconnect would fail with 23502.
+--
+-- MATCH SIMPLE (the default) is what keeps orphaned rows legal: once connection_id is
+-- NULL the constraint is not checked at all, so the rows §8 keeps as historical
+-- anchors stay valid.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+ALTER TABLE public.external_calendar_events
+  DROP CONSTRAINT external_calendar_events_connection_id_fkey;
+
+ALTER TABLE public.external_calendar_events
+  ADD CONSTRAINT external_calendar_events_connection_owner_fkey
+  FOREIGN KEY (connection_id, user_id)
+  REFERENCES public.calendar_connections (id, user_id)
+  ON DELETE SET NULL (connection_id);
+
+DO $$
+DECLARE
+  delete_action "char";
+  null_columns SMALLINT[];
+  referenced_columns SMALLINT[];
+  connection_id_attnum SMALLINT;
+BEGIN
+  SELECT confdeltype, confdelsetcols, conkey
+  INTO delete_action, null_columns, referenced_columns
+  FROM pg_constraint
+  WHERE conrelid = 'public.external_calendar_events'::regclass
+    AND conname = 'external_calendar_events_connection_owner_fkey'
+    AND contype = 'f';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'external_calendar_events_connection_owner_fkey was not created';
+  END IF;
+
+  IF array_length(referenced_columns, 1) <> 2 THEN
+    RAISE EXCEPTION 'the mirror connection FK must cover (connection_id, user_id)';
+  END IF;
+
+  IF delete_action <> 'n' THEN
+    RAISE EXCEPTION 'the mirror connection FK must use ON DELETE SET NULL, found %', delete_action;
+  END IF;
+
+  SELECT attnum
+  INTO connection_id_attnum
+  FROM pg_attribute
+  WHERE attrelid = 'public.external_calendar_events'::regclass
+    AND attname = 'connection_id'
+    AND NOT attisdropped;
+
+  -- Only connection_id may be nulled. Nulling user_id would violate its NOT NULL.
+  IF null_columns IS DISTINCT FROM ARRAY[connection_id_attnum]::SMALLINT[] THEN
+    RAISE EXCEPTION 'ON DELETE SET NULL must name connection_id only';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.external_calendar_events'::regclass
+      AND conname = 'external_calendar_events_connection_id_fkey'
+  ) THEN
+    RAISE EXCEPTION 'the single-column connection FK still exists';
+  END IF;
+END;
+$$;
+
+COMMIT;

--- a/supabase/schemas/010_tables_core.sql
+++ b/supabase/schemas/010_tables_core.sql
@@ -3,7 +3,7 @@
 -- ============================================================
 -- Dayopt のドメインモデルの中核テーブル
 -- 実際のマイグレーションは migrations/ を参照
--- 最終同期日: 2026-07-13
+-- 最終同期日: 2026-07-24
 -- 同期対象 migration:
 --   - 20260415000000_inline_entry_tag_id.sql
 --   - 20260424000000_restore_tag_parent_hierarchy.sql
@@ -13,6 +13,7 @@
 --   - 20260708232500_add_time_model_tables.sql
 --   - 20260712212527_records_table_and_drop_entries.sql
 --   - 20260712213550_rename_record_constraint_triggers.sql
+--   - 20260723233814_add_calendar_connection_tables.sql
 --
 -- カラム順序の規則:
 --   1. id (PK)
@@ -38,11 +39,63 @@ CREATE TABLE public.profiles (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
+-- calendar_connections: 外部カレンダーのアカウント接続（Phase 2 / external-calendar-import）
+-- 同一 provider の複数アカウントを許容する（UNIQUE は user_id + provider + provider_account_id）
+-- access token は保存しない。refresh_token_enc は AES-256-GCM 暗号文
+-- refresh_token_enc / granted_scopes / provider_account_id は authenticated へ grant しない
+-- （column-scoped SELECT。詳細は rls-snapshot.md）
+CREATE TABLE public.calendar_connections (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  provider TEXT NOT NULL,                 -- google 等。free text + not-blank（enum 不使用）
+  provider_account_id TEXT NOT NULL,      -- Google の sub
+  provider_account_email TEXT,
+  granted_scopes TEXT[] NOT NULL,
+  refresh_token_enc TEXT NOT NULL,
+  status TEXT NOT NULL,                   -- active / reauth_required
+  last_synced_at TIMESTAMPTZ,
+  last_sync_error TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- calendar_connections 関連 constraint / trigger:
+--   calendar_connections_status_check             -> status IN ('active','reauth_required')
+--   calendar_connections_granted_scopes_not_empty -> cardinality > 0 かつ NULL 要素なし
+--   calendar_connections_id_user_id_unique        -> 子テーブルの複合 FK 参照先
+--   calendar_connections_provider_account_unique  -> user_id + provider + provider_account_id
+--   trigger_update_calendar_connections_updated_at -> update_updated_at()
+
+-- calendar_connection_calendars: 取り込み対象として選択されたカレンダー
+-- 選択可能な一覧は provider API からオンデマンド取得し保存しない
+-- sync_token は per-calendar cursor（NULL = 次回 full sync）
+CREATE TABLE public.calendar_connection_calendars (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  connection_id UUID NOT NULL,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  provider_calendar_id TEXT NOT NULL,
+  calendar_name TEXT,
+  sync_token TEXT,
+  last_synced_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- calendar_connection_calendars 関連 constraint / trigger:
+--   calendar_connection_calendars_connection_owner_fkey
+--     -> (connection_id, user_id) が calendar_connections(id, user_id) を参照（ON DELETE CASCADE）
+--        owner 整合は constraint trigger ではなくこの複合 FK で担保する
+--   calendar_connection_calendars_provider_calendar_unique -> connection_id + provider_calendar_id
+--   trigger_update_calendar_connection_calendars_updated_at -> update_updated_at()
+
 -- external_calendar_events: 外部カレンダー同期ミラー
 -- Phase 1 では FK の受け皿だけを追加し、OAuth / sync / ghost UI は Phase 2 で実装する
+-- connection_id は Phase 2 で追加（ON DELETE SET NULL）。切断後も plans / records が参照する
+-- 行は履歴のアンカーとして残るため CASCADE にしない
 CREATE TABLE public.external_calendar_events (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  connection_id UUID REFERENCES public.calendar_connections(id) ON DELETE SET NULL,
   provider TEXT NOT NULL,
   provider_calendar_id TEXT NOT NULL,
   provider_event_id TEXT NOT NULL,
@@ -57,6 +110,12 @@ CREATE TABLE public.external_calendar_events (
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
+
+-- external_calendar_events 関連 constraint / index:
+--   external_calendar_events_provider_event_unique
+--     -> user_id + provider + connection_id + provider_calendar_id + provider_event_id
+--        connection_id を含むのは、同一 provider の複数アカウントが同じ共有カレンダーを
+--        購読しても行が衝突しないようにするため
 
 -- plans: Dayopt 内の予定
 CREATE TABLE public.plans (

--- a/supabase/schemas/010_tables_core.sql
+++ b/supabase/schemas/010_tables_core.sql
@@ -14,6 +14,7 @@
 --   - 20260712212527_records_table_and_drop_entries.sql
 --   - 20260712213550_rename_record_constraint_triggers.sql
 --   - 20260723233814_add_calendar_connection_tables.sql
+--   - 20260724000416_enforce_external_event_connection_owner.sql
 --
 -- カラム順序の規則:
 --   1. id (PK)
@@ -90,12 +91,12 @@ CREATE TABLE public.calendar_connection_calendars (
 
 -- external_calendar_events: 外部カレンダー同期ミラー
 -- Phase 1 では FK の受け皿だけを追加し、OAuth / sync / ghost UI は Phase 2 で実装する
--- connection_id は Phase 2 で追加（ON DELETE SET NULL）。切断後も plans / records が参照する
--- 行は履歴のアンカーとして残るため CASCADE にしない
+-- connection_id は Phase 2 で追加。切断後も plans / records が参照する行は履歴の
+-- アンカーとして残るため CASCADE にしない
 CREATE TABLE public.external_calendar_events (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
-  connection_id UUID REFERENCES public.calendar_connections(id) ON DELETE SET NULL,
+  connection_id UUID,
   provider TEXT NOT NULL,
   provider_calendar_id TEXT NOT NULL,
   provider_event_id TEXT NOT NULL,
@@ -116,6 +117,11 @@ CREATE TABLE public.external_calendar_events (
 --     -> user_id + provider + connection_id + provider_calendar_id + provider_event_id
 --        connection_id を含むのは、同一 provider の複数アカウントが同じ共有カレンダーを
 --        購読しても行が衝突しないようにするため
+--   external_calendar_events_connection_owner_fkey
+--     -> (connection_id, user_id) が calendar_connections(id, user_id) を参照。
+--        ON DELETE SET NULL (connection_id) — 列リスト指定が必須（bare SET NULL だと
+--        NOT NULL の user_id まで NULL 化しようとして 23502 になる）。
+--        MATCH SIMPLE なので connection_id が NULL の孤立行は検査対象外
 
 -- plans: Dayopt 内の予定
 CREATE TABLE public.plans (

--- a/supabase/schemas/030_rls_policies.sql
+++ b/supabase/schemas/030_rls_policies.sql
@@ -2,7 +2,7 @@
 -- RLS ポリシー一覧（読み物用 — CLIでは使用しない）
 -- ============================================================
 -- 全ユーザーデータテーブルで RLS が有効
--- 最終同期日: 2026-07-13
+-- 最終同期日: 2026-07-24
 -- 同期対象 migration:
 --   - 20260318150000_add_entries_soft_delete.sql
 --   - 20260323000000_fix_entries_soft_delete_rls.sql
@@ -15,6 +15,7 @@
 --   - 20260712212527_records_table_and_drop_entries.sql
 --   - 20260713120023_drop_time_model_compatibility_layer.sql
 --   - 20260713121911_restore_baseline_table_grants.sql
+--   - 20260723233814_add_calendar_connection_tables.sql
 --
 -- パターン:
 --   (select auth.uid()) でキャッシュ → auth.uid() 直呼びより 94-99% 高速
@@ -40,5 +41,14 @@
 -- ■ oauth_authorization_codes: browser client は全拒否（service-role のみ）
 -- ■ oauth_audit_log: SELECT のみ user_id = auth.uid()、INSERT は service-role のみ
 -- ■ stripe_webhook_events / email_suppressions: browser client は全拒否（service-role のみ）
+-- ■ calendar_connections: SELECT のみ user_id = auth.uid()。INSERT/UPDATE/DELETE は service-role のみ
+--   authenticated への SELECT は **column-scoped**（repo 初）。
+--   grant する 9 列: id, user_id, provider, provider_account_email, status,
+--                    last_synced_at, last_sync_error, created_at, updated_at
+--   grant しない 3 列: refresh_token_enc, granted_scopes, provider_account_id
+--   → select('*') も、未 grant 列を WHERE / ORDER BY に含むクエリも 42501 になる。
+--     service 層は列を明示指定すること
+-- ■ calendar_connection_calendars: SELECT のみ user_id = auth.uid()（table 単位）。
+--   mutation は service-role のみ。sync_token は provider cursor であり credential ではない
 
 -- 詳細は baseline.sql の RLS Policies セクションを参照


### PR DESCRIPTION
external-calendar-import の Step 1。Closes #1703（epic: #1702）。

接続モデルの DB 基盤だけを入れる。OAuth・同期・UI は Step 2 以降。

## 入れたもの

- `calendar_connections` — provider アカウント接続と AES-256-GCM 暗号化 refresh token
- `calendar_connection_calendars` — 選択カレンダーと per-calendar sync cursor
- RLS + policy + GRANT 一式、`update_updated_at()` trigger、index
- `supabase/schemas/` の読み物ミラー、生成型、`rls:snapshot` 再生成
- `rls-access.integration.test.ts` に column grant の専用 describe

## 設計書からの逸脱（すべてユーザー承認済み。overview.md §4 に反映済み）

| 変更 | 理由 |
| --- | --- |
| authenticated の SELECT 列に `user_id` / `updated_at` を追加（7 → 9 列） | `user_id` は JWT で既知なので開示ゼロ。除外すると repo 内 81 箇所の `.eq('user_id', …)` idiom が 42501 になる |
| owner 整合を constraint trigger → **複合 FK** | 子側 trigger は親の `UPDATE calendar_connections SET user_id` を素通りさせる（repo は [`20260706120100`](https://github.com/Dayopt/dayopt/blob/main/supabase/migrations/20260706120100_backfill_entry_tag_owner_mismatch.sql) でこの穴の backfill を実際に払っている）。RI は参照行に `FOR KEY SHARE` を取るので TOCTOU も無い。trigger 関数と REVOKE/GRANT EXECUTE 定型が不要になる |
| `external_calendar_events.connection_id` を追加し upsert key に含める | §4-1 が同一 provider の複数アカウントを許容するため、2 アカウントが同じ共有カレンダーを購読すると旧 4 列キーで行を奪い合う。両環境とも空テーブルなので backfill ゼロ |
| migration 内に権限 invariant の `DO` ブロック | 下記 |

### `ON DELETE SET NULL` にした理由（plan からの技術的修正）

plan では `connection_id` を `ON DELETE CASCADE` としていたが、実装時に破綻が判明した。overview.md §8 は「plans / records から参照済みのミラー行は残す」と決めており、それらの FK は `NO ACTION`。CASCADE だと切断時のミラー削除が `23503` で失敗し、**切断そのものが丸ごと落ちる**。`SET NULL` にすると孤立行が §8 の言う歴史的アンカーとして残る。unique index は既定の `NULLS DISTINCT` のまま（孤立行は二度と upsert に参加しないので、切断を阻むことがない）。

## 権限 invariant を migration 内に置いた理由

**production と local の `pg_default_acl` が非対称**であることを実測で確認した。

| 環境 | 新規 public テーブルの既定 grant（anon / authenticated） |
| --- | --- |
| production | `arwdDxtm`（フル DML） |
| local / Preview | `Dxtm`（TRUNCATE / REFERENCES / TRIGGER / MAINTAIN のみ） |

つまり `REVOKE` 漏れは **production でだけ `refresh_token_enc` を露出**する。`pnpm rls:snapshot` は local 由来かつ SELECT/INSERT/UPDATE/DELETE しか記録しないので、この漏れも TRUNCATE 付与も検出できない。CI が構造的に守れない領域なので、`has_table_privilege` / `has_column_privilege` の invariant を migration 自身に書き、production 適用時に落ちるようにした。

## 検証

- `pnpm db:fresh` — 全 migration の fresh replay 成功（invariant ブロックも通過）
- `pnpm test:integration` — 4 files / **116 tests** pass（新規 15 件を含む）
- `pnpm rls:snapshot:check` — drift なし
- `pnpm typecheck` / `pnpm lint` / `pnpm check:static` / `pnpm quality:deadcode:ci` / `pnpm docs:check` — pass
- psql 直接確認（`SET ROLE authenticated`）:
  - grant 済み 9 列の SELECT → 成功
  - `refresh_token_enc` / `granted_scopes` / `select('*')` / 未 grant 列の `WHERE` → すべて `42501`
  - INSERT / UPDATE / DELETE / TRUNCATE → すべて `42501`
  - 他ユーザーの行 → 0 件
- 使い捨てテーブルで検証し記録: **RLS の `USING` 句は呼び出し側の列権限チェックを受けない**（未 grant の `user_id` を参照する policy が正しく行を絞った）。repo 初の column-scoped SELECT なので事実として残す

`pnpm test:run`（unit）は 10 files / 65 tests fail するが、**本 PR の変更前後で完全に同一**（`localStorage is undefined`）。手元の Node が v26.5.0 で repo 要求の 24.x ではないことによる jsdom の問題で、本 PR とは無関係。

## レビュー観点

- 権限まわりは Supabase Preview Branch で `relacl` / `attacl` を確認したい（production 相当の default privileges で invariant が通るかがこの PR の本丸）
- `supabase/schemas/` は README の規約どおり読み物のみ更新（GRANT は元々ミラーに載せない。正本は `rls-snapshot.md`）
- `step-1-detail.md` は作らなかった。§4 が既に列単位の仕様表であり重複するため、判断は migration のコメントと本文に残した

🤖 Generated with [Claude Code](https://claude.com/claude-code)
