### PR TITLE
feat(mcp): 既存行のpreflight後にOAuth scope制約をvalidateする

### DIFF
--- a/apps/product/src/lib/test/integration/mcp-oauth-scope-constraints.integration.test.ts
+++ b/apps/product/src/lib/test/integration/mcp-oauth-scope-constraints.integration.test.ts
@@ -30,6 +30,14 @@ const candidateMigration = readFileSync(
   'utf8',
 );
 
+const validationMigration = readFileSync(
+  new URL(
+    '../../../../../../supabase/migrations/20260730090200_validate_mcp_oauth_scope_constraints.sql',
+    import.meta.url,
+  ),
+  'utf8',
+);
+
 const stagedConstraintNames = [
   'oauth_connections_write_requires_read_entries_check',
   'oauth_authorization_codes_write_requires_read_entries_check',
@@ -81,7 +89,7 @@ function expectConstraintViolation(
   expect(result.stderr).toContain(constraintName);
 }
 
-describe.skipIf(!RUN_LOCAL)('MCP Candidate 4 OAuth scope constraints', () => {
+describe.skipIf(!RUN_LOCAL)('MCP Candidate 4 and 5 OAuth scope constraints', () => {
   beforeAll(async () => {
     const { error } = await admin.auth.admin.createUser({
       id: userId,
@@ -201,7 +209,94 @@ describe.skipIf(!RUN_LOCAL)('MCP Candidate 4 OAuth scope constraints', () => {
     }
   });
 
-  it('leaves staged checks unvalidated and existing resource FKs validated', () => {
+  it('validates only the three staged checks after a read-only preflight', () => {
+    expect(validationMigration.match(/VALIDATE CONSTRAINT \w+;/g)).toHaveLength(3);
+    expect(validationMigration).not.toMatch(/NOT VALID\s*;/);
+    expect(validationMigration).not.toContain('ADD CONSTRAINT');
+    expect(validationMigration).not.toContain('DROP CONSTRAINT');
+    expect(validationMigration).not.toContain('GRANT ');
+    expect(validationMigration).not.toContain('REVOKE ');
+    expect(validationMigration).not.toContain('UPDATE public.mcp_mutation_control');
+
+    for (const constraintName of stagedConstraintNames) {
+      expect(validationMigration).toContain(`VALIDATE CONSTRAINT ${constraintName};`);
+    }
+
+    // Candidate 1 already validated these, so Candidate 5 must not restate them.
+    for (const constraintName of existingResourceConstraintNames) {
+      expect(validationMigration).not.toContain(constraintName);
+    }
+
+    // The preflight must abort the whole migration instead of letting the
+    // validation scan report a generic failure, and the scan needs more than the
+    // 30s Candidate 4 used for its metadata-only NOT VALID additions.
+    expect(validationMigration).toContain("USING ERRCODE = 'check_violation'");
+    expect(validationMigration).toContain("SET LOCAL statement_timeout = '60s'");
+
+    // The abort reports per-table counts only: no row identity reaches the log.
+    const exceptionMessage = validationMigration.match(/RAISE EXCEPTION\s+'([^']*)'/)?.[1];
+    expect(exceptionMessage).toContain('revocation alone is insufficient');
+    expect(exceptionMessage?.match(/%/g)).toHaveLength(3);
+    for (const identifier of ['user_id', 'client_id', 'token_hash', 'code_hash', 'scopes']) {
+      expect(exceptionMessage).not.toContain(identifier);
+    }
+  });
+
+  it('preflights with the same scope predicate as the staged checks', () => {
+    const normalize = (sql: string): string => sql.replace(/\s+/g, ' ');
+    const writeScopeArray =
+      "ARRAY[ 'write:plans', 'delete:plans', 'write:records', 'delete:records' ]::TEXT[]";
+    const readScopeArray = "ARRAY['read:entries']::TEXT[]";
+
+    // Candidate 4 spells its check with && for the write scopes and @> for
+    // read:entries. The preflight negates that exact expression, so it must not
+    // drift back to the `= ANY (scopes)` spelling of the earlier draft.
+    expect(normalize(candidateMigration)).toContain(writeScopeArray);
+    expect(normalize(validationMigration)).toContain(writeScopeArray);
+    expect(normalize(candidateMigration)).toContain(readScopeArray);
+    expect(normalize(validationMigration)).toContain(readScopeArray);
+    expect(validationMigration).not.toContain('= ANY (scopes)');
+
+    expect(validationMigration.match(/scopes && v_write_scopes/g)).toHaveLength(3);
+    expect(validationMigration.match(/NOT \(scopes @> v_read_scope\)/g)).toHaveLength(3);
+
+    for (const scope of ['write:plans', 'delete:plans', 'write:records', 'delete:records']) {
+      expect(validationMigration.match(new RegExp(`'${scope}'`, 'g'))).toHaveLength(1);
+    }
+  });
+
+  it('leaves no stored grant that the validated checks would reject', () => {
+    const result = runOwnerSql(`
+      SELECT NOT EXISTS (
+        SELECT 1
+        FROM (
+          SELECT scopes FROM public.oauth_connections
+          UNION ALL
+          SELECT scopes FROM public.oauth_authorization_codes
+          UNION ALL
+          SELECT scopes FROM public.oauth_tokens
+        ) AS stored_grants
+        WHERE scopes && ARRAY[
+            'write:plans',
+            'delete:plans',
+            'write:records',
+            'delete:records'
+          ]::TEXT[]
+          AND NOT (scopes @> ARRAY['read:entries']::TEXT[])
+      );
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe('t');
+  });
+
+  // The preflight abort path has no runtime test. Once Candidate 5 has run, the
+  // validated CHECK rejects every violating row and a CHECK constraint cannot be
+  // deferred, so seeding a fixture that trips the preflight would mean dropping
+  // the constraint this migration exists to enforce. The static assertions above
+  // cover the preflight instead.
+
+  it('marks the staged checks and the existing resource FKs as validated', () => {
     const result = runOwnerSql(`
       SELECT c.conname || '|' || c.contype::TEXT || '|' || c.convalidated::TEXT
       FROM pg_constraint AS c
@@ -219,11 +314,10 @@ describe.skipIf(!RUN_LOCAL)('MCP Candidate 4 OAuth scope constraints', () => {
     expect(result.status).toBe(0);
     const catalogRows = result.stdout.trim().split('\n');
     expect(catalogRows).toEqual(
-      [...existingResourceConstraintNames]
-        .sort()
-        .map((name) => `${name}|f|true`)
-        .concat([...stagedConstraintNames].sort().map((name) => `${name}|c|false`))
-        .sort(),
+      [
+        ...existingResourceConstraintNames.map((name) => `${name}|f|true`),
+        ...stagedConstraintNames.map((name) => `${name}|c|true`),
+      ].sort(),
     );
   });
 

--- a/apps/product/src/lib/test/integration/mcp-oauth-scope-constraints.integration.test.ts
+++ b/apps/product/src/lib/test/integration/mcp-oauth-scope-constraints.integration.test.ts
@@ -38,11 +38,75 @@ const validationMigration = readFileSync(
   'utf8',
 );
 
+const stagedTableNames = [
+  'oauth_connections',
+  'oauth_authorization_codes',
+  'oauth_tokens',
+] as const;
+
 const stagedConstraintNames = [
   'oauth_connections_write_requires_read_entries_check',
   'oauth_authorization_codes_write_requires_read_entries_check',
   'oauth_tokens_write_requires_read_entries_check',
 ] as const;
+
+/**
+ * Drops `--` comments so the guards below inspect executable SQL only. Both
+ * migrations narrate themselves heavily, and matching raw file text would make
+ * every comment rewording a false failure (`GRANT`, `NOT VALID` and the scope
+ * names all appear in prose).
+ */
+function stripSqlComments(sql: string): string {
+  return sql
+    .split('\n')
+    .map((line) => {
+      let quoted = false;
+      for (let index = 0; index < line.length; index += 1) {
+        if (line[index] === "'") quoted = !quoted;
+        else if (!quoted && line[index] === '-' && line[index + 1] === '-') {
+          return line.slice(0, index);
+        }
+      }
+      return line;
+    })
+    .join('\n');
+}
+
+const candidateSql = stripSqlComments(candidateMigration);
+const validationSql = stripSqlComments(validationMigration);
+
+function statementTimeoutSeconds(sql: string): number {
+  const seconds = sql.match(/SET LOCAL statement_timeout = '(\d+)s'/)?.[1];
+  expect(seconds).toBeDefined();
+  return Number(seconds);
+}
+
+/**
+ * The Candidate 4 CHECK body, as PostgreSQL will evaluate it. Candidate 4 is an
+ * applied migration and must never be edited, so anchoring on its exact shape is
+ * safe and makes any retro-edit fail loudly here.
+ */
+function stagedCheckExpression(): string {
+  const expression = candidateSql.match(/CHECK \(\n([\s\S]*?)\n {2}\)\n {2}NOT VALID;/)?.[1];
+  expect(expression).toBeDefined();
+  return String(expression);
+}
+
+/**
+ * The Candidate 5 preflight predicate with its PL/pgSQL locals inlined, so it can
+ * be evaluated as plain SQL alongside the Candidate 4 expression.
+ */
+function preflightPredicate(): string {
+  const writeScopes = validationSql.match(/v_write_scopes CONSTANT TEXT\[\] :=([\s\S]*?);/)?.[1];
+  const readScope = validationSql.match(/v_read_scope CONSTANT TEXT\[\] :=([\s\S]*?);/)?.[1];
+  const where = validationSql.match(/WHERE (scopes[\s\S]*?);/)?.[1];
+  expect(writeScopes).toBeDefined();
+  expect(readScope).toBeDefined();
+  expect(where).toBeDefined();
+  return String(where)
+    .replaceAll('v_write_scopes', `(${String(writeScopes)})`)
+    .replaceAll('v_read_scope', `(${String(readScope)})`);
+}
 
 const existingResourceConstraintNames = [
   'oauth_connections_environment_resource_fkey',
@@ -209,60 +273,94 @@ describe.skipIf(!RUN_LOCAL)('MCP Candidate 4 and 5 OAuth scope constraints', () 
     }
   });
 
-  it('validates only the three staged checks after a read-only preflight', () => {
-    expect(validationMigration.match(/VALIDATE CONSTRAINT \w+;/g)).toHaveLength(3);
-    expect(validationMigration).not.toMatch(/NOT VALID\s*;/);
-    expect(validationMigration).not.toContain('ADD CONSTRAINT');
-    expect(validationMigration).not.toContain('DROP CONSTRAINT');
-    expect(validationMigration).not.toContain('GRANT ');
-    expect(validationMigration).not.toContain('REVOKE ');
-    expect(validationMigration).not.toContain('UPDATE public.mcp_mutation_control');
-
+  it('validates only the three staged checks and changes nothing else', () => {
+    expect(validationSql.match(/VALIDATE CONSTRAINT \w+;/g)).toHaveLength(3);
     for (const constraintName of stagedConstraintNames) {
-      expect(validationMigration).toContain(`VALIDATE CONSTRAINT ${constraintName};`);
+      expect(validationSql).toContain(`VALIDATE CONSTRAINT ${constraintName};`);
     }
 
     // Candidate 1 already validated these, so Candidate 5 must not restate them.
     for (const constraintName of existingResourceConstraintNames) {
-      expect(validationMigration).not.toContain(constraintName);
+      expect(validationSql).not.toContain(constraintName);
     }
 
-    // The preflight must abort the whole migration instead of letting the
-    // validation scan report a generic failure, and the scan needs more than the
-    // 30s Candidate 4 used for its metadata-only NOT VALID additions.
-    expect(validationMigration).toContain("USING ERRCODE = 'check_violation'");
-    expect(validationMigration).toContain("SET LOCAL statement_timeout = '60s'");
-
-    // The abort reports per-table counts only: no row identity reaches the log.
-    const exceptionMessage = validationMigration.match(/RAISE EXCEPTION\s+'([^']*)'/)?.[1];
-    expect(exceptionMessage).toContain('revocation alone is insufficient');
-    expect(exceptionMessage?.match(/%/g)).toHaveLength(3);
-    for (const identifier of ['user_id', 'client_id', 'token_hash', 'code_hash', 'scopes']) {
-      expect(exceptionMessage).not.toContain(identifier);
-    }
+    // Candidate 5 only advances constraint state. No schema restructuring, no
+    // privilege change, no gate change, and above all no destructive
+    // "remediation" of the very rows the preflight exists to surface: deleting a
+    // write-only grant would destroy consent history instead of repairing it.
+    expect(validationSql).not.toMatch(/\bNOT VALID\b/i);
+    expect(validationSql).not.toMatch(/\bADD CONSTRAINT\b/i);
+    expect(validationSql).not.toMatch(/\bDROP CONSTRAINT\b/i);
+    expect(validationSql).not.toMatch(/\b(GRANT|REVOKE|TRUNCATE)\b/i);
+    expect(validationSql).not.toMatch(
+      /\b(DELETE\s+FROM|INSERT\s+INTO|UPDATE)\s+(public\.)?(oauth_|mcp_)/i,
+    );
   });
 
-  it('preflights with the same scope predicate as the staged checks', () => {
-    const normalize = (sql: string): string => sql.replace(/\s+/g, ' ');
-    const writeScopeArray =
-      "ARRAY[ 'write:plans', 'delete:plans', 'write:records', 'delete:records' ]::TEXT[]";
-    const readScopeArray = "ARRAY['read:entries']::TEXT[]";
+  it('runs the read-only preflight over all three tables before validating', () => {
+    // Order matters: with the scan first, validation fails on the same rows but
+    // with a generic PostgreSQL message and the actionable abort never runs.
+    const preflightIndex = validationSql.indexOf('DO $$');
+    const firstValidateIndex = validationSql.indexOf('VALIDATE CONSTRAINT');
+    expect(preflightIndex).toBeGreaterThan(-1);
+    expect(firstValidateIndex).toBeGreaterThan(preflightIndex);
 
-    // Candidate 4 spells its check with && for the write scopes and @> for
-    // read:entries. The preflight negates that exact expression, so it must not
-    // drift back to the `= ANY (scopes)` spelling of the earlier draft.
-    expect(normalize(candidateMigration)).toContain(writeScopeArray);
-    expect(normalize(validationMigration)).toContain(writeScopeArray);
-    expect(normalize(candidateMigration)).toContain(readScopeArray);
-    expect(normalize(validationMigration)).toContain(readScopeArray);
-    expect(validationMigration).not.toContain('= ANY (scopes)');
-
-    expect(validationMigration.match(/scopes && v_write_scopes/g)).toHaveLength(3);
-    expect(validationMigration.match(/NOT \(scopes @> v_read_scope\)/g)).toHaveLength(3);
-
-    for (const scope of ['write:plans', 'delete:plans', 'write:records', 'delete:records']) {
-      expect(validationMigration.match(new RegExp(`'${scope}'`, 'g'))).toHaveLength(1);
+    // Each table is counted exactly once. Scanning one table three times is the
+    // likely defect in a hand-duplicated block, and no runtime test would catch it.
+    for (const table of stagedTableNames) {
+      expect(validationSql.match(new RegExp(`FROM public\\.${table}\\b`, 'g'))).toHaveLength(1);
     }
+
+    // The abort must be a check violation, and every interpolated argument must
+    // be a plain count, so no row identity can reach the PostgreSQL log.
+    // Anchor on the terminator, not the first `;` — the message text contains one.
+    const raiseStatement = validationSql.match(
+      /RAISE EXCEPTION[\s\S]*?USING ERRCODE = 'check_violation';/,
+    )?.[0];
+    expect(raiseStatement).toBeDefined();
+    expect(raiseStatement).toContain('revocation alone is insufficient');
+    const raiseArguments = String(raiseStatement).slice(String(raiseStatement).indexOf("',") + 2);
+    expect(raiseArguments.match(/v_\w+_violations/g)).toHaveLength(3);
+    expect(raiseArguments).not.toMatch(/\b(scopes|_agg|user_id|client_id|token_hash|code_hash)\b/);
+    expect(
+      validationSql.match(/SELECT pg_catalog\.count\(\*\)\s+INTO v_\w+_violations\b/g),
+    ).toHaveLength(3);
+
+    // The scan reads every row, so it needs a larger budget than the
+    // metadata-only NOT VALID additions of Candidate 4. Assert the inequality
+    // rather than the literal, so raising Candidate 4 cannot silently invert it.
+    expect(statementTimeoutSeconds(validationSql)).toBeGreaterThan(
+      statementTimeoutSeconds(candidateSql),
+    );
+    expect(validationSql).toContain("SET LOCAL lock_timeout = '5s'");
+  });
+
+  it('preflights with the exact negation of the staged check expression', () => {
+    // Evaluate both expressions in PostgreSQL over a probe set instead of
+    // comparing source text. This catches an AND/OR inversion, a dropped NOT, a
+    // rewrite to `= ANY (scopes)`, and any scope-set drift — none of which a
+    // string match distinguishes. CHECK passes on TRUE or NULL; the preflight
+    // WHERE matches only on TRUE, so the two must be exact complements.
+    const result = runOwnerSql(`
+      WITH probe(scopes) AS (
+        VALUES
+          (ARRAY[]::TEXT[]),
+          (ARRAY['read:entries']::TEXT[]),
+          (ARRAY['write:plans']::TEXT[]),
+          (ARRAY['delete:records']::TEXT[]),
+          (ARRAY['read:entries', 'write:plans']::TEXT[]),
+          (ARRAY['read:entries', 'write:records', 'delete:plans']::TEXT[]),
+          (ARRAY['write:plans', NULL]::TEXT[]),
+          (ARRAY[NULL]::TEXT[])
+      )
+      SELECT pg_catalog.bool_and(
+        COALESCE((${preflightPredicate()}), false) = NOT COALESCE((${stagedCheckExpression()}), true)
+      )
+      FROM probe;
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe('t');
   });
 
   it('leaves no stored grant that the validated checks would reject', () => {
@@ -312,7 +410,9 @@ describe.skipIf(!RUN_LOCAL)('MCP Candidate 4 and 5 OAuth scope constraints', () 
     `);
 
     expect(result.status).toBe(0);
-    const catalogRows = result.stdout.trim().split('\n');
+    // Sort both sides: SQL orders by conname, JS by the whole `name|type|valid`
+    // string, and the two only agree while no name is a prefix of another.
+    const catalogRows = result.stdout.trim().split('\n').sort();
     expect(catalogRows).toEqual(
       [
         ...existingResourceConstraintNames.map((name) => `${name}|f|true`),

--- a/apps/product/src/lib/test/integration/mcp-oauth-scope-constraints.integration.test.ts
+++ b/apps/product/src/lib/test/integration/mcp-oauth-scope-constraints.integration.test.ts
@@ -363,6 +363,11 @@ describe.skipIf(!RUN_LOCAL)('MCP Candidate 4 and 5 OAuth scope constraints', () 
     expect(result.stdout.trim()).toBe('t');
   });
 
+  // Tautological once Candidate 5 has run: this re-evaluates the validated
+  // constraints' own predicate over the same tables, so it cannot fail unless a
+  // constraint is broken. It is kept as a cheap canary, not as evidence of data
+  // health — the real evidence is the read-only production count recorded in the
+  // Candidate 5 PR, plus the `convalidated` catalog assertion below.
   it('leaves no stored grant that the validated checks would reject', () => {
     const result = runOwnerSql(`
       SELECT NOT EXISTS (

--- a/scripts/ai-review/invariants.md
+++ b/scripts/ai-review/invariants.md
@@ -60,6 +60,10 @@ ai-review が「**あるべき検査の不在**」を判定するための正本
   ref/JWT refをservice-role RPCから一度だけ設定する。UUID/email/password/provider
   identityを固定し、未知user、session、MFA、Auth OAuth state、既存OAuth authorityが
   あれば拒否する。Persistent Staging identityは作らない
+- `oauth_connections` / `oauth_authorization_codes` / `oauth_tokens` のstored scopeは、
+  write / delete scopeを持つ行が必ず `read:entries` を含む。Candidate 4が `NOT VALID` で
+  配置し、Candidate 5がread-only preflightの後にvalidatedへ進めた。grant RPC側の
+  同等チェックとvalidated CHECK制約の二層でfail closedにする
 - Plan / Record writerはtransaction内で一人のuserとlock modeへbindする。direct DMLと
   typed commandを同じ境界へ入れ、sharedからexclusiveへのlock upgradeを即時拒否する。
   user revisionはcommitしたtransactionごとに最大1回進み、rollbackでは進まない

--- a/supabase/migrations/20260730090200_validate_mcp_oauth_scope_constraints.sql
+++ b/supabase/migrations/20260730090200_validate_mcp_oauth_scope_constraints.sql
@@ -1,0 +1,112 @@
+-- Candidate 5 finishes the stored-grant half of the OAuth scope contract that
+-- Candidate 4 staged as NOT VALID. It runs a read-only preflight over the three
+-- OAuth tables and then validates the three staged CHECK constraints, so the
+-- contract also covers rows that predate Candidate 4.
+--
+-- The preflight predicate is the exact negation of the Candidate 4 CHECK
+-- expression. A validation scan would fail on the same rows, but with a generic
+-- PostgreSQL message; stopping first keeps the failure actionable without
+-- reporting any row identity.
+--
+-- The three environment_resource_fkey constraints were already installed and
+-- validated by Candidate 1. Candidate 5 does not touch, drop, or duplicate
+-- them, and it changes no GRANT, RLS policy, or OAuth function.
+--
+-- The runtime guard that rejects write scopes without read:entries already
+-- lives in 20260729073125_mcp_environment_identity_client_fence.sql. This
+-- migration only advances the stored-row constraint state and does not
+-- reimplement that check.
+--
+-- MCP write tools stay unreachable: writes_enabled = false AND
+-- enabled_client_ids = [] is untouched here.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+-- VALIDATE CONSTRAINT holds SHARE UPDATE EXCLUSIVE for a full table scan on
+-- each OAuth table, so allow more than the 30s Candidate 4 used for the
+-- metadata-only NOT VALID additions.
+SET LOCAL statement_timeout = '60s';
+
+-- =============================================================================
+-- 1. Read-only preflight
+-- =============================================================================
+-- Revoking a write-only grant does not repair its stored scopes, so a revoked
+-- row still fails validation. Report counts only: no user id, client id,
+-- token hash, or scope value leaves this block.
+
+DO $$
+DECLARE
+  v_write_scopes CONSTANT TEXT[] := ARRAY[
+    'write:plans',
+    'delete:plans',
+    'write:records',
+    'delete:records'
+  ]::TEXT[];
+  v_read_scope CONSTANT TEXT[] := ARRAY['read:entries']::TEXT[];
+  v_connection_violations BIGINT;
+  v_authorization_code_violations BIGINT;
+  v_token_violations BIGINT;
+BEGIN
+  SELECT pg_catalog.count(*)
+  INTO v_connection_violations
+  FROM public.oauth_connections
+  WHERE scopes && v_write_scopes
+    AND NOT (scopes @> v_read_scope);
+
+  SELECT pg_catalog.count(*)
+  INTO v_authorization_code_violations
+  FROM public.oauth_authorization_codes
+  WHERE scopes && v_write_scopes
+    AND NOT (scopes @> v_read_scope);
+
+  SELECT pg_catalog.count(*)
+  INTO v_token_violations
+  FROM public.oauth_tokens
+  WHERE scopes && v_write_scopes
+    AND NOT (scopes @> v_read_scope);
+
+  IF v_connection_violations > 0
+    OR v_authorization_code_violations > 0
+    OR v_token_violations > 0
+  THEN
+    RAISE EXCEPTION
+      'OAuth write-only rows must be repaired or removed under an explicit consent-safe remediation before the base-read constraint is validated; revocation alone is insufficient (oauth_connections: % rows, oauth_authorization_codes: % rows, oauth_tokens: % rows)',
+      v_connection_violations,
+      v_authorization_code_violations,
+      v_token_violations
+      USING ERRCODE = 'check_violation';
+  END IF;
+END;
+$$;
+
+-- =============================================================================
+-- 2. Validate the staged checks
+-- =============================================================================
+
+ALTER TABLE public.oauth_connections
+  VALIDATE CONSTRAINT oauth_connections_write_requires_read_entries_check;
+
+ALTER TABLE public.oauth_authorization_codes
+  VALIDATE CONSTRAINT oauth_authorization_codes_write_requires_read_entries_check;
+
+ALTER TABLE public.oauth_tokens
+  VALIDATE CONSTRAINT oauth_tokens_write_requires_read_entries_check;
+
+-- =============================================================================
+-- 3. Replace the Candidate 4 staging comments
+-- =============================================================================
+-- The staged comments announced a pending Candidate 5 validation. Restate them
+-- as the validated contract so the catalog does not describe stale intent.
+
+COMMENT ON CONSTRAINT oauth_connections_write_requires_read_entries_check
+  ON public.oauth_connections IS
+  'Validated in Candidate 5: write and delete scopes extend read:entries for every stored row.';
+COMMENT ON CONSTRAINT oauth_authorization_codes_write_requires_read_entries_check
+  ON public.oauth_authorization_codes IS
+  'Validated in Candidate 5: write and delete scopes extend read:entries for every stored row.';
+COMMENT ON CONSTRAINT oauth_tokens_write_requires_read_entries_check
+  ON public.oauth_tokens IS
+  'Validated in Candidate 5: write and delete scopes extend read:entries for every stored row.';
+
+COMMIT;

--- a/supabase/schemas/017_tables_oauth.sql
+++ b/supabase/schemas/017_tables_oauth.sql
@@ -1,11 +1,12 @@
 -- ============================================================
 -- OAuth 2.1 / MCP DB基盤（読み物用 — CLIでは使用しない）
 -- ============================================================
--- Candidate 4 は connection-bound OAuth のstored scope契約を追加する。
+-- Candidate 4 が connection-bound OAuth のstored scope契約を追加し、Candidate 5 が
+-- 既存行まで含めて検証済みにした。
 -- MCP write tool はまだ公開せず、global gate OFF + client list empty が停止条件。
 -- 実際のマイグレーションは migrations/ を参照。
 -- 最終同期日: 2026-07-30
--- Candidate 4 terminal migration: 20260730090100_mcp_oauth_scope_constraints_not_valid.sql
+-- Candidate 5 terminal migration: 20260730090200_validate_mcp_oauth_scope_constraints.sql
 -- 同期対象 migration:
 --   - 20260501000000_oauth_tokens_from_api_keys.sql
 --   - 20260501000100_oauth_authorization_codes.sql
@@ -26,9 +27,11 @@
 --   - 20260729073126_mcp_stage1_receipt_generation_lifecycle.sql
 --   - 20260729073127_legacy_linked_record_restore_compatibility.sql
 --   - 20260730090100_mcp_oauth_scope_constraints_not_valid.sql
+--   - 20260730090200_validate_mcp_oauth_scope_constraints.sql
 --
--- Candidate 4の実migrationは下記3 CHECKをNOT VALIDで追加する。
--- 既存行のpreflightとVALIDATE CONSTRAINTはCandidate 5で行う。
+-- 下記3 CHECKはCandidate 4がNOT VALIDで追加し、Candidate 5が読み取り専用preflightの後に
+-- VALIDATE CONSTRAINTで検証済みへ進めた。この宣言スキーマは読み物なので、
+-- 検証状態（convalidated）はmigrationだけが持つ。
 -- ============================================================
 
 -- mcp_environment_identity: DBが所有する一度きり・変更不可のauthority identity。


### PR DESCRIPTION
## 概要

MCP段階導入のCandidate 5 / 8として、Candidate 4が`NOT VALID`で配置したOAuth scope制約を、読み取り専用preflightの後に`VALIDATE CONSTRAINT`で検証済みへ進めます。

これにより「write / delete scopeを持つstored grantは必ず`read:entries`を含む」がCandidate 4以前の既存行まで含めたDB不変条件になります。

MCPのwrite gateはOFF、許可client一覧は空のままです。このPRだけでは外部AIの書き込みは公開されません。

Refs #1754

## 変更内容

- `20260730090200_validate_mcp_oauth_scope_constraints.sql`を追加
  - Candidate 4のCHECK式の厳密な否定を述語とする読み取り専用preflightで、`oauth_connections` / `oauth_authorization_codes` / `oauth_tokens`の違反行を数える
  - 1件でもあれば`ERRCODE = 'check_violation'`でmigration全体を止める。メッセージはテーブルごとの件数だけで、行を同定できる値を出さない
  - 3つのCHECKを`VALIDATE CONSTRAINT`する
  - Candidate 4の「Candidate 5でvalidateする」予告コメントを、validated済みの文面へ差し替える
  - `VALIDATE CONSTRAINT`は全表スキャンのため`statement_timeout`を60s、`lock_timeout`は5s
- 既存integration testの`convalidated`期待値を3本とも`true`へ更新
- Candidate 5 migrationの静的検証を追加。実行SQLだけを対象にし、述語の同値性はPostgreSQL上で評価する
- `scripts/ai-review/invariants.md`の§MCP の DB 書き込み境界に、stored scope不変条件を1 bullet追記
- `supabase/schemas/017_tables_oauth.sql`のterminal migrationと予告文をvalidated済みの記述へ更新

Candidate 1が検証済みで配置した`*_environment_resource_fkey` 3本には触りません。GRANT、REVOKE、RLS policy、OAuth function、MCP write gateはいずれも変更しません。

runtime側の「write scopeは`read:entries`を要求する」チェックは`20260729073125_mcp_environment_identity_client_fence.sql`に既にあり、再実装していません。validated CHECKとの二層でfail closedになります。

## Mixed-version境界

- predecessor candidate merge SHA: `566ca79828fceb54f7e6e9358bf2b03047548edb` (Candidate 4 / PR #1769)
- 追従済みmain SHA: `e4fc93279`
- candidate SHA: `df96e95e4`
- terminal migration: `20260730090200_validate_mcp_oauth_scope_constraints.sql`
- staged CHECK: 3件、適用後の期待状態`convalidated = true`
- existing environment resource FK: 3件、期待状態`convalidated = true`（変更なし）
- MCP global write: `false`
- MCP enabled client: `0`

旧appと新appの互換は定義上維持されます。Candidate 4の`NOT VALID` CHECKは新規行と更新行には既に完全に効いているため、validated化で新たに失敗するDML経路は存在しません。Candidate 5が新たに検査するのは既存行だけです。このPRはappコードを1行も変更していません。

write scopeを持つ行を生成しうる経路（consent codeのinsert、code exchange、refresh rotation、grant RPC、legacy bind trigger、Preview seed fixture）はすべて`read:entries`を強制または write scopeを拒否済みです。refresh rotationのscope交差演算も制約を保存します（交差にwrite scopeが入るならtokenとconnectionの両方が持ち、両者のCHECKにより両方が`read:entries`を含む）。

## Production read-only事前確認

変更前のProductionをread-onlyで確認しました。

- terminal migration: `20260730090100`
- write/delete scopeがあり`read:entries`がない行: 3テーブルすべて0件
- 3テーブルの総行数: すべて0件
- staged CHECK 3件: `convalidated = false`（Candidate 4の配置を確認）
- environment resource FK 3件: すべて`convalidated = true`
- `mcp_mutation_control`: `writes_enabled = false`、`enabled_client_ids = []`、`revision = 0`

対象テーブルが空のため、`VALIDATE CONSTRAINT`の全表スキャンは即時に完了し、`SHARE UPDATE EXCLUSIVE`の保持時間は無視できます。

## 検証

追従マージ後にローカルで再実行しました。

- `pnpm db:fresh`: pass（`20260730090200`まで全件適用）
- `pnpm exec supabase db lint --local --level warning`: pass（No schema errors found）
- `pnpm rls:snapshot:check`: pass（差分ゼロ。GRANTを変更していないため期待通り）
- Candidate 5 focused integration: 1 file / 10 tests pass
- Integration全体: 21 files / 251 tests pass
- `pnpm typecheck`: pass（10 tasks）
- `pnpm lint`: pass（9 tasks）
- `pnpm lint:boundaries`: violation 0
- `pnpm docs:check`: pass

migration SQLの再実行が成功することも確認しました（`VALIDATE CONSTRAINT`は検証済み制約に対してno-op、`COMMENT ON`は冪等）。

### 静的検証の実効性

追加した静的検証は、次の5つの変異を実際に注入してそれぞれfailすることを確認済みです。

- preflightを`VALIDATE CONSTRAINT`の後ろへ移動する
- 同じテーブルを3回数える
- 違反行を`DELETE`する「修復」を混ぜる
- preflight述語の`AND`を`OR`へ反転する
- `statement_timeout`を30sへ下げる

判定対象を実行SQLだけに絞ったため、コメントの言い換えではfailしません。述語の同値性は文字列一致ではなく、空配列・read only・write only・read+write・NULL要素・全NULLの6パターンをPostgreSQL上で評価して補集合であることを検証しています。

### 独立レビュー

- risk review: blockerなし。指摘された`scripts/ai-review/invariants.md`の不変条件欠落はこのPR内で対応済み
- behavior review: 回帰リスクなし。指摘された「コメント文言依存の脆いassertion」と「preflight述語の検証が静的一致のみ」はこのPR内で対応済み

### ローカルunit testの既知の失敗

ローカルの`pnpm check`ではunit testが66件failしますが、**このPRとは無関係な環境要因**です。

- 全失敗の原因はnode 26で`localStorage`が既定で利用できないこと（`localStorage is not available because --localstorage-file was not provided`）。zustand persist middlewareの`setItem`が落ちます
- repoのengine指定は`node 24.x`、CIも node 24 を使います
- 失敗11ファイルはlocalStorage / cookie / analytics / store persist系のみで、OAuth・MCP・migrationに触れません
- 単体実行では pass します（例: `contact-service.test.ts` は 23/23 pass）。全体実行時のみ他testの汚染で落ちます

CIのnode 24環境での結果をmerge gateとします。

## Preview確認

- [ ] fresh Supabase Preview projectを作成する（明示承認が必要）
- [ ] candidate SHAでmigrationを適用し、実terminalが`20260730090200`と一致することを確認する
- [ ] 適用後に3 CHECKが`convalidated = true`、3 FKが`convalidated = true`であることを確認する
- [ ] `writes_enabled = false` / `enabled_client_ids = []`が不変であることを確認する
- [ ] 旧appと新appの両方が同じDBで動くことを確認する
- [ ] 逆GRANTと再cutoverのrehearsalを確認する

## このPRでは行わないもの

- MCP write gateの有効化、`MCP_WRITE_ENABLED_CLIENTS`への値設定
- GRANT / REVOKE / RLS policy / OAuth functionの変更
- Candidate 1が検証済みで配置した`*_environment_resource_fkey`の再作成や変更
- runtime側 read scopeチェックの再実装
- 違反行の自動修復・削除（consent履歴を壊すため、対象行がある場合はmigrationを止めて別の明示承認境界にする）
- Candidate 6以降のTimeblock ACL cutover、MCP/OAuth app配置、destructive cleanup
