### PR TITLE
fix(auth): パスワードリセットに Turnstile token を付けて送信する

### DIFF
--- a/apps/product/src/features/auth/components/PasswordResetForm.tsx
+++ b/apps/product/src/features/auth/components/PasswordResetForm.tsx
@@ -1,8 +1,12 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
+
+import { useParams } from 'next/navigation';
 
 import { Link } from '@dayopt/i18n/navigation';
+
+import { isTurnstileEnabled, Turnstile, type TurnstileInstance } from '@/lib/turnstile';
 
 import {
   Button,
@@ -30,6 +34,13 @@ export function PasswordResetForm({ className, ...props }: React.ComponentProps<
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
   const resetPassword = useAuthStore((state) => state.resetPassword);
+  const params = useParams();
+  const locale = (params?.locale as string) || 'ja';
+  const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
+  const turnstileRef = useRef<TurnstileInstance | null>(null);
+  const turnstileEnabled = isTurnstileEnabled();
+  const turnstileLocale: 'ja' | 'en' | 'auto' =
+    locale === 'ja' ? 'ja' : locale === 'en' ? 'en' : 'auto';
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -37,16 +48,24 @@ export function PasswordResetForm({ className, ...props }: React.ComponentProps<
     setError(null);
 
     try {
-      const { error } = await resetPassword(email);
+      const { error } = turnstileToken
+        ? await resetPassword(email, { captchaToken: turnstileToken })
+        : await resetPassword(email);
 
       if (error) {
         const errorKey = getAuthErrorKey(error.message, 'resetPassword');
         setError(t(errorKey));
+        // Turnstile token は single-use。失敗時は widget を reset して次の retry で
+        // 新しい challenge token を取得させる
+        setTurnstileToken(null);
+        turnstileRef.current?.reset();
       } else {
         setSuccess(true);
       }
     } catch {
       setError(t('auth.errors.unexpectedError'));
+      setTurnstileToken(null);
+      turnstileRef.current?.reset();
     } finally {
       setLoading(false);
     }
@@ -119,11 +138,27 @@ export function PasswordResetForm({ className, ...props }: React.ComponentProps<
                   aria-describedby="email-support"
                 />
               </Field>
+
+              {turnstileEnabled && (
+                <Field>
+                  <div className="flex justify-center">
+                    <Turnstile
+                      ref={turnstileRef}
+                      onSuccess={(token) => setTurnstileToken(token)}
+                      onError={() => setTurnstileToken(null)}
+                      onExpire={() => setTurnstileToken(null)}
+                      locale={turnstileLocale}
+                    />
+                  </div>
+                </Field>
+              )}
+
               <Field>
                 <Button
                   type="submit"
                   loading={loading}
                   loadingText={t('auth.passwordResetForm.sending')}
+                  disabled={turnstileEnabled && !turnstileToken}
                 >
                   {t('auth.passwordResetForm.sendResetLink')}
                 </Button>

--- a/apps/product/src/features/auth/components/__tests__/PasswordResetForm.test.tsx
+++ b/apps/product/src/features/auth/components/__tests__/PasswordResetForm.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PasswordResetForm } from '../PasswordResetForm';
+
+const mockResetPassword = vi.fn();
+const mockTurnstileReset = vi.fn();
+let mockTurnstileEnabled = true;
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ locale: 'ja' }),
+}));
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('@dayopt/i18n/navigation', async () => {
+  const React = await import('react');
+  return {
+    Link: ({ children, href, ...props }: { children: React.ReactNode; href: string }) =>
+      React.createElement('a', { href, ...props }, children),
+  };
+});
+
+vi.mock('@/features/auth/stores/useAuthStore', () => ({
+  useAuthStore: (selector: (state: { resetPassword: typeof mockResetPassword }) => unknown) =>
+    selector({ resetPassword: mockResetPassword }),
+}));
+
+// Turnstile widget は onSuccess でトークンを返すだけの最小モックにする。
+// ref.reset() が呼ばれることも検証したいので imperative handle を持たせる。
+vi.mock('@/lib/turnstile', async () => {
+  const React = await import('react');
+  const MockTurnstile = React.forwardRef(
+    ({ onSuccess }: { onSuccess: (token: string) => void }, ref: React.Ref<unknown>) => {
+      React.useImperativeHandle(ref, () => ({ reset: mockTurnstileReset }));
+      return React.createElement(
+        'button',
+        { type: 'button', onClick: () => onSuccess('test-captcha-token') },
+        'solve-captcha',
+      );
+    },
+  );
+  MockTurnstile.displayName = 'MockTurnstile';
+
+  return {
+    isTurnstileEnabled: () => mockTurnstileEnabled,
+    Turnstile: MockTurnstile,
+  };
+});
+
+describe('PasswordResetForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTurnstileEnabled = true;
+    mockResetPassword.mockResolvedValue({ error: null });
+  });
+
+  it('captcha を解いてから送信すると captchaToken を渡す', async () => {
+    const user = userEvent.setup();
+    render(<PasswordResetForm />);
+
+    await user.type(screen.getByLabelText(/email/i), 'user@example.com');
+    await user.click(screen.getByRole('button', { name: 'solve-captcha' }));
+    await user.click(screen.getByRole('button', { name: /sendResetLink/i }));
+
+    await waitFor(() => {
+      expect(mockResetPassword).toHaveBeenCalledWith('user@example.com', {
+        captchaToken: 'test-captcha-token',
+      });
+    });
+  });
+
+  it('captcha が未解決なら送信ボタンを押せない（token 無しで /recover を叩かない）', async () => {
+    const user = userEvent.setup();
+    render(<PasswordResetForm />);
+
+    await user.type(screen.getByLabelText(/email/i), 'user@example.com');
+
+    expect(screen.getByRole('button', { name: /sendResetLink/i })).toBeDisabled();
+    expect(mockResetPassword).not.toHaveBeenCalled();
+  });
+
+  it('送信に失敗したら token を捨てて widget を reset する', async () => {
+    mockResetPassword.mockResolvedValue({ error: { message: 'boom' } });
+    const user = userEvent.setup();
+    render(<PasswordResetForm />);
+
+    await user.type(screen.getByLabelText(/email/i), 'user@example.com');
+    await user.click(screen.getByRole('button', { name: 'solve-captcha' }));
+    await user.click(screen.getByRole('button', { name: /sendResetLink/i }));
+
+    await waitFor(() => expect(mockTurnstileReset).toHaveBeenCalled());
+    // single-use token を再利用しないよう、送信ボタンは再び disabled に戻る
+    expect(screen.getByRole('button', { name: /sendResetLink/i })).toBeDisabled();
+  });
+
+  it('Turnstile 無効の環境では captchaToken を渡さず送信できる', async () => {
+    mockTurnstileEnabled = false;
+    const user = userEvent.setup();
+    render(<PasswordResetForm />);
+
+    await user.type(screen.getByLabelText(/email/i), 'user@example.com');
+    await user.click(screen.getByRole('button', { name: /sendResetLink/i }));
+
+    await waitFor(() => {
+      expect(mockResetPassword).toHaveBeenCalledWith('user@example.com');
+    });
+  });
+});

--- a/apps/product/src/features/auth/stores/useAuthStore.ts
+++ b/apps/product/src/features/auth/stores/useAuthStore.ts
@@ -47,7 +47,10 @@ interface AuthState {
   ) => Promise<AuthResponse>;
   signInWithOAuth: (provider: 'google') => Promise<OAuthResponse>;
   signOut: () => Promise<{ error: AuthError | null }>;
-  resetPassword: (email: string) => Promise<{ error: AuthError | null }>;
+  resetPassword: (
+    email: string,
+    options?: { captchaToken?: string },
+  ) => Promise<{ error: AuthError | null }>;
   // @supabase/auth-js 2.106.2 以降 updateUser は session を含まない UserResponse を返す
   updatePassword: (password: string) => Promise<UserResponse>;
   clearError: () => void;
@@ -289,13 +292,16 @@ export const useAuthStore = create<AuthState>()(
 
       // Reset password
       // OWASP: パスワードリセットはエラーでも成功メッセージを表示（メール存在の漏洩防止）
-      resetPassword: async (email) => {
+      resetPassword: async (email, options) => {
         set({ loading: true, error: null });
 
         try {
           const supabase = createClient();
           const result = await supabase.auth.resetPasswordForEmail(email, {
             redirectTo: `${window.location.origin}/auth/reset-password`,
+            // Supabase 側で Bot Protection が有効なため、token が無いと /recover は
+            // captcha_failed で 400 を返す（送信自体が成立しない）
+            ...(options?.captchaToken && { captchaToken: options.captchaToken }),
           });
 
           if (result.error) {


### PR DESCRIPTION
## 概要

**本番でパスワードリセットメールが 1 通も送られていなかった**。[#1744](https://github.com/Dayopt/dayopt/pull/1744) 後の smoke テストで検出した既存バグの修正。

## 何が起きていたか

Supabase 側で Bot Protection（Turnstile）が有効なのに、`PasswordResetForm` が captcha token を送っていなかった。GoTrue の `/recover` は token 無しのリクエストを拒否する。

```
error_code: captcha_failed
400: captcha protection: request disallowed (no captcha_token found)
path: /recover
```

画面には「問題が発生しました。時間をおいて再度お試しください」としか出ないため、原因が分からないまま「たまに失敗する」ように見える状態だった。実際には **100% 失敗**していた。

`LoginForm` / `SignupForm` には Turnstile が実装済みで、リセット画面だけ漏れていた。今回の PR で入れた変更ではなく、CAPTCHA 有効化以降ずっと壊れていたことになる。

## 変更内容

- `useAuthStore.resetPassword` が `options.captchaToken` を受け取り、`resetPasswordForEmail` へ渡す
- `PasswordResetForm` に Turnstile を追加（LoginForm と同じ実装に揃える）
  - widget 表示、token 未取得なら送信ボタンを disabled
  - 送信失敗時は single-use token を捨てて widget を reset
- テストを追加。captchaToken を渡す経路が消えると落ちることを確認済み

## 触っていないもの

`/api/auth` の `reset-password` にも同じ欠落があるが、本番コードから呼ばれていない未使用 route のため対象外とした（将来使うなら同じ対応が要る）。

## 検証

- `pnpm typecheck` / `lint` / `lint:boundaries` pass
- auth 系 unit 75 件 pass（新規 4 件を含む）
- 実装から captchaToken の受け渡しを外すとテストが落ちることを確認
- Storybook で Turnstile 無効時に従来どおり描画されることを確認（env 未設定時は widget 非表示・送信可）

本番での実送信確認はマージ後の smoke で行う。

関連: #1460

🤖 Generated with [Claude Code](https://claude.com/claude-code)
