### PR TITLE
fix(git): branch:finish が同一SHAの古いcheck runを数えないようにする

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -278,6 +278,7 @@ pnpm branch:finish <PR番号> --dry-run  # 実行せず予定アクションだ�
 スクリプトが内部で行うこと（= 手動フォールバック時にたどる手順）:
 
 1. PR 状態を取得。OPEN かつ失敗 check が無ければ `gh pr merge <N> --merge --delete-branch`（main が他 worktree で checkout 中で失敗する場合は `gh api` の直接マージにフォールバック）
+   - check 判定は **`statusCheckRollup` を name / context ごとに 1 件へ畳んでから**行う。rollup は同名 check を畳まないため（`gh pr checks` は畳む）、同一 head SHA で 2 回 run が走ると古い run の failure / cancelled を数え続けてマージ不能になる。畳み方は非対称で、**実行中が 1 つでもあれば実行中**として扱う（queued な run は `startedAt` を持たないことがあり、単純な「最新」判定では実行中を見落として素通りする）。契約は `scripts/__tests__/finish-branch.test.ts` が固定する
 2. 該当 branch の worktree を特定し、`status --porcelain` が空であることを確認（**dirty なら停止**してユーザーに委ねる）
 3. `git worktree remove --force <path>` で worktree を解除
 4. `git fetch --prune` → main を checkout して `git pull --ff-only origin main`（**branch 削除より先に main を最新化する**）

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -278,7 +278,7 @@ pnpm branch:finish <PR番号> --dry-run  # 実行せず予定アクションだ�
 スクリプトが内部で行うこと（= 手動フォールバック時にたどる手順）:
 
 1. PR 状態を取得。OPEN かつ失敗 check が無ければ `gh pr merge <N> --merge --delete-branch`（main が他 worktree で checkout 中で失敗する場合は `gh api` の直接マージにフォールバック）
-   - check 判定は **`statusCheckRollup` を name / context ごとに 1 件へ畳んでから**行う。rollup は同名 check を畳まないため（`gh pr checks` は畳む）、同一 head SHA で 2 回 run が走ると古い run の failure / cancelled を数え続けてマージ不能になる。畳み方は非対称で、**実行中が 1 つでもあれば実行中**として扱う（queued な run は `startedAt` を持たないことがあり、単純な「最新」判定では実行中を見落として素通りする）。契約は `scripts/__tests__/finish-branch.test.ts` が固定する
+   - check 判定は **`statusCheckRollup` を畳んでから**行う。rollup は同名 check を畳まないため（`gh pr checks` は畳む）、同一 head SHA で 2 回 run が走ると古い run の failure / cancelled を数え続けてマージ不能になる。代表は「最新を採る」ではなく **① 実行中があれば実行中 → ② 判定を持つ entry の最新 → ③ それも無ければ最新** の順で選ぶ。②が要るのは `skipped` が失敗にも成功にも数えられないためで、**古い `failure` は新しい `skipped` より優先される**。詳細と根拠は [infra.md §merge gate の required checks](../../docs/engineering/infra.md#merge-gate-の-required-checks)、契約は `scripts/__tests__/finish-branch.test.ts` が固定する
 2. 該当 branch の worktree を特定し、`status --porcelain` が空であることを確認（**dirty なら停止**してユーザーに委ねる）
 3. `git worktree remove --force <path>` で worktree を解除
 4. `git fetch --prune` → main を checkout して `git pull --ff-only origin main`（**branch 削除より先に main を最新化する**）

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -20,12 +20,12 @@ name: AI Review
 on:
   pull_request_target:
     branches: [main]
-    # **labeled は入れない。** ラベル付与で再発火させると、同じ head SHA に 2 本目の
-    # run が積まれる。`gh pr view --json statusCheckRollup` は同名 check を畳まないため
-    # （2026-07-30 に PR #1765 で実測: check-runs 18 件のうち 8 名前が重複、rollup 21 件
-    # に対し `gh pr checks` は 13 行）、`finish-branch.sh` は古い run の failure を
-    # 数え続ける。つまりラベルを付けても赤が消えず、逃げ道として機能しない。
-    # ラベルは**次の push の run**で効く（新しい SHA なら rollup が綺麗になる）。
+    # **labeled は今は入れていない。** 元の理由は「同じ head SHA に 2 本目の run が積まれると
+    # `finish-branch.sh` が古い run の failure を数え続け、ラベルを付けても赤が消えない」
+    # だったが、その集計は #1768 で畳み込みを入れて解消済み。したがって labeled を足す
+    # 余地はある。ただし ai-review 側の再検証（無関係ラベルでの発火コスト、
+    # fingerprint cache の効き方）が要るため別作業とする。
+    # 現状ラベルは**次の push の run**で効く。
     #
     # `ready_for_review` を入れる代わりに、job 側で draft を skip する。両方を素通しにすると
     # 「draft で open → ready にする」で同じ head SHA に 2 本目の run が積まれ、上と同じ
@@ -91,11 +91,16 @@ permissions:
 jobs:
   review:
     name: "\U0001F50D AI Review"
-    # draft のうちは走らせない。`opened`(draft) と `ready_for_review` の両方で走ると、
-    # 同じ head SHA に 2 本目の run が積まれ、`cancel-in-progress` で 1 本目が cancelled に
-    # なる。`finish-branch.sh` は cancelled を failure として数えるため、あとから成功した
-    # run があっても次の push までマージできなくなる（trigger の types のコメント参照）。
-    # skip された job は failure / pending / success のどれにも数えられないので無害。
+    # draft のうちは走らせない。理由は 2 つあった。
+    # ① 同じ head SHA に 2 本目の run が積まれ、cancel された 1 本目が merge を止める
+    #    → #1768 の畳み込みで解消済み（もう merge は止まらない）
+    # ② draft の反復 push に Gemini の課金を使わない → **こちらは今も有効**
+    # ② が残るので guard は維持する。
+    #
+    # なお skip された job は `conclusion: skipped` の check run を作る。skipped は
+    # failure / success のどちらにも数えないため、畳み込みでは「判定を持つ entry」を
+    # 優先して代表に選ぶ必要がある（そうしないと同名の古い failure が skipped に
+    # 上書きされて消える）。その扱いは finish-branch.sh 側で固定済み。
     if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     # **review step の予算に加えて、その前段の時間を確保する。** job timeout は job 全体に

--- a/docs/engineering/infra.md
+++ b/docs/engineering/infra.md
@@ -268,12 +268,20 @@ main ruleset の required status checks は `ci.yml` の 4 job（`🔍 Static Ch
   移行 PR ではどちらの trigger も成立しない。**初回の trusted run は merge 後、次に危険クラス path を
   触る PR で確認する**（`Production Config Audit` 導入時と同じ bootstrap）
 - `ci.yml` は docs / rules のみの変更では `paths-ignore` で skip され、4 job の status 自体が付かない。private + Free plan では GitHub 側の required check 強制が効かず、マージ可否は `scripts/git/finish-branch.sh` が全 check を見て判定する（失敗 0 件・実行中 0 件・成功 1 件以上）。ruleset の required 指定を強制できる plan へ移行する場合は、skip される job の扱いを先に設計する
-- **判定は `statusCheckRollup` を name / context ごとに畳んでから行う。** rollup は同名 check を
-  畳まないため（`gh pr checks` は畳む）、同一 head SHA で 2 回 run が走ると古い run の
-  failure / cancelled が残り続け、再実行で解決してもマージ不能になる。畳み方は非対称で、
-  **実行中が 1 つでもあれば実行中**として扱い（queued な run は `startedAt` を持たないことがあり、
-  単純な「最新」判定では実行中を見落として素通りする）、完了済みだけなら `startedAt` が最大のものを採る。
-  契約は `scripts/__tests__/finish-branch.test.ts` が固定する（#1768）
+- **判定は `statusCheckRollup` を畳んでから行う。** rollup は同名 check を畳まないため
+  （`gh pr checks` は畳む）、同一 head SHA で 2 回 run が走ると古い run の failure / cancelled が
+  残り続け、再実行で解決してもマージ不能になる。畳む単位は `gh pr checks` に合わせて
+  **型 + workflow 名 + check 名**（name だけで畳むと別 workflow の同名 job の failure が隠れる）。
+  代表の選び方は「最新を採る」ではなく、次の優先順で決める:
+  1. **実行中が 1 つでもあれば実行中**（queued な run は `startedAt` を持たないことがあり、
+     単純な最新判定では実行中を見落として素通りする）
+  2. **判定を持つ entry**（`success` / `failure` / `cancelled` / `timed_out`）のうち `startedAt` 最大。
+     `skipped` / `neutral` / `stale` は失敗にも成功にも数えないため、これが代表になると同名の
+     古い failure が消える。**古い `failure` は新しい `skipped` より優先される**
+  3. どれも判定を持たなければ `startedAt` 最大
+
+  名前を特定できない entry は畳まず全件残す。契約は
+  `scripts/__tests__/finish-branch.test.ts` が固定する（#1768）
 
 段階的導入案と当時の計測値は履歴であり、現行構成として複製しない。経緯は [ADR-016](./log/2026-03-19-ci-quality-gates-roadmap.md) に残す。
 

--- a/docs/engineering/infra.md
+++ b/docs/engineering/infra.md
@@ -255,11 +255,10 @@ main ruleset の required status checks は `ci.yml` の 4 job（`🔍 Static Ch
   （review.ts 側で exit code を 0 にする）、`ai-review:contract-reviewed` は**監査契約の変更**
   （`scripts/ai-review/**` / `.github/actions/**` / `ai-review.yml` / `pnpm-workspace.yaml`）を
   危険クラスと同一 PR に束ねると判断した時に使う。承認の対象が別なので分けている
-- **ラベルは付けた後の push で効く。** `labeled` での再発火は入れていない。同じ head SHA に
-  2 本目の run が積まれると、`gh pr view --json statusCheckRollup` が同名 check を畳まないため
-  （2026-07-30 実測: PR #1765 は check-runs 18 件中 8 名前が重複、rollup 21 件に対し
-  `gh pr checks` は 13 行）、`finish-branch.sh` が古い run の failure を数え続けてラベルを付けても
-  赤が消えない。**`finish-branch.sh` が最新 run へ畳んでいない**のが根であり、そちらは別途の課題
+- **ラベルは付けた後の push で効く。** `labeled` での再発火は `ai-review.yml` の types に
+  入れていない。根にあった「同じ head SHA に 2 本目の run が積まれると
+  `finish-branch.sh` が古い run の failure を数え続ける」問題は #1768 で解消したので
+  （下記の畳み込み）、`labeled` を再度入れる余地はある。ai-review 側の再検証が要るため別作業とする
 - `🔍 AI Review`（`ai-review.yml` の job）は危険クラス path を含む PR でだけ発火するので、
   **ruleset の required には入れない**（発火しない PR では check 自体が付かず、required にすると
   全 PR が merge 不能になる）。`finish-branch.sh` は付いた check だけを見るうえ、
@@ -269,6 +268,12 @@ main ruleset の required status checks は `ci.yml` の 4 job（`🔍 Static Ch
   移行 PR ではどちらの trigger も成立しない。**初回の trusted run は merge 後、次に危険クラス path を
   触る PR で確認する**（`Production Config Audit` 導入時と同じ bootstrap）
 - `ci.yml` は docs / rules のみの変更では `paths-ignore` で skip され、4 job の status 自体が付かない。private + Free plan では GitHub 側の required check 強制が効かず、マージ可否は `scripts/git/finish-branch.sh` が全 check を見て判定する（失敗 0 件・実行中 0 件・成功 1 件以上）。ruleset の required 指定を強制できる plan へ移行する場合は、skip される job の扱いを先に設計する
+- **判定は `statusCheckRollup` を name / context ごとに畳んでから行う。** rollup は同名 check を
+  畳まないため（`gh pr checks` は畳む）、同一 head SHA で 2 回 run が走ると古い run の
+  failure / cancelled が残り続け、再実行で解決してもマージ不能になる。畳み方は非対称で、
+  **実行中が 1 つでもあれば実行中**として扱い（queued な run は `startedAt` を持たないことがあり、
+  単純な「最新」判定では実行中を見落として素通りする）、完了済みだけなら `startedAt` が最大のものを採る。
+  契約は `scripts/__tests__/finish-branch.test.ts` が固定する（#1768）
 
 段階的導入案と当時の計測値は履歴であり、現行構成として複製しない。経緯は [ADR-016](./log/2026-03-19-ci-quality-gates-roadmap.md) に残す。
 

--- a/scripts/__tests__/finish-branch.test.ts
+++ b/scripts/__tests__/finish-branch.test.ts
@@ -1,0 +1,287 @@
+import { spawnSync } from 'node:child_process';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+/**
+ * `finish-branch.sh` は Claude / Codex / 人間で共通のマージゲートで、判定を誤ると
+ * 「失敗を見落としてマージする」方向に倒れる。実スクリプトを子プロセスで動かし、
+ * `gh` だけ stub して check 判定の分岐を固定する。
+ *
+ * とくに **同一 head SHA に複数 run が積まれた rollup** を正しく畳めているかを見る。
+ * `gh pr view --json statusCheckRollup` は同名 check を畳まないため（`gh pr checks` は畳む）、
+ * 畳まずに数えると再実行で解決済みの failure を永久に数え続けてマージ不能になる。
+ */
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const scriptPath = join(rootDir, 'scripts/git/finish-branch.sh');
+const temporaryDirectories: string[] = [];
+
+const BRANCH = 'claude/example-branch-1';
+
+type RollupEntry = Record<string, unknown>;
+
+function checkRun(
+  name: string,
+  conclusion: string | null,
+  startedAt: string | null,
+  status = 'COMPLETED',
+  workflowName = 'CI',
+): RollupEntry {
+  return {
+    __typename: 'CheckRun',
+    name,
+    workflowName,
+    conclusion,
+    status,
+    startedAt,
+    completedAt: startedAt,
+    detailsUrl: 'https://example.test/run',
+  };
+}
+
+function statusContext(context: string, state: string, startedAt: string): RollupEntry {
+  return {
+    __typename: 'StatusContext',
+    context,
+    state,
+    startedAt,
+    targetUrl: 'https://example.test',
+  };
+}
+
+function runScript(rollup: RollupEntry[]): { status: number | null; stderr: string } {
+  // repo 直下ではなく os の temp に作る。プロセスが afterEach 前に落ちると untracked な
+  // ディレクトリが repo に残り、まさにこのスクリプトの dirty ゲートが以後の掃除を止める。
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), 'finish-branch-test-'));
+  temporaryDirectories.push(temporaryDirectory);
+
+  const binDirectory = join(temporaryDirectory, 'bin');
+  mkdirSync(binDirectory);
+
+  const payloadPath = join(temporaryDirectory, 'pr.json');
+  writeFileSync(
+    payloadPath,
+    JSON.stringify({
+      state: 'OPEN',
+      headRefName: BRANCH,
+      mergeable: 'MERGEABLE',
+      mergeStateStatus: 'CLEAN',
+      statusCheckRollup: rollup,
+    }),
+  );
+
+  // `gh` だけ差し替える。git は temp repo 上で本物を動かす（worktree / show-ref の判定を
+  // 実挙動に任せる方が、stub の作り込みより契約に近い）。
+  const ghStub = join(binDirectory, 'gh');
+  writeFileSync(
+    ghStub,
+    `#!/bin/bash
+set -euo pipefail
+case "$1" in
+  pr)
+    case "\${2:-}" in
+      view) cat "$FINISH_BRANCH_PR_JSON" ;;
+      *) exit 2 ;;
+    esac
+    ;;
+  api)
+    # up-to-date gate: compare の .status だけを返す
+    case "\${2:-}" in
+      *compare*) echo ahead ;;
+      *) exit 2 ;;
+    esac
+    ;;
+  *) exit 2 ;;
+esac
+`,
+  );
+  chmodSync(ghStub, 0o755);
+
+  const git = (...args: string[]) =>
+    spawnSync('git', args, { cwd: temporaryDirectory, encoding: 'utf8' });
+
+  git('init', '--initial-branch=main');
+  git('config', 'user.email', 'test@example.com');
+  git('config', 'user.name', 'test');
+  writeFileSync(join(temporaryDirectory, 'seed.txt'), 'seed\n');
+  git('add', 'seed.txt');
+  git('commit', '-m', 'seed');
+
+  const result = spawnSync('bash', [scriptPath, '123', '--dry-run'], {
+    cwd: temporaryDirectory,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${binDirectory}:${process.env.PATH ?? ''}`,
+      FINISH_BRANCH_PR_JSON: payloadPath,
+    },
+  });
+
+  return { status: result.status, stderr: result.stderr ?? '' };
+}
+
+afterEach(() => {
+  while (temporaryDirectories.length > 0) {
+    const directory = temporaryDirectories.pop();
+    if (directory) rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('同一 SHA に積まれた重複 check の畳み込み', () => {
+  it('古い failure が新しい success に置き換わっていればマージへ進む', () => {
+    // ラベル付与 / draft→ready / 手動 re-run で 2 本目が走った後の形。
+    // 畳まないと解決済みの failure を数えて永久にマージ不能になる。
+    const { status, stderr } = runScript([
+      checkRun('CI', 'FAILURE', '2026-07-30T10:00:00Z'),
+      checkRun('CI', 'SUCCESS', '2026-07-30T10:10:00Z'),
+    ]);
+    expect(stderr).not.toContain('失敗している check');
+    expect(status).toBe(0);
+  });
+
+  it('cancelled になった古い run も新しい success で解消される', () => {
+    // cancel-in-progress で 1 本目が cancelled になる経路（draft→ready 等）。
+    const { status, stderr } = runScript([
+      checkRun('CI', 'CANCELLED', '2026-07-30T10:00:00Z'),
+      checkRun('CI', 'SUCCESS', '2026-07-30T10:10:00Z'),
+    ]);
+    expect(stderr).not.toContain('失敗している check');
+    expect(status).toBe(0);
+  });
+
+  it('新しい run が failure なら止める（古い success で上書きしない）', () => {
+    const { status, stderr } = runScript([
+      checkRun('CI', 'SUCCESS', '2026-07-30T10:00:00Z'),
+      checkRun('CI', 'FAILURE', '2026-07-30T10:10:00Z'),
+    ]);
+    expect(stderr).toContain('失敗している check');
+    expect(status).toBe(1);
+  });
+
+  it('実行中の run が 1 つでもあれば止める（startedAt が無くても）', () => {
+    // queued な run は startedAt を持たないことがある。「最新」を startedAt だけで
+    // 決めると古い完了 run が勝ち、実行中を見落として素通りする（fail-open）。
+    const { status, stderr } = runScript([
+      checkRun('CI', 'SUCCESS', '2026-07-30T10:00:00Z'),
+      checkRun('CI', null, null, 'QUEUED'),
+    ]);
+    expect(stderr).toContain('実行中の check');
+    expect(status).toBe(1);
+  });
+
+  it('StatusContext と CheckRun が混在しても名前ごとに畳む', () => {
+    const { status, stderr } = runScript([
+      checkRun('CI', 'FAILURE', '2026-07-30T10:00:00Z'),
+      checkRun('CI', 'SUCCESS', '2026-07-30T10:10:00Z'),
+      statusContext('Vercel – product', 'SUCCESS', '2026-07-30T10:11:00Z'),
+    ]);
+    expect(stderr).not.toContain('失敗している check');
+    expect(status).toBe(0);
+  });
+});
+
+describe('畳み込みが失敗を消さないこと', () => {
+  it('後から積まれた skipped で古い failure を消さない', () => {
+    // job-level `if:` で skip された run は同一 SHA に conclusion: skipped の check run を
+    // 作る（ai-review は draft PR で skip する）。skipped は失敗にも成功にも数えないため、
+    // これを代表に選ぶと blocking な赤が消える。実在する経路:
+    // ready で FAILURE → draft へ戻す → close → reopen（draft なので skip）。
+    const { status, stderr } = runScript([
+      checkRun('🔍 AI Review', 'FAILURE', '2026-07-30T10:00:00Z', 'COMPLETED', 'AI Review'),
+      checkRun('🔍 AI Review', 'SKIPPED', '2026-07-30T10:10:00Z', 'COMPLETED', 'AI Review'),
+      checkRun('docs guard', 'SUCCESS', '2026-07-30T10:01:00Z'),
+    ]);
+    expect(stderr).toContain('失敗している check');
+    expect(status).toBe(1);
+  });
+
+  it('後から積まれた skipped で古い success も消さない', () => {
+    // 逆方向。skipped を代表にすると「成功 1 件以上」を割って別の理由で止まる。
+    const { status, stderr } = runScript([
+      checkRun('🔍 AI Review', 'SUCCESS', '2026-07-30T10:00:00Z', 'COMPLETED', 'AI Review'),
+      checkRun('🔍 AI Review', 'SKIPPED', '2026-07-30T10:10:00Z', 'COMPLETED', 'AI Review'),
+    ]);
+    expect(stderr).not.toContain('成功した check が 1 件もありません');
+    expect(status).toBe(0);
+  });
+
+  it('別名の古い failure を新しい success で畳まない', () => {
+    // 「name を見ずに rollup 全体から startedAt 最大の 1 件だけ残す」実装だと
+    // ここで failure が消える。group key が効いていることを固定する。
+    const { status, stderr } = runScript([
+      checkRun('CI', 'FAILURE', '2026-07-30T10:00:00Z'),
+      checkRun('E2E', 'SUCCESS', '2026-07-30T10:10:00Z'),
+    ]);
+    expect(stderr).toContain('失敗している check');
+    expect(status).toBe(1);
+  });
+
+  it('同名でも workflow が違えば畳まない', () => {
+    // gh pr checks の dedupe は name + workflow。name だけで畳むと、別 workflow の
+    // 同名 job の failure が新しい成功に隠れる。
+    const { status, stderr } = runScript([
+      checkRun('Integration Tests', 'FAILURE', '2026-07-30T10:00:00Z', 'COMPLETED', 'A'),
+      checkRun('Integration Tests', 'SUCCESS', '2026-07-30T10:10:00Z', 'COMPLETED', 'B'),
+    ]);
+    expect(stderr).toContain('失敗している check');
+    expect(status).toBe(1);
+  });
+});
+
+describe('実データの rollup（PR #1765）', () => {
+  it('gh pr checks と同じ件数まで畳み、失敗ゼロと判定する', () => {
+    // 2026-07-30 に実測した本物の rollup。21 件・8 名前が重複し、gh pr checks は 13 行。
+    // stub で作った JSON は shape を仮定してしまうので、実出力で固定する。
+    const fixture = JSON.parse(
+      readFileSync(
+        join(rootDir, 'scripts/__tests__/fixtures/status-check-rollup-duplicated.json'),
+        'utf8',
+      ),
+    ) as { statusCheckRollup: RollupEntry[] };
+    expect(fixture.statusCheckRollup).toHaveLength(21);
+
+    const { status, stderr } = runScript(fixture.statusCheckRollup);
+    expect(stderr).not.toContain('失敗している check');
+    expect(stderr).not.toContain('実行中の check');
+    expect(status).toBe(0);
+  });
+});
+
+describe('畳み込みで緩めてはいけない判定', () => {
+  it('単発の failure は従来どおり止める', () => {
+    const { status, stderr } = runScript([
+      checkRun('CI', 'SUCCESS', '2026-07-30T10:00:00Z'),
+      checkRun('E2E', 'FAILURE', '2026-07-30T10:01:00Z'),
+    ]);
+    expect(stderr).toContain('失敗している check');
+    expect(status).toBe(1);
+  });
+
+  it('success が 1 件も無ければ止める（全 skip / check 未登録）', () => {
+    const { status, stderr } = runScript([
+      checkRun('CI', 'SKIPPED', '2026-07-30T10:00:00Z'),
+      checkRun('E2E', 'SKIPPED', '2026-07-30T10:01:00Z'),
+    ]);
+    expect(stderr).toContain('成功した check が 1 件もありません');
+    expect(status).toBe(1);
+  });
+
+  it('rollup が空でも止める', () => {
+    const { status, stderr } = runScript([]);
+    expect(stderr).toContain('成功した check が 1 件もありません');
+    expect(status).toBe(1);
+  });
+
+  it('StatusContext の failure も止める', () => {
+    const { status, stderr } = runScript([
+      checkRun('CI', 'SUCCESS', '2026-07-30T10:00:00Z'),
+      statusContext('Vercel – product', 'FAILURE', '2026-07-30T10:01:00Z'),
+    ]);
+    expect(stderr).toContain('失敗している check');
+    expect(status).toBe(1);
+  });
+});

--- a/scripts/__tests__/fixtures/status-check-rollup-duplicated.json
+++ b/scripts/__tests__/fixtures/status-check-rollup-duplicated.json
@@ -1,0 +1,205 @@
+{
+  "statusCheckRollup": [
+    {
+      "__typename": "CheckRun",
+      "completedAt": "2026-07-29T13:52:51Z",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://github.com/Dayopt/dayopt/actions/runs/30457980757/job/90596405942",
+      "name": "🔍 AI Review",
+      "startedAt": "2026-07-29T13:51:44Z",
+      "status": "COMPLETED",
+      "workflowName": "AI Review"
+    },
+    {
+      "__typename": "CheckRun",
+      "completedAt": "2026-07-29T14:00:34Z",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://github.com/Dayopt/dayopt/actions/runs/30458614953/job/90598561447",
+      "name": "🔍 AI Review",
+      "startedAt": "2026-07-29T13:59:26Z",
+      "status": "COMPLETED",
+      "workflowName": "AI Review"
+    },
+    {
+      "__typename": "CheckRun",
+      "completedAt": "2026-07-29T13:54:27Z",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://github.com/Dayopt/dayopt/actions/runs/30457981157/job/90596407329",
+      "name": "🔍 Static Checks",
+      "startedAt": "2026-07-29T13:51:35Z",
+      "status": "COMPLETED",
+      "workflowName": "CI"
+    },
+    {
+      "__typename": "CheckRun",
+      "completedAt": "2026-07-29T14:03:06Z",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://github.com/Dayopt/dayopt/actions/runs/30458615403/job/90598631807",
+      "name": "🔍 Static Checks",
+      "startedAt": "2026-07-29T13:59:32Z",
+      "status": "COMPLETED",
+      "workflowName": "CI"
+    },
+    {
+      "__typename": "CheckRun",
+      "completedAt": "2026-07-29T13:52:25Z",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://github.com/Dayopt/dayopt/actions/runs/30457981116/job/90596406807",
+      "name": "🛡️ docs & secrets guard",
+      "startedAt": "2026-07-29T13:51:44Z",
+      "status": "COMPLETED",
+      "workflowName": "Docs Guard"
+    },
+    {
+      "__typename": "CheckRun",
+      "completedAt": "2026-07-29T13:59:54Z",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://github.com/Dayopt/dayopt/actions/runs/30458615042/job/90598561706",
+      "name": "🛡️ docs & secrets guard",
+      "startedAt": "2026-07-29T13:59:17Z",
+      "status": "COMPLETED",
+      "workflowName": "Docs Guard"
+    },
+    {
+      "__typename": "CheckRun",
+      "completedAt": "2026-07-29T13:56:10Z",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://github.com/Dayopt/dayopt/actions/runs/30457980945/job/90596406376",
+      "name": "Integration Tests",
+      "startedAt": "2026-07-29T13:51:42Z",
+      "status": "COMPLETED",
+      "workflowName": "Integration Tests"
+    },
+    {
+      "__typename": "CheckRun",
+      "completedAt": "2026-07-29T14:03:56Z",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://github.com/Dayopt/dayopt/actions/runs/30458614856/job/90598561197",
+      "name": "Integration Tests",
+      "startedAt": "2026-07-29T13:59:17Z",
+      "status": "COMPLETED",
+      "workflowName": "Integration Tests"
+    },
+    {
+      "__typename": "CheckRun",
+      "completedAt": "2026-07-29T13:51:45Z",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://github.com/Dayopt/dayopt/actions/runs/30457977084/job/90596391930",
+      "name": "Audit Vercel metadata (trusted)",
+      "startedAt": "2026-07-29T13:51:31Z",
+      "status": "COMPLETED",
+      "workflowName": "Production Config Audit"
+    },
+    {
+      "__typename": "CheckRun",
+      "completedAt": "2026-07-29T13:59:39Z",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://github.com/Dayopt/dayopt/actions/runs/30458622235/job/90598586999",
+      "name": "Audit Vercel metadata (trusted)",
+      "startedAt": "2026-07-29T13:59:23Z",
+      "status": "COMPLETED",
+      "workflowName": "Production Config Audit"
+    },
+    {
+      "__typename": "CheckRun",
+      "completedAt": "2026-07-29T13:59:28Z",
+      "conclusion": "CANCELLED",
+      "detailsUrl": "https://github.com/Dayopt/dayopt/actions/runs/30457981157/job/90596407200",
+      "name": "📦 Build & Test",
+      "startedAt": "2026-07-29T13:51:44Z",
+      "status": "COMPLETED",
+      "workflowName": "CI"
+    },
+    {
+      "__typename": "CheckRun",
+      "completedAt": "2026-07-29T14:07:22Z",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://github.com/Dayopt/dayopt/actions/runs/30458615403/job/90598631869",
+      "name": "📦 Build & Test",
+      "startedAt": "2026-07-29T13:59:33Z",
+      "status": "COMPLETED",
+      "workflowName": "CI"
+    },
+    {
+      "__typename": "CheckRun",
+      "completedAt": "2026-07-29T13:54:20Z",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://github.com/Dayopt/dayopt/actions/runs/30457981157/job/90596407450",
+      "name": "🎭 E2E Tests",
+      "startedAt": "2026-07-29T13:51:43Z",
+      "status": "COMPLETED",
+      "workflowName": "CI"
+    },
+    {
+      "__typename": "CheckRun",
+      "completedAt": "2026-07-29T14:02:15Z",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://github.com/Dayopt/dayopt/actions/runs/30458615403/job/90598631791",
+      "name": "🎭 E2E Tests",
+      "startedAt": "2026-07-29T13:59:33Z",
+      "status": "COMPLETED",
+      "workflowName": "CI"
+    },
+    {
+      "__typename": "CheckRun",
+      "completedAt": "2026-07-29T13:55:04Z",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://github.com/Dayopt/dayopt/actions/runs/30457981157/job/90596407181",
+      "name": "🌐 Web Build & E2E",
+      "startedAt": "2026-07-29T13:51:37Z",
+      "status": "COMPLETED",
+      "workflowName": "CI"
+    },
+    {
+      "__typename": "CheckRun",
+      "completedAt": "2026-07-29T14:02:47Z",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://github.com/Dayopt/dayopt/actions/runs/30458615403/job/90598631743",
+      "name": "🌐 Web Build & E2E",
+      "startedAt": "2026-07-29T13:59:32Z",
+      "status": "COMPLETED",
+      "workflowName": "CI"
+    },
+    {
+      "__typename": "StatusContext",
+      "context": "Production Config Audit",
+      "startedAt": "2026-07-29T13:59:35Z",
+      "state": "SUCCESS",
+      "targetUrl": "https://github.com/Dayopt/dayopt/actions/runs/30458622235"
+    },
+    {
+      "__typename": "CheckRun",
+      "completedAt": "2026-07-29T14:01:24Z",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://supabase.com/dashboard/project/gdnlxfvggfeugcsvlatr",
+      "name": "Supabase Preview",
+      "startedAt": "2026-07-29T13:59:54Z",
+      "status": "COMPLETED",
+      "workflowName": ""
+    },
+    {
+      "__typename": "CheckRun",
+      "completedAt": "2026-07-29T14:01:19Z",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://vercel.com/github",
+      "name": "Vercel Preview Comments",
+      "startedAt": "2026-07-29T14:01:19Z",
+      "status": "COMPLETED",
+      "workflowName": ""
+    },
+    {
+      "__typename": "StatusContext",
+      "context": "Vercel – product",
+      "startedAt": "2026-07-29T14:01:15Z",
+      "state": "SUCCESS",
+      "targetUrl": "https://vercel.com/dayopt/product/Ah6SEFCf4trCf4sUPcvhJQJT6Xho"
+    },
+    {
+      "__typename": "StatusContext",
+      "context": "Vercel – web",
+      "startedAt": "2026-07-29T13:53:30Z",
+      "state": "SUCCESS",
+      "targetUrl": "https://vercel.com/dayopt/web/2pgvVAAvrdUZpPpn8CeX1K9beG1W"
+    }
+  ]
+}

--- a/scripts/git/finish-branch.sh
+++ b/scripts/git/finish-branch.sh
@@ -78,7 +78,7 @@ if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
-for bin in git gh; do
+for bin in git gh jq; do
   if ! command -v "$bin" >/dev/null 2>&1; then
     error "$bin が見つかりません。"
     exit 1
@@ -122,10 +122,57 @@ fi
 if [[ "$PR_STATE" == "OPEN" ]]; then
   step "PR #$PR_NUMBER をマージ"
 
+  # ── statusCheckRollup を name / context ごとに 1 件へ畳む ──────────
+  #
+  # **同一 head SHA で 2 回以上 run が走ると、古い run の entry が残り続ける。**
+  # `gh pr checks` は同名を畳むが `gh pr view --json statusCheckRollup` は畳まない
+  # （2026-07-30 実測: PR #1765 は check-runs 18 件のうち 8 名前が重複し、
+  # rollup 21 件に対して `gh pr checks` は 13 行）。畳まずに数えると、再実行で
+  # 解決済みの failure / cancelled を永久に数え続けてマージ不能になる。
+  # 同一 SHA で 2 回走る経路は現実にある: ラベル付与での再発火、draft → ready、
+  # ready → draft → ready、手動 re-run、reopened。
+  #
+  # 畳み方には 2 つの非対称性を持たせる。どちらも「緩む側へ倒れない」ためのもの。
+  #
+  # ① **pending は「どれか 1 つでも実行中なら実行中」** として扱う。queued な run は
+  #    startedAt を持たないことがあり、単純な「最新」判定では古い完了 run が勝つ
+  #    （= 実行中の run を見落として素通りする fail-open）。
+  # ② **完了済みの代表は「判定を持つ entry」を優先する。** `skipped` / `neutral` /
+  #    `stale` は失敗にも成功にも数えないため、これが代表になると同じ名前の古い
+  #    failure が消える。job-level `if:` で skip された run は同一 SHA に
+  #    `conclusion: skipped` の check run を作るので、これは実在する経路
+  #    （例: ai-review は draft PR で skip する。ready で FAILURE → draft へ戻して
+  #    reopen すると skipped が後から積まれ、blocking な赤が消えてしまう）。
+  #
+  # 畳む単位は `gh pr checks` の dedupe に合わせ、型 + workflow 名 + check 名。
+  # 名前を特定できない entry は畳まず全件残す（identity 不明を fail-closed 側へ倒す）。
+  ROLLUP="$(printf '%s' "$PR_JSON" | jq -c '
+    def is_pending:
+      ((.status // "") | ascii_downcase
+        | . == "in_progress" or . == "queued" or . == "pending" or . == "waiting" or . == "requested")
+      or ((.state // "") | ascii_downcase | . == "pending");
+    def is_decisive:
+      ((.conclusion // "") | ascii_downcase
+        | . == "success" or . == "failure" or . == "cancelled" or . == "timed_out")
+      or ((.state // "") | ascii_downcase | . == "success" or . == "failure" or . == "error");
+    def check_name: (.name // .context // "");
+    [ (.statusCheckRollup // [])
+      | group_by([(.__typename // ""), (.workflowName // ""), check_name])
+      | .[]
+      | if (.[0] | check_name) == "" then .[]
+        elif any(.[]; is_pending) then (map(select(is_pending)) | .[0])
+        else ((map(select(is_decisive)) | max_by(.startedAt // "")) // max_by(.startedAt // ""))
+        end
+    ]')"
+
+  if [[ -z "$ROLLUP" ]]; then
+    error "check 一覧を解析できませんでした。gh pr checks $PR_NUMBER で状態を確認してください。"
+    exit 1
+  fi
+
   # 失敗している check がないか確認する（CheckRun は .conclusion、StatusContext は .state を持つ）
-  FAILED_CHECKS="$(printf '%s' "$PR_JSON" | jq -r '
-    (.statusCheckRollup // [])
-    | map(select(
+  FAILED_CHECKS="$(printf '%s' "$ROLLUP" | jq -r '
+    map(select(
         ((.conclusion // "") | ascii_downcase | . == "failure" or . == "cancelled" or . == "timed_out")
         or ((.state // "") | ascii_downcase | . == "failure" or . == "error")
       ))
@@ -151,9 +198,8 @@ if [[ "$PR_STATE" == "OPEN" ]]; then
 
   # 実行中・待機中の check も待つ。private repo + Free plan では GitHub 側の
   # required check 強制が効かないため、ここで止めないと CI 完了前にマージできてしまう。
-  PENDING_CHECKS="$(printf '%s' "$PR_JSON" | jq -r '
-    (.statusCheckRollup // [])
-    | map(select(
+  PENDING_CHECKS="$(printf '%s' "$ROLLUP" | jq -r '
+    map(select(
         ((.status // "") | ascii_downcase | . == "in_progress" or . == "queued" or . == "pending" or . == "waiting" or . == "requested")
         or ((.state // "") | ascii_downcase | . == "pending")
       ))
@@ -174,9 +220,8 @@ if [[ "$PR_STATE" == "OPEN" ]]; then
   # ci.yml は docs のみの変更なら paths-ignore で skip されるので、「CI が
   # 走らない PR」自体は異常ではない。ただし Docs Guard は paths フィルタを持たず
   # 全 PR で走るため、success が 1 件も無い状態は構成の異常を意味する。
-  SUCCESS_CHECKS="$(printf '%s' "$PR_JSON" | jq -r '
-    (.statusCheckRollup // [])
-    | map(select(
+  SUCCESS_CHECKS="$(printf '%s' "$ROLLUP" | jq -r '
+    map(select(
         ((.conclusion // "") | ascii_downcase | . == "success")
         or ((.state // "") | ascii_downcase | . == "success")
       ))


### PR DESCRIPTION
Closes #1768

## 何が壊れていたか

`scripts/git/finish-branch.sh` は `gh pr view --json statusCheckRollup` の全 entry を数えてマージ可否を判定していた。しかし **rollup は同名 check を畳まない**（`gh pr checks` は畳む）。同一 head SHA で 2 回 run が走ると古い run の entry が残るため、再実行で解決済みの failure / cancelled を数え続けて永久にマージ不能になる。

2026-07-30 実測:

| PR | check-runs API | statusCheckRollup | `gh pr checks` | 重複 |
| --- | --- | --- | --- | --- |
| #1765 | 18 | 21 | 13 | 8 名前が各 2 件 |
| #1760 | 10 | 13 | 13 | なし |

同一 SHA で 2 回走る経路は現実にある: ラベル付与での再発火 / draft→ready / ready→draft→ready / 手動 re-run / reopened。PR #1767 では ai-review の逃げ道ラベルと draft の扱いを、この問題を避けるために設計変更している（3 変種が #1768 に記録済み）。

## 直し方

3 ゲート（失敗 0 / 実行中 0 / 成功 1 以上）の集計前に、**型 + workflow 名 + check 名**で 1 件へ畳む。畳む単位は `gh pr checks` の dedupe に合わせた（name だけで畳むと別 workflow の同名 job の failure が隠れる）。

畳み方には「緩む側へ倒れない」ための非対称性を 2 つ入れた。

1. **実行中が 1 つでもあれば実行中**として扱う。queued な run は `startedAt` を持たないことがあり、単純な最新判定では古い完了 run が勝って実行中を見落とす（fail-open）
2. **完了済みの代表は判定を持つ entry を優先する。** `skipped` / `neutral` / `stale` は失敗にも成功にも数えないため、代表になると同名の古い failure が消える

2 は risk-reviewer の指摘で見つかった、**この PR の初版が自分で開けた fail-open**。job-level `if:` で skip された run は同一 SHA に `conclusion: skipped` の check run を作るので実在する経路: ai-review は draft PR で skip するため、ready で FAILURE → draft へ戻して reopen すると skipped が後から積まれ、blocking な赤が消えてマージできてしまう。

名前を特定できない entry は畳まず全件残す（identity 不明を fail-closed 側へ倒す）。

## 検証

**テスト 14 件を追加**（`scripts/__tests__/finish-branch.test.ts`）。実スクリプトを子プロセスで動かし `gh` だけ stub する形で、既存 `dev-with-op.test.ts` と同じ pattern。git は temp repo 上で本物を使う。

実 PR #1765 の rollup を fixture として commit した（`scripts/__tests__/fixtures/`）。stub だけだと shape を仮定してしまうため、実出力で固定する。

**テストが回帰を止めることを 2 段で確認した**:

| 実装 | fail する件数 |
| --- | --- |
| main（畳み込みなし） | 4 件 |
| 畳み込みあり・判定優先なし（初版） | 2 件 |
| このPR | 0 件（14/14 pass） |

実データでの回帰確認: #1765 は 21 → 13 件（`gh pr checks` と一致、失敗 0 / 成功 13）、#1767 は 11 → 11 件（判定変化なし）。

その他: `pnpm test:scripts` 224/224、`docs:check` / `format:check` / `secrets:check` / `bash -n` pass。`risk-reviewer` を通した。

## 併せて直したもの

- `jq` を依存チェック（`for bin in git gh jq`）へ追加。参照が 1 → 4 箇所に増えた
- テストの temp dir を repo 直下から `os.tmpdir()` へ。プロセスが afterEach 前に落ちると untracked ディレクトリが残り、**まさにこのスクリプトの dirty ゲートが以後の掃除を止める**
- `.claude/rules/workflow.md`（`branch:finish` の正本）と `docs/engineering/infra.md` に畳み込みの契約を追記
- `.github/workflows/ai-review.yml` のコメント修正。「`finish-branch.sh` が古い run の failure を数え続ける」を現在形の根拠として書いていた箇所が、この PR で false になる

## やっていないこと

**ai-review の `labeled` 再発火は入れていない。** 根が直ったので技術的には可能になったが、ai-review 側の再検証（無関係ラベルでの発火コスト、fingerprint cache の効き方）が要るため別作業とする。PR #1767 で scope creep を 4 回踏んだ反省として、ここで足さない。

draft skip の guard は維持する。重複 run の理由は解消したが、「draft の反復 push に Gemini の課金を使わない」理由は残るため。

🤖 Generated with [Claude Code](https://claude.com/claude-code)