### PR TITLE
chore(workflow): worktree/branch 運用を統一し掃除スクリプトを追加

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -195,6 +195,24 @@ gh pr merge <PR番号> --merge --delete-branch
 
 **原則: 1 worktree = 1 branch = 1 PR。役目（PR の merge / close）を終えた worktree はその場で削除する。** 放置すると worktree・ブランチ・孤児ディレクトリが積み上がり、どれが生きている作業か判別できなくなる。
 
+### 概念整理（branch と worktree の違い）
+
+混同しやすいので明確にする。
+
+- **branch** = コミット履歴を指すポインタ（ラベル）。ローカルとリモート（`origin/*`）に別々に存在する
+- **worktree** = branch を実際に checkout して編集する作業ディレクトリ。1 つの repo に複数の worktree を並べ、それぞれ別 branch を同時に開ける（並行 AI セッションの土台）
+- 両者は別物: **worktree を消しても branch は残る**。だから掃除では「worktree・ローカル branch・リモート branch」の 3 つを揃えて消す必要がある。「リモートだけ残る」「ローカルだけ残る」はこの 3 点の消し忘れが原因
+
+### 命名規則
+
+branch 名は **`{agent}/{domain}-{action}[-{issue番号}]`** で統一する（provider 共通）。
+
+- **agent**: `claude` / `codex` など、作った AI / 人を表す接頭辞
+- **domain-action**: Project 命名規則（本ファイル §Project 命名規則）と同型の kebab-case。例: `calendar-sync-fix`, `i18n-audit`, `sidebar-routing-unification`
+- **issue 番号**: 対応 issue があれば末尾に付ける。例: `codex/external-calendar-sync-1705`
+- 良い例: `claude/calendar-sync-fix` / `codex/i18n-audit-1705`。悪い例: `claude/worktree-branch-strategy-9383e9`（内容が読めないランダム suffix）, `fix-stuff`（domain 不明）
+- **Claude Code が自動生成するランダム suffix 名は、最初の PR を作る前に `git branch -m {agent}/{domain}-{action}` でリネームする**。worktree のディレクトリ名は使い捨てなのでリネーム不要（branch 名だけ直せば PR に正しい名前が乗る）
+
 ### 置き場と作成
 
 - Claude Code は `.claude/worktrees/<name>/` に自動作成する（gitignore 済み）。Codex は `~/.codex/worktrees/` を使う。**手動で `git worktree add` する場合も `.claude/worktrees/` 配下に置く**（repo 直下や無関係な場所に散らさない）
@@ -203,21 +221,35 @@ gh pr merge <PR番号> --merge --delete-branch
 
 ### マージ後の掃除（AI の責務、merge と同一セッションで実施）
 
-```bash
-gh pr merge <N> --merge --delete-branch  # remote は deleteBranchOnMerge でも自動削除
-# 1) 通常時: worktree から切り離してからローカル branch を削除
-git worktree remove <worktree-path>      # worktree 側の checkout を先に解放
-git branch -d <branch>                   # merge 済みなら -d が通る（-D は使わない）
+**標準は `pnpm branch:finish <PR番号>` のワンセット実行。** マージ〜掃除〜main 最新化までを 1 コマンドで行う（`scripts/git/finish-branch.sh`。Claude / Codex / 人間で共通）。
 
-# 2) worktree remove が失敗する場合（dirty/uncommitted 差分など）
-git -C <worktree-path> status --porcelain    # ワークツリーの差分確認
-git -C <worktree-path> checkout main          # worktree 内で main に戻す
-git worktree remove <worktree-path> --force    # 差分がない/確認済みなら強制解除
-git branch -d <branch>                        # 依然として merge 済みなら実行
+```bash
+pnpm branch:finish <PR番号>            # マージ→worktree削除→branch削除→リモート確認→main最新化
+pnpm branch:finish <PR番号> --dry-run  # 実行せず予定アクションだけ確認
 ```
 
-順序に意味がある: **worktree が参照する branch を先に解除しないと branch 削除が不可能**なため `worktree remove` を優先する。
-ただし `worktree remove` がそのまま通らない場合は、worktree 内で主系列（例: `main`）へ checkout してから、`remove --force` や `branch -d` を続行する。
+スクリプトが内部で行うこと（= 手動フォールバック時にたどる手順）:
+
+1. PR 状態を取得。OPEN かつ失敗 check が無ければ `gh pr merge <N> --merge --delete-branch`（main が他 worktree で checkout 中で失敗する場合は `gh api` の直接マージにフォールバック）
+2. 該当 branch の worktree を特定し、`status --porcelain` が空であることを確認（**dirty なら停止**してユーザーに委ねる）
+3. `git worktree remove --force <path>` で worktree を解除
+4. `git fetch --prune` → main を checkout して `git pull --ff-only origin main`（**branch 削除より先に main を最新化する**）
+5. `git -C <main> branch -d <branch>`（**`-d` のみ。not fully merged なら停止**）
+6. リモートに `origin/<branch>` が残っていれば `git push origin --delete <branch>` → `git worktree prune`
+
+順序に意味がある: ① **worktree が参照する branch を先に解除しないと branch 削除が不可能**なため `worktree remove` を先に行う。② **`branch -d` の前に main を pull する**（`gh pr merge` はリモートしか更新しないので、pull 前だと branch 先端がローカル main から辿れず、追跡設定の無い branch は誤って not fully merged 扱いになる）。スクリプトが途中で停止した場合（dirty / not fully merged）は、下記「削除時の安全確認」に従って手動で判断する。
+
+### 完了定義（ワンセット）
+
+以下 5 点すべてを満たして初めて「作業終了」とする。1 つでも欠けたら未完了（「リモートだけ残る」等はこの積み残し）。
+
+1. PR がマージ済み
+2. worktree が削除済み
+3. ローカル branch が削除済み
+4. リモート branch が消滅（`git fetch --prune` 後に `origin/<branch>` が無い）
+5. main checkout が最新（`git pull --ff-only` 済み）
+
+`pnpm branch:finish` はこの 5 点を満たすと完了サマリーを出す。手動で進めた場合も同じ 5 点を自分で確認する。
 
 ### 削除時の安全確認
 

--- a/.codex/rules/git-workflow.md
+++ b/.codex/rules/git-workflow.md
@@ -4,7 +4,9 @@ Codex が Dayopt repo で branch / commit / PR / merge を扱う時の薄い ove
 
 ## Branch
 
-- 新規作業は `codex/{short-description}` ブランチを切る
+- 新規作業は **`codex/{domain}-{action}[-{issue番号}]`** ブランチを切る（命名規則は共通。`.claude/rules/workflow.md` §命名規則 が canonical）
+  - 良い例: `codex/i18n-audit-1705` / `codex/calendar-sync-fix`
+  - 悪い例: 内容の読めないランダム名、`codex/work` のような action 不明の名前
 - 既存 dirty file はユーザー作業として扱い、関係ない限り触らない
 - `main` にいる時は作業前に branch を切る
 
@@ -35,8 +37,7 @@ Codex が Dayopt repo で branch / commit / PR / merge を扱う時の薄い ove
 
 ## Branch cleanup（マージ後）
 
-- マージ済み PR のブランチ削除は、通常順で実施する:
-  - `git worktree remove <worktree-path>`（worktree が branch を持っている場合に先に解除）
-  - `git branch -d <branch>`（merge 済みなら成功）
-- `worktree remove` が失敗する場合は、worktree 内で `main` に checkout してから再度実施する
-- `git branch -d` が `not fully merged` で失敗したときは `-D` は原則禁止。必要ならユーザー判断で別途確認
+- 標準は **`pnpm branch:finish <PR番号>`** のワンセット実行（マージ→worktree削除→branch削除→リモート確認→main最新化）。Claude / Codex / 人間で共通のスクリプト（`scripts/git/finish-branch.sh`）
+- 事前確認したい時は `pnpm branch:finish <PR番号> --dry-run`
+- スクリプトが dirty / not fully merged で停止したら、手動フォールバックは `.claude/rules/workflow.md` §Worktree 運用 の手順に従う。`git branch -d` が `not fully merged` で失敗したときは `-D` は原則禁止で、ユーザー判断を仰ぐ
+- 完了定義（5点）: ① PR マージ済み ② worktree 削除 ③ ローカル branch 削除 ④ リモート branch 消滅 ⑤ main 最新化。すべて満たして初めて作業終了

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,8 @@ pnpm docs:check               # link/metadata/path/project/命名/append-only �
   | `docs`     | ドキュメントのみの変更         |
   | `test`     | テストの追加・修正             |
   | `perf`     | パフォーマンス改善             |
-- PR を merge する時は、枝分かれを履歴に残すため `gh pr merge --merge --delete-branch` を標準にする。**マージ後は同一セッション内でローカルブランチと作業に使った worktree も削除する**（worktree remove → branch -d の順。`.claude/rules/workflow.md` §Worktree 運用）
+- PR は枝分かれを履歴に残すため merge commit でマージする。**マージ〜掃除は同一セッション内で `pnpm branch:finish <PR番号>` をワンセットで実行する**（マージ→worktree削除→ローカル/リモート branch 削除→main 最新化まで。完了定義 5 点と手動フォールバックは `.claude/rules/workflow.md` §Worktree 運用）
+- branch 名は `{agent}/{domain}-{action}[-{issue番号}]` に統一する。Claude Code 自動生成のランダム名は最初の PR 作成前に `git branch -m` でリネームする（`.claude/rules/workflow.md` §命名規則）
 
 ## Coding Rules
 

--- a/docs/engineering/log/2026-07-24-worktree-branch-unification.md
+++ b/docs/engineering/log/2026-07-24-worktree-branch-unification.md
@@ -1,0 +1,39 @@
+---
+status: frozen
+date: 2026-07-24
+---
+
+# Worktree / branch 運用を統一する（命名規則 + ワンセット掃除スクリプト）
+
+## 背景・当時の前提
+
+- 複数 AI（Claude / Codex / 将来の他ツール）に並行セッションを依頼する前提で、worktree と branch の運用がバラバラになり、ユーザーが「worktree と branch が同じ概念なのか」から混乱していた
+- 命名が不揃い: Claude Code の自動 worktree は `claude/worktree-branch-strategy-9383e9` のようなランダム suffix、Codex は `codex/{自由記述}`。名前から作業内容が読めない
+- マージ後の掃除が手順の羅列で、`.claude/rules/workflow.md` §Worktree 運用に手順はあったが「リモート確認 → main 復帰 & pull」までを含む**完了定義**がなく、実行漏れで「リモートだけ残る」「ローカルだけ残る」が発生していた
+- 2026-07-24 時点の実態調査:
+  - リモートは `origin/main` のみでクリーン（`deleteBranchOnMerge: true` が効いている）
+  - ローカルの残骸は 2 件 — `claude/issue-1705`（未マージ作業あり・進行中扱い）と `codex/mcp-plan-track-learn`（main から 73 コミット遅れ・PR なし・未マージコミットあり）
+
+## 決定と理由
+
+**branch 命名を `{agent}/{domain}-{action}[-{issue番号}]` に統一し、マージ〜掃除を共通スクリプト `pnpm branch:finish <PR番号>` にワンセット化する。**
+
+- **命名統一**: Project 命名規則（domain-action）と同型にそろえ、provider をまたいで一貫させる。Claude Code の自動ランダム名は最初の PR 作成前に `git branch -m` でリネームする運用にする（worktree ディレクトリ名は使い捨てなので branch 名だけ直せば PR に正しい名前が乗る）
+- **共通スクリプト化**: 掃除が手順の羅列だと実行漏れが起きる。1 コマンドに畳み、完了定義 5 点（① PR マージ済み ② worktree 削除 ③ ローカル branch 削除 ④ リモート branch 消滅 ⑤ main 最新化）を満たすまでを機械的に保証する。Claude / Codex / 人間が同じコマンドを使うことで運用を統一する
+- **概念整理を rules に明記**: branch（履歴ポインタ）と worktree（作業ディレクトリ）は別物で、「worktree を消しても branch は残る」ことを明文化。3 点（worktree・ローカル branch・リモート branch）を揃えて消す必要があることを掃除の根拠として書いた
+
+## 却下した選択肢と、なぜ捨てたか
+
+- **スクリプトを作らず rules のチェックリスト強化だけ**: 手順は既にあったのに実行漏れが起きていた。人間の注意力に頼る形は同じ失敗を繰り返す。機械化して初めて完了定義が保証される
+- **issue 番号ベースの命名に一本化**: すべての作業に issue 起票を強制することになり、小さな docs 修正などで overhead。issue 番号は「あれば末尾に付ける」任意要素にとどめた
+
+## 影響・やること
+
+- 追加: `scripts/git/finish-branch.sh`、`package.json` に `branch:finish` script
+- 改訂: `.claude/rules/workflow.md`（概念整理・命名規則・完了定義・スクリプト標準化）、`.codex/rules/git-workflow.md`、`AGENTS.md` Non-Negotiables
+- スクリプトは `--dry-run` 対応。dirty / not fully merged では停止してユーザー判断に委ねる（`-D` 強制はしない）
+
+## 保留（ユーザー判断待ち）
+
+- `codex/mcp-plan-track-learn` branch と `~/.codex/worktrees/16e2/dayopt`（main から大きく遅れ・PR なし・未マージコミットあり）は今回触らない。救出（rebase / PR 化）か破棄かはユーザーが別途判断する
+- `claude/issue-1705` worktree は進行中作業のため対象外

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "typecheck:product": "pnpm --filter @dayopt/product typecheck",
     "typecheck:packages": "turbo run typecheck --filter='./packages/*'",
     "prepare": "husky",
+    "branch:finish": "bash scripts/git/finish-branch.sh",
     "migration:create": "supabase migration new",
     "migration:list": "supabase migration list",
     "migration:status": "supabase db diff",

--- a/scripts/git/finish-branch.sh
+++ b/scripts/git/finish-branch.sh
@@ -1,0 +1,262 @@
+#!/bin/bash
+
+# PR のマージ〜掃除をワンセットで行う共通スクリプト。
+# Claude / Codex / 人間が同じコマンドで実行できる。
+#
+#   pnpm branch:finish <PR番号> [--dry-run]
+#
+# 完了定義（5点すべてを満たして初めて「作業終了」）:
+#   ① PR マージ済み
+#   ② worktree 削除
+#   ③ ローカル branch 削除
+#   ④ リモート branch 消滅（fetch --prune で確認）
+#   ⑤ main checkout が最新
+#
+# 詳細な設計と手動フォールバックは .claude/rules/workflow.md §Worktree 運用 を参照。
+
+set -euo pipefail
+
+DRY_RUN=false
+PR_NUMBER=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)
+      DRY_RUN=true
+      ;;
+    -h | --help)
+      cat <<'EOF'
+Usage: pnpm branch:finish <PR番号> [--dry-run]
+
+PR をマージし、worktree・ローカル branch・リモート branch を掃除して main を最新化する。
+
+  <PR番号>     掃除対象の Pull Request 番号（必須）
+  --dry-run    実際には変更せず、実行予定のアクションだけ表示する
+EOF
+      exit 0
+      ;;
+    *)
+      if [[ -z "$PR_NUMBER" ]]; then
+        PR_NUMBER="$arg"
+      else
+        echo "❌ 引数が多すぎます: $arg" >&2
+        exit 1
+      fi
+      ;;
+  esac
+done
+
+error() {
+  echo "❌ $1" >&2
+}
+
+info() {
+  echo "ℹ️  $1" >&2
+}
+
+step() {
+  echo "" >&2
+  echo "▶ $1" >&2
+}
+
+# --dry-run 時はコマンドを実行せず表示だけする
+run() {
+  if [[ "$DRY_RUN" == true ]]; then
+    echo "   [dry-run] $*" >&2
+  else
+    "$@"
+  fi
+}
+
+if [[ -z "$PR_NUMBER" ]]; then
+  error "PR 番号を指定してください: pnpm branch:finish <PR番号> [--dry-run]"
+  exit 1
+fi
+
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  error "PR 番号は数値で指定してください（受け取った値: $PR_NUMBER）"
+  exit 1
+fi
+
+for bin in git gh; do
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    error "$bin が見つかりません。"
+    exit 1
+  fi
+done
+
+# repo のルート（main checkout）を git-common-dir から解決する。
+# worktree の中から実行しても main checkout を正しく指す。
+GIT_COMMON_DIR="$(git rev-parse --git-common-dir)"
+MAIN_ROOT="$(cd "$(dirname "$GIT_COMMON_DIR")" && pwd)"
+
+if [[ "$DRY_RUN" == true ]]; then
+  info "dry-run モード: 変更は行いません"
+fi
+
+# ── 1. PR 状態を取得 ────────────────────────────────────────────────
+step "PR #$PR_NUMBER の状態を確認"
+
+PR_JSON="$(gh pr view "$PR_NUMBER" --json state,headRefName,mergeable,mergeStateStatus,statusCheckRollup 2>/dev/null || true)"
+
+if [[ -z "$PR_JSON" ]]; then
+  error "PR #$PR_NUMBER を取得できませんでした。番号とネットワークを確認してください。"
+  exit 1
+fi
+
+PR_STATE="$(printf '%s' "$PR_JSON" | jq -r '.state')"
+BRANCH="$(printf '%s' "$PR_JSON" | jq -r '.headRefName')"
+
+if [[ -z "$BRANCH" || "$BRANCH" == "null" ]]; then
+  error "PR #$PR_NUMBER の head branch を特定できませんでした。"
+  exit 1
+fi
+
+info "branch: $BRANCH / state: $PR_STATE"
+
+if [[ "$PR_STATE" == "CLOSED" ]]; then
+  info "PR は CLOSED（未マージ）です。branch 掃除のみ続行します。"
+fi
+
+# ── 2. 未マージなら checks を確認してマージ ──────────────────────────
+if [[ "$PR_STATE" == "OPEN" ]]; then
+  step "PR #$PR_NUMBER をマージ"
+
+  # 失敗している required check がないか確認する
+  FAILED_CHECKS="$(printf '%s' "$PR_JSON" | jq -r '
+    (.statusCheckRollup // [])
+    | map(select((.conclusion // "") | ascii_downcase | . == "failure" or . == "cancelled" or . == "timed_out"))
+    | length')"
+
+  if [[ "$FAILED_CHECKS" != "0" ]]; then
+    error "失敗している check が $FAILED_CHECKS 件あります。マージを中止します。"
+    error "gh pr checks $PR_NUMBER で詳細を確認してください。"
+    exit 1
+  fi
+
+  if [[ "$DRY_RUN" == true ]]; then
+    echo "   [dry-run] gh pr merge $PR_NUMBER --merge --delete-branch" >&2
+  else
+    # main が他 worktree で checkout 中だと gh pr merge が失敗しうる。
+    # その場合は gh api で直接マージにフォールバックする。
+    if ! gh pr merge "$PR_NUMBER" --merge --delete-branch 2>/tmp/branch-finish-merge-err; then
+      cat /tmp/branch-finish-merge-err >&2 || true
+      info "gh pr merge が失敗しました。gh api での直接マージを試みます。"
+      REPO="$(gh repo view --json nameWithOwner -q '.nameWithOwner')"
+      gh api -X PUT "repos/$REPO/pulls/$PR_NUMBER/merge" -f merge_method=merge >/dev/null
+      info "gh api でマージしました。リモート branch を削除します。"
+      gh api -X DELETE "repos/$REPO/git/refs/heads/$BRANCH" >/dev/null 2>&1 || true
+    fi
+    rm -f /tmp/branch-finish-merge-err
+  fi
+else
+  info "PR は既にクローズ済みのためマージ手順はスキップします。"
+fi
+
+# ── 3. 該当 branch の worktree を特定 ────────────────────────────────
+step "worktree を特定"
+
+# `git worktree list --porcelain` を解析し branch が一致する worktree path を得る
+WORKTREE_PATH="$(git worktree list --porcelain | awk -v br="refs/heads/$BRANCH" '
+  /^worktree / { path = substr($0, 10) }
+  /^branch / && $2 == br { print path; exit }
+')"
+
+if [[ -n "$WORKTREE_PATH" ]]; then
+  info "worktree: $WORKTREE_PATH"
+else
+  info "この branch に紐づく worktree はありません。"
+fi
+
+# ── 4. worktree の dirty 確認 ───────────────────────────────────────
+if [[ -n "$WORKTREE_PATH" ]]; then
+  step "worktree の未コミット差分を確認"
+
+  DIRTY="$(git -C "$WORKTREE_PATH" status --porcelain 2>/dev/null || true)"
+
+  if [[ -n "$DIRTY" ]]; then
+    # tracked ファイルの差分があるかを判定する。
+    # gitignore された生成物（--porcelain には出ない）ではなく、
+    # tracked の変更や未追跡ファイルが残っている場合はユーザー作業として扱う。
+    error "worktree に未コミットの差分があります。掃除を中止します。"
+    error "内容を確認してください: git -C \"$WORKTREE_PATH\" status"
+    printf '%s\n' "$DIRTY" | sed 's/^/    /' >&2
+    exit 1
+  fi
+
+  info "差分なし。削除して問題ありません。"
+fi
+
+# ── 5. worktree 削除 ────────────────────────────────────────────────
+if [[ -n "$WORKTREE_PATH" ]]; then
+  step "worktree を削除"
+  # gitignore された生成物（.next/ 等）だけが残って remove が拒否される場合に備え、
+  # dirty 確認（step 4）を通過している前提で --force を付ける。
+  run git worktree remove --force "$WORKTREE_PATH"
+fi
+
+# ── 6. main を最新化（branch 削除より先に行う） ─────────────────────
+# gh pr merge はリモートのみ更新するため、この時点ではローカル main に
+# マージコミットが無い。先に fetch + pull して main を最新化しておくと、
+# マージコミットの第2親 = branch 先端がローカル main から辿れるようになり、
+# 続く `git branch -d` が「マージ済み」と判定して確実に成功する。
+# （Claude Code の worktree branch は upstream 追跡が無いことが多く、
+#  pull 前に -d すると not fully merged で誤って失敗する）
+step "main を最新化"
+
+run git -C "$MAIN_ROOT" fetch --prune origin
+run git -C "$MAIN_ROOT" checkout main
+run git -C "$MAIN_ROOT" pull --ff-only origin main
+
+# ── 7. ローカル branch を削除 ───────────────────────────────────────
+step "ローカル branch を削除"
+
+if git -C "$MAIN_ROOT" show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  # -d は merge 済みなら成功する。not fully merged なら失敗させて停止する（-D は使わない）。
+  if [[ "$DRY_RUN" == true ]]; then
+    echo "   [dry-run] git -C \"$MAIN_ROOT\" branch -d $BRANCH" >&2
+  elif ! git -C "$MAIN_ROOT" branch -d "$BRANCH" 2>/tmp/branch-finish-branch-err; then
+    cat /tmp/branch-finish-branch-err >&2 || true
+    rm -f /tmp/branch-finish-branch-err
+    error "branch '$BRANCH' は未マージ扱いで削除できませんでした。"
+    error "main を pull 済みか、本当にマージ済みかを確認してください（-D 強制は避ける）。"
+    exit 1
+  fi
+  rm -f /tmp/branch-finish-branch-err
+else
+  info "ローカル branch '$BRANCH' は既にありません。"
+fi
+
+# ── 8. リモート branch の消滅を確認 ─────────────────────────────────
+# step 6 の fetch --prune で origin/<branch> は消えているはず。
+# 万一 --delete-branch が効かず残っていれば明示的に削除する。
+step "リモート branch を確認"
+
+if [[ "$DRY_RUN" == false ]]; then
+  if git -C "$MAIN_ROOT" show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
+    info "リモートに origin/$BRANCH が残っています。削除します。"
+    git -C "$MAIN_ROOT" push origin --delete "$BRANCH" || \
+      error "リモート branch の削除に失敗しました。手動で確認してください。"
+  else
+    info "リモート branch は消滅済みです。"
+  fi
+fi
+
+# ── 9. 孤児化した worktree 管理情報を掃除 ───────────────────────────
+run git -C "$MAIN_ROOT" worktree prune
+
+# ── 10. サマリー ────────────────────────────────────────────────────
+step "完了"
+
+if [[ "$DRY_RUN" == true ]]; then
+  info "dry-run のため実際の変更は行っていません。"
+else
+  echo "✅ PR #$PR_NUMBER を片付けました:" >&2
+  echo "   - branch: $BRANCH（ローカル / リモートとも削除）" >&2
+  [[ -n "$WORKTREE_PATH" ]] && echo "   - worktree: $WORKTREE_PATH（削除）" >&2
+  echo "   - main HEAD: $(git -C "$MAIN_ROOT" rev-parse --short main)" >&2
+fi
+
+echo "" >&2
+echo "残っている worktree:" >&2
+git -C "$MAIN_ROOT" worktree list >&2


### PR DESCRIPTION
## 背景

複数 AI（Claude / Codex / 他ツール）に並行セッションを依頼する前提で、worktree と branch の運用がバラバラで迷いが生じていた。

- 命名が不揃い（Claude Code の自動ランダム suffix vs Codex の自由記述）で作業内容が読めない
- マージ後の掃除が手順の羅列で「完了定義」がなく、「リモートだけ残る／ローカルだけ残る」が発生していた
- branch と worktree の概念が混同されがち

## 変更点

- **`pnpm branch:finish <PR番号>`** を追加（`scripts/git/finish-branch.sh`）。マージ → worktree 削除 → ローカル/リモート branch 削除 → main 最新化までをワンセットで実行する共通スクリプト。Claude / Codex / 人間で共通。`--dry-run` 対応
- **命名規則を統一**: `{agent}/{domain}-{action}[-{issue番号}]`。Claude Code の自動ランダム名は PR 作成前に `git branch -m` でリネーム
- **完了定義（5点）と branch/worktree の概念整理**を `.claude/rules/workflow.md` に明記
- `.codex/rules/git-workflow.md` / `AGENTS.md` も同じ運用に追随
- 意思決定ログ `docs/engineering/log/2026-07-24-worktree-branch-unification.md` を追加

## 設計上のポイント

- **安全側に停止**: worktree に未コミット差分がある／branch が本当に未マージのときは止めてユーザー判断に委ねる（`-D` 強制なし）
- **`branch -d` は main を pull した後に実行**: `gh pr merge` はリモートのみ更新するため、pull 前だと upstream 追跡の無い branch が誤って not fully merged 扱いになる。順序で回避
- **自分自身の worktree も片付け可能**: 全 git 操作を main checkout の絶対パス（`-C`）で行うため、実行中の worktree を消しても完走する

## 検証

- `bash -n scripts/git/finish-branch.sh`（構文）
- `pnpm docs:check`（rebase 後も pass）
- prettier / lint-staged（commit 時に pass）
- マージ済み PR に対する `pnpm branch:finish <番号> --dry-run` で制御フローを確認
- **この PR 自身を `pnpm branch:finish <この PR 番号>` で片付けるのが実地 E2E テストになる**

## 触っていないもの

- `codex/mcp-plan-track-learn`（main から大きく遅れ・PR なし。ユーザー判断待ち）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
