### PR TITLE
fix(auth): レート制限とサーバー側 MFA 境界を強化する

### DIFF
--- a/apps/product/src/__tests__/proxy.test.ts
+++ b/apps/product/src/__tests__/proxy.test.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  updateSession: vi.fn(),
+  captureUnexpectedError: vi.fn(),
+}));
+
+vi.mock('next-intl/middleware', async () => {
+  const { NextResponse: MockNextResponse } = await import('next/server');
+  return { default: () => () => MockNextResponse.next() };
+});
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('@/lib/sentry', () => ({
+  captureUnexpectedError: mocks.captureUnexpectedError,
+  observeAuthOperation: (_operation: string, call: () => PromiseLike<unknown>) => call(),
+}));
+
+vi.mock('@/lib/supabase/middleware', () => ({ updateSession: mocks.updateSession }));
+
+import { proxy } from '../proxy';
+
+function mockAuthenticatedSession(aalResult: {
+  data: { currentLevel: string | null; nextLevel: string | null } | null;
+  error: unknown;
+}) {
+  mocks.updateSession.mockResolvedValue({
+    response: NextResponse.next(),
+    user: { id: 'user-1' },
+    supabase: {
+      auth: {
+        mfa: {
+          getAuthenticatorAssuranceLevel: vi.fn().mockResolvedValue(aalResult),
+        },
+      },
+    },
+  });
+}
+
+describe('proxy MFA gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('NEXT_PUBLIC_MAINTENANCE_MODE', 'false');
+    vi.stubEnv('SKIP_AUTH_IN_DEV', 'false');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('preserves the locale when redirecting an AAL1 session with enrolled MFA', async () => {
+    mockAuthenticatedSession({
+      data: { currentLevel: 'aal1', nextLevel: 'aal2' },
+      error: null,
+    });
+
+    const response = await proxy(new NextRequest('https://app.dayopt.app/ja/week'));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe('https://app.dayopt.app/ja/auth/mfa-verify');
+  });
+
+  it('redirects to login when the MFA assurance lookup returns an error', async () => {
+    mockAuthenticatedSession({ data: null, error: { message: 'lookup failed' } });
+
+    const response = await proxy(new NextRequest('https://app.dayopt.app/week'));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe('https://app.dayopt.app/auth/login');
+  });
+
+  it.each([
+    { currentLevel: 'aal1', nextLevel: 'aal1' },
+    { currentLevel: 'aal2', nextLevel: 'aal2' },
+  ])('does not redirect a valid $currentLevel session', async (data) => {
+    mockAuthenticatedSession({ data, error: null });
+
+    const response = await proxy(new NextRequest('https://app.dayopt.app/week'));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('location')).toBeNull();
+  });
+});

--- a/apps/product/src/app/api/auth/__tests__/route.test.ts
+++ b/apps/product/src/app/api/auth/__tests__/route.test.ts
@@ -5,14 +5,17 @@ const mocks = vi.hoisted(() => ({
   withUpstashRateLimit: vi.fn(),
   createClient: vi.fn(),
   signInWithPassword: vi.fn(),
+  signUp: vi.fn(),
+  signOut: vi.fn(),
+  resetPasswordForEmail: vi.fn(),
   captureUnexpectedAuthError: vi.fn(),
 }));
 
 vi.mock('@/lib/logger', () => ({ logger: { error: vi.fn() } }));
 
 vi.mock('@/lib/rate-limit/upstash', () => ({
-  loginRateLimit: {},
-  passwordResetRateLimit: {},
+  loginRateLimit: { kind: 'login' },
+  passwordResetRateLimit: { kind: 'password-reset' },
   withUpstashRateLimit: mocks.withUpstashRateLimit,
 }));
 
@@ -24,17 +27,22 @@ vi.mock('@/lib/sentry', () => ({
 
 vi.mock('@/lib/supabase/server', () => ({ createClient: mocks.createClient }));
 
+import { loginRateLimit, passwordResetRateLimit } from '@/lib/rate-limit/upstash';
 import { POST } from '../route';
 
-function signInRequest(): NextRequest {
+function authRequest(body: unknown): NextRequest {
   return new NextRequest('https://app.dayopt.app/api/auth', {
     method: 'POST',
     headers: { 'content-type': 'application/json', 'x-real-ip': '203.0.113.10' },
-    body: JSON.stringify({
-      action: 'signin',
-      email: 'person@example.com',
-      password: 'not-a-real-password',
-    }),
+    body: JSON.stringify(body),
+  });
+}
+
+function signInRequest(email = 'person@example.com'): NextRequest {
+  return authRequest({
+    action: 'signin',
+    email,
+    password: 'not-a-real-password',
   });
 }
 
@@ -45,9 +53,79 @@ describe('POST /api/auth rate-limit boundary', () => {
       data: { user: { id: 'user-123' }, session: { access_token: 'test-session' } },
       error: null,
     });
-    mocks.createClient.mockResolvedValue({
-      auth: { signInWithPassword: mocks.signInWithPassword },
+    mocks.signUp.mockResolvedValue({
+      data: { user: { id: 'user-123' }, session: null },
+      error: null,
     });
+    mocks.signOut.mockResolvedValue({ error: null });
+    mocks.resetPasswordForEmail.mockResolvedValue({ data: {}, error: null });
+    mocks.withUpstashRateLimit.mockResolvedValue({ state: 'disabled' });
+    mocks.createClient.mockResolvedValue({
+      auth: {
+        signInWithPassword: mocks.signInWithPassword,
+        signUp: mocks.signUp,
+        signOut: mocks.signOut,
+        resetPasswordForEmail: mocks.resetPasswordForEmail,
+      },
+    });
+  });
+
+  it('checks independent IP and normalized email buckets for signin', async () => {
+    const response = await POST(signInRequest('Person@Example.COM'));
+
+    expect(response.status).toBe(200);
+    expect(mocks.withUpstashRateLimit).toHaveBeenCalledWith(
+      expect.any(NextRequest),
+      loginRateLimit,
+      'email:person@example.com',
+    );
+    expect(mocks.signInWithPassword).toHaveBeenCalledWith({
+      email: 'Person@Example.COM',
+      password: 'not-a-real-password',
+    });
+  });
+
+  it('checks independent IP and normalized email buckets for password reset', async () => {
+    const response = await POST(
+      authRequest({ action: 'reset-password', email: 'Person@Example.COM' }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.withUpstashRateLimit).toHaveBeenCalledWith(
+      expect.any(NextRequest),
+      passwordResetRateLimit,
+      'email:person@example.com',
+    );
+    expect(mocks.resetPasswordForEmail).toHaveBeenCalledWith('Person@Example.COM', {
+      redirectTo: 'http://localhost:3000/auth/reset-password',
+    });
+  });
+
+  it('keeps signup on the existing IP-only limiter', async () => {
+    const response = await POST(
+      authRequest({
+        action: 'signup',
+        email: 'person@example.com',
+        password: 'not-a-real-password',
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.withUpstashRateLimit).toHaveBeenCalledWith(
+      expect.any(NextRequest),
+      loginRateLimit,
+      undefined,
+    );
+    expect(mocks.withUpstashRateLimit).toHaveBeenCalledOnce();
+  });
+
+  it('does not rate limit signout or invalid request bodies', async () => {
+    const signoutResponse = await POST(authRequest({ action: 'signout' }));
+    const invalidResponse = await POST(authRequest({ action: 'signin', email: 'invalid' }));
+
+    expect(signoutResponse.status).toBe(200);
+    expect(invalidResponse.status).toBe(400);
+    expect(mocks.withUpstashRateLimit).not.toHaveBeenCalled();
   });
 
   it('fails closed with 503 and never reaches Supabase when Upstash is unavailable', async () => {

--- a/apps/product/src/app/api/auth/route.ts
+++ b/apps/product/src/app/api/auth/route.ts
@@ -3,7 +3,9 @@
  * @description Supabase 認証の管理（Route Handler）
  *
  * レート制限:
- * - POST（signin/signup/reset）: 10回/分
+ * - signin: IP + emailごとに5回/15分
+ * - signup: IPごとに5回/15分
+ * - reset-password: IP + emailごとに3回/1時間
  * - GET（session/user）: 制限なし
  *
  * @see Issue #531 - Supabase × Vercel × Next.js 認証チェックリスト
@@ -50,8 +52,12 @@ const authPostSchema = z.discriminatedUnion('action', [
 /**
  * レート制限チェック用ヘルパー
  */
-async function checkRateLimit(request: NextRequest, rateLimit: typeof loginRateLimit) {
-  const result = await withUpstashRateLimit(request, rateLimit);
+async function checkRateLimit(
+  request: NextRequest,
+  rateLimit: typeof loginRateLimit,
+  additionalIdentifier?: string,
+) {
+  const result = await withUpstashRateLimit(request, rateLimit, additionalIdentifier);
 
   if (result.state === 'unavailable') {
     return NextResponse.json(
@@ -76,6 +82,10 @@ async function checkRateLimit(request: NextRequest, rateLimit: typeof loginRateL
   }
 
   return null;
+}
+
+function getEmailRateLimitIdentifier(email: string): string {
+  return `email:${email.trim().toLowerCase()}`;
 }
 
 function expectedAuthErrorResponse(error: unknown): NextResponse {
@@ -158,15 +168,28 @@ export async function POST(request: NextRequest) {
 
     switch (validated.action) {
       case 'signin':
+        // ログイン: IPとemailの独立bucketで各5回/15分
+        rateLimitResponse = await checkRateLimit(
+          request,
+          loginRateLimit,
+          getEmailRateLimitIdentifier(validated.email),
+        );
+        if (rateLimitResponse) return rateLimitResponse;
+        break;
+
       case 'signup':
-        // ログイン/サインアップ: 5回/15分（厳格）
+        // サインアップ: 既存どおりIPのみ5回/15分
         rateLimitResponse = await checkRateLimit(request, loginRateLimit);
         if (rateLimitResponse) return rateLimitResponse;
         break;
 
       case 'reset-password':
-        // パスワードリセット: 3回/1時間（より厳格）
-        rateLimitResponse = await checkRateLimit(request, passwordResetRateLimit);
+        // パスワードリセット: IPとemailの独立bucketで各3回/1時間
+        rateLimitResponse = await checkRateLimit(
+          request,
+          passwordResetRateLimit,
+          getEmailRateLimitIdentifier(validated.email),
+        );
         if (rateLimitResponse) return rateLimitResponse;
         break;
 

--- a/apps/product/src/lib/auth/__tests__/token-expiry.test.ts
+++ b/apps/product/src/lib/auth/__tests__/token-expiry.test.ts
@@ -63,6 +63,27 @@ describe('トークン期限切れ・セッション検証', () => {
       expect(result.userId).toBe('user-1');
     });
 
+    it('session context にMFA assuranceがない場合はfail closedでFORBIDDEN', async () => {
+      const ctx = createMockContext({ userId: 'user-1' });
+      ctx.mfaAssurance = undefined;
+      const caller = createCaller(ctx as never);
+
+      await expect(caller.whoami()).rejects.toThrow(expect.objectContaining({ code: 'FORBIDDEN' }));
+      await expect(caller.user.verifyRecoveryCode()).rejects.toThrow(
+        expect.objectContaining({ code: 'FORBIDDEN' }),
+      );
+    });
+
+    it('不正なMFA assurance組み合わせはfail closedでFORBIDDEN', async () => {
+      const ctx = createMockContext({
+        userId: 'user-1',
+        mfaAssurance: { currentLevel: 'aal2', nextLevel: 'aal1' },
+      });
+      const caller = createCaller(ctx as never);
+
+      await expect(caller.whoami()).rejects.toThrow(expect.objectContaining({ code: 'FORBIDDEN' }));
+    });
+
     it('MFA登録済みAAL1セッションはFORBIDDEN', async () => {
       const ctx = createMockContext({
         userId: 'user-1',

--- a/apps/product/src/lib/rate-limit/__tests__/upstash.test.ts
+++ b/apps/product/src/lib/rate-limit/__tests__/upstash.test.ts
@@ -66,7 +66,7 @@ describe('Upstash Rate Limit', () => {
     expect(cspReportGlobalRateLimit).toBeNull();
   });
 
-  it('hashes identifiers deterministically without retaining raw IP or user IDs', async () => {
+  it('hashes identifiers deterministically without retaining raw IP, email, or user IDs', async () => {
     const rawIdentifier = 'ip:203.0.113.10';
     const first = await hashRateLimitIdentifier(rawIdentifier);
     const second = await hashRateLimitIdentifier(rawIdentifier);
@@ -75,6 +75,10 @@ describe('Upstash Rate Limit', () => {
     expect(first).toMatch(/^[a-f0-9]{64}$/u);
     expect(first).not.toContain(rawIdentifier);
     expect(await hashRateLimitIdentifier('user-123')).not.toBe(first);
+    const emailHash = await hashRateLimitIdentifier('email:person@example.com');
+    expect(emailHash).toMatch(/^[a-f0-9]{64}$/u);
+    expect(emailHash).not.toContain('person@example.com');
+    expect(emailHash).not.toBe(first);
   });
 
   it('converts the SDK fail-open timeout result into backend unavailable', () => {
@@ -126,6 +130,119 @@ describe('Upstash Rate Limit', () => {
     });
   });
 
+  it('uses only the Vercel platform IP and ignores spoofed forwarded chains', async () => {
+    const limiter = { limit: vi.fn().mockResolvedValue(allowedResult) };
+    const firstRequest = new Request('https://app.dayopt.app/api/auth', {
+      headers: {
+        'x-real-ip': '203.0.113.10',
+        'x-forwarded-for': '198.51.100.1',
+      },
+    });
+    const secondRequest = new Request('https://app.dayopt.app/api/auth', {
+      headers: {
+        'x-real-ip': '203.0.113.10',
+        'x-forwarded-for': '192.0.2.55',
+      },
+    });
+
+    await withUpstashRateLimit(firstRequest, limiter);
+    await withUpstashRateLimit(secondRequest, limiter);
+
+    expect(limiter.limit).toHaveBeenNthCalledWith(1, 'ip:203.0.113.10');
+    expect(limiter.limit).toHaveBeenNthCalledWith(2, 'ip:203.0.113.10');
+  });
+
+  it('uses one shared unknown bucket when the platform IP is missing or invalid', async () => {
+    const limiter = { limit: vi.fn().mockResolvedValue(allowedResult) };
+    const forwardedOnly = new Request('https://app.dayopt.app/api/auth', {
+      headers: { 'x-forwarded-for': '203.0.113.10' },
+    });
+    const invalidPlatformIp = new Request('https://app.dayopt.app/api/auth', {
+      headers: {
+        'x-real-ip': 'invalid',
+        'x-forwarded-for': '198.51.100.20',
+      },
+    });
+
+    await withUpstashRateLimit(forwardedOnly, limiter);
+    await withUpstashRateLimit(invalidPlatformIp, limiter);
+
+    expect(limiter.limit).toHaveBeenNthCalledWith(1, 'ip:unknown');
+    expect(limiter.limit).toHaveBeenNthCalledWith(2, 'ip:unknown');
+  });
+
+  it('checks an independent account bucket only after the IP bucket allows the request', async () => {
+    const limiter = { limit: vi.fn().mockResolvedValue(allowedResult) };
+    const request = new Request('https://app.dayopt.app/api/auth', {
+      headers: { 'x-real-ip': '203.0.113.10' },
+    });
+
+    await withUpstashRateLimit(request, limiter, 'email:person@example.com');
+
+    expect(limiter.limit).toHaveBeenNthCalledWith(1, 'ip:203.0.113.10');
+    expect(limiter.limit).toHaveBeenNthCalledWith(2, 'email:person@example.com');
+  });
+
+  it('reuses the account bucket across changing platform IPs and returns its denial', async () => {
+    const deniedResult = { ...allowedResult, success: false, remaining: 0 };
+    const limiter = {
+      limit: vi
+        .fn()
+        .mockResolvedValueOnce(allowedResult)
+        .mockResolvedValueOnce(allowedResult)
+        .mockResolvedValueOnce(allowedResult)
+        .mockResolvedValueOnce(deniedResult),
+    };
+    const firstRequest = new Request('https://app.dayopt.app/api/auth', {
+      headers: { 'x-real-ip': '203.0.113.10' },
+    });
+    const secondRequest = new Request('https://app.dayopt.app/api/auth', {
+      headers: { 'x-real-ip': '198.51.100.20' },
+    });
+
+    await withUpstashRateLimit(firstRequest, limiter, 'email:person@example.com');
+    await expect(
+      withUpstashRateLimit(secondRequest, limiter, 'email:person@example.com'),
+    ).resolves.toMatchObject({ state: 'checked', success: false, remaining: 0 });
+
+    expect(limiter.limit).toHaveBeenNthCalledWith(1, 'ip:203.0.113.10');
+    expect(limiter.limit).toHaveBeenNthCalledWith(2, 'email:person@example.com');
+    expect(limiter.limit).toHaveBeenNthCalledWith(3, 'ip:198.51.100.20');
+    expect(limiter.limit).toHaveBeenNthCalledWith(4, 'email:person@example.com');
+  });
+
+  it('does not consume the account bucket after the IP bucket denies the request', async () => {
+    const deniedResult = { ...allowedResult, success: false, remaining: 0 };
+    const limiter = { limit: vi.fn().mockResolvedValue(deniedResult) };
+    const request = new Request('https://app.dayopt.app/api/auth', {
+      headers: { 'x-real-ip': '203.0.113.10' },
+    });
+
+    await expect(
+      withUpstashRateLimit(request, limiter, 'email:person@example.com'),
+    ).resolves.toMatchObject({ state: 'checked', success: false, remaining: 0 });
+    expect(limiter.limit).toHaveBeenCalledOnce();
+  });
+
+  it('fails closed when the account bucket backend check fails', async () => {
+    const backendError = new Error('secondary bucket unavailable');
+    const limiter = {
+      limit: vi.fn().mockResolvedValueOnce(allowedResult).mockRejectedValueOnce(backendError),
+    };
+    const request = new Request('https://app.dayopt.app/api/auth', {
+      headers: { 'x-real-ip': '203.0.113.10' },
+    });
+
+    await expect(
+      withUpstashRateLimit(request, limiter, 'email:person@example.com'),
+    ).resolves.toEqual({ state: 'unavailable' });
+    expect(mocks.captureUnexpectedError).toHaveBeenCalledWith(backendError, {
+      feature: 'rate_limit',
+      operation: 'upstash_rate_limit_check',
+      source: 'upstash',
+    });
+  });
+
   it('constructs every enabled limiter with no analytics, a 2 second timeout, and hashed keys', async () => {
     vi.resetModules();
     const constructorOptions: Array<Record<string, unknown>> = [];
@@ -161,9 +278,15 @@ describe('Upstash Rate Limit', () => {
     }
 
     await enabledModule.loginRateLimit?.limit('ip:203.0.113.10');
-    const persistedIdentifier = limit.mock.calls.at(-1)?.[0];
-    expect(persistedIdentifier).toMatch(/^[a-f0-9]{64}$/u);
-    expect(persistedIdentifier).not.toContain('203.0.113.10');
+    const persistedIpIdentifier = limit.mock.calls.at(-1)?.[0];
+    expect(persistedIpIdentifier).toMatch(/^[a-f0-9]{64}$/u);
+    expect(persistedIpIdentifier).not.toContain('203.0.113.10');
+
+    await enabledModule.loginRateLimit?.limit('email:person@example.com');
+    const persistedEmailIdentifier = limit.mock.calls.at(-1)?.[0];
+    expect(persistedEmailIdentifier).toMatch(/^[a-f0-9]{64}$/u);
+    expect(persistedEmailIdentifier).not.toContain('person@example.com');
+    expect(persistedEmailIdentifier).not.toBe(persistedIpIdentifier);
   });
 
   it('keeps documented presets and cost constants stable', () => {

--- a/apps/product/src/lib/rate-limit/upstash.ts
+++ b/apps/product/src/lib/rate-limit/upstash.ts
@@ -314,18 +314,21 @@ type RateLimitCheckResult =
 export async function withUpstashRateLimit(
   request: Request,
   rateLimit: ProductRateLimiter | null,
+  additionalIdentifier?: string,
 ): Promise<RateLimitCheckResult> {
   if (!rateLimit) {
     return { state: 'disabled' };
   }
 
-  // クライアント識別子取得
-  const identifier = getClientIdentifier(request);
+  const ipIdentifier = getClientIdentifier(request);
 
   try {
-    // レート制限チェック
-    const { success, limit, remaining, reset, pending } = await rateLimit.limit(identifier);
-    return { state: 'checked', success, limit, remaining, reset, pending };
+    // IPを先に評価し、遮断済みIPからaccount bucketを消費させない。
+    const ipResult = toCheckedRateLimitResult(await rateLimit.limit(ipIdentifier));
+    if (!ipResult.success || additionalIdentifier === undefined) return ipResult;
+
+    // IPとaccount/emailは結合せず、独立したbucketとして同じquotaを適用する。
+    return toCheckedRateLimitResult(await rateLimit.limit(additionalIdentifier));
   } catch (error) {
     logger.error('[RateLimit] Upstash rate limit check failed');
     const original = error instanceof Error ? error : new Error('Upstash rate limit check failed');
@@ -338,16 +341,20 @@ export async function withUpstashRateLimit(
   }
 }
 
+function toCheckedRateLimitResult(
+  result: RatelimitResponse,
+): Extract<RateLimitCheckResult, { state: 'checked' }> {
+  const { success, limit, remaining, reset, pending } = result;
+  return { state: 'checked', success, limit, remaining, reset, pending };
+}
+
 /**
  * クライアント識別子の取得
- * 公開requestは検証済みIPを使い、limiter factory内でSHA-256化する。
+ * 公開requestは検証済みIPを使い、limiter factory内でHMAC-SHA-256化する。
  */
 function getClientIdentifier(request: Request): string {
-  // IPアドレスをフォールバック
-  const ip = extractClientIp(
-    request.headers.get('x-forwarded-for'),
-    request.headers.get('x-real-ip'),
-  );
+  // Vercelが上書きするX-Real-IPだけを信頼する。別CDNを追加する場合は再評価する。
+  const ip = extractClientIp(request.headers.get('x-real-ip'));
 
   return `ip:${ip}`;
 }

--- a/apps/product/src/lib/security/__tests__/ip-validation.test.ts
+++ b/apps/product/src/lib/security/__tests__/ip-validation.test.ts
@@ -2,7 +2,7 @@
  * IP Validation Unit Tests
  *
  * IPアドレス検証ユーティリティのテスト
- * OWASP推奨のX-Forwarded-Forヘッダー検証
+ * Vercel由来IPの検証
  */
 
 import { describe, expect, it } from 'vitest';
@@ -65,62 +65,37 @@ describe('IP Validation', () => {
   });
 
   describe('extractClientIp', () => {
-    describe('X-Real-IP priority', () => {
-      it('should prefer X-Real-IP when valid', () => {
-        const result = extractClientIp('192.168.1.1, 10.0.0.1', '8.8.8.8');
-        expect(result).toBe('8.8.8.8');
+    describe('Vercel X-Real-IP', () => {
+      it('should accept valid IPv4 and IPv6 addresses', () => {
+        expect(extractClientIp('8.8.8.8')).toBe('8.8.8.8');
+        expect(extractClientIp('2001:db8:85a3::8a2e:370:7334')).toBe(
+          '2001:db8:85a3::8a2e:370:7334',
+        );
       });
 
-      it('should ignore invalid X-Real-IP', () => {
-        const result = extractClientIp('192.168.1.1', 'invalid');
-        expect(result).toBe('192.168.1.1');
-      });
-    });
-
-    describe('X-Forwarded-For parsing', () => {
-      it('should extract first valid IP from X-Forwarded-For', () => {
-        const result = extractClientIp('203.0.113.195, 70.41.3.18, 150.172.238.178', null);
-        expect(result).toBe('203.0.113.195');
-      });
-
-      it('should skip invalid IPs in chain', () => {
-        const result = extractClientIp('invalid, 192.168.1.1, 10.0.0.1', null);
-        expect(result).toBe('192.168.1.1');
-      });
-
-      it('should handle single IP', () => {
-        const result = extractClientIp('192.168.1.100', null);
-        expect(result).toBe('192.168.1.100');
-      });
-
-      it('should handle extra whitespace', () => {
-        const result = extractClientIp('  192.168.1.1  ,  10.0.0.1  ', null);
-        expect(result).toBe('192.168.1.1');
+      it('should trim a valid platform IP', () => {
+        expect(extractClientIp(' 203.0.113.195 ')).toBe('203.0.113.195');
       });
     });
 
     describe('Edge cases', () => {
-      it('should return unknown for null/undefined inputs', () => {
-        expect(extractClientIp(null, null)).toBe('unknown');
-        expect(extractClientIp(undefined, undefined)).toBe('unknown');
+      it('should return unknown for null, undefined, and empty values', () => {
+        expect(extractClientIp(null)).toBe('unknown');
+        expect(extractClientIp(undefined)).toBe('unknown');
+        expect(extractClientIp('')).toBe('unknown');
       });
 
-      it('should return unknown for empty string', () => {
-        expect(extractClientIp('', '')).toBe('unknown');
-      });
-
-      it('should return unknown when all IPs are invalid', () => {
-        expect(extractClientIp('invalid1, invalid2', 'also-invalid')).toBe('unknown');
+      it('should reject invalid and comma-separated values', () => {
+        expect(extractClientIp('invalid')).toBe('unknown');
+        expect(extractClientIp('203.0.113.195, 70.41.3.18')).toBe('unknown');
       });
     });
 
     describe('Security: Header injection prevention', () => {
       it('should reject malicious header values', () => {
-        // 攻撃者がヘッダーを偽装しようとするケース
-        expect(extractClientIp('"><script>alert(1)</script>', null)).toBe('unknown');
-        expect(extractClientIp("'; DROP TABLE users;--", null)).toBe('unknown');
-        // 改行を含む文字列は有効なIPとして認識しない（セキュリティ上正しい動作）
-        expect(extractClientIp('192.168.1.1\r\nX-Injected: malicious', null)).toBe('unknown');
+        expect(extractClientIp('"><script>alert(1)</script>')).toBe('unknown');
+        expect(extractClientIp("'; DROP TABLE users;--")).toBe('unknown');
+        expect(extractClientIp('192.168.1.1\r\nX-Injected: malicious')).toBe('unknown');
       });
     });
   });
@@ -223,27 +198,16 @@ describe('IP Validation', () => {
   });
 
   describe('Integration: Common usage patterns', () => {
-    it('should handle typical proxy chain', () => {
-      // クライアント -> プロキシ1 -> プロキシ2 -> サーバー
-      const xff = '203.0.113.195, 70.41.3.18, 150.172.238.178';
-
-      const clientIp = extractClientIp(xff, null);
-      expect(clientIp).toBe('203.0.113.195');
+    it('should handle the Vercel platform IP', () => {
+      const realIp = '203.0.113.195';
+      const clientIp = extractClientIp(realIp);
+      expect(clientIp).toBe(realIp);
       expect(isValidIpAddress(clientIp)).toBe(true);
       expect(isPrivateIp(clientIp)).toBe(false);
     });
 
-    it('should handle Cloudflare/CDN setup', () => {
-      // CDNが設定するX-Real-IP
-      const realIp = '203.0.113.195';
-      const xff = 'internal-proxy, 10.0.0.1';
-
-      const clientIp = extractClientIp(xff, realIp);
-      expect(clientIp).toBe(realIp);
-    });
-
     it('should handle local development', () => {
-      const clientIp = extractClientIp(null, '127.0.0.1');
+      const clientIp = extractClientIp('127.0.0.1');
       expect(clientIp).toBe('127.0.0.1');
       expect(isPrivateIp(clientIp)).toBe(true);
     });

--- a/apps/product/src/lib/security/ip-validation.ts
+++ b/apps/product/src/lib/security/ip-validation.ts
@@ -1,8 +1,7 @@
 /**
  * IP Address Validation Utilities
  *
- * X-Forwarded-Forヘッダーインジェクション対策
- * OWASP推奨のIP検証を実装
+ * プラットフォーム由来IPの検証を実装
  *
  * @see https://owasp.org/www-community/attacks/Web_Parameter_Tampering
  */
@@ -34,36 +33,16 @@ export function isValidIpAddress(ip: string): boolean {
 }
 
 /**
- * X-Forwarded-Forヘッダーから安全にクライアントIPを抽出
+ * Vercel edgeが上書きするX-Real-IPだけを接続元IPとして採用する。
+ * X-Forwarded-Forはプロキシ構成によって攻撃者入力を含み得るため解析しない。
+ * この信頼境界はVercel単独topologyが前提であり、別CDN追加時は再評価が必要。
  *
- * X-Forwarded-For形式: "client, proxy1, proxy2"
- * - 最初のIPがクライアントIPだが、偽装可能
- * - 各IPを検証し、最初の有効なIPを返す
- * - 無効なIPは除外
- *
- * @param forwardedFor X-Forwarded-Forヘッダー値
- * @param realIp X-Real-IPヘッダー値（フォールバック）
+ * @param realIp Vercel由来のX-Real-IPヘッダー値
  * @returns 検証済みIPアドレス、または 'unknown'
  */
-export function extractClientIp(
-  forwardedFor: string | null | undefined,
-  realIp?: string | null,
-): string {
-  // X-Real-IPを優先（単一IP、プロキシ設定済み）
+export function extractClientIp(realIp?: string | null): string {
   if (realIp && isValidIpAddress(realIp)) {
     return realIp.trim();
-  }
-
-  // X-Forwarded-Forを解析
-  if (forwardedFor) {
-    const ips = forwardedFor.split(',').map((ip) => ip.trim());
-
-    // 最初の有効なIPを返す
-    for (const ip of ips) {
-      if (isValidIpAddress(ip)) {
-        return ip;
-      }
-    }
   }
 
   return 'unknown';

--- a/apps/product/src/lib/test/integration/gdpr.integration.test.ts
+++ b/apps/product/src/lib/test/integration/gdpr.integration.test.ts
@@ -162,6 +162,7 @@ describe.skipIf(SKIP_INTEGRATION)('GDPR Router Integration', () => {
       } as unknown as Context['res'],
       userId: TEST_USER_ID,
       sessionId: 'test-session-id',
+      mfaAssurance: { currentLevel: 'aal1', nextLevel: 'aal1' },
       supabase: supabase,
       authMode: 'session' as const,
     };
@@ -299,6 +300,7 @@ describe.skipIf(SKIP_INTEGRATION)('GDPR Router Integration', () => {
         } as unknown as Context['res'],
         userId: deleteTestUserId,
         sessionId: 'delete-test-session-id',
+        mfaAssurance: { currentLevel: 'aal1', nextLevel: 'aal1' },
         supabase: deleteTestSupabase,
         authMode: 'session' as const,
       };

--- a/apps/product/src/lib/test/integration/tags.integration.test.ts
+++ b/apps/product/src/lib/test/integration/tags.integration.test.ts
@@ -125,6 +125,7 @@ describe.skipIf(SKIP_INTEGRATION)('Tags Router Integration', () => {
       } as unknown as Context['res'],
       userId: TEST_USER_ID,
       sessionId: 'test-session-id',
+      mfaAssurance: { currentLevel: 'aal1', nextLevel: 'aal1' },
       supabase: supabase,
       authMode: 'session' as const,
     };

--- a/apps/product/src/lib/test/integration/user-settings.integration.test.ts
+++ b/apps/product/src/lib/test/integration/user-settings.integration.test.ts
@@ -96,6 +96,7 @@ describe.skipIf(SKIP_INTEGRATION)('UserSettings Router Integration', () => {
       } as unknown as Context['res'],
       userId: TEST_USER_ID,
       sessionId: 'test-session-id',
+      mfaAssurance: { currentLevel: 'aal1', nextLevel: 'aal1' },
       supabase: supabase,
       authMode: 'session' as const,
     };

--- a/apps/product/src/lib/test/trpc-test-helpers.ts
+++ b/apps/product/src/lib/test/trpc-test-helpers.ts
@@ -102,6 +102,10 @@ export function createMockContext(options: MockContextOptions = {}): Context {
   } = options;
 
   const mockSupabase = createMockSupabase(supabaseOverrides);
+  const resolvedMfaAssurance =
+    authMode === 'session' && userId && mfaAssurance === undefined
+      ? { currentLevel: 'aal1' as const, nextLevel: 'aal1' as const }
+      : mfaAssurance;
 
   return {
     req: {
@@ -117,7 +121,7 @@ export function createMockContext(options: MockContextOptions = {}): Context {
     sessionId,
     oauthClientId,
     oauthScopes,
-    mfaAssurance,
+    mfaAssurance: resolvedMfaAssurance,
     supabase: mockSupabase as unknown as SupabaseClient<Database>,
     authMode,
   };

--- a/apps/product/src/lib/trpc/__tests__/context-parity.test.ts
+++ b/apps/product/src/lib/trpc/__tests__/context-parity.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  capturedContexts: [] as unknown[],
+  createServerClient: vi.fn(),
+  createServerSideHelpers: vi.fn(),
+  observeAuthOperation: vi.fn(),
+}));
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react')>();
+  return { ...actual, cache: <TFunction>(fn: TFunction) => fn };
+});
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn().mockResolvedValue({ getAll: vi.fn().mockReturnValue([]), set: vi.fn() }),
+}));
+
+vi.mock('@supabase/ssr', () => ({
+  createServerClient: mocks.createServerClient,
+}));
+
+vi.mock('@trpc/react-query/server', () => ({
+  createServerSideHelpers: mocks.createServerSideHelpers,
+}));
+
+vi.mock('@/env', () => ({
+  env: {
+    NEXT_PUBLIC_SUPABASE_URL: 'https://example.supabase.co',
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: 'test-anon-key',
+  },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('@/lib/mcp/auth', () => ({
+  extractBearerToken: vi.fn(),
+  verifyAccessToken: vi.fn(),
+}));
+
+vi.mock('@/lib/oauth-server', () => ({
+  OAuthServerError: class OAuthServerError extends Error {},
+}));
+
+vi.mock('@/lib/sentry', () => ({
+  captureUnexpectedError: vi.fn(),
+  observeAuthOperation: mocks.observeAuthOperation,
+}));
+
+vi.mock('@/lib/supabase/oauth', () => ({
+  createServiceRoleClient: vi.fn(),
+  detectAuthMode: () => 'session',
+}));
+
+vi.mock('@/lib/trpc/root', () => ({ appRouter: {} }));
+
+import { createFetchTRPCContext } from '../context';
+import { createServerHelpers } from '../server';
+
+describe('HTTP/RSC tRPC context parity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.capturedContexts.length = 0;
+    mocks.observeAuthOperation.mockImplementation(
+      (_operation: string, call: () => PromiseLike<unknown>) => call(),
+    );
+    mocks.createServerSideHelpers.mockImplementation((options: { ctx: unknown }) => {
+      mocks.capturedContexts.push(options.ctx);
+      return {};
+    });
+  });
+
+  it('populates identical MFA assurance data in HTTP and RSC contexts', async () => {
+    const supabase = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: 'user-1' } },
+          error: null,
+        }),
+        getSession: vi.fn().mockResolvedValue({
+          data: { session: { access_token: 'session-token' } },
+          error: null,
+        }),
+        mfa: {
+          getAuthenticatorAssuranceLevel: vi.fn().mockResolvedValue({
+            data: { currentLevel: 'aal1', nextLevel: 'aal2' },
+            error: null,
+          }),
+        },
+      },
+    };
+    mocks.createServerClient.mockReturnValue(supabase);
+
+    const httpContext = await createFetchTRPCContext({
+      req: new Request('https://app.dayopt.app/api/trpc'),
+      resHeaders: new Headers(),
+    } as never);
+    await createServerHelpers();
+
+    const rscContext = mocks.capturedContexts.at(-1) as {
+      userId?: string;
+      sessionId?: string;
+      mfaAssurance?: unknown;
+    };
+    expect(rscContext).toMatchObject({
+      userId: httpContext.userId,
+      sessionId: httpContext.sessionId,
+      mfaAssurance: httpContext.mfaAssurance,
+    });
+    expect(mocks.observeAuthOperation.mock.calls.map(([operation]) => operation)).toEqual([
+      'trpc_context_get_user',
+      'trpc_context_get_session',
+      'trpc_context_get_authenticator_assurance_level',
+      'rsc_trpc_get_user',
+      'rsc_trpc_get_session',
+      'rsc_trpc_get_authenticator_assurance_level',
+    ]);
+  });
+});

--- a/apps/product/src/lib/trpc/__tests__/pro-procedure.test.ts
+++ b/apps/product/src/lib/trpc/__tests__/pro-procedure.test.ts
@@ -42,6 +42,7 @@ function createProTestContext(
     res: { setHeader: () => {}, end: () => {} },
     userId,
     sessionId: 'test-session',
+    mfaAssurance: { currentLevel: 'aal1' as const, nextLevel: 'aal1' as const },
     supabase,
     authMode: 'session' as const,
   };
@@ -108,6 +109,7 @@ describe('proProcedure', () => {
         res: { setHeader: () => {}, end: () => {} },
         userId: 'test-user-id',
         sessionId: 'test-session',
+        mfaAssurance: { currentLevel: 'aal1' as const, nextLevel: 'aal1' as const },
         supabase,
         authMode: 'session' as const,
       };

--- a/apps/product/src/lib/trpc/__tests__/session-auth-context.test.ts
+++ b/apps/product/src/lib/trpc/__tests__/session-auth-context.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  loggerWarn: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { warn: mocks.loggerWarn },
+}));
+
+vi.mock('@/lib/sentry', () => ({
+  observeAuthOperation: (_operation: string, call: () => PromiseLike<unknown>) => call(),
+}));
+
+import { resolveSessionAuthContext } from '../session-auth-context';
+
+function createSupabaseMock(options: {
+  user?: { id: string } | null;
+  userError?: unknown;
+  sessionResult?: unknown;
+  sessionError?: unknown;
+  mfaData?: { currentLevel: unknown; nextLevel: unknown } | null | undefined;
+  mfaError?: unknown;
+}) {
+  const getSession = vi.fn();
+  if (options.sessionError instanceof Error) {
+    getSession.mockRejectedValue(options.sessionError);
+  } else {
+    getSession.mockResolvedValue({
+      data: {
+        session:
+          options.sessionResult === undefined
+            ? { access_token: 'session-token' }
+            : options.sessionResult,
+      },
+      error: options.sessionError ?? null,
+    });
+  }
+
+  const getAuthenticatorAssuranceLevel = vi.fn();
+  if (options.mfaError instanceof Error) {
+    getAuthenticatorAssuranceLevel.mockRejectedValue(options.mfaError);
+  } else {
+    getAuthenticatorAssuranceLevel.mockResolvedValue({
+      data:
+        options.mfaData === undefined
+          ? { currentLevel: 'aal1', nextLevel: 'aal1' }
+          : options.mfaData,
+      error: options.mfaError ?? null,
+    });
+  }
+
+  return {
+    client: {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: options.user === undefined ? { id: 'user-1' } : options.user },
+          error: options.userError ?? null,
+        }),
+        getSession,
+        mfa: { getAuthenticatorAssuranceLevel },
+      },
+    },
+    getSession,
+    getAuthenticatorAssuranceLevel,
+  };
+}
+
+describe('resolveSessionAuthContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('skips session and MFA lookups when no verified user exists', async () => {
+    const { client, getSession, getAuthenticatorAssuranceLevel } = createSupabaseMock({
+      user: null,
+    });
+
+    await expect(resolveSessionAuthContext(client as never, 'trpc_context')).resolves.toEqual({});
+    expect(getSession).not.toHaveBeenCalled();
+    expect(getAuthenticatorAssuranceLevel).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { currentLevel: 'aal1', nextLevel: 'aal1' },
+    { currentLevel: 'aal1', nextLevel: 'aal2' },
+    { currentLevel: 'aal2', nextLevel: 'aal2' },
+  ])('returns a valid $currentLevel -> $nextLevel assurance pair', async (mfaData) => {
+    const { client } = createSupabaseMock({ mfaData });
+
+    await expect(resolveSessionAuthContext(client as never, 'trpc_context')).resolves.toEqual({
+      userId: 'user-1',
+      sessionId: 'session-token',
+      mfaAssurance: mfaData,
+    });
+  });
+
+  it.each([
+    {
+      label: 'no enrolled factor',
+      mfaData: { currentLevel: null, nextLevel: null },
+      expected: { currentLevel: 'aal1', nextLevel: 'aal1' },
+    },
+    {
+      label: 'an enrolled factor',
+      mfaData: { currentLevel: null, nextLevel: 'aal2' },
+      expected: { currentLevel: 'aal1', nextLevel: 'aal2' },
+    },
+  ])('normalizes a missing current AAL claim for $label', async ({ mfaData, expected }) => {
+    const { client } = createSupabaseMock({ mfaData });
+
+    await expect(resolveSessionAuthContext(client as never, 'trpc_context')).resolves.toMatchObject(
+      {
+        mfaAssurance: expected,
+      },
+    );
+  });
+
+  it('continues the MFA lookup after the session token lookup throws', async () => {
+    const { client, getAuthenticatorAssuranceLevel } = createSupabaseMock({
+      sessionError: new Error('session unavailable'),
+      mfaData: { currentLevel: 'aal1', nextLevel: 'aal2' },
+    });
+
+    await expect(resolveSessionAuthContext(client as never, 'rsc_trpc')).resolves.toEqual({
+      userId: 'user-1',
+      sessionId: undefined,
+      mfaAssurance: { currentLevel: 'aal1', nextLevel: 'aal2' },
+    });
+    expect(getAuthenticatorAssuranceLevel).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { label: 'returned error', mfaError: { message: 'lookup failed' } },
+    { label: 'thrown error', mfaError: new Error('lookup failed') },
+    { label: 'null data', mfaData: null },
+    { label: 'unknown level', mfaData: { currentLevel: 'aal3', nextLevel: 'aal3' } },
+    { label: 'invalid downgrade', mfaData: { currentLevel: 'aal2', nextLevel: 'aal1' } },
+  ])('fails closed for $label', async ({ mfaData, mfaError }) => {
+    const { client } = createSupabaseMock({ mfaData, mfaError });
+
+    await expect(resolveSessionAuthContext(client as never, 'trpc_context')).resolves.toMatchObject(
+      {
+        userId: 'user-1',
+        mfaAssurance: { currentLevel: null, nextLevel: null, lookupFailed: true },
+      },
+    );
+  });
+});

--- a/apps/product/src/lib/trpc/context.ts
+++ b/apps/product/src/lib/trpc/context.ts
@@ -15,8 +15,9 @@ import { type Database } from '@/lib/database';
 import { logger } from '@/lib/logger';
 import { extractBearerToken, verifyAccessToken } from '@/lib/mcp/auth';
 import { OAuthServerError, type OAuthClientId, type SupportedScope } from '@/lib/oauth-server';
-import { captureUnexpectedError, observeAuthOperation } from '@/lib/sentry';
+import { captureUnexpectedError } from '@/lib/sentry';
 import { AuthMode, createServiceRoleClient, detectAuthMode } from '@/lib/supabase/oauth';
+import { resolveSessionAuthContext, type MfaAssurance } from '@/lib/trpc/session-auth-context';
 
 /**
  * リクエストコンテキストの型定義
@@ -36,8 +37,6 @@ export interface TrpcResponseLike {
   end?: (...args: unknown[]) => void;
 }
 
-type MfaAssuranceLevel = 'aal1' | 'aal2';
-
 /** tRPCプロシージャのコンテキスト型 */
 export interface Context {
   req: TrpcRequestLike;
@@ -54,13 +53,7 @@ export interface Context {
   /** 検証済み OAuth scopes（oauth modeの場合のみ） */
   oauthScopes?: SupportedScope[] | undefined;
   /** Supabase Auth MFA assurance level（session modeの場合のみ） */
-  mfaAssurance?:
-    | {
-        currentLevel: MfaAssuranceLevel | null;
-        nextLevel: MfaAssuranceLevel | null;
-        lookupFailed?: boolean | undefined;
-      }
-    | undefined;
+  mfaAssurance?: MfaAssurance | undefined;
   /** JWTカスタムクレームから取得したサブスクリプション状態（custom_access_token hook） */
   subscriptionStatus?: string | undefined;
 }
@@ -181,51 +174,10 @@ async function createTRPCContext(opts: {
       },
     );
 
-    try {
-      // getUser()はSupabase Authサーバーに問い合わせてJWTを検証する（getSession()は署名未検証）
-      const {
-        data: { user },
-      } = await observeAuthOperation('trpc_context_get_user', () => supabase.auth.getUser());
-
-      if (user) {
-        userId = user.id;
-        // セッションからアクセストークンを取得（ログ・追跡用）
-        try {
-          const {
-            data: { session },
-          } = await observeAuthOperation('trpc_context_get_session', () =>
-            supabase.auth.getSession(),
-          );
-          sessionId = session?.access_token;
-        } catch {
-          logger.warn('Session token lookup failed');
-        }
-
-        try {
-          const { data: aalData, error: aalError } = await observeAuthOperation(
-            'trpc_context_get_authenticator_assurance_level',
-            () => supabase.auth.mfa.getAuthenticatorAssuranceLevel(),
-          );
-          mfaAssurance = {
-            currentLevel: normalizeMfaAssuranceLevel(aalData?.currentLevel),
-            nextLevel: normalizeMfaAssuranceLevel(aalData?.nextLevel),
-            lookupFailed: Boolean(aalError),
-          };
-          if (aalError) {
-            logger.warn('MFA assurance lookup failed');
-          }
-        } catch {
-          mfaAssurance = {
-            currentLevel: null,
-            nextLevel: null,
-            lookupFailed: true,
-          };
-          logger.warn('MFA assurance lookup threw');
-        }
-      }
-    } catch {
-      // 認証エラーは無視（ゲストユーザーとして扱う）
-    }
+    const sessionAuthContext = await resolveSessionAuthContext(supabase, 'trpc_context');
+    userId = sessionAuthContext.userId;
+    sessionId = sessionAuthContext.sessionId;
+    mfaAssurance = sessionAuthContext.mfaAssurance;
   }
 
   // JWTカスタムクレームからsubscription_statusを取得（custom_access_token hook）
@@ -309,8 +261,4 @@ function parseCookieHeader(cookieHeader: string | null): Record<string, string> 
   }
 
   return cookies;
-}
-
-function normalizeMfaAssuranceLevel(level: unknown): MfaAssuranceLevel | null {
-  return level === 'aal1' || level === 'aal2' ? level : null;
 }

--- a/apps/product/src/lib/trpc/procedures.ts
+++ b/apps/product/src/lib/trpc/procedures.ts
@@ -16,6 +16,7 @@ import { trpcUserRateLimit } from '@/lib/rate-limit/upstash';
 import { captureUnexpectedDatabaseError, captureUnexpectedError } from '@/lib/sentry';
 import { ServiceError } from '@/lib/trpc/errors';
 import { createCallerFactory, createTRPCRouter, mergeRouters, t } from '@/lib/trpc/router';
+import { isValidMfaAssuranceTransition } from '@/lib/trpc/session-auth-context';
 export type { Context } from '@/lib/trpc/context';
 const USER_RATE_LIMIT = 100;
 const USER_RATE_WINDOW_MS = 60 * 1000;
@@ -95,7 +96,12 @@ export const protectedProcedure = t.procedure
     }
 
     if (ctx.authMode === 'session') {
-      if (ctx.mfaAssurance?.lookupFailed) {
+      const mfaAssurance = ctx.mfaAssurance;
+      if (
+        !mfaAssurance ||
+        mfaAssurance.lookupFailed ||
+        !isValidMfaAssuranceTransition(mfaAssurance.currentLevel, mfaAssurance.nextLevel)
+      ) {
         throw new TRPCError({
           code: 'FORBIDDEN',
           message: 'MFA verification required',
@@ -105,8 +111,8 @@ export const protectedProcedure = t.procedure
 
       if (
         !MFA_CHALLENGE_TRPC_PATHS.has(path) &&
-        ctx.mfaAssurance?.currentLevel === 'aal1' &&
-        ctx.mfaAssurance.nextLevel === 'aal2'
+        mfaAssurance.currentLevel === 'aal1' &&
+        mfaAssurance.nextLevel === 'aal2'
       ) {
         throw new TRPCError({
           code: 'FORBIDDEN',

--- a/apps/product/src/lib/trpc/server.ts
+++ b/apps/product/src/lib/trpc/server.ts
@@ -34,9 +34,9 @@ import superjson from 'superjson';
 
 import { env } from '@/env';
 import type { Database } from '@/lib/database';
-import { observeAuthOperation } from '@/lib/sentry';
 import type { Context } from '@/lib/trpc/context';
 import { appRouter } from '@/lib/trpc/root';
+import { resolveSessionAuthContext } from '@/lib/trpc/session-auth-context';
 
 // Re-export for convenience
 export { dehydrate, HydrationBoundary };
@@ -74,26 +74,7 @@ async function createSupabaseServerClient() {
  */
 async function createServerContext(): Promise<Context> {
   const supabase = await createSupabaseServerClient();
-
-  let userId: string | undefined;
-  let sessionId: string | undefined;
-
-  try {
-    // getUser()はSupabase Authサーバーに問い合わせてJWTを検証する
-    const {
-      data: { user },
-    } = await observeAuthOperation('rsc_trpc_get_user', () => supabase.auth.getUser());
-
-    if (user) {
-      userId = user.id;
-      const {
-        data: { session },
-      } = await observeAuthOperation('rsc_trpc_get_session', () => supabase.auth.getSession());
-      sessionId = session?.access_token;
-    }
-  } catch {
-    // Server Component での認証エラーは無視
-  }
+  const { userId, sessionId, mfaAssurance } = await resolveSessionAuthContext(supabase, 'rsc_trpc');
 
   // Server Componentではreq/resは不要なのでダミーを渡す
   return {
@@ -101,6 +82,7 @@ async function createServerContext(): Promise<Context> {
     res: {} as Context['res'],
     userId,
     sessionId,
+    mfaAssurance,
     supabase,
     authMode: 'session' as const, // Server Componentは常にsession認証
   };

--- a/apps/product/src/lib/trpc/session-auth-context.ts
+++ b/apps/product/src/lib/trpc/session-auth-context.ts
@@ -1,0 +1,110 @@
+import 'server-only';
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import type { Database } from '@/lib/database';
+import { logger } from '@/lib/logger';
+import { observeAuthOperation } from '@/lib/sentry';
+
+export type MfaAssuranceLevel = 'aal1' | 'aal2';
+
+export interface MfaAssurance {
+  currentLevel: MfaAssuranceLevel | null;
+  nextLevel: MfaAssuranceLevel | null;
+  lookupFailed?: boolean | undefined;
+}
+
+interface SessionAuthContext {
+  userId?: string | undefined;
+  sessionId?: string | undefined;
+  mfaAssurance?: MfaAssurance | undefined;
+}
+
+type SessionAuthOperationPrefix = 'trpc_context' | 'rsc_trpc';
+
+function createFailedMfaAssurance(): MfaAssurance {
+  return {
+    currentLevel: null,
+    nextLevel: null,
+    lookupFailed: true,
+  };
+}
+
+/** SupabaseはAAL claimがない従来sessionをnullで返すため、AAL1として扱う。 */
+function normalizeMfaAssuranceLevel(level: unknown): MfaAssuranceLevel | undefined {
+  if (level === null || level === 'aal1') return 'aal1';
+  if (level === 'aal2') return 'aal2';
+  return undefined;
+}
+
+export function isValidMfaAssuranceTransition(currentLevel: unknown, nextLevel: unknown): boolean {
+  if (currentLevel === 'aal1') return nextLevel === 'aal1' || nextLevel === 'aal2';
+  return currentLevel === 'aal2' && nextLevel === 'aal2';
+}
+
+/** HTTP/RSCのsession contextへ同じ認証情報とfail-closed MFA状態を設定する。 */
+export async function resolveSessionAuthContext(
+  supabase: SupabaseClient<Database>,
+  operationPrefix: SessionAuthOperationPrefix,
+): Promise<SessionAuthContext> {
+  let userId: string | undefined;
+
+  try {
+    // getUser()でAuth serverに問い合わせ、cookie由来JWTを検証する。
+    const {
+      data: { user },
+      error: userError,
+    } = await observeAuthOperation(`${operationPrefix}_get_user`, () => supabase.auth.getUser());
+
+    if (userError || !user) return {};
+    userId = user.id;
+  } catch {
+    // 未検証のuserIdはcontextへ入れず、protectedProcedureでUNAUTHORIZEDにする。
+    return {};
+  }
+
+  let sessionId: string | undefined;
+  try {
+    const {
+      data: { session },
+      error: sessionError,
+    } = await observeAuthOperation(`${operationPrefix}_get_session`, () =>
+      supabase.auth.getSession(),
+    );
+    if (sessionError) {
+      logger.warn('Session token lookup failed');
+    } else {
+      sessionId = session?.access_token;
+    }
+  } catch {
+    // session tokenはログ用であり、失敗しても独立したMFA lookupを継続する。
+    logger.warn('Session token lookup threw');
+  }
+
+  let mfaAssurance: MfaAssurance;
+  try {
+    const { data: aalData, error: aalError } = await observeAuthOperation(
+      `${operationPrefix}_get_authenticator_assurance_level`,
+      () => supabase.auth.mfa.getAuthenticatorAssuranceLevel(),
+    );
+    const currentLevel = normalizeMfaAssuranceLevel(aalData?.currentLevel);
+    const nextLevel = normalizeMfaAssuranceLevel(aalData?.nextLevel);
+
+    if (
+      aalError ||
+      currentLevel === undefined ||
+      nextLevel === undefined ||
+      !isValidMfaAssuranceTransition(currentLevel, nextLevel)
+    ) {
+      logger.warn('MFA assurance lookup failed');
+      mfaAssurance = createFailedMfaAssurance();
+    } else {
+      mfaAssurance = { currentLevel, nextLevel };
+    }
+  } catch {
+    logger.warn('MFA assurance lookup threw');
+    mfaAssurance = createFailedMfaAssurance();
+  }
+
+  return { userId, sessionId, mfaAssurance };
+}

--- a/docs/engineering/infra.md
+++ b/docs/engineering/infra.md
@@ -449,18 +449,18 @@ Product / Webの`src/app/api/**`配下にある主要REST / Webhook endpoint総�
 
 ### 一覧
 
-| App     | Path                       | Method     | 認証                     | Rate Limit               | Runtime                  | 副作用 / 説明                                                                                                  |
-| ------- | -------------------------- | ---------- | ------------------------ | ------------------------ | ------------------------ | -------------------------------------------------------------------------------------------------------------- |
-| Product | `/api/health`              | GET        | なし                     | なし                     | nodejs                   | DB / Upstash Redisの疎通をcheckし`healthy / degraded / unhealthy`を返す。Productionは`{ status }`だけを公開    |
-| Product | `/api/csp-report`          | POST       | なし                     | IP 20/分 + 全体120/分    | nodejs                   | Product originの16 KiB以下のCSP reportだけを検証し、URL queryを除去してSentryへ送信                            |
-| Product | `/api/trpc/[trpc]`         | GET / POST | procedure依存            | procedure依存            | nodejs                   | tRPC procedureのルーティング本体。Contactは認証済み`contact.submit`を使う                                      |
-| Product | `/api/beacon/entry-save`   | POST       | Supabase Auth (Cookie)   | なし                     | nodejs                   | `navigator.sendBeacon()`経由のentry緊急保存                                                                    |
-| Product | `/api/auth`                | GET / POST | mixed                    | login 5/15分、reset 3/時 | nodejs                   | Supabase認証管理                                                                                               |
-| Product | `/api/v1/calendar/[token]` | GET        | token (URL)              | `icalFeedRateLimit`      | nodejs                   | Service Roleで対象userのplansをiCalendar形式へ変換                                                             |
-| Product | `/api/webhooks/resend`     | POST       | Product Resend signature | Redis processing lease   | nodejs (maxDuration 30s) | Product contact failureをPIIなしでSentryへ通知し、既存transactional mailのbounce / complaint suppressionも維持 |
-| Product | `/api/webhooks/stripe`     | POST       | Stripe signature         | なし                     | nodejs (maxDuration 30s) | subscription stateを反映しtransactional emailを送る                                                            |
-| Web     | `/api/contact`             | POST       | CSRF + Turnstile         | IP + Web全体             | nodejs                   | 16 KiB以下のstrict inputをProduction限定でResendへ配送。成功形式は`{ success: true }`                          |
-| Web     | `/api/webhooks/resend`     | POST       | Web Resend signature     | Redis processing lease   | nodejs (maxDuration 15s) | Web contact failureだけをsource tagで所有判定し、PIIなしでSentryへ通知                                         |
+| App     | Path                       | Method     | 認証                     | Rate Limit                                                        | Runtime                  | 副作用 / 説明                                                                                                  |
+| ------- | -------------------------- | ---------- | ------------------------ | ----------------------------------------------------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| Product | `/api/health`              | GET        | なし                     | なし                                                              | nodejs                   | DB / Upstash Redisの疎通をcheckし`healthy / degraded / unhealthy`を返す。Productionは`{ status }`だけを公開    |
+| Product | `/api/csp-report`          | POST       | なし                     | IP 20/分 + 全体120/分                                             | nodejs                   | Product originの16 KiB以下のCSP reportだけを検証し、URL queryを除去してSentryへ送信                            |
+| Product | `/api/trpc/[trpc]`         | GET / POST | procedure依存            | procedure依存                                                     | nodejs                   | tRPC procedureのルーティング本体。Contactは認証済み`contact.submit`を使う                                      |
+| Product | `/api/beacon/entry-save`   | POST       | Supabase Auth (Cookie)   | なし                                                              | nodejs                   | `navigator.sendBeacon()`経由のentry緊急保存                                                                    |
+| Product | `/api/auth`                | GET / POST | mixed                    | signin IP+email 各5/15分、signup IP 5/15分、reset IP+email 各3/時 | nodejs                   | Supabase認証管理。通常UIは現在Supabase Authを直接利用                                                          |
+| Product | `/api/v1/calendar/[token]` | GET        | token (URL)              | `icalFeedRateLimit`                                               | nodejs                   | Service Roleで対象userのplansをiCalendar形式へ変換                                                             |
+| Product | `/api/webhooks/resend`     | POST       | Product Resend signature | Redis processing lease                                            | nodejs (maxDuration 30s) | Product contact failureをPIIなしでSentryへ通知し、既存transactional mailのbounce / complaint suppressionも維持 |
+| Product | `/api/webhooks/stripe`     | POST       | Stripe signature         | なし                                                              | nodejs (maxDuration 30s) | subscription stateを反映しtransactional emailを送る                                                            |
+| Web     | `/api/contact`             | POST       | CSRF + Turnstile         | IP + Web全体                                                      | nodejs                   | 16 KiB以下のstrict inputをProduction限定でResendへ配送。成功形式は`{ success: true }`                          |
+| Web     | `/api/webhooks/resend`     | POST       | Web Resend signature     | Redis processing lease                                            | nodejs (maxDuration 15s) | Web contact failureだけをsource tagで所有判定し、PIIなしでSentryへ通知                                         |
 
 ### 共通方針
 
@@ -483,6 +483,7 @@ Product / Webの`src/app/api/**`配下にある主要REST / Webhook endpoint総�
 - REST 維持の理由に該当しない場合は tRPC を採用
 - 認証必須の endpoint は Supabase server client + Cookie で `getUser()` 検証、または webhook signature 検証
 - 公開requestのrate limit identifierは保存前に不可逆化する。Contact / Auth / CSPはbackend unavailable時にfail-closed、既存tRPC / iCalは定義済みfallbackを維持する
+- AuthのIP identifierはVercelが上書きする`X-Real-IP`だけを検証し、`X-Forwarded-For`を解析しない。欠落・不正値は共有`ip:unknown`、signin / resetはIP-firstで独立した正規化email bucketも確認する。この前提はVercel単独topologyに依存する
 - 副作用はloggerで技術状態だけを追跡し、問い合わせ本文・氏名・email・raw webhook bodyを記録しない
 
 ### 関連ドキュメント

--- a/docs/product/specs/auth.md
+++ b/docs/product/specs/auth.md
@@ -1,7 +1,10 @@
 ---
 status: current
-last_verified: 2026-07-30
+last_verified: 2026-08-01
 code:
+  - apps/product/src/app/api/auth/route.ts
+  - apps/product/src/lib/trpc/session-auth-context.ts
+  - apps/product/src/lib/trpc/procedures.ts
   - apps/product/src/app/api/trpc/_server/_composition/account-deletion-selector.ts
   - apps/product/src/app/api/trpc/_server/_composition/account-deletion-coordinator.ts
   - apps/product/src/features/auth/server/user-service.ts
@@ -22,7 +25,7 @@ Supabase Auth ベースの認証機能。
 - ソーシャルログインは Google のみ。Apple（有料 Developer Program が必須）と Meta（アプリ審査コスト）は不採用（2026-07 決定、[ログ](../log/2026-07-24-social-login-google-only.md)）。本番の provider 設定は Supabase Dashboard が正本
 - 認証メール（signup 確認 / パスワードリセット / メールアドレス変更）は Auth send_email hook → Edge Function `send-auth-email` → Resend で送信する。メールアドレス変更は Secure Email Change により現・新両アドレスへ確認メールを 2 通送る
 - `protectedProcedure` で保護された tRPC procedure が `ctx.userId` でデータアクセスを制限する
-- MFA登録済みで session assurance level が `aal1` のブラウザセッションは、画面遷移だけでなく tRPC API 側でも protected procedure を拒否する
+- MFA登録済みで session assurance level が `aal1` のブラウザセッションは、画面遷移だけでなく HTTP / RSC の両 tRPC context でも protected procedure を拒否する
 - RLS（Row Level Security）によるDBレベルでの認可を併用する
 
 ## ログイン手段によるアカウント操作の分岐
@@ -59,12 +62,25 @@ gateを有効にした後は、同じユーザーの操作をDB内で直列化�
 
 「すべてのデータを削除」の公開入力は、従来どおり`{ confirmText: 'DELETE' }`を維持する。世代番号を使う新しいDB処理は配置するが、このPRでは画面から使わない。
 
+## Auth REST API rate limit
+
+公開 `/api/auth` route は、signin / signup に 5 回 / 15 分、reset-password に 3 回 / 1 時間の制限を持つ。
+
+- 接続元は Vercel edge が上書きする `X-Real-IP` だけを検証して使い、`X-Forwarded-For` は解析しない。Vercel IP が欠落・不正なら全 request を共有 `ip:unknown` bucket に入れて fail closed にする
+- signin と reset-password は IP bucket を先に確認し、通過後に `trim().toLowerCase()` した email の独立 bucket を確認する。IP と email の結合キーにはしない
+- signup は既存どおり IP bucket だけを使う
+- Redis key は `ip:` / `email:` の purpose prefix を付けて HMAC 化し、raw IP / email を保存・記録しない
+- email bucket は同一アカウントへの攻撃を絞る一方、第三者が signin を 15 分、reset を 1 時間制限できる。IP-first の短絡で遮断済み IP から多数の email bucket を消費する攻撃を抑える
+
+Product の通常 UI は現在この route を使わず Supabase Auth を直接呼ぶため、この制限は公開 route の defense-in-depth であり UI 全体の app-side rate limit ではない。Supabase Auth 自身の project-level rate limit は別の backstop として働く。
+
 ## tRPC API auth policy
 
 `/api/trpc` は middleware/proxy を通らないため、API gate 自体で認証状態を再評価する。
 
-- Session cookie mode: Supabase Auth の `getUser()` でユーザーを検証し、MFA登録済み `aal1 -> aal2` の状態なら `FORBIDDEN` を返す
-- MFA AAL 取得に失敗した session cookie mode は fail closed として `FORBIDDEN` を返す
+- Session cookie mode: HTTP / RSC の両 context が共通 resolver を使い、Supabase Auth の `getUser()` でユーザーを検証してから session token と MFA AAL を独立して取得する。session token 取得に失敗しても MFA lookup は続行する
+- AAL claim がない有効な従来 session は Supabase の契約どおり `aal1` として扱う。API error / throw、未知値、不正な AAL 遷移、または認証済み context で assurance 自体が欠けた場合は fail closed として `FORBIDDEN` を返す
+- MFA登録済み `aal1 -> aal2` の状態は `FORBIDDEN`、MFA未登録 `aal1 -> aal1` と検証済み `aal2 -> aal2` は通過する
 - `user.verifyRecoveryCode` は recovery-code 検証により MFA factor を解除するため、既知の `aal1 -> aal2` 状態でも通過を許可する
 - OAuth bearer mode: token を `oauth_tokens` で検証し、`client_id` と `scopes` を tRPC context に保持する
 - OAuth bearer mode の汎用 tRPC 呼び出しは、procedure path ごとの allowlist と scope が一致した場合だけ許可する

--- a/scripts/ai-review/invariants.md
+++ b/scripts/ai-review/invariants.md
@@ -27,8 +27,16 @@ ai-review が「**あるべき検査の不在**」を判定するための正本
 ## 公開 HTTP エンドポイント
 
 - 公開エンドポイント（OAuth callback / webhook / contact）は rate limit を持つ
+- `/api/auth` のIP rate limitはVercel由来の`X-Real-IP`だけを使い、`X-Forwarded-For`へfallbackしない。欠落・不正値は共有`ip:unknown`でfail closedにする
+- `/api/auth` のsignin / resetはIP-firstで、正規化emailの独立bucketも同じquotaで確認する。IP / emailはpurpose prefix付きでHMAC化し、生値を保存・記録しない。signupはIP-onlyを維持する
 - cron ルート（`app/api/cron/**`）は `CRON_SECRET` を検証する
 - redirect 先はユーザー入力をそのまま使わず、`lib/safe-redirect.ts` の検証を通す
+
+## 認証・MFA
+
+- Session認証のHTTP / RSC tRPC contextは共通resolverでverified user、session token、MFA assuranceを解決する。session token取得失敗でMFA lookupを抑止しない
+- 認証済みsessionでMFA lookupがerror / throw、未知・不正遷移、またはassurance欠落なら`protectedProcedure`はfail closedで拒否する。AAL claimなしはSupabase契約どおりAAL1へ正規化する
+- proxyのMFA redirectをprocedure backstop追加と引き換えに弱めない
 
 ## データ分離（RLS）
 


### PR DESCRIPTION
## Summary

#1772 と #1777 を dispatch 指定どおり 1 branch / 1 PR で対応します。

- `/api/auth` の接続元判定を Vercel `X-Real-IP` のみに限定し、欠落・不正値を共有 `ip:unknown` bucket へ寄せた
- signin / reset-password に、IP-first で正規化 email の独立 bucket を追加した（signup は IP-only のまま）
- HTTP / RSC tRPC context の session auth 解決を共通化し、RSC にも MFA assurance を設定した
- MFA lookup failure・未知値・不正遷移・assurance 欠落を procedure 側で fail closed にした
- proxy の既存 MFA redirect は変更せず、回帰 test で固定した

Closes #1772
Closes #1777

## Root cause / implementation

### Rate limit

従来は構文上 valid な `X-Real-IP` と `X-Forwarded-For` を request から採用でき、攻撃者が identifier を変えられました。今回、Vercel edge が上書きする `X-Real-IP` だけを検証し、XFF は解析しません。この信頼境界は Vercel 単独 topology に依存するため、別 CDN / bypass 経路を追加する場合は再評価が必要です。

`@vercel/functions` の `ipAddress()` も現行実装では `x-real-ip` だけを読むため、同じ trust boundary のために新しい runtime dependency は追加せず直接参照を維持しました: [Vercel source](https://github.com/vercel/vercel/blob/main/packages/functions/src/headers.ts), [request header docs](https://vercel.com/docs/headers/request-headers)

signin / reset は以下の順です。

1. IP bucket を確認
2. IP deny なら短絡し、email bucket を消費しない
3. IP allow 後に `email:${trim().toLowerCase()}` の独立 bucket を確認
4. どちらの backend error / timeout も provider 呼び出し前に 503

identifier は purpose prefix を含め limiter factory 内で HMAC-SHA-256 化し、raw IP / email を Upstash key や log に残しません。

### MFA parity

HTTP / RSC が同じ `resolveSessionAuthContext()` を使用します。

- `getUser()` で verified user を先に確定
- session token 取得失敗後も MFA lookup を継続
- 現行 Supabase contract に合わせ、missing/null AAL を AAL1 互換として正規化
- API error / throw、未知値、`aal2 -> aal1`、data 欠落は fail closed
- `aal1 -> aal2` は既存の `user.verifyRecoveryCode` だけを通し、他の protected procedure は拒否

参考: [Supabase MFA assurance API](https://supabase.com/docs/reference/javascript/auth-mfa-getauthenticatorassurancelevel), [MFA guide](https://supabase.com/docs/guides/auth/auth-mfa)

## Verification

Passed:

- `cd apps/product && pnpm exec vitest --project unit run src/lib/security/__tests__/ip-validation.test.ts src/lib/rate-limit/__tests__/upstash.test.ts src/app/api/auth/__tests__/route.test.ts` — 47/47
- `cd apps/product && pnpm exec vitest --project unit run src/lib/trpc/__tests__/session-auth-context.test.ts src/lib/trpc/__tests__/context-parity.test.ts src/lib/auth/__tests__/token-expiry.test.ts src/lib/trpc/__tests__/pro-procedure.test.ts src/__tests__/proxy.test.ts` — 57/57
- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:boundaries`
- `pnpm format:check`
- `pnpm docs:check`（append-only link warning 16件、guard は pass）
- behavior-verifier: blocker 0 / proceed
- risk-reviewer: blocker 0 / proceed

`npx --yes node@24 /opt/homebrew/bin/pnpm check` は今回の Product 276 files / 2574 tests と Web 37 files / 260 tests まで pass し、既存の macOS Bash 回帰 2 tests だけで停止します。今回の差分に script 変更はなく、focused reproduction と追跡は #1789。

`pnpm security:check` は default branch 由来の既存 advisory 6件（high 4 / moderate 2）で停止します。package / lockfile 差分はなく、依存更新レーン #1569 を reopen 済みです。

## Residual risk / scope

- 通常の Product UI は現在 Supabase Auth を直接呼ぶため、この app-side limiter は公開 `/api/auth` route の defense-in-depth であり、UI 全体を覆いません
- 独立 email bucket は同一 account への分散試行を絞る一方、第三者が対象 email を signin で15分、reset で1時間制限できる可用性トレードオフがあります
- IP-first は遮断済み IP から大量 email bucket を消費する攻撃を抑えますが、分散攻撃そのものは防ぎません
- Product Preview live probe は実施したが、既存の Preview env 不足により `/api/auth` が rate-limit 到達前に 500 となり証拠取得不能でした。#1461 を reopen して追跡します

## Preview live probe（blocked）

Deployment `dpl_HDvLCqWBMXqAoHrv498ZGDtdCmJF` へ、存在しない `.invalid` email と request ごとに異なる XFF で7回 signin probeを実施しました。全て 500。Vercel runtime error は `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` / `SUPABASE_SERVICE_ROLE_KEY` の不足を示し、同 error group の first seen は 2026-07-16 です。#1790 固有の回帰ではありません。

値は取得・表示していません。Preview env / external secret mutation は本PRのauthority外なので #1461 に分離しました。

## Merge decision / post-merge follow-up

- [ ] Post-merge: #1461 の Preview env contract を secret-safe に復旧し、Upstash が有効な非Production Previewで、所有する固有の不存在 email を使い、送信側 XFF を変えても同一クライアントの 1〜5 回目が provider response、6 回目が 429 になることを確認する
- [x] CI / Vercel deployment checks が green であることを確認済み
- [x] 2026-08-01 のユーザー明示指示により、Preview live rate-limit 検証は #1461 へ延期し、既知の残余リスクとしてマージする
