### PR TITLE
fix(auth): 認証メール pipeline の全欠陥を修復する

### DIFF
--- a/.claude/skills/supabase/SKILL.md
+++ b/.claude/skills/supabase/SKILL.md
@@ -329,6 +329,12 @@ export function useEntityRealtime(onUpdate: () => void) {
 
 **方針**: preview branch には「PR検証に必要な function のみ」デプロイする。cron は preview で動いても意味がなく、Anthropic API 等のコスト要因になるため除外。
 
+### Auth Hook を Edge Function で受ける時の verify_jwt
+
+**`verify_jwt = false` にする。** Auth の send_email hook は standardwebhooks の署名を付けて POST するが、**JWT は付けない**。`true` のままだと入口で弾かれ、GoTrue 側に `500: Hook requires authorization token` が返り、**認証メールが 1 通も送れない**。画面には汎用エラーしか出ないため、Auth ログを見るまで原因が分からない（2026-07-27 に本番で発生）。
+
+真正性は function 側の署名検証（`SEND_EMAIL_HOOK_SECRET`）で担保する。この設定は `scripts/auth-hook-config.test.ts` で固定している。
+
 ### デプロイ経路
 
 **既定は config.toml 宣言による自動デプロイ。** `supabase/config.toml` に `[functions.<slug>]` を宣言した function だけが、Preview branch と production へ自動デプロイされる。宣言が無いと、function を変更した PR をマージしても本番に反映されない(手動デプロイ忘れの分だけ乖離する)。新しい function を追加したら宣言も同じ PR に含める。

--- a/docs/operations/log/2026-07-27-incident-auth-email-pipeline.md
+++ b/docs/operations/log/2026-07-27-incident-auth-email-pipeline.md
@@ -1,0 +1,51 @@
+---
+status: frozen
+date: 2026-07-27
+---
+
+# 認証メールが本番で一度も送信できない構成だった
+
+PR #1744 マージ後の smoke テストで、認証メール（signup 確認 / パスワードリセット / メール変更）が本番で構造的に送信不能であることを検出した。単一障害ではなく、**パイプラインの各段に独立した欠陥が 4 つ**あり、手前の段が失敗するため奥の欠陥が露見しないまま積み重なっていた。
+
+## 障害の連鎖（検出順）
+
+各修正で次の段の欠陥が露見した。すべて同日中に修復した。
+
+| #   | 段                     | 症状                                     | 原因                                                                                                                        | 修正                                                                |
+| --- | ---------------------- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| 1   | フォーム → GoTrue      | `/recover` が 400 `captcha_failed`       | `PasswordResetForm` だけ Turnstile 未実装（login / signup にはあった）                                                      | PR #1745                                                            |
+| 2   | GoTrue → Edge Function | `500: Hook requires authorization token` | `verify_jwt = true`。Auth hook は JWT を付けずに POST する                                                                  | verify_jwt を false へ（Management API + config.toml + 回帰テスト） |
+| 3   | 署名検証               | 401 `No matching signature found`        | **GoTrue と Edge Function が別々の hook secret を保持**。1Password の master は空                                           | secret を新規生成し 1Password → GoTrue / EF の 3 点へ同期           |
+| 4   | テンプレート描画       | 401 `React is not defined`               | `functions/deno.json` に `compilerOptions.jsx` が無く classic transform になるが、テンプレートは React を import していない | `jsx: react-jsx` を設定し `--use-api` で手動デプロイ                |
+
+隣接して、Edge Function の From fallback が `auth@send.dayopt.app`（Return-Path 用 DNS で From には使えない。2026-07-21 incident で確定済み）に戻っていた。apps 側には回帰テストがあるが Edge Function は網の外だった。`noreply@dayopt.app` へ修正し、EF secrets に `RESEND_FROM_EMAIL` / `NEXT_PUBLIC_APP_URL` を明示設定した。
+
+## なぜ長期間気づかなかったか
+
+- signup 確認は `mailer_autoconfirm = true` で**送信自体が発生しない設定**だった
+- パスワードリセットは #1（captcha）で入口落ちし、hook まで到達しなかった
+- メール変更は Edge Function が `email_change` 未対応で別途 400 だった（PR #1744 で修正）
+- 画面には汎用エラーしか出ず、Auth ログを読むまでどの段で落ちたか分からない
+
+「稼働中の本番設定」を正として信頼したことも敗因。PR #1744 で `verify_jwt` を宣言した際、production の現行値（true）に合わせたが、**その現行値で hook は一度も成立していなかった**。動作実績のない設定は現行値でも正にならない。
+
+## 検証（修復後の E2E、本番実測）
+
+1. `https://app.dayopt.app/auth/password` から送信（Turnstile 通過）
+2. `noreply@dayopt.app` から Gmail へ受信
+3. リンク形式 `https://app.dayopt.app/auth/confirm?token_hash=pkce_...&type=recovery&next=/auth/reset-password`
+4. リンクを踏み、`app.dayopt.app` 上の新パスワード設定画面へ着地
+
+これにより #1460 の最終受け入れ条件（confirm / reset が意図した origin へ戻る）も実測で満たした。
+
+## 恒久対策
+
+- `scripts/auth-hook-config.test.ts`: `[functions.send-auth-email]` の宣言・`verify_jwt = false`・import map の実在・From fallback の apex 縛りを CI で固定
+- `supabase/config.toml` の `[functions.send-auth-email]` 宣言により、以後は merge で自動デプロイ（手動デプロイ忘れによる乖離を根絶）
+- supabase skill に「Auth Hook を受ける Edge Function は `verify_jwt = false`」を明記
+
+## 学び
+
+- パイプラインの検証は「1 箇所直して再試行」ではなく、**最初に全段を列挙して各段の前提を突き合わせる**。今回は secret の 3 点照合（1Password / GoTrue / EF）をハッシュ比較で行い、値を見ずに不一致を特定できた
+- 読み戻し API が返すのは保存値とは限らない（Supabase の secrets API は sha256 表現を返す）。照合は実際の署名検証で確定させる
+- 一度も実行されていない経路の設定値は、本番の現行値であっても信頼しない

--- a/scripts/auth-hook-config.test.ts
+++ b/scripts/auth-hook-config.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Auth send_email hook の Edge Function 設定を固定する。
+ *
+ * この hook は standardwebhooks の署名を付けて POST されるが JWT は付かない。
+ * verify_jwt = true にすると入口で弾かれ、GoTrue 側に
+ * `500: Hook requires authorization token` が返り、**認証メールが 1 通も送れない**。
+ * 画面には汎用エラーしか出ず、Auth ログを見るまで原因が分からないため、
+ * 設定だけを頼りにせずテストで固定する（2026-07-27 に本番で発生）。
+ */
+const configPath = resolve(import.meta.dirname, '../supabase/config.toml');
+
+/**
+ * 対象 function ブロックの「設定行だけ」を返す。
+ * コメント行を残すと、説明文中の `verify_jwt = true` のような記述を
+ * 実設定と誤認してしまうため落とす。
+ */
+function readFunctionBlock(slug: string): string {
+  const config = readFileSync(configPath, 'utf8');
+  const start = config.indexOf(`[functions.${slug}]`);
+  if (start === -1) {
+    throw new Error(`[functions.${slug}] が config.toml に宣言されていません`);
+  }
+  const rest = config.slice(start + 1);
+  const nextSection = rest.indexOf('\n[');
+  const block =
+    nextSection === -1 ? config.slice(start) : config.slice(start, start + 1 + nextSection);
+
+  return block
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('#'))
+    .join('\n');
+}
+
+describe('supabase/config.toml の send-auth-email', () => {
+  it('自動デプロイ対象として宣言されている', () => {
+    // 宣言が無いと Preview / production へ配布されず、変更をマージしても本番に届かない
+    const block = readFunctionBlock('send-auth-email');
+    expect(block).toMatch(/enabled\s*=\s*true/);
+  });
+
+  it('verify_jwt が false（Auth hook は JWT を付けないため）', () => {
+    const block = readFunctionBlock('send-auth-email');
+    expect(block).toMatch(/verify_jwt\s*=\s*false/);
+    expect(block).not.toMatch(/verify_jwt\s*=\s*true/);
+  });
+
+  it('import map が実在する共有 deno.json を指している', () => {
+    const block = readFunctionBlock('send-auth-email');
+    const match = block.match(/import_map\s*=\s*"([^"]+)"/);
+    expect(match).not.toBeNull();
+
+    const importMapPath = resolve(import.meta.dirname, '../supabase', match![1]!);
+    expect(() => readFileSync(importMapPath, 'utf8')).not.toThrow();
+  });
+});

--- a/scripts/auth-hook-config.test.ts
+++ b/scripts/auth-hook-config.test.ts
@@ -49,6 +49,19 @@ describe('supabase/config.toml の send-auth-email', () => {
     expect(block).not.toMatch(/verify_jwt\s*=\s*true/);
   });
 
+  it('From の fallback が apex dayopt.app（send.dayopt.app は From に使えない）', () => {
+    // 2026-07-21 incident: send.dayopt.app は Return-Path 用 DNS subdomain で、
+    // Resend の検証済み From domain ではない（403 になる）。apps 側には同じ回帰テストが
+    // あるが Edge Function は網の外だったため、ここで固定する
+    const indexPath = resolve(
+      import.meta.dirname,
+      '../supabase/functions/send-auth-email/index.ts',
+    );
+    const source = readFileSync(indexPath, 'utf8');
+    expect(source).not.toContain("send.dayopt.app'");
+    expect(source).toMatch(/RESEND_FROM_EMAIL'\)\s*\|\|\s*'[a-z-]+@dayopt\.app'/);
+  });
+
   it('import map が実在する共有 deno.json を指している', () => {
     const block = readFunctionBlock('send-auth-email');
     const match = block.match(/import_map\s*=\s*"([^"]+)"/);

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -354,9 +354,11 @@ deno_version = 2
 # 値は production の現行設定（verify_jwt = true / import map は同ディレクトリの deno.json）に合わせる。
 [functions.send-auth-email]
 enabled = true
-# Auth の send_email hook から呼ばれる。ペイロードの真正性は standardwebhooks の
-# 署名検証（SEND_EMAIL_HOOK_SECRET）で担保しており、JWT 検証はその手前の入口ガード。
-verify_jwt = true
+# Auth の send_email hook は standardwebhooks の署名を付けて POST するが、JWT は付けない。
+# verify_jwt = true だと入口で弾かれ、GoTrue 側に
+# `500: Hook requires authorization token` が返って認証メールが 1 通も送れない。
+# ペイロードの真正性は index.ts の署名検証（SEND_EMAIL_HOOK_SECRET）で担保する。
+verify_jwt = false
 # import map は functions/ 直下の共有 deno.json（各 function ディレクトリ内には無い）。
 # path は config.toml からの相対で解決される。
 import_map = "./functions/deno.json"

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -1,4 +1,8 @@
 {
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "react"
+  },
   "imports": {
     "@supabase/supabase-js": "npm:@supabase/supabase-js@2.49.1",
     "react": "npm:react@18.3.1",

--- a/supabase/functions/send-auth-email/index.ts
+++ b/supabase/functions/send-auth-email/index.ts
@@ -22,7 +22,9 @@ import { PasswordResetEmail } from './PasswordResetEmail.tsx';
 
 const resend = new Resend(Deno.env.get('RESEND_API_KEY') as string);
 const hookSecret = (Deno.env.get('SEND_EMAIL_HOOK_SECRET') as string).replace('v1,whsec_', '');
-const FROM_EMAIL = Deno.env.get('RESEND_FROM_EMAIL') || 'auth@send.dayopt.app';
+// From は apex dayopt.app のみ（2026-07-21 incident で確定。send.dayopt.app は
+// Return-Path 用 DNS で、Resend の検証済み From domain ではなく 403 になる）
+const FROM_EMAIL = Deno.env.get('RESEND_FROM_EMAIL') || 'noreply@dayopt.app';
 const APP_URL = Deno.env.get('NEXT_PUBLIC_APP_URL') || 'https://app.dayopt.app';
 
 type Locale = 'en' | 'ja';


### PR DESCRIPTION
## 概要

**認証メールは本番で一度も送信できない構成だった。** smoke テストで判明したパイプライン全段の欠陥を修復し、本番でリセットメールの送信 → Gmail 受信 → リンク着地まで **E2E を実測で通した**。

## 障害の連鎖

captcha 修正（#1745）で次の段が露見する、を繰り返した。各段に独立した欠陥があった。

| # | 段 | 症状 | 原因 |
| --- | --- | --- | --- |
| 1 | フォーム → GoTrue | 400 `captcha_failed` | リセット画面だけ Turnstile 未実装（#1745 で修正済み） |
| 2 | GoTrue → Edge Function | `500: Hook requires authorization token` | `verify_jwt = true`。Auth hook は JWT を付けない |
| 3 | 署名検証 | 401 `No matching signature found` | **GoTrue と EF が別々の hook secret を保持**、1Password の master は空 |
| 4 | テンプレート描画 | 401 `React is not defined` | `deno.json` に `compilerOptions.jsx` が無く classic transform |

隣接して、EF の From fallback が `auth@send.dayopt.app`（Return-Path 用 DNS、From 不可 — 2026-07-21 incident で確定）に戻っていた。apps 側の回帰テストの網の外だった。

## 変更内容（コード）

- `config.toml`: `verify_jwt = false`（#2）
- `deno.json`: `jsx: react-jsx`（#4）
- `index.ts`: From fallback を `noreply@dayopt.app` へ（apex 縛り）
- `scripts/auth-hook-config.test.ts`: 宣言の存在・verify_jwt・import map 実在・From apex 縛りを CI で固定。**それぞれ壊すと落ちることを確認済み**
- supabase skill: Auth Hook を受ける EF は `verify_jwt = false` を明記
- incident log: `docs/operations/log/2026-07-27-incident-auth-email-pipeline.md`

## 実施済みの本番オペレーション（コード外）

- hook secret を新規生成し、1Password（master）→ GoTrue / EF secrets の 3 点へ同期
- EF secrets に `RESEND_FROM_EMAIL` / `NEXT_PUBLIC_APP_URL` を明示設定
- EF の `verify_jwt` を Management API で false へ（本 PR の config.toml と一致）
- 修正版 EF を `--use-api` でデプロイ済み（マージ後は config.toml 宣言による自動デプロイと一致する）
- `mailer_autoconfirm = false`（signup のメール確認）を恒久有効化

## 検証（本番実測）

1. `https://app.dayopt.app/auth/password` から送信（Turnstile 通過）
2. `noreply@dayopt.app` から Gmail に受信
3. リンク `https://app.dayopt.app/auth/confirm?token_hash=pkce_...&type=recovery&next=/auth/reset-password`
4. リンクを踏んで `app.dayopt.app` の新パスワード設定画面へ着地

これにより **#1460 の最終受け入れ条件（confirm / reset が意図した origin に戻る）を実測で満たした**。マージ後に #1460 を close する。

関連: #1460 / #1744 / #1745 / #1558（1Password master 欠落の背景）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
