### PR TITLE
feat: 書き込みscope制約を段階追加する

### DIFF
--- a/apps/product/src/lib/test/integration/external-authority-maintenance.integration.test.ts
+++ b/apps/product/src/lib/test/integration/external-authority-maintenance.integration.test.ts
@@ -18,6 +18,16 @@ const authenticated = createClient<Database>(LOCAL_DB_URL, ANON_KEY, {
 });
 const anonymous = createClient<Database>(LOCAL_DB_URL, ANON_KEY, {
   auth: { autoRefreshToken: false, persistSession: false },
+  global: {
+    // New local Supabase projects expose asymmetric JWT keys. The legacy anon
+    // API key remains valid at the gateway, but must not also be presented as
+    // a Bearer JWT when this client intentionally exercises the anon DB role.
+    fetch: async (input, init) => {
+      const headers = new Headers(init?.headers);
+      headers.delete('Authorization');
+      return fetch(input, { ...init, headers });
+    },
+  },
 });
 
 const userId = crypto.randomUUID();

--- a/apps/product/src/lib/test/integration/mcp-oauth-scope-constraints.integration.test.ts
+++ b/apps/product/src/lib/test/integration/mcp-oauth-scope-constraints.integration.test.ts
@@ -1,0 +1,459 @@
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+import { createClient } from '@supabase/supabase-js';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import type { Database } from '@/lib/database';
+
+const LOCAL_DB_URL = 'http://127.0.0.1:54321';
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const RUN_LOCAL = process.env.USE_LOCAL_DB === 'true';
+const productionResource = 'https://mcp.dayopt.app';
+
+const admin = createClient<Database>(LOCAL_DB_URL, SERVICE_ROLE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+const userId = crypto.randomUUID();
+const connectionId = crypto.randomUUID();
+const tokenId = crypto.randomUUID();
+const codeHash = `candidate-4-code-${crypto.randomUUID()}`;
+const email = `mcp-candidate-4-${userId}@example.com`;
+const password = 'test-password-123';
+
+const candidateMigration = readFileSync(
+  new URL(
+    '../../../../../../supabase/migrations/20260730090100_mcp_oauth_scope_constraints_not_valid.sql',
+    import.meta.url,
+  ),
+  'utf8',
+);
+
+const stagedConstraintNames = [
+  'oauth_connections_write_requires_read_entries_check',
+  'oauth_authorization_codes_write_requires_read_entries_check',
+  'oauth_tokens_write_requires_read_entries_check',
+] as const;
+
+const existingResourceConstraintNames = [
+  'oauth_connections_environment_resource_fkey',
+  'oauth_authorization_codes_environment_resource_fkey',
+  'oauth_tokens_environment_resource_fkey',
+] as const;
+
+function runOwnerSql(
+  sql: string,
+  variables: Record<string, string> = {},
+): SpawnSyncReturns<string> {
+  return spawnSync(
+    'psql',
+    [
+      '-X',
+      '-qAt',
+      '-v',
+      'ON_ERROR_STOP=1',
+      ...Object.entries(variables).flatMap(([name, value]) => ['-v', `${name}=${value}`]),
+      '-h',
+      '127.0.0.1',
+      '-p',
+      '54322',
+      '-U',
+      'postgres',
+      '-d',
+      'postgres',
+    ],
+    {
+      env: { ...process.env, PGPASSWORD: 'postgres' },
+      encoding: 'utf8',
+      input: `\\set VERBOSITY verbose\n${sql}`,
+    },
+  );
+}
+
+function expectConstraintViolation(
+  result: SpawnSyncReturns<string>,
+  constraintName: (typeof stagedConstraintNames)[number],
+): void {
+  expect(result.status).not.toBe(0);
+  expect(result.stderr).toContain('23514');
+  expect(result.stderr).toContain('violates check constraint');
+  expect(result.stderr).toContain(constraintName);
+}
+
+describe.skipIf(!RUN_LOCAL)('MCP Candidate 4 OAuth scope constraints', () => {
+  beforeAll(async () => {
+    const { error } = await admin.auth.admin.createUser({
+      id: userId,
+      email,
+      password,
+      email_confirm: true,
+    });
+    if (error) throw error;
+
+    const fixture = runOwnerSql(
+      `
+        INSERT INTO public.oauth_connections (
+          id,
+          user_id,
+          client_id,
+          resource_uri,
+          scopes,
+          write_enabled_at
+        ) VALUES (
+          :'connection_id'::UUID,
+          :'user_id'::UUID,
+          'chatgpt',
+          :'resource_uri',
+          ARRAY[
+            'read:entries',
+            'write:plans',
+            'delete:plans',
+            'write:records',
+            'delete:records'
+          ]::TEXT[],
+          pg_catalog.now()
+        );
+
+        INSERT INTO public.oauth_authorization_codes (
+          code_hash,
+          user_id,
+          client_id,
+          redirect_uri,
+          code_challenge,
+          code_challenge_method,
+          scopes,
+          connection_id,
+          resource_uri
+        ) VALUES (
+          :'code_hash',
+          :'user_id'::UUID,
+          'chatgpt',
+          'https://chatgpt.com/connector_platform_oauth_redirect',
+          'candidate-4-challenge',
+          'S256',
+          ARRAY[
+            'read:entries',
+            'write:plans',
+            'delete:plans',
+            'write:records',
+            'delete:records'
+          ]::TEXT[],
+          :'connection_id'::UUID,
+          :'resource_uri'
+        );
+
+        INSERT INTO public.oauth_tokens (
+          id,
+          user_id,
+          token_hash,
+          token_type,
+          client_id,
+          scopes,
+          expires_at,
+          connection_id,
+          resource_uri
+        ) VALUES (
+          :'token_id'::UUID,
+          :'user_id'::UUID,
+          'candidate-4-token-' || :'token_id',
+          'access',
+          'chatgpt',
+          ARRAY[
+            'read:entries',
+            'write:plans',
+            'delete:plans',
+            'write:records',
+            'delete:records'
+          ]::TEXT[],
+          pg_catalog.now() + INTERVAL '5 minutes',
+          :'connection_id'::UUID,
+          :'resource_uri'
+        );
+      `,
+      {
+        user_id: userId,
+        connection_id: connectionId,
+        token_id: tokenId,
+        code_hash: codeHash,
+        resource_uri: productionResource,
+      },
+    );
+
+    if (fixture.status !== 0) {
+      throw new Error(fixture.stderr || 'Candidate 4 fixture setup failed');
+    }
+  });
+
+  afterAll(async () => {
+    await admin.auth.admin.deleteUser(userId);
+  });
+
+  it('adds only the three staged checks without preflight or validation', () => {
+    expect(candidateMigration.match(/NOT VALID;/g)).toHaveLength(3);
+    expect(candidateMigration).not.toContain('VALIDATE CONSTRAINT');
+    expect(candidateMigration).not.toContain('GRANT ');
+    expect(candidateMigration).not.toContain('REVOKE ');
+    expect(candidateMigration).not.toContain('UPDATE public.mcp_mutation_control');
+
+    for (const scope of ['write:plans', 'delete:plans', 'write:records', 'delete:records']) {
+      expect(candidateMigration.match(new RegExp(`'${scope}'`, 'g'))).toHaveLength(3);
+    }
+  });
+
+  it('leaves staged checks unvalidated and existing resource FKs validated', () => {
+    const result = runOwnerSql(`
+      SELECT c.conname || '|' || c.contype::TEXT || '|' || c.convalidated::TEXT
+      FROM pg_constraint AS c
+      JOIN pg_class AS relation ON relation.oid = c.conrelid
+      JOIN pg_namespace AS schema ON schema.oid = relation.relnamespace
+      WHERE schema.nspname = 'public'
+        AND c.conname = ANY (ARRAY[
+          ${[...stagedConstraintNames, ...existingResourceConstraintNames]
+            .map((name) => `'${name}'`)
+            .join(',\n          ')}
+        ]::TEXT[])
+      ORDER BY c.conname;
+    `);
+
+    expect(result.status).toBe(0);
+    const catalogRows = result.stdout.trim().split('\n');
+    expect(catalogRows).toEqual(
+      [...existingResourceConstraintNames]
+        .sort()
+        .map((name) => `${name}|f|true`)
+        .concat([...stagedConstraintNames].sort().map((name) => `${name}|c|false`))
+        .sort(),
+    );
+  });
+
+  it('accepts read plus write scopes while every write gate remains off', () => {
+    const result = runOwnerSql(
+      `
+        SELECT
+          (
+            SELECT count(*) = 3
+            FROM (
+              SELECT scopes
+              FROM public.oauth_connections
+              WHERE id = :'connection_id'::UUID
+              UNION ALL
+              SELECT scopes
+              FROM public.oauth_authorization_codes
+              WHERE code_hash = :'code_hash'
+              UNION ALL
+              SELECT scopes
+              FROM public.oauth_tokens
+              WHERE id = :'token_id'::UUID
+            ) AS valid_rows
+            WHERE 'read:entries' = ANY (scopes)
+              AND scopes && ARRAY[
+                'write:plans',
+                'delete:plans',
+                'write:records',
+                'delete:records'
+              ]::TEXT[]
+          )
+          AND (
+            SELECT NOT writes_enabled
+              AND COALESCE(pg_catalog.cardinality(enabled_client_ids), 0) = 0
+            FROM public.mcp_mutation_control
+            WHERE singleton_key = true
+          );
+      `,
+      {
+        connection_id: connectionId,
+        token_id: tokenId,
+        code_hash: codeHash,
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe('t');
+  });
+
+  it('rejects new write-only rows through each staged constraint', () => {
+    const connectionInsert = runOwnerSql(
+      `
+        INSERT INTO public.oauth_connections (
+          user_id,
+          client_id,
+          resource_uri,
+          scopes,
+          write_enabled_at
+        ) VALUES (
+          :'user_id'::UUID,
+          'chatgpt',
+          :'resource_uri',
+          ARRAY['write:plans']::TEXT[],
+          pg_catalog.now()
+        );
+      `,
+      { user_id: userId, resource_uri: productionResource },
+    );
+    expectConstraintViolation(
+      connectionInsert,
+      'oauth_connections_write_requires_read_entries_check',
+    );
+
+    const codeInsert = runOwnerSql(
+      `
+        INSERT INTO public.oauth_authorization_codes (
+          code_hash,
+          user_id,
+          client_id,
+          redirect_uri,
+          code_challenge,
+          code_challenge_method,
+          scopes,
+          connection_id,
+          resource_uri
+        ) VALUES (
+          'candidate-4-invalid-code-' || :'user_id',
+          :'user_id'::UUID,
+          'chatgpt',
+          'https://chatgpt.com/connector_platform_oauth_redirect',
+          'candidate-4-challenge',
+          'S256',
+          ARRAY['write:plans']::TEXT[],
+          :'connection_id'::UUID,
+          :'resource_uri'
+        );
+      `,
+      {
+        user_id: userId,
+        connection_id: connectionId,
+        resource_uri: productionResource,
+      },
+    );
+    expectConstraintViolation(
+      codeInsert,
+      'oauth_authorization_codes_write_requires_read_entries_check',
+    );
+
+    const tokenInsert = runOwnerSql(
+      `
+        INSERT INTO public.oauth_tokens (
+          user_id,
+          token_hash,
+          token_type,
+          client_id,
+          scopes,
+          expires_at,
+          connection_id,
+          resource_uri
+        ) VALUES (
+          :'user_id'::UUID,
+          'candidate-4-invalid-token-' || :'user_id',
+          'access',
+          'chatgpt',
+          ARRAY['write:plans']::TEXT[],
+          pg_catalog.now() + INTERVAL '5 minutes',
+          :'connection_id'::UUID,
+          :'resource_uri'
+        );
+      `,
+      {
+        user_id: userId,
+        connection_id: connectionId,
+        resource_uri: productionResource,
+      },
+    );
+    expectConstraintViolation(tokenInsert, 'oauth_tokens_write_requires_read_entries_check');
+  });
+
+  it('rejects updates from valid rows to write-only scopes', () => {
+    const connectionUpdate = runOwnerSql(
+      `
+        UPDATE public.oauth_connections
+        SET scopes = ARRAY['write:plans']::TEXT[]
+        WHERE id = :'connection_id'::UUID;
+      `,
+      { connection_id: connectionId },
+    );
+    expectConstraintViolation(
+      connectionUpdate,
+      'oauth_connections_write_requires_read_entries_check',
+    );
+
+    const codeUpdate = runOwnerSql(
+      `
+        UPDATE public.oauth_authorization_codes
+        SET scopes = ARRAY['write:plans']::TEXT[]
+        WHERE code_hash = :'code_hash';
+      `,
+      { code_hash: codeHash },
+    );
+    expectConstraintViolation(
+      codeUpdate,
+      'oauth_authorization_codes_write_requires_read_entries_check',
+    );
+
+    const tokenUpdate = runOwnerSql(
+      `
+        UPDATE public.oauth_tokens
+        SET scopes = ARRAY['write:plans']::TEXT[]
+        WHERE id = :'token_id'::UUID;
+      `,
+      { token_id: tokenId },
+    );
+    expectConstraintViolation(tokenUpdate, 'oauth_tokens_write_requires_read_entries_check');
+  });
+
+  it('preserves the mixed-version OAuth compatibility grants', () => {
+    const result = runOwnerSql(`
+      SELECT
+        pg_catalog.has_table_privilege(
+          'authenticated',
+          'public.oauth_connections',
+          'SELECT'
+        )
+        AND NOT pg_catalog.has_table_privilege(
+          'authenticated',
+          'public.oauth_connections',
+          'INSERT'
+        )
+        AND NOT pg_catalog.has_table_privilege(
+          'authenticated',
+          'public.oauth_tokens',
+          'SELECT'
+        )
+        AND pg_catalog.has_column_privilege(
+          'authenticated',
+          'public.oauth_tokens',
+          'id',
+          'SELECT'
+        )
+        AND NOT pg_catalog.has_column_privilege(
+          'authenticated',
+          'public.oauth_tokens',
+          'token_hash',
+          'SELECT'
+        )
+        AND NOT pg_catalog.has_table_privilege(
+          'service_role',
+          'public.oauth_connections',
+          'INSERT'
+        )
+        AND pg_catalog.has_column_privilege(
+          'service_role',
+          'public.oauth_connections',
+          'last_used_at',
+          'UPDATE'
+        )
+        AND pg_catalog.has_table_privilege(
+          'service_role',
+          'public.oauth_authorization_codes',
+          'INSERT'
+        )
+        AND pg_catalog.has_table_privilege(
+          'service_role',
+          'public.oauth_tokens',
+          'INSERT'
+        );
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe('t');
+  });
+});

--- a/supabase/migrations/20260730090100_mcp_oauth_scope_constraints_not_valid.sql
+++ b/supabase/migrations/20260730090100_mcp_oauth_scope_constraints_not_valid.sql
@@ -1,0 +1,69 @@
+-- Candidate 4 adds the stored-grant half of the OAuth scope contract without
+-- scanning legacy rows. PostgreSQL still enforces NOT VALID checks for every
+-- new or updated row. Candidate 5 owns the read-only preflight and validation.
+--
+-- The three environment_resource_fkey constraints were already installed and
+-- validated by Candidate 1. Keep those stronger constraints in place instead
+-- of dropping or duplicating them for this staged rollout.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+ALTER TABLE public.oauth_connections
+  ADD CONSTRAINT oauth_connections_write_requires_read_entries_check
+  CHECK (
+    NOT (
+      scopes && ARRAY[
+        'write:plans',
+        'delete:plans',
+        'write:records',
+        'delete:records'
+      ]::TEXT[]
+    )
+    OR scopes @> ARRAY['read:entries']::TEXT[]
+  )
+  NOT VALID;
+
+ALTER TABLE public.oauth_authorization_codes
+  ADD CONSTRAINT oauth_authorization_codes_write_requires_read_entries_check
+  CHECK (
+    NOT (
+      scopes && ARRAY[
+        'write:plans',
+        'delete:plans',
+        'write:records',
+        'delete:records'
+      ]::TEXT[]
+    )
+    OR scopes @> ARRAY['read:entries']::TEXT[]
+  )
+  NOT VALID;
+
+ALTER TABLE public.oauth_tokens
+  ADD CONSTRAINT oauth_tokens_write_requires_read_entries_check
+  CHECK (
+    NOT (
+      scopes && ARRAY[
+        'write:plans',
+        'delete:plans',
+        'write:records',
+        'delete:records'
+      ]::TEXT[]
+    )
+    OR scopes @> ARRAY['read:entries']::TEXT[]
+  )
+  NOT VALID;
+
+COMMENT ON CONSTRAINT oauth_connections_write_requires_read_entries_check
+  ON public.oauth_connections IS
+  'Candidate 4 staged constraint: write and delete scopes extend read:entries; validate in Candidate 5.';
+COMMENT ON CONSTRAINT oauth_authorization_codes_write_requires_read_entries_check
+  ON public.oauth_authorization_codes IS
+  'Candidate 4 staged constraint: write and delete scopes extend read:entries; validate in Candidate 5.';
+COMMENT ON CONSTRAINT oauth_tokens_write_requires_read_entries_check
+  ON public.oauth_tokens IS
+  'Candidate 4 staged constraint: write and delete scopes extend read:entries; validate in Candidate 5.';
+
+COMMIT;

--- a/supabase/schemas/017_tables_oauth.sql
+++ b/supabase/schemas/017_tables_oauth.sql
@@ -1,11 +1,11 @@
 -- ============================================================
 -- OAuth 2.1 / MCP DB基盤（読み物用 — CLIでは使用しない）
 -- ============================================================
--- Stage 1 は connection-bound OAuth と typed mutation のDB境界だけを追加する。
+-- Candidate 4 は connection-bound OAuth のstored scope契約を追加する。
 -- MCP write tool はまだ公開せず、global gate OFF + client list empty が停止条件。
 -- 実際のマイグレーションは migrations/ を参照。
--- 最終同期日: 2026-07-29
--- Stage 1 terminal migration: 20260729073127_legacy_linked_record_restore_compatibility.sql
+-- 最終同期日: 2026-07-30
+-- Candidate 4 terminal migration: 20260730090100_mcp_oauth_scope_constraints_not_valid.sql
 -- 同期対象 migration:
 --   - 20260501000000_oauth_tokens_from_api_keys.sql
 --   - 20260501000100_oauth_authorization_codes.sql
@@ -25,6 +25,10 @@
 --   - 20260729073125_mcp_environment_identity_client_fence.sql
 --   - 20260729073126_mcp_stage1_receipt_generation_lifecycle.sql
 --   - 20260729073127_legacy_linked_record_restore_compatibility.sql
+--   - 20260730090100_mcp_oauth_scope_constraints_not_valid.sql
+--
+-- Candidate 4の実migrationは下記3 CHECKをNOT VALIDで追加する。
+-- 既存行のpreflightとVALIDATE CONSTRAINTはCandidate 5で行う。
 -- ============================================================
 
 -- mcp_environment_identity: DBが所有する一度きり・変更不可のauthority identity。
@@ -58,6 +62,17 @@ CREATE TABLE public.oauth_connections (
   revoked_reason TEXT,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT oauth_connections_write_requires_read_entries_check CHECK (
+    NOT (
+      scopes && ARRAY[
+        'write:plans',
+        'delete:plans',
+        'write:records',
+        'delete:records'
+      ]::TEXT[]
+    )
+    OR scopes @> ARRAY['read:entries']::TEXT[]
+  ),
   UNIQUE (id, user_id, client_id, resource_uri)
 );
 
@@ -83,6 +98,17 @@ CREATE TABLE public.oauth_tokens (
     ON DELETE CASCADE,
   FOREIGN KEY (resource_uri)
     REFERENCES public.mcp_environment_identity(resource_uri),
+  CONSTRAINT oauth_tokens_write_requires_read_entries_check CHECK (
+    NOT (
+      scopes && ARRAY[
+        'write:plans',
+        'delete:plans',
+        'write:records',
+        'delete:records'
+      ]::TEXT[]
+    )
+    OR scopes @> ARRAY['read:entries']::TEXT[]
+  ),
   CHECK (connection_id IS NOT NULL AND resource_uri IS NOT NULL)
 );
 
@@ -105,6 +131,17 @@ CREATE TABLE public.oauth_authorization_codes (
     ON DELETE CASCADE,
   FOREIGN KEY (resource_uri)
     REFERENCES public.mcp_environment_identity(resource_uri),
+  CONSTRAINT oauth_authorization_codes_write_requires_read_entries_check CHECK (
+    NOT (
+      scopes && ARRAY[
+        'write:plans',
+        'delete:plans',
+        'write:records',
+        'delete:records'
+      ]::TEXT[]
+    )
+    OR scopes @> ARRAY['read:entries']::TEXT[]
+  ),
   CHECK (connection_id IS NOT NULL AND resource_uri IS NOT NULL)
 );
 


### PR DESCRIPTION
## 概要

MCP段階導入のCandidate 4 / 8として、OAuthの保存済みscopeに「write / delete scopeは`read:entries`を含む」というDB制約を配置します。

3つのCHECKは`NOT VALID`で追加します。既存行の全件走査は行わず、新規INSERTとUPDATEだけを直ちに検査します。preflightと`VALIDATE CONSTRAINT`はCandidate 5で行います。

## 変更内容

- `oauth_connections`、`oauth_authorization_codes`、`oauth_tokens`へscope CHECKを追加
- CHECKはすべて`NOT VALID`、lock timeout 5秒、statement timeout 30秒
- `scopes @> ARRAY['read:entries']`で制約単独でもfail closed
- 既存の検証済みenvironment resource FKは維持し、重複FKを追加しない
- GRANT、RLS、OAuth function、MCP write gateは変更しない
- Supabaseの新しい署名方式でも匿名DB roleを正しく検証できるよう既存integration testを調整

## Mixed-version境界

- predecessor main SHA: `ed4a61013ad53ae14eb479b92c5f3706a9604600`
- candidate SHA: `b58a052f8`
- terminal migration: `20260730090100_mcp_oauth_scope_constraints_not_valid.sql`
- staged CHECK: 3件、期待状態`convalidated = false`
- existing environment resource FK: 3件、期待状態`convalidated = true`
- MCP global write: `false`
- MCP enabled client: `0`

Candidate 1ですでにenvironment resource FKが検証済みで存在するため、Candidate 4ではその強い保証を落としません。旧read-only appと現行grant RPCは新しいCHECKを満たすため、mixed-version互換を維持します。

## Production read-only事前確認

変更前のProductionをread-onlyで確認しました。

- terminal migration: `20260730090056`
- environment resource FK: 3件すべてvalidated
- write/delete scopeがあり`read:entries`がない行: 3テーブルすべて0件
- MCP global write: `false`
- MCP enabled client: 空

## 検証

- `pnpm db:fresh`
- `pnpm exec supabase db lint --local --level warning`
- `pnpm rls:snapshot:check`
- Candidate 4 focused integration: 6 tests
- 既存OAuth mixed-version focused integration: 9 tests
- Integration全体: 21 files / 247 tests
- Node 24 `pnpm check`
  - Product: 273 files / 2,549 tests
  - Web: 38 files / 262 tests
  - scripts: 17 files / 196 tests
  - typecheck、lint、boundary、format、secret scanを含む

独立レビュー:

- behavior-verifier: behavior blockerなし
- risk-reviewer: high / medium blockerなし。Preview確認後にmerge可
- architecture-guard: 依存・所有境界を変更しないため意図的に未使用

## Preview確認

- [x] Supabase Previewでmigration `20260730090100`まで適用
- [x] staged CHECK 3件が`convalidated = false`
- [x] existing environment resource FK 3件が`convalidated = true`
- [x] write/delete scope違反行が3テーブルすべて0件
- [x] MCP global writeが`false`、enabled clientが0
- [x] CIが全件成功

## このPRでは行わないもの

- 既存行の修復・削除
- `VALIDATE CONSTRAINT`
- resource FKのdrop / 再作成
- GRANT / RLS / OAuth functionの変更
- MCP write gateまたはclient gateの有効化

Issue: #1754

