### PR TITLE
fix(ai-review): 危険クラス path の漏れを塞ぎ、push 前セルフレビューの規律を追加

### DIFF
--- a/.claude/rules/quality.md
+++ b/.claude/rules/quality.md
@@ -2,6 +2,8 @@
 paths:
   - 'apps/product/src/**/*.{ts,tsx}'
   - 'apps/product/src/**/*.test.{ts,tsx}'
+  - 'apps/web/src/app/api/**/*.{ts,tsx}'
+  - 'supabase/functions/**/*.{ts,tsx}'
 ---
 
 # 品質・テスト・パフォーマンス

--- a/.claude/rules/quality.md
+++ b/.claude/rules/quality.md
@@ -17,6 +17,14 @@ pnpm test -- path  # 特定ファイル
 
 詳細: `.claude/skills/test/SKILL.md`
 
+## 外部 API 統合の検証
+
+外部 API（OAuth / provider API / webhook）との統合は、**mock テストが通っただけで完了扱いにしない**。mock は実装者の仮定を写すだけで、仮定そのものの誤り（レスポンスに入るフィールド、必要な scope、エラーの形）は検出できない。
+
+- 契約は一次資料で確認する: 公式 docs / Context7 で「このリクエストに対して実際に何が返るか」を確認してから schema と mock を書く
+- 可能なら実レスポンス（またはドキュメント記載の実例）を fixture 化し、自作 mock との乖離を残さない
+- 実例: Google OAuth は scope に `openid` が無いと `id_token` を返さないが、token レスポンスを丸ごと mock した unit test は 23/23 pass のまま「接続が 100% 失敗する」バグを見逃した（PR #1721）
+
 ## アクセシビリティ
 
 - アイコンボタンに `aria-label`

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -159,6 +159,15 @@ commit 前に必ず `git diff --cached` で index 内容を確認する。Edit �
 - `pnpm lint:boundaries`
 - `pnpm build`（routing / layout 変更時）
 
+### push 前の敵対的セルフレビュー
+
+外部レビュー（Codex / ai-review）は push ごとに走るため、指摘 → 修正 push のラウンドがそのまま時間コストになる。effort で拾える層は push 前に自分で拾う:
+
+- `AGENTS.md` §Read-only delegation の自動委任条件に該当する diff（auth / RLS / billing / migration / 公開契約 / cross-feature）は、**初回 push 前に**該当 subagent（`risk-reviewer` / `behavior-verifier` / `architecture-guard`）へ反証レビューをかける
+- 観点は「反証」に固定する: 配線漏れ（workflow ↔ script の env 受け渡し等）、定数間の不等式（timeout / 予算）、直前の修正コミットが新たに開けた穴
+- 指摘対応の push 前にも同じ確認を行う。外部レビューの指摘を直すコミット自体が新しい回帰を作る事例が繰り返し起きている（PR #1712 / #1738）
+- §束ねた PR のレビュー の merge 前クロスレビューは別途維持する（あちらは束ね PR の最終確認、こちらは push ラウンド削減）
+
 ### Storybook 視覚確認
 
 UI 変更を含む作業では、関連 Story がある場合は Storybook を起動し、Main が視覚確認する。ユーザーと画面を共有できる provider では、同じ browser surface を優先する:

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -21,12 +21,16 @@ on:
       - 'apps/product/src/lib/oauth-server/**'
       - 'apps/product/src/lib/security/**'
       - 'apps/product/src/lib/safe-redirect.ts'
+      - 'apps/product/src/proxy.ts'
       # サーバー境界
       - 'apps/product/src/features/*/server/**'
       - 'apps/product/src/lib/trpc/**'
       - 'apps/product/src/lib/rate-limit/**'
       - 'apps/product/src/app/api/**'
       - 'apps/web/src/app/api/**'
+      # env 契約・送信境界
+      - 'apps/product/src/env.ts'
+      - 'apps/product/src/lib/email/**'
       # 課金
       - 'apps/product/src/lib/billing/**'
       - 'apps/product/src/lib/stripe/**'

--- a/scripts/ai-review/review.ts
+++ b/scripts/ai-review/review.ts
@@ -102,12 +102,16 @@ export const DANGEROUS_PATH_GLOBS: readonly string[] = [
   'apps/product/src/lib/oauth-server/**',
   'apps/product/src/lib/security/**',
   'apps/product/src/lib/safe-redirect.ts',
+  'apps/product/src/proxy.ts',
   // サーバー境界（1 と 3 の入口）
   'apps/product/src/features/*/server/**',
   'apps/product/src/lib/trpc/**',
   'apps/product/src/lib/rate-limit/**',
   'apps/product/src/app/api/**',
   'apps/web/src/app/api/**',
+  // env 契約・送信境界（secret 露出は 1、宛先誤り・認証メールは 1 / 3 に帰着。#1740）
+  'apps/product/src/env.ts',
+  'apps/product/src/lib/email/**',
   // 4. 課金の不整合
   'apps/product/src/lib/billing/**',
   'apps/product/src/lib/stripe/**',


### PR DESCRIPTION
## Summary
- `DANGEROUS_PATH_PATTERNS` / `ai-review.yml` paths に `proxy.ts`（redirect 入口）、`env.ts`（SERVICE_ROLE を含む env 契約）、`lib/email/**`（送信境界）を追加し、ai-review gate の取りこぼしを塞ぐ（#1740 を解消）
- workflow.md に push 前の敵対的セルフレビュー規律を追加（外部レビュー指摘への対応 push が新しい回帰を作る事例が繰り返し起きたため）
- quality.md に外部 API 統合の検証規律を追加（mock だけで完了扱いにしない）

## Test plan
- [x] `pnpm test:scripts`（196 tests, contract test 含む）
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] merge 後、次に auth/RLS/billing/env/email/proxy を触る PR で ai-review が新 path に反応することを確認

Closes #1740

🤖 Generated with [Claude Code](https://claude.com/claude-code)