### PR TITLE
chore: repo private化に伴う CI 課金最適化とガード代替

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,12 @@
 version: 2
 updates:
   # npm依存関係の自動更新
+  # private repo の Actions 課金対策として monthly に間引く（PR ごとにフル CI が走るため）。
+  # security update は Dependabot security updates が schedule と無関係に即時 PR を出す。
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
-      day: 'monday'
+      interval: 'monthly'
       time: '09:00'
       timezone: 'Asia/Tokyo'
 
@@ -127,8 +128,7 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
-      day: 'monday'
+      interval: 'monthly'
       time: '09:00'
       timezone: 'Asia/Tokyo'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,22 +13,26 @@ concurrency:
 permissions:
   contents: read
 
+# private repo の Actions 課金は job ごとに 1 分単位で切り上げられるため、
+# job 数を絞り checkout + setup の重複を減らす構成にしている。
+# 実行コマンドは旧 11 job 構成と同一で、検証内容は減らしていない。
+# push:main では PR 側で検証済みの e2e / web e2e を省略し、
+# 並行レーンのマージ順衝突検知（typecheck / test / build）に絞る。
 jobs:
-  # ── Stage 1 (~2 min) ─────────────────────────────────
-  lint:
-    name: "\U0001F50D ESLint & Prettier"
+  static:
+    name: "\U0001F50D Static Checks"
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: ./.github/actions/setup
 
-      # 独立した lint チェックを 1 step 内の shell background lane で並列実行する（#1422）。
+      # 独立した static チェックを 1 step 内の shell background lane で並列実行する（#1422）。
       # 2026-06-25 GA の native `parallel` 構文は hosted runner 未対応（workflow parse error）
-      # だったため、確実に動く `&` / `wait` 方式を採用。install は共有し、重い ESLint / knip を
-      # 個別 lane に分離。lane ごとに log を退避し ::group:: で表示して失敗箇所を明確にする。
-      - name: Lint checks (parallel lanes)
+      # だったため、確実に動く `&` / `wait` 方式を採用。install は共有し、重い ESLint / knip /
+      # typecheck を個別 lane に分離。lane ごとに log を退避し ::group:: で表示して失敗箇所を明確にする。
+      - name: Static checks (parallel lanes)
         run: |
           set +e # rc は lane ごとに手動集計するため errexit は使わない
 
@@ -50,49 +54,35 @@ jobs:
           ) >/tmp/lane-rest.log 2>&1 &
           pid_rest=$!
 
+          (pnpm typecheck) >/tmp/lane-typecheck.log 2>&1 &
+          pid_typecheck=$!
+
           wait "$pid_eslint"; rc_eslint=$?
           wait "$pid_knip";   rc_knip=$?
           wait "$pid_rest";   rc_rest=$?
+          wait "$pid_typecheck"; rc_typecheck=$?
 
-          echo "::group::lint lane: ESLint (rc=$rc_eslint)"; cat /tmp/lane-eslint.log; echo "::endgroup::"
-          echo "::group::lint lane: Dead code (rc=$rc_knip)"; cat /tmp/lane-knip.log; echo "::endgroup::"
-          echo "::group::lint lane: Boundaries/format/i18n/taxonomy (rc=$rc_rest)"; cat /tmp/lane-rest.log; echo "::endgroup::"
+          echo "::group::lane: ESLint (rc=$rc_eslint)"; cat /tmp/lane-eslint.log; echo "::endgroup::"
+          echo "::group::lane: Dead code (rc=$rc_knip)"; cat /tmp/lane-knip.log; echo "::endgroup::"
+          echo "::group::lane: Boundaries/format/i18n/taxonomy (rc=$rc_rest)"; cat /tmp/lane-rest.log; echo "::endgroup::"
+          echo "::group::lane: TypeScript (rc=$rc_typecheck)"; cat /tmp/lane-typecheck.log; echo "::endgroup::"
 
-          if [ "$rc_eslint" -ne 0 ] || [ "$rc_knip" -ne 0 ] || [ "$rc_rest" -ne 0 ]; then
-            echo "::error::lint lane failed (eslint=$rc_eslint knip=$rc_knip rest=$rc_rest)"
+          if [ "$rc_eslint" -ne 0 ] || [ "$rc_knip" -ne 0 ] || [ "$rc_rest" -ne 0 ] || [ "$rc_typecheck" -ne 0 ]; then
+            echo "::error::static lane failed (eslint=$rc_eslint knip=$rc_knip rest=$rc_rest typecheck=$rc_typecheck)"
             exit 1
           fi
 
-  typecheck:
-    name: "\U0001F524 TypeScript"
+  product:
+    name: "\U0001F4E6 Build & Test"
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: ./.github/actions/setup
-      - run: pnpm typecheck
 
-  packages-build:
-    name: "\U0001F4E6 Packages Build"
-    runs-on: ubuntu-latest
-    needs: [lint, typecheck]
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - uses: ./.github/actions/setup
-      - run: pnpm build:packages
-
-  production-contract:
-    name: Production Contract
-    runs-on: ubuntu-latest
-    needs: [lint, typecheck]
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - uses: ./.github/actions/setup
+      - name: Build packages
+        run: pnpm build:packages
 
       - name: Verify Product and Web Production contracts with safe dummy values
         run: |
@@ -100,16 +90,6 @@ jobs:
           pnpm --dir apps/product exec vitest --project unit run production-build-gate.test.mjs
           pnpm --dir apps/web exec vitest run production-build-gate.test.mjs
 
-  # ── Stage 2 (~3 min) ─────────────────────────────────
-  test:
-    name: "\U0001F9EA Unit Tests"
-    runs-on: ubuntu-latest
-    needs: [lint, typecheck, packages-build]
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - uses: ./.github/actions/setup
       - name: Product unit tests with coverage
         run: pnpm test:coverage
 
@@ -121,16 +101,6 @@ jobs:
 
       - name: Shared observability unit tests
         run: pnpm --filter @dayopt/observability test:run
-
-  build:
-    name: "\U0001F3D7\uFE0F Build"
-    runs-on: ubuntu-latest
-    needs: [lint, typecheck, packages-build]
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - uses: ./.github/actions/setup
 
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.0.0
         with:
@@ -158,50 +128,6 @@ jobs:
       - name: Compute bundle budget
         run: pnpm exec tsx scripts/check-bundle-budget.ts --output=.next/diagnostics/budget-result.json
 
-      - name: Upload build diagnostics
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: nextjs-build-diagnostics
-          path: |
-            apps/product/.next/diagnostics/budget-result.json
-            apps/product/.next/static/chunks/*.css
-          retention-days: 1
-
-  web-build:
-    name: "\U0001F310 Web Build"
-    runs-on: ubuntu-latest
-    needs: [lint, typecheck, packages-build]
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - uses: ./.github/actions/setup
-
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.0.0
-        with:
-          path: apps/web/.next/cache
-          key: nextjs-web-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('apps/web/src/**/*.{ts,tsx}', 'apps/web/content/**/*.{md,mdx,json}') }}
-          restore-keys: nextjs-web-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
-
-      - name: Build web
-        run: pnpm build:web
-
-  bundle-size:
-    name: "\U0001F4E6 Bundle Size"
-    runs-on: ubuntu-latest
-    needs: [build]
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - uses: ./.github/actions/setup
-
-      - name: Download build diagnostics
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
-        with:
-          name: nextjs-build-diagnostics
-          path: apps/product/.next
-
       - name: Report JS bundle budget
         run: |
           if [ -f apps/product/.next/diagnostics/budget-result.json ]; then
@@ -225,11 +151,10 @@ jobs:
       - name: Check CSS bundle size
         run: pnpm size
 
-  # ── Stage 3 (~3 min) ─────────────────────────────────
   e2e:
     name: "\U0001F3AD E2E Tests"
     runs-on: ubuntu-latest
-    needs: [build]
+    if: github.event_name == 'pull_request'
     environment: development
     timeout-minutes: 15
     steps:
@@ -263,25 +188,36 @@ jobs:
           path: apps/product/test-results/
           retention-days: 7
 
-  web-e2e:
-    name: "🌐 Web E2E Tests"
+  web:
+    name: "\U0001F310 Web Build & E2E"
     runs-on: ubuntu-latest
-    needs: [web-build]
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: ./.github/actions/setup
 
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.0.0
+        with:
+          path: apps/web/.next/cache
+          key: nextjs-web-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('apps/web/src/**/*.{ts,tsx}', 'apps/web/content/**/*.{md,mdx,json}') }}
+          restore-keys: nextjs-web-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+
+      - name: Build web
+        run: pnpm build:web
+
+      # 以下 e2e は PR のみ。push:main では build 検証まで。
       - name: Install Playwright browser
+        if: github.event_name == 'pull_request'
         run: pnpm --filter @dayopt/web exec playwright install --with-deps chromium chromium-headless-shell
 
       - name: Run web E2E tests
+        if: github.event_name == 'pull_request'
         run: pnpm --filter @dayopt/web test:e2e:smoke
 
       - name: Upload web report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: always()
+        if: always() && github.event_name == 'pull_request'
         with:
           name: web-playwright-report
           path: apps/web/playwright-report/
@@ -289,30 +225,8 @@ jobs:
 
       - name: Upload web test results on failure
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: failure()
+        if: failure() && github.event_name == 'pull_request'
         with:
           name: web-test-results
           path: apps/web/test-results/
           retention-days: 7
-
-  # ── Gate ──────────────────────────────────────────────
-  quality-gate:
-    name: "\U0001F6AA Quality Gate"
-    runs-on: ubuntu-latest
-    needs: [lint, typecheck, packages-build, production-contract, test, build, web-build, bundle-size, e2e, web-e2e]
-    if: always()
-    steps:
-      - run: |
-          if [ "${{ needs.lint.result }}" != "success" ] || \
-             [ "${{ needs.typecheck.result }}" != "success" ] || \
-             [ "${{ needs.packages-build.result }}" != "success" ] || \
-             [ "${{ needs.production-contract.result }}" != "success" ] || \
-             [ "${{ needs.test.result }}" != "success" ] || \
-             [ "${{ needs.build.result }}" != "success" ] || \
-             [ "${{ needs.web-build.result }}" != "success" ] || \
-             [ "${{ needs.bundle-size.result }}" != "success" ] || \
-             [ "${{ needs.e2e.result }}" != "success" ] || \
-             [ "${{ needs.web-e2e.result }}" != "success" ]; then
-            echo "One or more jobs failed"
-            exit 1
-          fi

--- a/.github/workflows/docs-guard.yml
+++ b/.github/workflows/docs-guard.yml
@@ -13,83 +13,27 @@ concurrency:
 permissions:
   contents: read
 
+# private repo の Actions 課金は job ごとに 1 分単位で切り上げられるため、
+# 旧 4 job（docs-checks / docs-reminder / gitleaks / secrets-check）を 1 job の
+# 逐次 step に統合している。チェック内容は分割時代と同一。
 jobs:
-  # docs/ に変更があるときだけ実際のチェックを走らせる。トリガー自体は絞らず、
-  # gitleaks ジョブ（リポジトリ全体対象）と同じワークフローに同居させるため job 側で判定する。
-  docs-checks:
-    name: "\U0001F4DA docs-guard"
+  guard:
+    name: "\U0001F6E1️ docs & secrets guard"
     runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          # append-only guard が base ref との差分を見るため full history が必要
-          fetch-depth: 0
-
-      - name: docs/ 変更の有無を確認
-        id: docs-changed
-        run: |
-          BASE="${{ github.event.pull_request.base.sha || github.event.before }}"
-          if [ -z "$BASE" ] || ! git cat-file -e "$BASE" 2>/dev/null; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          elif git diff --name-only "$BASE"...HEAD -- docs/ | grep -q .; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - uses: ./.github/actions/setup
-        if: steps.docs-changed.outputs.changed == 'true'
-
-      - name: pnpm docs:check
-        if: steps.docs-changed.outputs.changed == 'true'
-        run: pnpm docs:check
-        env:
-          DOCS_GUARD_BASE_REF: origin/${{ github.event.pull_request.base.ref || 'main' }}
-
-  docs-reminder:
-    name: "\U0001F4DD docs reminder"
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
-
-      - name: src 変更に対応する docs 更新の有無を確認
-        run: |
-          BASE="${{ github.event.pull_request.base.sha || github.event.before }}"
-          if [ -z "$BASE" ] || ! git cat-file -e "$BASE" 2>/dev/null; then
-            BASE="HEAD~1"
-            git cat-file -e "$BASE" 2>/dev/null || BASE="HEAD"
-          fi
-
-          changed_files="$(git diff --name-only "$BASE"...HEAD)"
-          echo "$changed_files"
-
-          src_changed="$(printf '%s\n' "$changed_files" | grep -E '^apps/product/src/' || true)"
-          docs_changed="$(printf '%s\n' "$changed_files" | grep -E '^docs/' || true)"
-
-          if [ -n "$src_changed" ] && [ -z "$docs_changed" ]; then
-            echo "::warning::apps/product/src/ に変更がありますが docs/ の更新がありません。仕様・運用・アーキテクチャへの影響がないか確認してください。"
-          fi
-
-  # secret scan はリポジトリ全体・全 push/PR が対象（docs 以外の変更でも走る）
-  # org の Actions 許可リストが actions/* github/* zaproxy/* codecov/* softprops/* supabase/*
-  # oven-sh/* に限定されており gitleaks/gitleaks-action は使えないため、バイナリを直接取得して実行する。
-  gitleaks:
-    name: "\U0001F512 gitleaks"
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     env:
       GITLEAKS_VERSION: '8.9.0'
       GITLEAKS_SHA256: '188d84394cfbb287e5acf789f313fca55a385ba738cb014e7a9bef6e6b0f4d69'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # append-only guard と gitleaks が base ref との差分を見るため full history が必要
           fetch-depth: 0
 
+      # ── secret scan（リポジトリ全体・全 push/PR が対象）─────────────
+      # org の Actions 許可リストが actions/* github/* zaproxy/* codecov/* softprops/*
+      # supabase/* oven-sh/* に限定されており gitleaks/gitleaks-action は使えないため、
+      # バイナリを直接取得して実行する。
       - name: gitleaks インストール
         run: |
           curl -sSLO "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
@@ -109,17 +53,50 @@ jobs:
           fi
           gitleaks detect --source . --redact --log-opts="${BASE}..HEAD" --exit-code 1
 
-  # gitleaks が commit 範囲しか見ない分をここで埋める。
-  # gitleaks は「このPRで新しく入った差分」、secrets:check は「今の tracked tree 全体」を見る。
-  # 両方無いと、既に main に入っている literal は誰にも検出されない状態が続く。
-  secrets-check:
-    name: "\U0001F511 secrets:check"
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # ── docs reminder（PR のみ・warning）────────────────────────────
+      - name: src 変更に対応する docs 更新の有無を確認
+        if: github.event_name == 'pull_request'
+        run: |
+          BASE="${{ github.event.pull_request.base.sha || github.event.before }}"
+          if [ -z "$BASE" ] || ! git cat-file -e "$BASE" 2>/dev/null; then
+            BASE="HEAD~1"
+            git cat-file -e "$BASE" 2>/dev/null || BASE="HEAD"
+          fi
 
+          changed_files="$(git diff --name-only "$BASE"...HEAD)"
+          echo "$changed_files"
+
+          src_changed="$(printf '%s\n' "$changed_files" | grep -E '^apps/product/src/' || true)"
+          docs_changed="$(printf '%s\n' "$changed_files" | grep -E '^docs/' || true)"
+
+          if [ -n "$src_changed" ] && [ -z "$docs_changed" ]; then
+            echo "::warning::apps/product/src/ に変更がありますが docs/ の更新がありません。仕様・運用・アーキテクチャへの影響がないか確認してください。"
+          fi
+
+      # ── docs:check（docs/ に変更があるときだけ）──────────────────────
+      - name: docs/ 変更の有無を確認
+        id: docs-changed
+        run: |
+          BASE="${{ github.event.pull_request.base.sha || github.event.before }}"
+          if [ -z "$BASE" ] || ! git cat-file -e "$BASE" 2>/dev/null; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          elif git diff --name-only "$BASE"...HEAD -- docs/ | grep -q .; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # setup は secrets:check が常に必要とするため無条件に実行する
       - uses: ./.github/actions/setup
 
+      # gitleaks が commit 範囲しか見ない分をここで埋める。
+      # gitleaks は「このPR/pushで新しく入った差分」、secrets:check は「今の tracked tree 全体」を見る。
+      # 両方無いと、既に main に入っている literal は誰にも検出されない状態が続く。
       - name: pnpm secrets:check
         run: pnpm secrets:check
+
+      - name: pnpm docs:check
+        if: steps.docs-changed.outputs.changed == 'true'
+        run: pnpm docs:check
+        env:
+          DOCS_GUARD_BASE_REF: origin/${{ github.event.pull_request.base.ref || 'main' }}

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,9 @@
+# main への直接 push を禁止する。マージは PR + pnpm branch:finish 経由に限定する。
+# private repo + Free plan では GitHub 側の branch protection が強制されないため、
+# この hook が唯一の main 保護になる（tag push や他 branch は通す）。
+while read -r _local_ref _local_sha remote_ref _remote_sha; do
+  if [ "$remote_ref" = "refs/heads/main" ]; then
+    echo "✗ main への直接 push は禁止です。PR を作成し pnpm branch:finish でマージしてください。" >&2
+    exit 1
+  fi
+done

--- a/docs/engineering/architecture.md
+++ b/docs/engineering/architecture.md
@@ -626,9 +626,9 @@ Apps 側に残る legal / i18n / docs / test fixture の URL, email, price 文�
 
 ### Foundation Readiness
 
-Package foundation は第一段階として運用可能な状態にある。root scripts の `build:packages`, `typecheck:packages`, `check:workspace`, `lint:boundaries`, `build`, `build:web`, `build-storybook` は現在の package 構成を検証対象に含め、CI も `packages-build` job で `pnpm build:packages` を実行する。
+Package foundation は第一段階として運用可能な状態にある。root scripts の `build:packages`, `typecheck:packages`, `check:workspace`, `lint:boundaries`, `build`, `build:web`, `build-storybook` は現在の package 構成を検証対象に含め、CI も `product` job（旧 `packages-build` job）で `pnpm build:packages` を実行する。
 
-品質ゲートは apps と同じ水準に揃っている。tsconfig の共通部分は root `tsconfig.base.json` に集約し、各 package はそこから `extends` して固有オプションだけを持つ。ESLint は root `eslint.config.packages.mjs` を共有 flat config とし、各 package の `eslint.config.mjs` が re-export する。全 package が `lint: eslint src --max-warnings 0` を持つため `turbo run lint`（= `pnpm lint`）と CI の lint job が packages を検証対象に含む。Prettier も root `format:check` が `packages/*/src` の TS/TSX/CSS/MDX を対象にする。packages は Next.js に依存しないため、app 側の `core-web-vitals` ではなく TypeScript ルール + Storybook plugin を base にする。
+品質ゲートは apps と同じ水準に揃っている。tsconfig の共通部分は root `tsconfig.base.json` に集約し、各 package はそこから `extends` して固有オプションだけを持つ。ESLint は root `eslint.config.packages.mjs` を共有 flat config とし、各 package の `eslint.config.mjs` が re-export する。全 package が `lint: eslint src --max-warnings 0` を持つため `turbo run lint`（= `pnpm lint`）と CI の `static` job（旧 lint job）が packages を検証対象に含む。Prettier も root `format:check` が `packages/*/src` の TS/TSX/CSS/MDX を対象にする。packages は Next.js に依存しないため、app 側の `core-web-vitals` ではなく TypeScript ルール + Storybook plugin を base にする。
 
 apps への adoption は完了している。[ADR-021](./log/2026-06-22-shared-packages-canonical-and-app-shims.md)（2026-06-22）で packages を canonical とし、product / web は shim を介さず直接 import する形に統一した。UI・トークンの app 側重複は解消済みで、i18n も routing / navigation を `@dayopt/i18n/*` から直接 import する。app 側には message loading と next-intl plugin entrypoint を担う `request.ts`、app 固有 Provider だけを残す。残る follow-up は `.from('table')` への `databaseTables` 段階適用など小粒のものに限られる。
 

--- a/scripts/git/finish-branch.sh
+++ b/scripts/git/finish-branch.sh
@@ -122,15 +122,34 @@ fi
 if [[ "$PR_STATE" == "OPEN" ]]; then
   step "PR #$PR_NUMBER をマージ"
 
-  # 失敗している required check がないか確認する
+  # 失敗している check がないか確認する（CheckRun は .conclusion、StatusContext は .state を持つ）
   FAILED_CHECKS="$(printf '%s' "$PR_JSON" | jq -r '
     (.statusCheckRollup // [])
-    | map(select((.conclusion // "") | ascii_downcase | . == "failure" or . == "cancelled" or . == "timed_out"))
+    | map(select(
+        ((.conclusion // "") | ascii_downcase | . == "failure" or . == "cancelled" or . == "timed_out")
+        or ((.state // "") | ascii_downcase | . == "failure" or . == "error")
+      ))
     | length')"
 
   if [[ "$FAILED_CHECKS" != "0" ]]; then
     error "失敗している check が $FAILED_CHECKS 件あります。マージを中止します。"
     error "gh pr checks $PR_NUMBER で詳細を確認してください。"
+    exit 1
+  fi
+
+  # 実行中・待機中の check も待つ。private repo + Free plan では GitHub 側の
+  # required check 強制が効かないため、ここで止めないと CI 完了前にマージできてしまう。
+  PENDING_CHECKS="$(printf '%s' "$PR_JSON" | jq -r '
+    (.statusCheckRollup // [])
+    | map(select(
+        ((.status // "") | ascii_downcase | . == "in_progress" or . == "queued" or . == "pending" or . == "waiting" or . == "requested")
+        or ((.state // "") | ascii_downcase | . == "pending")
+      ))
+    | length')"
+
+  if [[ "$PENDING_CHECKS" != "0" ]]; then
+    error "実行中の check が $PENDING_CHECKS 件あります。完了を待ってから再実行してください。"
+    error "gh pr checks $PR_NUMBER --watch で完了を待てます。"
     exit 1
   fi
 


### PR DESCRIPTION
## 概要

repo の private 化(実施済み)に伴い、Free plan で失われる GitHub 側の強制機能を代替し、Actions 課金(job ごと 1 分切り上げ)を最適化する。

## 変更内容

- **CI job 統合**: 11 jobs → static / product / e2e / web の 4 jobs。実行コマンドは不変。課金 ~20分/run → ~13分見込み
- **push:main の軽量化**: PR 側で検証済みの e2e / web e2e を省略し、並行レーンのマージ順衝突検知(typecheck / test / build)に絞る
- **Docs Guard 統合**: 4 jobs → 1 job(gitleaks / secrets:check / docs:check / docs reminder は全て維持)
- **quality-gate aggregator 廃止**: branch:finish が全 check の失敗・実行中を直接見るため不要
- **pre-push hook**: main への直接 push を禁止(branch protection 強制の代替)
- **branch:finish 強化**: 実行中 check があるうちはマージ中止(required check 強制の代替)
- **Dependabot monthly 化**: run 数削減。security update は即時 PR のため影響なし

## 検証

- YAML / shell 構文チェック済み、pnpm docs:check pass
- この PR の CI 自体が新構成の実地テスト(全 job green を確認してからマージ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)