### PR TITLE
chore: main push CI を廃止し up-to-date gate で事前防止に切り替え

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,13 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
+  # main への push では走らせない。branch:finish が「branch が main 最新を
+  # 含み、その状態で CI green」をマージ前に強制するため（up-to-date gate）、
+  # マージ後の main は常に PR で検証済みの tree と一致する。
+  # 手動で main を検証したい時は workflow_dispatch を使う。
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -16,8 +19,6 @@ permissions:
 # private repo の Actions 課金は job ごとに 1 分単位で切り上げられるため、
 # job 数を絞り checkout + setup の重複を減らす構成にしている。
 # 実行コマンドは旧 11 job 構成と同一で、検証内容は減らしていない。
-# push:main では PR 側で検証済みの e2e / web e2e を省略し、
-# 並行レーンのマージ順衝突検知（typecheck / test / build）に絞る。
 jobs:
   static:
     name: "\U0001F50D Static Checks"
@@ -154,7 +155,6 @@ jobs:
   e2e:
     name: "\U0001F3AD E2E Tests"
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
     environment: development
     timeout-minutes: 15
     steps:
@@ -206,18 +206,15 @@ jobs:
       - name: Build web
         run: pnpm build:web
 
-      # 以下 e2e は PR のみ。push:main では build 検証まで。
       - name: Install Playwright browser
-        if: github.event_name == 'pull_request'
         run: pnpm --filter @dayopt/web exec playwright install --with-deps chromium chromium-headless-shell
 
       - name: Run web E2E tests
-        if: github.event_name == 'pull_request'
         run: pnpm --filter @dayopt/web test:e2e:smoke
 
       - name: Upload web report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: always() && github.event_name == 'pull_request'
+        if: always()
         with:
           name: web-playwright-report
           path: apps/web/playwright-report/
@@ -225,7 +222,7 @@ jobs:
 
       - name: Upload web test results on failure
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: failure() && github.event_name == 'pull_request'
+        if: failure()
         with:
           name: web-test-results
           path: apps/web/test-results/

--- a/.github/workflows/docs-guard.yml
+++ b/.github/workflows/docs-guard.yml
@@ -1,10 +1,12 @@
 name: Docs Guard
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
+  # main への push では走らせない。branch:finish の up-to-date gate により、
+  # マージ後の main は常に PR で検証済みの tree と一致する（main への直接
+  # push は pre-push hook で禁止済み）。手動検証には workflow_dispatch を使う。
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/scripts/git/finish-branch.sh
+++ b/scripts/git/finish-branch.sh
@@ -137,6 +137,18 @@ if [[ "$PR_STATE" == "OPEN" ]]; then
     exit 1
   fi
 
+  # branch が main の最新を含んでいるか確認する（up-to-date gate）。
+  # CI は PR 側でしか走らせないため、古い main ベースのままマージすると
+  # 「A・B 単体では green だが合わせると壊れる」マージ順衝突を検知できない。
+  # branch protection の strict mode 相当をここで代替する。
+  BASE_STATUS="$(gh api "repos/{owner}/{repo}/compare/main...$BRANCH" --jq '.status' 2>/dev/null || echo unknown)"
+  if [[ "$BASE_STATUS" != "ahead" && "$BASE_STATUS" != "identical" ]]; then
+    error "branch が main の最新を含んでいません（compare status: $BASE_STATUS）。"
+    error "main を取り込んで push し、CI green を待ってから再実行してください:"
+    error "  git fetch origin && git merge origin/main && git push"
+    exit 1
+  fi
+
   # 実行中・待機中の check も待つ。private repo + Free plan では GitHub 側の
   # required check 強制が効かないため、ここで止めないと CI 完了前にマージできてしまう。
   PENDING_CHECKS="$(printf '%s' "$PR_JSON" | jq -r '


### PR DESCRIPTION
## 概要

[#1732](https://github.com/Dayopt/dayopt/pull/1732) の続き。main マージ後の CI 再実行(事後検知)を廃止し、branch:finish の up-to-date gate(事前防止)に切り替える。

## 変更内容

- **branch:finish**: branch が main の最新を含まない場合はマージ拒否。main 取り込み → push → CI green 後に再実行を要求(branch protection strict mode 相当の代替)
- **CI / Docs Guard**: push:main トリガーを削除。マージ後の main は常に PR 検証済み tree と一致するため冗長。手動検証用に workflow_dispatch を残す
- Production Config Audit / Production Release の push:main は維持(release gate が Audit status に依存)

## 効果

- マージ順衝突を「壊れた main を作ってから検知」ではなく「マージ前に防止」できる
- main push ごとの CI コスト(~10-15分/回)がゼロになる

## 運用上の前提

マージは常に `pnpm branch:finish` 経由で行う。GitHub UI の Merge ボタンはこの gate を通らない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)