### PR TITLE
fix(scripts): secrets:checkの誤検知2件を直しCIで常時実行する

### DIFF
--- a/.github/workflows/docs-guard.yml
+++ b/.github/workflows/docs-guard.yml
@@ -108,3 +108,18 @@ jobs:
             git cat-file -e "$BASE" 2>/dev/null || BASE="HEAD"
           fi
           gitleaks detect --source . --redact --log-opts="${BASE}..HEAD" --exit-code 1
+
+  # gitleaks が commit 範囲しか見ない分をここで埋める。
+  # gitleaks は「このPRで新しく入った差分」、secrets:check は「今の tracked tree 全体」を見る。
+  # 両方無いと、既に main に入っている literal は誰にも検出されない状態が続く。
+  secrets-check:
+    name: "\U0001F511 secrets:check"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: ./.github/actions/setup
+
+      - name: pnpm secrets:check
+        run: pnpm secrets:check

--- a/docs/operations/secrets.md
+++ b/docs/operations/secrets.md
@@ -154,7 +154,10 @@ pnpm 1password:check
 ```
 
 - `env:check` — required env を `OK / EMPTY / MISSING` だけで確認する
-- `secrets:check` — tracked files と untracked `.env*` を scan し、literal secret は `value: [redacted]` で報告する
+- `secrets:check` — tracked files と untracked `.env*` を scan し、literal secret は `value: [redacted]` で報告する。CI でも全 PR / push で走る（`docs-guard.yml` の `secrets-check` job）
+
+secret scan は 2 本立てで、担当範囲が違う。gitleaks は「この PR で新しく入った commit 範囲」だけを見る（全履歴には削除済みプレースホルダ由来の既知ノイズが積もっており、毎回 re-flag すると gate として機能しなくなるため）。`secrets:check` は「現在の tracked tree 全体」を見る。片方だけでは、既に main に入っている literal が誰にも検出されない。
+
 - `1password:check` — 1Password の vault / item / field / empty 状態だけを確認する。schemaで`required: true`のentryまたはoperational itemが不足・空の場合だけ失敗し、optional entryは不足・空の状態を表示しても成功する。item の作成・変更・削除はしない
 
 `.op-env.local.example` の `op://` 参照は正規の local injection schema なので leak として扱わない。

--- a/scripts/__tests__/check-secrets.test.ts
+++ b/scripts/__tests__/check-secrets.test.ts
@@ -1,0 +1,104 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const rootDir = resolve(import.meta.dirname, '../..');
+const scriptPath = join(rootDir, 'scripts/env/check-secrets.ts');
+const tsxBin = join(rootDir, 'node_modules/.bin/tsx');
+const temporaryDirectories: string[] = [];
+
+/**
+ * check-secrets.ts は cwd の `git ls-files` を走査対象にするので、
+ * fixture ごとに使い捨ての git repo を作って本体をそのまま起動する。
+ * commit は不要（`git ls-files` は index を読む）。
+ */
+function runCheck(files: Record<string, string>) {
+  const directory = mkdtempSync(join(tmpdir(), 'dayopt-check-secrets-'));
+  temporaryDirectories.push(directory);
+
+  execFileSync('git', ['init', '-q'], { cwd: directory });
+  for (const [name, content] of Object.entries(files)) {
+    writeFileSync(join(directory, name), content);
+  }
+  execFileSync('git', ['add', '-A'], { cwd: directory });
+
+  return spawnSync(tsxBin, [scriptPath], { cwd: directory, encoding: 'utf8' });
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe('check-secrets.ts', () => {
+  it('秘密らしい値が無ければ成功する', () => {
+    const result = runCheck({ 'notes.md': '# just docs\n' });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('OK: no secret literals found');
+  });
+
+  describe('postgres 接続文字列', () => {
+    it('Supabase local の既定接続文字列は手順書に書ける', () => {
+      const result = runCheck({
+        'runbook.md': "psql 'postgresql://postgres:postgres@127.0.0.1:54322/postgres' -At\n",
+      });
+
+      expect(result.status, result.stdout).toBe(0);
+    });
+
+    it('loopback でも既定 password でなければ検出する', () => {
+      // 実 secret が literal で 1 行に並ばないよう組み立てる（CI の gitleaks 対策）。
+      const password = 'hunter2';
+      const result = runCheck({
+        'runbook.md': `psql 'postgresql://postgres:${password}@127.0.0.1:54322/postgres'\n`,
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain('pattern: postgres_url_with_password');
+    });
+
+    it('リモートホスト宛は既定 password でも検出する', () => {
+      const host = 'db.example.com';
+      const result = runCheck({
+        'runbook.md': `psql 'postgresql://postgres:postgres@${host}:5432/prod'\n`,
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain('pattern: postgres_url_with_password');
+    });
+  });
+
+  describe('sensitive な env 代入', () => {
+    it('test- 接頭辞の fixture は通す', () => {
+      const result = runCheck({
+        'stub.sh': 'SERVICE_ROLE_KEY="test-service-role-key"\n',
+      });
+
+      expect(result.status, result.stdout).toBe(0);
+    });
+
+    it('placeholder でない値は検出する', () => {
+      const result = runCheck({
+        'stub.sh': 'SERVICE_ROLE_KEY="notaplaceholder"\n',
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain('pattern: sensitive_env_assignment');
+    });
+
+    it('検出しても値そのものは出力しない', () => {
+      const value = 'notaplaceholder';
+      const result = runCheck({ 'stub.sh': `SERVICE_ROLE_KEY="${value}"\n` });
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain('value: [redacted]');
+      expect(result.stdout).not.toContain(value);
+      expect(result.stderr).not.toContain(value);
+    });
+  });
+});

--- a/scripts/__tests__/check-secrets.test.ts
+++ b/scripts/__tests__/check-secrets.test.ts
@@ -11,6 +11,16 @@ const tsxBin = join(rootDir, 'node_modules/.bin/tsx');
 const temporaryDirectories: string[] = [];
 
 /**
+ * このファイル自身も `pnpm secrets:check` の走査対象になる。
+ *
+ * 「検出されるべき」fixture をソースに literal で書くと自分自身が引っかかるので、
+ * scheme を変数に出して完全な接続文字列がソース上に現れないようにする。
+ * 逆に「除外されるべき」fixture はあえて literal のまま置き、tracked file に
+ * 実在する形で例外が効くことを示す。
+ */
+const scheme = 'postgresql';
+
+/**
  * check-secrets.ts は cwd の `git ls-files` を走査対象にするので、
  * fixture ごとに使い捨ての git repo を作って本体をそのまま起動する。
  * commit は不要（`git ls-files` は index を読む）。
@@ -52,10 +62,8 @@ describe('check-secrets.ts', () => {
     });
 
     it('loopback でも既定 password でなければ検出する', () => {
-      // 実 secret が literal で 1 行に並ばないよう組み立てる（CI の gitleaks 対策）。
-      const password = 'hunter2';
       const result = runCheck({
-        'runbook.md': `psql 'postgresql://postgres:${password}@127.0.0.1:54322/postgres'\n`,
+        'runbook.md': `psql '${scheme}://postgres:hunter2@127.0.0.1:54322/postgres'\n`,
       });
 
       expect(result.status).toBe(1);
@@ -63,9 +71,8 @@ describe('check-secrets.ts', () => {
     });
 
     it('リモートホスト宛は既定 password でも検出する', () => {
-      const host = 'db.example.com';
       const result = runCheck({
-        'runbook.md': `psql 'postgresql://postgres:postgres@${host}:5432/prod'\n`,
+        'runbook.md': `psql '${scheme}://postgres:postgres@db.example.com:5432/prod'\n`,
       });
 
       expect(result.status).toBe(1);

--- a/scripts/env/check-secrets.ts
+++ b/scripts/env/check-secrets.ts
@@ -12,7 +12,32 @@ type Finding = {
 const maxFileBytes = 1024 * 1024;
 const ignoredPathParts = new Set(['node_modules', '.next', 'storybook-static', '.turbo', '.git']);
 
-const literalPatterns: Array<{ name: string; regex: RegExp; alwaysFlag?: boolean }> = [
+/**
+ * Supabase local の既定接続文字列だけを除外する。
+ *
+ * `postgres:postgres@127.0.0.1` は Supabase CLI が全環境へ同じ値で配る固定 default で、
+ * 秘密ではない。手順書がこの文字列を書けないと `psql` の実行例を載せられなくなる。
+ * loopback host かつ password が既定値、の両方を満たす時だけ通す。
+ */
+function isLocalPostgresUrl(match: string): boolean {
+  const loopbackHosts = new Set(['127.0.0.1', 'localhost', '::1', '[::1]']);
+
+  try {
+    // 正規表現は `[^)\s]+` なので、引用符で囲まれた実行例では末尾の quote まで拾う。
+    const url = new URL(match.replace(/['"`]+$/, ''));
+    return loopbackHosts.has(url.hostname) && url.password === 'postgres';
+  } catch {
+    // parse できない形は判断材料がないので除外しない。
+    return false;
+  }
+}
+
+const literalPatterns: Array<{
+  name: string;
+  regex: RegExp;
+  alwaysFlag?: boolean;
+  isAllowedMatch?: (match: string) => boolean;
+}> = [
   { name: 'stripe_secret_key', regex: /\bsk_(?:live|test)_[A-Za-z0-9_=-]{3,}\b/, alwaysFlag: true },
   { name: 'stripe_webhook_secret', regex: /\bwhsec_[A-Za-z0-9_=-]{3,}\b/, alwaysFlag: true },
   {
@@ -30,6 +55,7 @@ const literalPatterns: Array<{ name: string; regex: RegExp; alwaysFlag?: boolean
     name: 'postgres_url_with_password',
     regex: /\bpostgres(?:ql)?:\/\/[^:\s/@]+:[^@\s]+@[^)\s]+/,
     alwaysFlag: true,
+    isAllowedMatch: isLocalPostgresUrl,
   },
   { name: 'private_key_block', regex: /-----BEGIN [A-Z ]*PRIVATE KEY-----/, alwaysFlag: true },
 ];
@@ -73,15 +99,22 @@ function isAllowedValue(rawValue: string): boolean {
     'mock',
     'changeme',
     'example',
-    'test-token',
-    'test-secret',
     'your-test-password',
     'xxx',
     'required',
     'optional',
   ]);
 
-  return exactPlaceholders.has(lower) || lower.startsWith('your_') || lower.startsWith('your-');
+  // `test-` 接頭辞は、元々 `test-token` / `test-secret` を 1 件ずつ列挙していたものの一般化。
+  // fixture を足すたびにこの Set へ追記が要る形だと必ず腐るので接頭辞で受ける。
+  // 実 secret が `test-` で始まることはない（Supabase の service role key は JWT、
+  // Stripe は sk_/whsec_ のように発行元が接頭辞を固定している）。
+  return (
+    exactPlaceholders.has(lower) ||
+    lower.startsWith('test-') ||
+    lower.startsWith('your_') ||
+    lower.startsWith('your-')
+  );
 }
 
 function isYamlFile(file: string): boolean {
@@ -172,10 +205,13 @@ function scanLine(file: string, line: string, lineNumber: number): Finding[] {
   }
 
   for (const pattern of literalPatterns) {
+    // ここは value ではなく行全体を渡す（既存挙動）。そのため `test-` 接頭辞の緩和が効くのは
+    // 行そのものが `test-` で始まる時だけで、`KEY="test-..."` の形には影響しない。
     if (!pattern.alwaysFlag && isAllowedValue(line)) continue;
     const match = line.match(pattern.regex);
     if (match) {
       if (pattern.name === 'jwt_like_token' && isAllowedJwtFixture(file, line, match[0])) continue;
+      if (pattern.isAllowedMatch?.(match[0])) continue;
       findings.push({
         file,
         line: lineNumber,


### PR DESCRIPTION
## 背景

`pnpm secrets:check` は main で exit 1 のまま失敗し続けていた。`AGENTS.md` は必須検証コマンドとして挙げているが、`rg 'secrets:check' .github/workflows/` は何も返さない — **どの workflow からも呼ばれていない**。だから red のまま誰も気づかなかった。

さらに悪いことに、これは単に「壊れた check が1つある」話ではない。gitleaks は意図的に `--log-opts="${BASE}..HEAD"` で **この PR の commit 範囲だけ**を見る（全履歴には削除済みプレースホルダ由来の既知ノイズが積もっており、毎回 re-flag すると gate として機能しなくなるため）。つまり `secrets:check` が動いていない間、**現在の tracked tree 全体を見る担当が不在**だった。既に main に入っている literal は、どちらの gate にも引っかからない。

## 検出されていた2件は実 credential ではない

| 箇所 | 値 | 判定 |
| --- | --- | --- |
| `docs/projects/migration-baseline-squash/overview.md:238` | `postgresql://postgres:postgres@127.0.0.1:54322/postgres` | Supabase CLI が全環境へ同じ値で配る local の既定接続文字列。loopback 宛。tracked tree 内でこの1箇所だけ |
| `scripts/__tests__/dev-with-op.test.ts:39` | `SERVICE_ROLE_KEY="test-service-role-key"` | fake supabase バイナリが `status` で吐く fixture |

**rotation も履歴の書き換えも不要。**

## なぜ fixture ではなく検出器を直すか

どちらも値の側は既に「明らかに偽物」で、書き換えても検出器は正しくならない。手順書は `psql` の実行例を載せられなくなり、fixture は意味の薄い名前になるだけ。誤検知の原因は検出器側にある。

- `postgres_url_with_password` に `isAllowedMatch` を足し、**loopback host かつ password が既定値 `postgres`** の組み合わせだけ除外する。リモート宛、または loopback でも別 password なら従来どおり検出する
- `isAllowedValue` の `test-token` / `test-secret` 個別列挙を `test-` 接頭辞へ一般化する。fixture を足すたび Set への追記が要る形は必ず腐る。実 secret が `test-` で始まることはない（Supabase の service role key は JWT、Stripe は `sk_` / `whsec_` と発行元が接頭辞を固定している）

## 変更

- `scripts/env/check-secrets.ts` — 上記2点
- `.github/workflows/docs-guard.yml` — `secrets-check` job を追加。gitleaks と役割分担する（gitleaks = 新規 commit 範囲 / secrets:check = 現在の tree 全体）
- `scripts/__tests__/check-secrets.test.ts` — **新規**。この script には test が無かった
- `docs/operations/secrets.md` — 2本立ての担当範囲を明記

## 緩和が狭いことの担保

test は使い捨ての git repo を作って本体を子プロセス実行する（`check-1password.test.ts` と同じ idiom）。negative control を含む:

- ✅ Supabase local の既定文字列は通る
- ✅ **loopback でも別 password なら検出する**
- ✅ **リモートホスト宛は既定 password でも検出する**
- ✅ `test-` 接頭辞の fixture は通る
- ✅ **placeholder でない値は検出する**
- ✅ 検出しても値そのものは出力しない（`value: [redacted]`）

## 検証

- `pnpm secrets:check` → `OK: no secret literals found`
- `pnpm test:scripts` → 15 files / 125 tests passed（新規7件含む）
- `pnpm docs:check` / `pnpm typecheck` pass
- `gitleaks detect --no-git` を手元で実行し、**本 PR が触った4ファイルに検出ゼロ**を確認（tree 全体の16件はすべて既存ファイルで、CI の範囲スキャンには乗らない）

## 補足（本 PR では直さない）

`scripts/` はどの tsconfig からも include されておらず `pnpm typecheck` の対象外。既存の gap で、別途切り出すのが妥当。

🤖 Generated with [Claude Code](https://claude.com/claude-code)