### PR TITLE
feat(external-calendar): Step 4 — tRPC router / connection-service（6 procedures）

### DIFF
--- a/apps/product/src/app/api/trpc/_server/app-router.ts
+++ b/apps/product/src/app/api/trpc/_server/app-router.ts
@@ -7,6 +7,7 @@ import 'server-only';
 
 import { userRouter } from '@/features/auth/server/router';
 import { contactRouter } from '@/features/contact/server/router';
+import { externalCalendarRouter } from '@/features/external-calendar/server/router';
 import { billingRouter } from '@/features/settings/server/billing-router';
 import { userSettingsRouter } from '@/features/settings/server/router';
 import { tagsRouter } from '@/features/tags/server/router';
@@ -20,6 +21,7 @@ export const appRouter = createTRPCRouter({
   billing: billingRouter,
   contact: contactRouter,
   email: emailRouter,
+  externalCalendar: externalCalendarRouter,
   records: recordsRouter,
   plans: plansRouter,
   statistics: statisticsRouter,

--- a/apps/product/src/features/external-calendar/server/__tests__/connection-service.test.ts
+++ b/apps/product/src/features/external-calendar/server/__tests__/connection-service.test.ts
@@ -1,0 +1,370 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Database } from '@/lib/database';
+import { createChainableMock } from '@/lib/test/trpc-test-helpers';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { ExternalCalendarServiceError } from '../external-calendar-service-error';
+
+const createClient = vi.hoisted(() => vi.fn());
+const deleteUnreferencedEvents = vi.hoisted(() => vi.fn());
+const startSession = vi.hoisted(() => vi.fn());
+const listCalendars = vi.hoisted(() => vi.fn());
+const revoke = vi.hoisted(() => vi.fn());
+const decryptToken = vi.hoisted(() => vi.fn());
+const encryptToken = vi.hoisted(() => vi.fn());
+const loggerWarn = vi.hoisted(() => vi.fn());
+
+vi.mock('@/env', () => ({
+  env: {
+    NEXT_PUBLIC_SUPABASE_URL: 'https://project.supabase.co',
+    SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+    CALENDAR_TOKEN_ENCRYPTION_KEY: 'A'.repeat(43) + '=',
+  },
+}));
+vi.mock('@supabase/supabase-js', () => ({ createClient }));
+vi.mock('../event-pruning', () => ({ deleteUnreferencedEvents }));
+vi.mock('../providers/google', () => ({
+  googleCalendarAdapter: { provider: 'google', startSession, listCalendars, revoke },
+}));
+vi.mock('../token-crypto', () => ({ decryptToken, encryptToken }));
+vi.mock('@/lib/logger', () => ({
+  logger: { log: vi.fn(), error: vi.fn(), warn: loggerWarn, info: vi.fn(), debug: vi.fn() },
+}));
+
+import {
+  disconnect,
+  getSyncStatus,
+  listConnections,
+  listProviderCalendars,
+  updateSelectedCalendars,
+} from '../connection-service';
+
+const USER_ID = '00000000-0000-4000-8000-0000000000a1';
+const CONNECTION_ID = '00000000-0000-4000-8000-0000000000c1';
+
+type Recorder = { table: string; chain: Array<{ method: string; args: unknown[] }> };
+
+type Config = {
+  connection?: { status: string; refresh_token_enc: string } | null;
+  childRows?: Array<{ provider_calendar_id: string }>;
+};
+
+function setupServiceRoleDb(config: Config) {
+  const calls: Recorder[] = [];
+
+  function resolve(recorder: Recorder): { data: unknown; error: unknown } {
+    const methods = recorder.chain.map((entry) => entry.method);
+    if (recorder.table === 'calendar_connections') {
+      if (methods.includes('maybeSingle')) return { data: config.connection ?? null, error: null };
+      return { data: null, error: null }; // update / delete
+    }
+    if (recorder.table === 'calendar_connection_calendars') {
+      return { data: config.childRows ?? [], error: null };
+    }
+    return { data: [], error: null };
+  }
+
+  const from = vi.fn((table: string) => {
+    const recorder: Recorder = { table, chain: [] };
+    calls.push(recorder);
+    const proxy: unknown = new Proxy(
+      {},
+      {
+        get(_t, prop: string) {
+          if (prop === 'then') {
+            return (
+              onF: (v: { data: unknown; error: unknown }) => unknown,
+              onR?: (e: unknown) => unknown,
+            ) => Promise.resolve(resolve(recorder)).then(onF, onR);
+          }
+          return (...args: unknown[]) => {
+            recorder.chain.push({ method: prop, args });
+            if (prop === 'maybeSingle' || prop === 'single') {
+              return Promise.resolve(resolve(recorder));
+            }
+            return proxy;
+          };
+        },
+      },
+    );
+    return proxy;
+  });
+
+  createClient.mockReturnValue({ from });
+  return { calls };
+}
+
+function recordersFor(calls: Recorder[], table: string): Recorder[] {
+  return calls.filter((r) => r.table === table);
+}
+
+function findWith(calls: Recorder[], table: string, method: string): Recorder | undefined {
+  return recordersFor(calls, table).find((r) => r.chain.some((e) => e.method === method));
+}
+
+function argsOf(recorder: Recorder, method: string): unknown[] {
+  const entry = recorder.chain.find((e) => e.method === method);
+  if (!entry) throw new Error(`${method} not called`);
+  return entry.args;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  decryptToken.mockReturnValue('refresh-token');
+  encryptToken.mockReturnValue('enc');
+  startSession.mockResolvedValue({ accessToken: 'access', rotatedRefreshToken: null });
+  listCalendars.mockResolvedValue([]);
+  revoke.mockResolvedValue(true);
+  deleteUnreferencedEvents.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// =============================================================================
+// 読み取り（authenticated client）
+// =============================================================================
+
+describe('listConnections', () => {
+  it('token 系を含まない列だけを明示 SELECT する', async () => {
+    const query = createChainableMock([{ id: CONNECTION_ID, status: 'active' }]);
+    const supabase = { from: vi.fn(() => query) } as unknown as SupabaseClient<Database>;
+
+    await listConnections(supabase, USER_ID);
+
+    const selectArg = query.select!.mock.calls[0]?.[0] as string;
+    expect(selectArg).not.toContain('*');
+    expect(selectArg).not.toContain('refresh_token_enc');
+    expect(selectArg).not.toContain('granted_scopes');
+    expect(selectArg).toContain('status');
+    expect(query.eq).toHaveBeenCalledWith('user_id', USER_ID);
+  });
+});
+
+describe('getSyncStatus', () => {
+  it('接続が無ければ CONNECTION_NOT_FOUND', async () => {
+    const query = createChainableMock(null);
+    const supabase = { from: vi.fn(() => query) } as unknown as SupabaseClient<Database>;
+
+    await expect(getSyncStatus(supabase, USER_ID, CONNECTION_ID)).rejects.toMatchObject({
+      code: 'CONNECTION_NOT_FOUND',
+    });
+  });
+});
+
+// =============================================================================
+// listProviderCalendars
+// =============================================================================
+
+describe('listProviderCalendars', () => {
+  it('選択済みカレンダーに selected=true を付ける', async () => {
+    setupServiceRoleDb({
+      connection: { status: 'active', refresh_token_enc: 'enc' },
+      childRows: [{ provider_calendar_id: 'cal-a' }],
+    });
+    listCalendars.mockResolvedValue([
+      { id: 'cal-a', name: 'A', primary: true },
+      { id: 'cal-b', name: 'B', primary: false },
+    ]);
+
+    const result = await listProviderCalendars(USER_ID, CONNECTION_ID);
+
+    expect(result).toEqual([
+      { id: 'cal-a', name: 'A', primary: true, selected: true },
+      { id: 'cal-b', name: 'B', primary: false, selected: false },
+    ]);
+  });
+
+  it('reauth_required の接続は provider を叩かず REAUTH_REQUIRED', async () => {
+    setupServiceRoleDb({ connection: { status: 'reauth_required', refresh_token_enc: 'enc' } });
+
+    await expect(listProviderCalendars(USER_ID, CONNECTION_ID)).rejects.toMatchObject({
+      code: 'REAUTH_REQUIRED',
+    });
+    expect(startSession).not.toHaveBeenCalled();
+  });
+
+  it('startSession の invalid_grant で status を reauth_required にして弾く', async () => {
+    const { calls } = setupServiceRoleDb({
+      connection: { status: 'active', refresh_token_enc: 'enc' },
+    });
+    const { CalendarProviderError } = await import('../providers/types');
+    startSession.mockRejectedValue(new CalendarProviderError('revoked', 'reauth_required'));
+
+    await expect(listProviderCalendars(USER_ID, CONNECTION_ID)).rejects.toMatchObject({
+      code: 'REAUTH_REQUIRED',
+    });
+    const update = findWith(calls, 'calendar_connections', 'update')!;
+    expect(argsOf(update, 'update')[0]).toMatchObject({ status: 'reauth_required' });
+  });
+
+  it('rotation された refresh token を再暗号化して保存する', async () => {
+    const { calls } = setupServiceRoleDb({
+      connection: { status: 'active', refresh_token_enc: 'enc' },
+    });
+    startSession.mockResolvedValue({ accessToken: 'a', rotatedRefreshToken: 'rotated' });
+
+    await listProviderCalendars(USER_ID, CONNECTION_ID);
+
+    expect(encryptToken).toHaveBeenCalledWith('rotated', expect.any(String));
+    const saved = recordersFor(calls, 'calendar_connections').find((r) =>
+      r.chain.some((e) => e.method === 'update' && 'refresh_token_enc' in (e.args[0] as object)),
+    );
+    expect(saved).toBeDefined();
+  });
+});
+
+// =============================================================================
+// updateSelectedCalendars
+// =============================================================================
+
+describe('updateSelectedCalendars', () => {
+  it('選択を upsert し、sync_token をキーに含めない（残す行の cursor 保持）', async () => {
+    const { calls } = setupServiceRoleDb({
+      connection: { status: 'active', refresh_token_enc: 'enc' },
+      childRows: [{ provider_calendar_id: 'cal-a' }],
+    });
+
+    await updateSelectedCalendars(USER_ID, CONNECTION_ID, [
+      { providerCalendarId: 'cal-a', calendarName: 'A' },
+    ]);
+
+    const upsert = findWith(calls, 'calendar_connection_calendars', 'upsert')!;
+    const [rows, options] = argsOf(upsert, 'upsert') as [
+      Array<Record<string, unknown>>,
+      { onConflict: string },
+    ];
+    expect(options.onConflict).toBe('connection_id,provider_calendar_id');
+    for (const row of rows) {
+      expect(Object.prototype.hasOwnProperty.call(row, 'sync_token')).toBe(false);
+    }
+  });
+
+  it('外したカレンダーの子行を delete し、そのミラーを即時掃除する', async () => {
+    const { calls } = setupServiceRoleDb({
+      connection: { status: 'active', refresh_token_enc: 'enc' },
+      childRows: [{ provider_calendar_id: 'cal-a' }, { provider_calendar_id: 'cal-b' }],
+    });
+
+    // cal-b を外す
+    await updateSelectedCalendars(USER_ID, CONNECTION_ID, [
+      { providerCalendarId: 'cal-a', calendarName: 'A' },
+    ]);
+
+    const childDelete = findWith(calls, 'calendar_connection_calendars', 'delete')!;
+    expect(argsOf(childDelete, 'in')).toEqual(['provider_calendar_id', ['cal-b']]);
+    expect(deleteUnreferencedEvents).toHaveBeenCalledWith({
+      userId: USER_ID,
+      connectionId: CONNECTION_ID,
+      scope: { kind: 'calendars', providerCalendarIds: ['cal-b'] },
+    });
+  });
+
+  it('外した行が無ければミラー掃除を呼ばない', async () => {
+    setupServiceRoleDb({
+      connection: { status: 'active', refresh_token_enc: 'enc' },
+      childRows: [{ provider_calendar_id: 'cal-a' }],
+    });
+
+    await updateSelectedCalendars(USER_ID, CONNECTION_ID, [
+      { providerCalendarId: 'cal-a', calendarName: 'A' },
+    ]);
+
+    expect(deleteUnreferencedEvents).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// disconnect
+// =============================================================================
+
+describe('disconnect', () => {
+  it('revoke → prune → connection 削除 の順で実行する', async () => {
+    const { calls } = setupServiceRoleDb({
+      connection: { status: 'active', refresh_token_enc: 'enc' },
+    });
+
+    let prunedBeforeConnectionDelete = false;
+    deleteUnreferencedEvents.mockImplementation(async () => {
+      // prune 呼び出し時点で connection の delete はまだ発行されていないはず（§8 順序）
+      prunedBeforeConnectionDelete = !calls.some(
+        (r) => r.table === 'calendar_connections' && r.chain.some((e) => e.method === 'delete'),
+      );
+    });
+
+    await disconnect(USER_ID, CONNECTION_ID);
+
+    expect(revoke).toHaveBeenCalledWith('refresh-token');
+    expect(deleteUnreferencedEvents).toHaveBeenCalledWith({
+      userId: USER_ID,
+      connectionId: CONNECTION_ID,
+      scope: { kind: 'connection' },
+    });
+    expect(prunedBeforeConnectionDelete).toBe(true);
+    expect(findWith(calls, 'calendar_connections', 'delete')).toBeDefined();
+  });
+
+  it('接続が既に無ければ冪等に何もしない', async () => {
+    setupServiceRoleDb({ connection: null });
+
+    await disconnect(USER_ID, CONNECTION_ID);
+
+    expect(revoke).not.toHaveBeenCalled();
+    expect(deleteUnreferencedEvents).not.toHaveBeenCalled();
+  });
+
+  it('復号に失敗しても切断を続行する（revoke は諦める）', async () => {
+    const { calls } = setupServiceRoleDb({
+      connection: { status: 'active', refresh_token_enc: 'enc' },
+    });
+    decryptToken.mockImplementation(() => {
+      throw new Error('bad key');
+    });
+
+    await disconnect(USER_ID, CONNECTION_ID);
+
+    expect(revoke).not.toHaveBeenCalled();
+    expect(deleteUnreferencedEvents).toHaveBeenCalled();
+    expect(findWith(calls, 'calendar_connections', 'delete')).toBeDefined();
+  });
+
+  it('接続削除の DB 失敗は ExternalCalendarServiceError を投げる', async () => {
+    setupServiceRoleDb({ connection: { status: 'active', refresh_token_enc: 'enc' } });
+    // connection delete を失敗させるため resolve を差し替える必要があるが、ここでは
+    // deleteConnectionError を使わずに throw 経路の存在だけ確認する形にはできないので、
+    // 代わりに削除エラーを返す最小構成にする。
+    const failingFrom = vi.fn((table: string) => {
+      const chain: Record<string, unknown> = {};
+      const proxy: unknown = new Proxy(chain, {
+        get(_t, prop: string) {
+          if (prop === 'then') {
+            const isConnectionDelete = table === 'calendar_connections';
+            return (onF: (v: { data: unknown; error: unknown }) => unknown) =>
+              Promise.resolve(
+                isConnectionDelete
+                  ? { data: null, error: { code: '55000' } }
+                  : { data: null, error: null },
+              ).then(onF);
+          }
+          return (..._args: unknown[]) => {
+            if (prop === 'maybeSingle') {
+              return Promise.resolve({
+                data: { status: 'active', refresh_token_enc: 'enc' },
+                error: null,
+              });
+            }
+            return proxy;
+          };
+        },
+      });
+      return proxy;
+    });
+    createClient.mockReturnValue({ from: failingFrom });
+
+    await expect(disconnect(USER_ID, CONNECTION_ID)).rejects.toBeInstanceOf(
+      ExternalCalendarServiceError,
+    );
+  });
+});

--- a/apps/product/src/features/external-calendar/server/__tests__/event-pruning.test.ts
+++ b/apps/product/src/features/external-calendar/server/__tests__/event-pruning.test.ts
@@ -1,0 +1,257 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * event-pruning.ts のテスト。
+ *
+ * overview.md §13 の必須 regression（prune anti-join）はここが正本。sync の window prune /
+ * 選択解除 / disconnect の 3 経路が共有する不変条件を凍結する。
+ */
+
+const createClient = vi.hoisted(() => vi.fn());
+const captureUnexpectedDatabaseError = vi.hoisted(() => vi.fn((error: unknown) => error));
+const loggerWarn = vi.hoisted(() => vi.fn());
+
+vi.mock('@/env', () => ({
+  env: {
+    NEXT_PUBLIC_SUPABASE_URL: 'https://project.supabase.co',
+    SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+  },
+}));
+vi.mock('@supabase/supabase-js', () => ({ createClient }));
+vi.mock('@/lib/sentry', () => ({ captureUnexpectedDatabaseError }));
+vi.mock('@/lib/logger', () => ({
+  logger: { log: vi.fn(), error: vi.fn(), warn: loggerWarn, info: vi.fn(), debug: vi.fn() },
+}));
+
+import { deleteUnreferencedEvents } from '../event-pruning';
+
+const USER_ID = '00000000-0000-4000-8000-0000000000a1';
+const CONNECTION_ID = '00000000-0000-4000-8000-0000000000c1';
+
+type Recorder = { table: string; chain: Array<{ method: string; args: unknown[] }> };
+
+type Config = {
+  candidates?: Array<{ id: string }>;
+  referencedByPlans?: Array<{ external_calendar_event_id: string | null }>;
+  referencedByRecords?: Array<{ external_calendar_event_id: string | null }>;
+  selectError?: unknown;
+  deleteError?: unknown;
+};
+
+function setupDb(config: Config) {
+  const calls: Recorder[] = [];
+  let candidateBatch = 0;
+
+  function resolve(recorder: Recorder): { data: unknown; error: unknown } {
+    const methods = recorder.chain.map((entry) => entry.method);
+    if (recorder.table === 'external_calendar_events') {
+      if (methods.includes('delete')) return { data: null, error: config.deleteError ?? null };
+      const batch = candidateBatch;
+      candidateBatch += 1;
+      return {
+        data: batch === 0 ? (config.candidates ?? []) : [],
+        error: config.selectError ?? null,
+      };
+    }
+    if (recorder.table === 'plans') return { data: config.referencedByPlans ?? [], error: null };
+    if (recorder.table === 'records')
+      return { data: config.referencedByRecords ?? [], error: null };
+    return { data: [], error: null };
+  }
+
+  const from = vi.fn((table: string) => {
+    const recorder: Recorder = { table, chain: [] };
+    calls.push(recorder);
+    const proxy: unknown = new Proxy(
+      {},
+      {
+        get(_t, prop: string) {
+          if (prop === 'then') {
+            return (
+              onF: (v: { data: unknown; error: unknown }) => unknown,
+              onR?: (e: unknown) => unknown,
+            ) => Promise.resolve(resolve(recorder)).then(onF, onR);
+          }
+          return (...args: unknown[]) => {
+            recorder.chain.push({ method: prop, args });
+            return proxy;
+          };
+        },
+      },
+    );
+    return proxy;
+  });
+
+  createClient.mockReturnValue({ from });
+  return { calls, from };
+}
+
+function candidateSelect(calls: Recorder[]): Recorder | undefined {
+  return calls.find(
+    (r) => r.table === 'external_calendar_events' && r.chain.some((e) => e.method === 'select'),
+  );
+}
+
+function deleteCall(calls: Recorder[]): Recorder | undefined {
+  return calls.find(
+    (r) => r.table === 'external_calendar_events' && r.chain.some((e) => e.method === 'delete'),
+  );
+}
+
+function argsOf(recorder: Recorder, method: string): unknown[] {
+  const entry = recorder.chain.find((e) => e.method === method);
+  if (!entry) throw new Error(`${method} not called`);
+  return entry.args;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('deleteUnreferencedEvents — anti-join', () => {
+  // regression（overview.md §13）: plans / records から参照される行を消さない。
+  // soft-delete 済み plan もまだ FK でミラー行を掴んでいるので除外する。
+  it('参照済み行（soft-deleted plan 参照を含む）を delete から除外する', async () => {
+    const { calls } = setupDb({
+      candidates: [{ id: 'ev-1' }, { id: 'ev-2' }, { id: 'ev-3' }],
+      referencedByPlans: [{ external_calendar_event_id: 'ev-1' }], // soft-deleted plan の参照
+      referencedByRecords: [{ external_calendar_event_id: 'ev-2' }],
+    });
+
+    await deleteUnreferencedEvents({
+      userId: USER_ID,
+      connectionId: CONNECTION_ID,
+      scope: { kind: 'connection' },
+    });
+
+    const del = deleteCall(calls);
+    expect(del).toBeDefined();
+    expect(argsOf(del!, 'in')).toEqual(['id', ['ev-3']]);
+    // service_role は RLS を bypass するので delete に user_id ガードが載る
+    expect(argsOf(del!, 'eq')).toEqual(['user_id', USER_ID]);
+
+    // 参照クエリは deleted_at で絞らない（soft-deleted も FK を掴む）
+    const plans = calls.find((r) => r.table === 'plans');
+    expect(plans?.chain.some((e) => e.method === 'is')).toBe(false);
+  });
+
+  it('候補が空なら delete を発行しない', async () => {
+    const { calls } = setupDb({ candidates: [] });
+
+    await deleteUnreferencedEvents({
+      userId: USER_ID,
+      connectionId: CONNECTION_ID,
+      scope: { kind: 'connection' },
+    });
+
+    expect(deleteCall(calls)).toBeUndefined();
+  });
+
+  it('全候補が参照済みなら delete を発行しない（空リスト全削除の回避）', async () => {
+    const { calls } = setupDb({
+      candidates: [{ id: 'ev-1' }],
+      referencedByPlans: [{ external_calendar_event_id: 'ev-1' }],
+    });
+
+    await deleteUnreferencedEvents({
+      userId: USER_ID,
+      connectionId: CONNECTION_ID,
+      scope: { kind: 'connection' },
+    });
+
+    expect(deleteCall(calls)).toBeUndefined();
+  });
+
+  it('select 失敗では throw せず記録して中断する', async () => {
+    const { calls } = setupDb({ selectError: { code: '42501' } });
+
+    await expect(
+      deleteUnreferencedEvents({
+        userId: USER_ID,
+        connectionId: CONNECTION_ID,
+        scope: { kind: 'connection' },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(deleteCall(calls)).toBeUndefined();
+    expect(captureUnexpectedDatabaseError).toHaveBeenCalled();
+  });
+});
+
+describe('deleteUnreferencedEvents — scope 別フィルタ', () => {
+  it('window scope は end_at/start_at の or フィルタを付ける', async () => {
+    const { calls } = setupDb({ candidates: [{ id: 'ev-1' }] });
+
+    await deleteUnreferencedEvents({
+      userId: USER_ID,
+      connectionId: CONNECTION_ID,
+      scope: {
+        kind: 'window',
+        notBefore: '2026-04-25T00:00:00.000Z',
+        notAfter: '2026-10-22T00:00:00.000Z',
+      },
+    });
+
+    const select = candidateSelect(calls)!;
+    expect(argsOf(select, 'or')).toEqual([
+      'end_at.lt.2026-04-25T00:00:00.000Z,start_at.gt.2026-10-22T00:00:00.000Z',
+    ]);
+    expect(
+      select.chain.some((e) => e.method === 'in' && e.args[0] === 'provider_calendar_id'),
+    ).toBe(false);
+  });
+
+  it('calendars scope は provider_calendar_id の in フィルタを付ける', async () => {
+    const { calls } = setupDb({ candidates: [{ id: 'ev-1' }] });
+
+    await deleteUnreferencedEvents({
+      userId: USER_ID,
+      connectionId: CONNECTION_ID,
+      scope: { kind: 'calendars', providerCalendarIds: ['cal-a', 'cal-b'] },
+    });
+
+    const select = candidateSelect(calls)!;
+    const inCall = select.chain.find(
+      (e) => e.method === 'in' && e.args[0] === 'provider_calendar_id',
+    );
+    expect(inCall?.args[1]).toEqual(['cal-a', 'cal-b']);
+    expect(select.chain.some((e) => e.method === 'or')).toBe(false);
+  });
+
+  it('calendars scope が空なら DB に一切触れない（空 in を撃たない）', async () => {
+    const { from } = setupDb({ candidates: [{ id: 'ev-1' }] });
+
+    await deleteUnreferencedEvents({
+      userId: USER_ID,
+      connectionId: CONNECTION_ID,
+      scope: { kind: 'calendars', providerCalendarIds: [] },
+    });
+
+    expect(createClient).not.toHaveBeenCalled();
+    expect(from).not.toHaveBeenCalled();
+  });
+
+  it('connection scope は or も provider_calendar_id in も付けない', async () => {
+    const { calls } = setupDb({ candidates: [{ id: 'ev-1' }] });
+
+    await deleteUnreferencedEvents({
+      userId: USER_ID,
+      connectionId: CONNECTION_ID,
+      scope: { kind: 'connection' },
+    });
+
+    const select = candidateSelect(calls)!;
+    expect(select.chain.some((e) => e.method === 'or')).toBe(false);
+    expect(
+      select.chain.some((e) => e.method === 'in' && e.args[0] === 'provider_calendar_id'),
+    ).toBe(false);
+    // ただし user_id / connection_id スコープは必ず付く
+    const eqCols = select.chain.filter((e) => e.method === 'eq').map((e) => e.args[0]);
+    expect(eqCols).toContain('user_id');
+    expect(eqCols).toContain('connection_id');
+  });
+});

--- a/apps/product/src/features/external-calendar/server/__tests__/router.test.ts
+++ b/apps/product/src/features/external-calendar/server/__tests__/router.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createMockContext } from '@/lib/test/trpc-test-helpers';
+import { createCallerFactory } from '@/lib/trpc/procedures';
+
+const listConnections = vi.hoisted(() => vi.fn());
+const getSyncStatus = vi.hoisted(() => vi.fn());
+const listProviderCalendars = vi.hoisted(() => vi.fn());
+const updateSelectedCalendars = vi.hoisted(() => vi.fn());
+const disconnect = vi.hoisted(() => vi.fn());
+const syncConnection = vi.hoisted(() => vi.fn());
+const rateLimit = vi.hoisted(() => vi.fn());
+const isBillingEnforced = vi.hoisted(() => vi.fn(() => false));
+
+vi.mock('../connection-service', () => ({
+  listConnections,
+  getSyncStatus,
+  listProviderCalendars,
+  updateSelectedCalendars,
+  disconnect,
+}));
+vi.mock('../sync-service', () => ({ syncConnection }));
+vi.mock('@/lib/rate-limit/upstash', () => ({
+  calendarSyncNowRateLimit: { limit: rateLimit },
+  // protectedProcedure が毎リクエスト参照する。ここでは常に成功させる。
+  trpcUserRateLimit: { limit: vi.fn().mockResolvedValue({ success: true }) },
+}));
+vi.mock('@/lib/billing/enforcement', () => ({ isBillingEnforced }));
+
+import { externalCalendarRouter } from '../router';
+
+const USER_ID = '00000000-0000-4000-8000-0000000000a1';
+const CONNECTION_ID = '00000000-0000-4000-8000-0000000000c1';
+
+const createCaller = createCallerFactory(externalCalendarRouter);
+
+function caller() {
+  return createCaller(createMockContext({ userId: USER_ID }));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isBillingEnforced.mockReturnValue(false);
+  rateLimit.mockResolvedValue({ success: true });
+  syncConnection.mockResolvedValue({ outcome: 'synced', calendarsSynced: 1, calendarsFailed: 0 });
+  listConnections.mockResolvedValue([]);
+  getSyncStatus.mockResolvedValue({ connection: {}, calendars: [] });
+  listProviderCalendars.mockResolvedValue([]);
+  updateSelectedCalendars.mockResolvedValue(undefined);
+  disconnect.mockResolvedValue(undefined);
+});
+
+describe('externalCalendarRouter — 認可', () => {
+  it('proProcedure は BILLING_ENFORCED off で素通りする', async () => {
+    await expect(caller().listProviderCalendars({ connectionId: CONNECTION_ID })).resolves.toEqual(
+      [],
+    );
+    await expect(caller().syncNow({ connectionId: CONNECTION_ID })).resolves.toMatchObject({
+      outcome: 'synced',
+    });
+  });
+
+  it('未認証（userId なし）は listConnections で弾かれる', async () => {
+    const unauth = createCaller(createMockContext({}));
+    await expect(unauth.listConnections()).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+  });
+});
+
+describe('externalCalendarRouter — syncNow rate limit', () => {
+  it('超過で TOO_MANY_REQUESTS を返し、sync を呼ばない', async () => {
+    rateLimit.mockResolvedValue({ success: false });
+
+    await expect(caller().syncNow({ connectionId: CONNECTION_ID })).rejects.toMatchObject({
+      code: 'TOO_MANY_REQUESTS',
+    });
+    expect(syncConnection).not.toHaveBeenCalled();
+  });
+
+  it('rate-limit サービス障害は SERVICE_UNAVAILABLE', async () => {
+    rateLimit.mockRejectedValue(new Error('upstash down'));
+
+    await expect(caller().syncNow({ connectionId: CONNECTION_ID })).rejects.toMatchObject({
+      code: 'SERVICE_UNAVAILABLE',
+    });
+  });
+});
+
+describe('externalCalendarRouter — updateSelectedCalendars', () => {
+  it('選択更新後に同期を kick する', async () => {
+    await caller().updateSelectedCalendars({
+      connectionId: CONNECTION_ID,
+      calendars: [{ providerCalendarId: 'cal-a', calendarName: 'A' }],
+    });
+
+    expect(updateSelectedCalendars).toHaveBeenCalledWith(USER_ID, CONNECTION_ID, [
+      { providerCalendarId: 'cal-a', calendarName: 'A' },
+    ]);
+    expect(syncConnection).toHaveBeenCalledWith({ connectionId: CONNECTION_ID, userId: USER_ID });
+  });
+
+  it('calendarName 省略は null に正規化して渡す', async () => {
+    await caller().updateSelectedCalendars({
+      connectionId: CONNECTION_ID,
+      calendars: [{ providerCalendarId: 'cal-a' }],
+    });
+
+    expect(updateSelectedCalendars).toHaveBeenCalledWith(USER_ID, CONNECTION_ID, [
+      { providerCalendarId: 'cal-a', calendarName: null },
+    ]);
+  });
+});
+
+describe('externalCalendarRouter — disconnect', () => {
+  it('protectedProcedure なので Pro でなくても切断できる', async () => {
+    await expect(caller().disconnect({ connectionId: CONNECTION_ID })).resolves.toEqual({
+      success: true,
+    });
+    expect(disconnect).toHaveBeenCalledWith(USER_ID, CONNECTION_ID);
+  });
+});
+
+describe('externalCalendarRouter — 入力バリデーション', () => {
+  it('connectionId が uuid でなければ BAD_REQUEST', async () => {
+    await expect(caller().getSyncStatus({ connectionId: 'not-a-uuid' })).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+    });
+  });
+});

--- a/apps/product/src/features/external-calendar/server/__tests__/sync-service.test.ts
+++ b/apps/product/src/features/external-calendar/server/__tests__/sync-service.test.ts
@@ -238,45 +238,29 @@ describe('syncConnection — active イベントの upsert', () => {
   });
 });
 
-describe('syncConnection — prune anti-join', () => {
-  // regression（overview.md §13）: plans / records から参照される行を消さない。
-  // soft-delete 済み plan もまだ FK でミラー行を掴んでいるので除外する。
-  it('参照済み行（soft-deleted plan 参照を含む）を delete から除外する', async () => {
+describe('syncConnection — prune 委譲', () => {
+  // anti-join の詳細な regression は event-pruning.test.ts が正本。ここでは sync が
+  // window scope で prune を呼び出す配線だけを確認する（未参照行が消えること）。
+  it('window 境界の candidate select を発行し、未参照行を delete する', async () => {
     const { calls } = setupDb({
       connection: activeConnection(),
       calendars: oneCalendar(),
-      pruneCandidates: [{ id: 'ev-1' }, { id: 'ev-2' }, { id: 'ev-3' }],
-      // soft-deleted plan が ev-1 を参照している想定
+      pruneCandidates: [{ id: 'ev-1' }, { id: 'ev-2' }],
       referencedByPlans: [{ external_calendar_event_id: 'ev-1' }],
-      referencedByRecords: [{ external_calendar_event_id: 'ev-2' }],
     });
     syncCalendar.mockResolvedValue(syncResult());
 
     await syncConnection({ connectionId: CONNECTION_ID, userId: USER_ID });
+
+    // event-pruning の window scope は end_at/start_at の or フィルタで候補を引く
+    const candidateSelect = recordersFor(calls, 'external_calendar_events').find((recorder) =>
+      recorder.chain.some((entry) => entry.method === 'or'),
+    );
+    expect(candidateSelect).toBeDefined();
 
     const del = findCall(calls, 'external_calendar_events', 'delete');
     expect(del).toBeDefined();
-    const inArgs = argsOf(del!, 'in');
-    expect(inArgs[0]).toBe('id');
-    expect(inArgs[1]).toEqual(['ev-3']);
-
-    // plans / records の参照クエリは deleted_at で絞らない（soft-deleted も FK を掴む）
-    const plansSelect = findCall(calls, 'plans', 'select')!;
-    expect(plansSelect.chain.some((entry) => entry.method === 'is')).toBe(false);
-  });
-
-  it('全候補が参照されていれば delete を発行しない', async () => {
-    const { calls } = setupDb({
-      connection: activeConnection(),
-      calendars: oneCalendar(),
-      pruneCandidates: [{ id: 'ev-1' }],
-      referencedByPlans: [{ external_calendar_event_id: 'ev-1' }],
-    });
-    syncCalendar.mockResolvedValue(syncResult());
-
-    await syncConnection({ connectionId: CONNECTION_ID, userId: USER_ID });
-
-    expect(findCall(calls, 'external_calendar_events', 'delete')).toBeUndefined();
+    expect(argsOf(del!, 'in')[1]).toEqual(['ev-2']);
   });
 });
 

--- a/apps/product/src/features/external-calendar/server/connection-service.ts
+++ b/apps/product/src/features/external-calendar/server/connection-service.ts
@@ -6,7 +6,13 @@ import { env } from '@/env';
 import type { Database } from '@/lib/database';
 import { databaseTables } from '@/lib/database';
 
-import { encryptToken } from './token-crypto';
+import { logger } from '@/lib/logger';
+
+import { deleteUnreferencedEvents } from './event-pruning';
+import { ExternalCalendarServiceError } from './external-calendar-service-error';
+import { googleCalendarAdapter } from './providers/google';
+import { CalendarProviderError } from './providers/types';
+import { decryptToken, encryptToken } from './token-crypto';
 
 /**
  * `calendar_connections` への書き込み。
@@ -88,5 +94,363 @@ export async function saveConnection(input: SaveConnectionInput): Promise<void> 
   if (error) {
     // error にトークンは含まれないが、message をそのまま外へ出さない。
     throw new Error(`failed to save calendar connection: ${error.code ?? 'unknown'}`);
+  }
+}
+
+// =============================================================================
+// 読み取り（authenticated client 経由。RLS スコープ + 列明示）
+// =============================================================================
+
+/** authenticated client から見える connection の列（token 系は grant 外なので含めない）。 */
+const CONNECTION_PUBLIC_COLUMNS =
+  'id, provider, provider_account_email, status, last_synced_at, last_sync_error, created_at, updated_at' as const;
+
+type CalendarConnectionSummary = {
+  id: string;
+  provider: string;
+  provider_account_email: string | null;
+  status: string;
+  last_synced_at: string | null;
+  last_sync_error: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type CalendarSyncStatus = {
+  connection: CalendarConnectionSummary;
+  calendars: Array<{
+    provider_calendar_id: string;
+    calendar_name: string | null;
+    last_synced_at: string | null;
+  }>;
+};
+
+/**
+ * 接続一覧。解約後も自分の接続状態は見えるべきなので protectedProcedure から呼ぶ。
+ *
+ * authenticated client（RLS スコープ済み）を受け取り、`select('*')` を使わず列明示する
+ * （column-scoped grant のため未 grant 列を触ると 42501）。
+ */
+export async function listConnections(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+): Promise<CalendarConnectionSummary[]> {
+  const { data, error } = await supabase
+    .from(databaseTables.calendarConnections)
+    .select(CONNECTION_PUBLIC_COLUMNS)
+    .eq('user_id', userId)
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    throw new ExternalCalendarServiceError('FETCH_FAILED', 'failed to list calendar connections', {
+      cause: error,
+    });
+  }
+  return data ?? [];
+}
+
+/** 接続 + 選択カレンダーの同期状況。 */
+export async function getSyncStatus(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+  connectionId: string,
+): Promise<CalendarSyncStatus> {
+  const { data: connection, error: connectionError } = await supabase
+    .from(databaseTables.calendarConnections)
+    .select(CONNECTION_PUBLIC_COLUMNS)
+    .eq('id', connectionId)
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (connectionError) {
+    throw new ExternalCalendarServiceError('FETCH_FAILED', 'failed to load connection', {
+      cause: connectionError,
+    });
+  }
+  if (!connection) {
+    throw new ExternalCalendarServiceError('CONNECTION_NOT_FOUND', 'calendar connection not found');
+  }
+
+  const { data: calendars, error: calendarsError } = await supabase
+    .from(databaseTables.calendarConnectionCalendars)
+    .select('provider_calendar_id, calendar_name, last_synced_at')
+    .eq('connection_id', connectionId)
+    .eq('user_id', userId)
+    .order('provider_calendar_id', { ascending: true });
+
+  if (calendarsError) {
+    throw new ExternalCalendarServiceError('FETCH_FAILED', 'failed to load selected calendars', {
+      cause: calendarsError,
+    });
+  }
+
+  return { connection, calendars: calendars ?? [] };
+}
+
+// =============================================================================
+// mutation / provider 呼び出し（service_role client）
+// =============================================================================
+
+type SelectedCalendarInput = {
+  providerCalendarId: string;
+  calendarName?: string | null;
+};
+
+type ProviderCalendarOption = {
+  id: string;
+  name: string | null;
+  primary: boolean;
+  selected: boolean;
+};
+
+/** service_role で connection の token 行を読む。無ければ null。 */
+async function loadConnectionSecret(
+  db: CalendarConnectionClient,
+  userId: string,
+  connectionId: string,
+): Promise<{ status: string; refreshTokenEnc: string } | null> {
+  const { data, error } = await db
+    .from(databaseTables.calendarConnections)
+    .select('status, refresh_token_enc')
+    .eq('id', connectionId)
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error) {
+    throw new ExternalCalendarServiceError('FETCH_FAILED', 'failed to load calendar connection', {
+      cause: error,
+    });
+  }
+  if (!data) return null;
+  return { status: data.status, refreshTokenEnc: data.refresh_token_enc };
+}
+
+async function markReauthRequired(
+  db: CalendarConnectionClient,
+  userId: string,
+  connectionId: string,
+): Promise<void> {
+  await db
+    .from(databaseTables.calendarConnections)
+    .update({ status: 'reauth_required', last_sync_error: 'reauth_required' })
+    .eq('id', connectionId)
+    .eq('user_id', userId);
+}
+
+/**
+ * provider の calendarList をオンデマンドで取得し、選択済みフラグを付けて返す。
+ *
+ * refresh token を読むため service_role。`reauth_required` の接続は provider を叩かず弾く。
+ * rotation された refresh token は保存し直す（Step 3 と同じ規律）。
+ */
+export async function listProviderCalendars(
+  userId: string,
+  connectionId: string,
+): Promise<ProviderCalendarOption[]> {
+  const db = createCalendarConnectionDbClient();
+
+  const secret = await loadConnectionSecret(db, userId, connectionId);
+  if (!secret) {
+    throw new ExternalCalendarServiceError('CONNECTION_NOT_FOUND', 'calendar connection not found');
+  }
+  if (secret.status === 'reauth_required') {
+    throw new ExternalCalendarServiceError('REAUTH_REQUIRED', 'calendar connection needs reauth');
+  }
+
+  const refreshToken = decryptToken(
+    secret.refreshTokenEnc,
+    env.CALENDAR_TOKEN_ENCRYPTION_KEY ?? '',
+  );
+
+  let session;
+  try {
+    session = await googleCalendarAdapter.startSession(refreshToken);
+  } catch (error) {
+    if (error instanceof CalendarProviderError && error.kind === 'reauth_required') {
+      await markReauthRequired(db, userId, connectionId);
+      throw new ExternalCalendarServiceError(
+        'REAUTH_REQUIRED',
+        'calendar connection needs reauth',
+        {
+          cause: error,
+        },
+      );
+    }
+    throw new ExternalCalendarServiceError('PROVIDER_UNAVAILABLE', 'failed to reach the provider', {
+      cause: error,
+    });
+  }
+
+  if (session.rotatedRefreshToken !== null) {
+    await persistRotatedToken(db, userId, connectionId, session.rotatedRefreshToken);
+  }
+
+  const providerCalendars = await googleCalendarAdapter.listCalendars(session);
+
+  const { data: selectedRows, error: selectedError } = await db
+    .from(databaseTables.calendarConnectionCalendars)
+    .select('provider_calendar_id')
+    .eq('connection_id', connectionId)
+    .eq('user_id', userId);
+
+  if (selectedError) {
+    throw new ExternalCalendarServiceError('FETCH_FAILED', 'failed to load selected calendars', {
+      cause: selectedError,
+    });
+  }
+
+  const selectedIds = new Set((selectedRows ?? []).map((row) => row.provider_calendar_id));
+
+  return providerCalendars.map((calendar) => ({
+    id: calendar.id,
+    name: calendar.name,
+    primary: calendar.primary,
+    selected: selectedIds.has(calendar.id),
+  }));
+}
+
+async function persistRotatedToken(
+  db: CalendarConnectionClient,
+  userId: string,
+  connectionId: string,
+  rotatedRefreshToken: string,
+): Promise<void> {
+  const { error } = await db
+    .from(databaseTables.calendarConnections)
+    .update({
+      refresh_token_enc: encryptToken(rotatedRefreshToken, env.CALENDAR_TOKEN_ENCRYPTION_KEY ?? ''),
+    })
+    .eq('id', connectionId)
+    .eq('user_id', userId);
+
+  // 保存に失敗しても今回の一覧取得は続行する（access token は既に mint 済み）。
+  if (error) logger.warn('[calendar-connection] failed to persist a rotated refresh token');
+}
+
+/**
+ * 選択カレンダーを差し替える。
+ *
+ * 残すカレンダーの `sync_token` は保持する（upsert payload に含めないことで既存値が残る）。
+ * 外したカレンダーは子行を delete し、そのミラー行のうち未参照のものを即時掃除する
+ * （ユーザーが「外した」意思をすぐ反映。参照済みは歴史的アンカーとして残す）。
+ */
+export async function updateSelectedCalendars(
+  userId: string,
+  connectionId: string,
+  selected: SelectedCalendarInput[],
+): Promise<void> {
+  const db = createCalendarConnectionDbClient();
+
+  const secret = await loadConnectionSecret(db, userId, connectionId);
+  if (!secret) {
+    throw new ExternalCalendarServiceError('CONNECTION_NOT_FOUND', 'calendar connection not found');
+  }
+
+  const { data: existingRows, error: existingError } = await db
+    .from(databaseTables.calendarConnectionCalendars)
+    .select('provider_calendar_id')
+    .eq('connection_id', connectionId)
+    .eq('user_id', userId);
+
+  if (existingError) {
+    throw new ExternalCalendarServiceError('FETCH_FAILED', 'failed to load selected calendars', {
+      cause: existingError,
+    });
+  }
+
+  const selectedIds = new Set(selected.map((calendar) => calendar.providerCalendarId));
+  const removedIds = (existingRows ?? [])
+    .map((row) => row.provider_calendar_id)
+    .filter((id) => !selectedIds.has(id));
+
+  if (selected.length > 0) {
+    // sync_token をキーに含めない → 残す行の cursor は保持され、新規行だけ NULL（= 次回 full sync）。
+    const { error: upsertError } = await db.from(databaseTables.calendarConnectionCalendars).upsert(
+      selected.map((calendar) => ({
+        user_id: userId,
+        connection_id: connectionId,
+        provider_calendar_id: calendar.providerCalendarId,
+        calendar_name: calendar.calendarName ?? null,
+      })),
+      { onConflict: 'connection_id,provider_calendar_id' },
+    );
+
+    if (upsertError) {
+      throw new ExternalCalendarServiceError('UPDATE_FAILED', 'failed to save selected calendars', {
+        cause: upsertError,
+      });
+    }
+  }
+
+  if (removedIds.length > 0) {
+    const { error: deleteError } = await db
+      .from(databaseTables.calendarConnectionCalendars)
+      .delete()
+      .eq('user_id', userId)
+      .eq('connection_id', connectionId)
+      .in('provider_calendar_id', removedIds);
+
+    if (deleteError) {
+      throw new ExternalCalendarServiceError('DELETE_FAILED', 'failed to remove calendars', {
+        cause: deleteError,
+      });
+    }
+
+    // 外したカレンダーの未参照ミラー行を即時掃除する。
+    await deleteUnreferencedEvents({
+      userId,
+      connectionId,
+      scope: { kind: 'calendars', providerCalendarIds: removedIds },
+    });
+  }
+}
+
+/**
+ * 接続を切断する（overview.md §8 の 3 段。順序が重要）。
+ *
+ * 1. provider の revoke を best-effort で呼ぶ（失敗しても続行）
+ * 2. connection を消す前に、未参照ミラー行を anti-join で掃除する（削除後は FK が
+ *    connection_id を NULL 化してスコープを失う）
+ * 3. `calendar_connections` を hard delete（子は CASCADE、参照済みミラーは connection_id が
+ *    SET NULL され歴史的アンカーとして残る）
+ *
+ * 解約済みユーザーも切断できるよう protectedProcedure から呼ぶ。接続が既に無ければ冪等に成功。
+ */
+export async function disconnect(userId: string, connectionId: string): Promise<void> {
+  const db = createCalendarConnectionDbClient();
+
+  const secret = await loadConnectionSecret(db, userId, connectionId);
+  if (!secret) return; // 既に切断済み。冪等。
+
+  // 1. revoke（best-effort）。復号に失敗しても切断自体は続行する。
+  try {
+    const refreshToken = decryptToken(
+      secret.refreshTokenEnc,
+      env.CALENDAR_TOKEN_ENCRYPTION_KEY ?? '',
+    );
+    const revoked = await googleCalendarAdapter.revoke(refreshToken);
+    if (!revoked) logger.warn('[calendar-connection] provider revoke was not confirmed');
+  } catch {
+    logger.warn('[calendar-connection] could not revoke the provider grant; continuing disconnect');
+  }
+
+  // 2. connection 削除より先にミラーを掃除する。
+  await deleteUnreferencedEvents({ userId, connectionId, scope: { kind: 'connection' } });
+
+  // 3. connection を hard delete。子テーブルは CASCADE。
+  const { error } = await db
+    .from(databaseTables.calendarConnections)
+    .delete()
+    .eq('id', connectionId)
+    .eq('user_id', userId);
+
+  if (error) {
+    throw new ExternalCalendarServiceError(
+      'DELETE_FAILED',
+      'failed to delete calendar connection',
+      {
+        cause: error,
+      },
+    );
   }
 }

--- a/apps/product/src/features/external-calendar/server/event-pruning.ts
+++ b/apps/product/src/features/external-calendar/server/event-pruning.ts
@@ -1,0 +1,181 @@
+import 'server-only';
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+import { env } from '@/env';
+import { databaseTables, type Database } from '@/lib/database';
+import { logger } from '@/lib/logger';
+import { captureUnexpectedDatabaseError } from '@/lib/sentry';
+
+/**
+ * ミラー（`external_calendar_events`）から「plans / records に参照されていない行」だけを
+ * delete する共有 helper。
+ *
+ * 3 つの呼び出し点（sync の window prune / 選択解除の掃除 / disconnect の全削除）が同じ
+ * anti-join を必要とし、その不変条件はデータ欠損に直結するので 1 箇所に集約する:
+ *
+ * - **soft-delete 済みの plan / record も参照とみなす**。`external_calendar_event_id` の FK は
+ *   ON DELETE 句なし（NO ACTION）なので、`deleted_at` で絞ると参照行の DELETE が 23503 で落ちる
+ * - **候補が空 / 全参照済みなら delete を発行しない**。空リストへの delete が全削除にならないよう、
+ *   常に非空の id リストだけを `.in('id', …)` に渡す
+ * - **keyset ページング**で `max_rows=1000` と URL 長 8192B（UUID 約 210 件）の両方を避ける
+ * - service_role は RLS を bypass するので、delete にも `user_id` を明示的に添える
+ */
+
+/** sync / connection service と同じ外部呼び出しタイムアウト（`lib/supabase/oauth.ts`）。 */
+const DB_REQUEST_TIMEOUT_MS = 15_000;
+
+/** 1 バッチあたり件数。max_rows=1000 と URL 長 8192B に触れない。 */
+const PRUNE_BATCH_SIZE = 150;
+
+/** バッチ上限。150 × 40 = 6,000 件で ±90 日 window / 1 接続の想定を大きく超える。 */
+const MAX_PRUNE_BATCHES = 40;
+
+/**
+ * 掃除する行の絞り込み条件。
+ *
+ * - `window`: sync の window prune。`end_at < notBefore OR start_at > notAfter`
+ * - `calendars`: 選択解除。指定 provider_calendar_id の行だけ（空なら no-op）
+ * - `connection`: disconnect。接続配下の全行
+ */
+type EventPruneScope =
+  | { kind: 'window'; notBefore: string; notAfter: string }
+  | { kind: 'calendars'; providerCalendarIds: string[] }
+  | { kind: 'connection' };
+
+/**
+ * service_role client が触れる surface を anti-join に必要な 3 テーブルへ narrow する。
+ * plans / records は参照判定のため SELECT のみ使う。
+ */
+type EventPruningDatabase = {
+  public: {
+    Tables: Pick<Database['public']['Tables'], 'external_calendar_events' | 'plans' | 'records'>;
+    Views: Record<string, never>;
+    Functions: Record<string, never>;
+    Enums: Record<string, never>;
+    CompositeTypes: Record<string, never>;
+  };
+};
+
+type EventPruningClient = SupabaseClient<EventPruningDatabase>;
+
+function createEventPruningClient(): EventPruningClient {
+  return createClient<EventPruningDatabase>(
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.SUPABASE_SERVICE_ROLE_KEY,
+    {
+      auth: { autoRefreshToken: false, persistSession: false },
+      global: {
+        fetch: (url, options) =>
+          fetch(url, {
+            ...options,
+            signal: options?.signal ?? AbortSignal.timeout(DB_REQUEST_TIMEOUT_MS),
+          }),
+      },
+    },
+  );
+}
+
+/** plans / records の両方から、与えた id を参照している external_calendar_event_id を集める。 */
+async function loadReferencedEventIds(
+  db: EventPruningClient,
+  userId: string,
+  ids: string[],
+): Promise<Set<string>> {
+  const referenced = new Set<string>();
+
+  for (const table of [databaseTables.plans, databaseTables.records] as const) {
+    const { data, error } = await db
+      .from(table)
+      .select('external_calendar_event_id')
+      .eq('user_id', userId)
+      .in('external_calendar_event_id', ids);
+
+    if (error) throw error;
+
+    for (const row of data ?? []) {
+      if (row.external_calendar_event_id !== null) referenced.add(row.external_calendar_event_id);
+    }
+  }
+
+  return referenced;
+}
+
+/**
+ * scope に一致する未参照ミラー行を anti-join で delete する。
+ *
+ * 失敗（select / 参照読み取り / delete）では throw せず、ここまでの成功を壊さないよう
+ * 記録して中断する（呼び出し側は sync の一部・disconnect の一部として続行できる）。
+ */
+export async function deleteUnreferencedEvents(params: {
+  userId: string;
+  connectionId: string;
+  scope: EventPruneScope;
+}): Promise<void> {
+  const { userId, connectionId, scope } = params;
+
+  // 選択解除で外したカレンダーが 0 件なら掃除対象も無い。空 `.in()` を撃たない。
+  if (scope.kind === 'calendars' && scope.providerCalendarIds.length === 0) return;
+
+  const db = createEventPruningClient();
+  let cursor = '';
+
+  for (let batch = 0; batch < MAX_PRUNE_BATCHES; batch += 1) {
+    let query = db
+      .from(databaseTables.externalCalendarEvents)
+      .select('id')
+      .eq('user_id', userId)
+      .eq('connection_id', connectionId);
+
+    if (scope.kind === 'window') {
+      query = query.or(`end_at.lt.${scope.notBefore},start_at.gt.${scope.notAfter}`);
+    } else if (scope.kind === 'calendars') {
+      query = query.in('provider_calendar_id', scope.providerCalendarIds);
+    }
+
+    const { data: candidates, error: selectError } = await query
+      .gt('id', cursor)
+      .order('id', { ascending: true })
+      .limit(PRUNE_BATCH_SIZE);
+
+    if (selectError) {
+      captureDatabaseError(selectError, 'prune_select_candidates');
+      return;
+    }
+    if (!candidates || candidates.length === 0) return;
+
+    const ids = candidates.map((row) => row.id);
+
+    let referenced: Set<string>;
+    try {
+      referenced = await loadReferencedEventIds(db, userId, ids);
+    } catch (error) {
+      captureDatabaseError(error, 'prune_load_referenced');
+      return;
+    }
+    const prunable = ids.filter((id) => !referenced.has(id));
+
+    if (prunable.length > 0) {
+      const { error: deleteError } = await db
+        .from(databaseTables.externalCalendarEvents)
+        .delete()
+        // service_role は RLS を bypass するので user_id を明示的に添える（defense-in-depth）。
+        .eq('user_id', userId)
+        .in('id', prunable);
+
+      if (deleteError) {
+        // select と delete の間に plan が作られると 23503。次回に回収されるので警告に留める。
+        logger.warn('[calendar-prune] skipped some rows due to a reference race');
+      }
+    }
+
+    cursor = ids[ids.length - 1] ?? cursor;
+    if (candidates.length < PRUNE_BATCH_SIZE) return;
+  }
+
+  logger.warn('[calendar-prune] stopped at the batch limit', { batches: MAX_PRUNE_BATCHES });
+}
+
+function captureDatabaseError(error: unknown, operation: string): void {
+  captureUnexpectedDatabaseError(error, { feature: 'external_calendar', operation });
+}

--- a/apps/product/src/features/external-calendar/server/router.ts
+++ b/apps/product/src/features/external-calendar/server/router.ts
@@ -1,0 +1,138 @@
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+
+import { calendarSyncNowRateLimit } from '@/lib/rate-limit/upstash';
+import { handleServiceError } from '@/lib/trpc/errors';
+import { createTRPCRouter, proProcedure, protectedProcedure } from '@/lib/trpc/procedures';
+
+import {
+  disconnect,
+  getSyncStatus,
+  listConnections,
+  listProviderCalendars,
+  updateSelectedCalendars,
+} from './connection-service';
+import { syncConnection } from './sync-service';
+
+/**
+ * 外部カレンダー接続の tRPC router（overview.md §7-2）。
+ *
+ * 読み取り 3 本は protectedProcedure、provider を叩く / 書き込む 3 本は proProcedure
+ * （課金ゲート。`BILLING_ENFORCED` off の間は素通り）。ghost 用 `listEvents` / `dismiss` は
+ * 次 project の予約席なのでここには置かない。
+ */
+
+const connectionIdInput = z.object({ connectionId: z.string().uuid() });
+
+const updateSelectedCalendarsInput = z.object({
+  connectionId: z.string().uuid(),
+  calendars: z
+    .array(
+      z.object({
+        providerCalendarId: z.string().min(1).max(1024),
+        calendarName: z.string().max(1024).nullish(),
+      }),
+    )
+    .max(50),
+});
+
+/** 手動同期の per-user rate limit。upstash 未設定なら素通り（fallback は route 側に無い）。 */
+async function enforceSyncNowRateLimit(userId: string): Promise<void> {
+  if (!calendarSyncNowRateLimit) return;
+
+  let success: boolean;
+  try {
+    ({ success } = await calendarSyncNowRateLimit.limit(userId));
+  } catch (error) {
+    throw new TRPCError({
+      code: 'SERVICE_UNAVAILABLE',
+      message: 'Calendar sync rate-limit service is unavailable',
+      cause: error,
+    });
+  }
+
+  if (!success) {
+    throw new TRPCError({
+      code: 'TOO_MANY_REQUESTS',
+      message: 'Too many manual syncs. Please try again later.',
+    });
+  }
+}
+
+export const externalCalendarRouter = createTRPCRouter({
+  listConnections: protectedProcedure
+    .meta({ description: '外部カレンダー接続一覧' })
+    .query(async ({ ctx }) => {
+      try {
+        return await listConnections(ctx.supabase, ctx.userId);
+      } catch (error) {
+        return handleServiceError(error);
+      }
+    }),
+
+  getSyncStatus: protectedProcedure
+    .meta({ description: '接続の同期状況（接続 + 選択カレンダー）' })
+    .input(connectionIdInput)
+    .query(async ({ ctx, input }) => {
+      try {
+        return await getSyncStatus(ctx.supabase, ctx.userId, input.connectionId);
+      } catch (error) {
+        return handleServiceError(error);
+      }
+    }),
+
+  listProviderCalendars: proProcedure
+    .meta({ description: 'provider のカレンダー一覧をオンデマンド取得' })
+    .input(connectionIdInput)
+    .query(async ({ ctx, input }) => {
+      try {
+        return await listProviderCalendars(ctx.userId, input.connectionId);
+      } catch (error) {
+        return handleServiceError(error);
+      }
+    }),
+
+  updateSelectedCalendars: proProcedure
+    .meta({ description: '取り込むカレンダーの選択を差し替え、即時同期する' })
+    .input(updateSelectedCalendarsInput)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        await updateSelectedCalendars(
+          ctx.userId,
+          input.connectionId,
+          input.calendars.map((calendar) => ({
+            providerCalendarId: calendar.providerCalendarId,
+            calendarName: calendar.calendarName ?? null,
+          })),
+        );
+        // ユーザーが待つ導線なので即時 full sync を kick する（overview.md §6-1）。
+        return await syncConnection({ connectionId: input.connectionId, userId: ctx.userId });
+      } catch (error) {
+        return handleServiceError(error);
+      }
+    }),
+
+  syncNow: proProcedure
+    .meta({ description: '今すぐ同期（rate-limited）' })
+    .input(connectionIdInput)
+    .mutation(async ({ ctx, input }) => {
+      await enforceSyncNowRateLimit(ctx.userId);
+      try {
+        return await syncConnection({ connectionId: input.connectionId, userId: ctx.userId });
+      } catch (error) {
+        return handleServiceError(error);
+      }
+    }),
+
+  disconnect: protectedProcedure
+    .meta({ description: '接続を切断（解約済みでも実行できる）' })
+    .input(connectionIdInput)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        await disconnect(ctx.userId, input.connectionId);
+        return { success: true as const };
+      } catch (error) {
+        return handleServiceError(error);
+      }
+    }),
+});

--- a/apps/product/src/features/external-calendar/server/sync-service.ts
+++ b/apps/product/src/features/external-calendar/server/sync-service.ts
@@ -7,6 +7,7 @@ import { databaseTables, type Database } from '@/lib/database';
 import { logger } from '@/lib/logger';
 import { captureUnexpectedDatabaseError, captureUnexpectedError } from '@/lib/sentry';
 
+import { deleteUnreferencedEvents } from './event-pruning';
 import { ExternalCalendarServiceError } from './external-calendar-service-error';
 import { googleCalendarAdapter } from './providers/google';
 import {
@@ -32,13 +33,7 @@ const DB_REQUEST_TIMEOUT_MS = 15_000;
 /** 取り込み window の半径。iCal export と同じ ±90 日（overview.md §1）。 */
 const WINDOW_RADIUS_MS = 90 * 24 * 60 * 60 * 1000;
 
-/** prune の 1 バッチあたり件数。max_rows=1000 と URL 長 8192B（UUID 約 210 件）に触れない。 */
-const PRUNE_BATCH_SIZE = 150;
-
-/** prune のバッチ上限。150 × 40 = 6,000 件で ±90 日 window の想定を大きく超える。 */
-const MAX_PRUNE_BATCHES = 40;
-
-/** tombstone UPDATE の 1 バッチあたり件数。同じく URL 長を意識した値。 */
+/** tombstone UPDATE の 1 バッチあたり件数。URL 長を意識した値。 */
 const TOMBSTONE_BATCH_SIZE = 150;
 
 const PROVIDER = 'google';
@@ -73,20 +68,16 @@ type SyncConnectionResult = {
 };
 
 /**
- * service_role client が触れる surface を同期に必要な 5 テーブルへ narrow する。
+ * service_role client が触れる surface を同期に必要な 3 テーブルへ narrow する。
  * `connection-service.ts` と同じ理由 — RLS を bypass する client が他テーブルへ到達できると
- * cross-tenant leak になるので compile error で止める。plans / records は anti-join のため
- * SELECT のみ使う。
+ * cross-tenant leak になるので compile error で止める。plans / records の anti-join は
+ * `event-pruning.ts` が別 client で担うので、ここには含めない。
  */
 type SyncDatabase = {
   public: {
     Tables: Pick<
       Database['public']['Tables'],
-      | 'external_calendar_events'
-      | 'calendar_connections'
-      | 'calendar_connection_calendars'
-      | 'plans'
-      | 'records'
+      'external_calendar_events' | 'calendar_connections' | 'calendar_connection_calendars'
     >;
     Views: Record<string, never>;
     Functions: Record<string, never>;
@@ -226,8 +217,13 @@ export async function syncConnection(params: {
   }
 
   // 参照されていない window 外行を掃除する。connection 単位で 1 回だけ（calendar ごとに
-  // 回すと他カレンダーの行も対象になり、無駄に N 回走る）。
-  await pruneWindow(db, connection, runStartedAt);
+  // 回すと他カレンダーの行も対象になり、無駄に N 回走る）。window 境界は provider へ渡したのと
+  // 同じ値を使う。anti-join の本体は event-pruning.ts に集約している。
+  await deleteUnreferencedEvents({
+    userId,
+    connectionId,
+    scope: { kind: 'window', notBefore: window.timeMin, notAfter: window.timeMax },
+  });
 
   if (calendarsFailed > 0) {
     await writeConnectionError(db, connectionId, userId, 'partial_failure', runStartedAtIso);
@@ -466,101 +462,6 @@ async function clearSyncToken(
     .eq('provider_calendar_id', calendar.provider_calendar_id);
 
   if (error) throw error;
-}
-
-/**
- * window 外の未参照ミラー行を掃除する（overview.md §6-2-6）。
- *
- * plans / records から参照される行は anti-join で除外する。FK が NO ACTION なので参照行の
- * DELETE は 23503 になる。参照判定は `deleted_at` で絞らない — soft-delete 済みの plan も
- * まだ FK でミラー行を掴んでいる。keyset ページングで max_rows と URL 長の両方を避ける。
- */
-async function pruneWindow(
-  db: SyncClient,
-  connection: ConnectionRow,
-  runStartedAt: Date,
-): Promise<void> {
-  const lower = new Date(runStartedAt.getTime() - WINDOW_RADIUS_MS).toISOString();
-  const upper = new Date(runStartedAt.getTime() + WINDOW_RADIUS_MS).toISOString();
-
-  let cursor = '';
-
-  for (let batch = 0; batch < MAX_PRUNE_BATCHES; batch += 1) {
-    const { data: candidates, error: selectError } = await db
-      .from(databaseTables.externalCalendarEvents)
-      .select('id')
-      .eq('user_id', connection.user_id)
-      .eq('connection_id', connection.id)
-      .or(`end_at.lt.${lower},start_at.gt.${upper}`)
-      .gt('id', cursor)
-      .order('id', { ascending: true })
-      .limit(PRUNE_BATCH_SIZE);
-
-    if (selectError) {
-      captureDatabaseError(selectError, 'prune_select_candidates');
-      return;
-    }
-    if (!candidates || candidates.length === 0) return;
-
-    const ids = candidates.map((row) => row.id);
-
-    let referenced: Set<string>;
-    try {
-      referenced = await loadReferencedEventIds(db, connection.user_id, ids);
-    } catch (error) {
-      // prune はここまでの upsert / sweep の成功を壊さないよう、参照の読み取り失敗では
-      // 中断するだけにする（throw して syncConnection 全体を落とさない）。
-      captureDatabaseError(error, 'prune_load_referenced');
-      return;
-    }
-    const prunable = ids.filter((id) => !referenced.has(id));
-
-    if (prunable.length > 0) {
-      const { error: deleteError } = await db
-        .from(databaseTables.externalCalendarEvents)
-        .delete()
-        // id は user/connection スコープの select から得ているが、service_role は RLS を
-        // bypass するので user_id を明示的に添える（defense-in-depth）。
-        .eq('user_id', connection.user_id)
-        .in('id', prunable);
-
-      if (deleteError) {
-        // select と delete の間に plan が作られると 23503。次回 cron で回収されるので
-        // ここでは警告に留めて先へ進む。
-        logger.warn('[calendar-sync] prune skipped some rows due to a reference race');
-      }
-    }
-
-    cursor = ids[ids.length - 1] ?? cursor;
-    if (candidates.length < PRUNE_BATCH_SIZE) return;
-  }
-
-  logger.warn('[calendar-sync] prune stopped at the batch limit', { batches: MAX_PRUNE_BATCHES });
-}
-
-/** plans / records の両方から、与えた id を参照している external_calendar_event_id を集める。 */
-async function loadReferencedEventIds(
-  db: SyncClient,
-  userId: string,
-  ids: string[],
-): Promise<Set<string>> {
-  const referenced = new Set<string>();
-
-  for (const table of [databaseTables.plans, databaseTables.records] as const) {
-    const { data, error } = await db
-      .from(table)
-      .select('external_calendar_event_id')
-      .eq('user_id', userId)
-      .in('external_calendar_event_id', ids);
-
-    if (error) throw error;
-
-    for (const row of data ?? []) {
-      if (row.external_calendar_event_id !== null) referenced.add(row.external_calendar_event_id);
-    }
-  }
-
-  return referenced;
 }
 
 // =============================================================================

--- a/apps/product/src/lib/rate-limit/__tests__/upstash.test.ts
+++ b/apps/product/src/lib/rate-limit/__tests__/upstash.test.ts
@@ -153,7 +153,7 @@ describe('Upstash Rate Limit', () => {
     }));
 
     const enabledModule = await import('../upstash');
-    expect(constructorOptions).toHaveLength(10);
+    expect(constructorOptions).toHaveLength(11);
     for (const options of constructorOptions) {
       expect(options.analytics).toBe(false);
       expect(options.timeout).toBe(RATE_LIMIT_TIMEOUT_MS);

--- a/apps/product/src/lib/rate-limit/upstash.ts
+++ b/apps/product/src/lib/rate-limit/upstash.ts
@@ -254,6 +254,17 @@ export const calendarConnectRateLimit = createRateLimiter(
   'ratelimit:product:calendar-connect',
 );
 
+/**
+ * 手動同期（tRPC `syncNow`）の per-user rate limit。
+ *
+ * 1 回で全カレンダーの provider 往復が走るので、連打を抑える。cron が 15 分毎に回すため、
+ * 手動同期は補助的な導線であり 1 時間 6 回で足りる。
+ */
+export const calendarSyncNowRateLimit = createRateLimiter(
+  Ratelimit.slidingWindow(6, '1 h'),
+  'ratelimit:product:calendar-sync-now',
+);
+
 /** CSP reportは公開入力なのでIP単位と全体上限を別々に持つ。 */
 export const cspReportRateLimit = createRateLimiter(
   Ratelimit.slidingWindow(20, '1 m'),

--- a/apps/product/src/lib/trpc/error-code-map.ts
+++ b/apps/product/src/lib/trpc/error-code-map.ts
@@ -85,4 +85,7 @@ export const ERROR_CODE_MAP: Record<string, TRPCErrorCode> = {
   // ===== 外部カレンダー関連 =====
   SYNC_FAILED: 'INTERNAL_SERVER_ERROR',
   CONNECTION_NOT_FOUND: 'NOT_FOUND',
+  // 接続が失効し再認証が必要。ユーザー起因の想定内状態なので 500 ではなく 409 にする。
+  REAUTH_REQUIRED: 'CONFLICT',
+  PROVIDER_UNAVAILABLE: 'INTERNAL_SERVER_ERROR',
 };


### PR DESCRIPTION
epic #1702 の Step 4。close #1706

Settings UI（Step 6）と cron（Step 5）が呼ぶ tRPC surface を実装する。ghost 用 `listEvents` / `dismiss` は次 project の予約席なので追加しない。

## 実装

- **`event-pruning.ts`（共有 helper）**: `deleteUnreferencedEvents({ userId, connectionId, scope })`。`scope` は window / calendars / connection の 3 種。anti-join のデータ欠損に直結する不変条件（soft-delete 参照も除外・空リストで全削除しない・FK 23503 許容・keyset ページング・user_id ガード）を 1 箇所に集約。sync-service の window prune もここへ委譲（挙動不変）
- **`connection-service.ts` に 5 関数**: 読み取り 2 本は authenticated client + 列明示（token 系は grant 外）、mutation / provider 呼び出し 3 本は service_role + user_id ガード。`disconnect` は §8 の 3 段を正しい順序で（connection 削除より**先に**ミラー掃除）、`updateSelectedCalendars` は残す行の sync_token を保持しつつ外したカレンダーのミラーを即時掃除
- **`router.ts`（6 procedure）**: 読み取り 3 本 = protectedProcedure、provider を叩く / 書き込む 3 本 = proProcedure（`BILLING_ENFORCED` off で素通り）。`syncNow` は per-user rate limit（6/1h）、`updateSelectedCalendars` / `syncNow` は成功後に `syncConnection` を即時 kick。`app-router.ts` に登録

## 設計判断

- **選択解除の掃除**: 外したカレンダーの未参照ミラー行を即時 anti-join delete する（stale な ghost 候補を残さない）。§8 と同じ規律を `scope: calendars` で再利用
- **anti-join を共有 helper に抽出**: disconnect / 選択解除 / sync の 3 経路が同じ不変条件を持ち、divergence がデータ欠損になるため single source of truth 化

## 検証

- テスト 95 件 pass（event-pruning の anti-join regression を含む。scope 別・soft-delete 参照除外・空リスト安全・disconnect 順序・rate limit・proProcedure gating）
- `typecheck` / `lint` / `lint:boundaries` / `knip` / `prettier` すべて green
- migration・外部設定・公開契約の変更なし（reversibility は全て [minutes]）

## 備考

- ローカルの `pnpm test:run` は node 26 環境で localStorage 系の unit test が 10 ファイル環境依存で落ちる（main でも同様に落ちるため本 PR とは無関係。CI の node 24 では pass）
- 実 UI での確認は Settings UI が付く Step 6 以降

🤖 Generated with [Claude Code](https://claude.com/claude-code)