### PR TITLE
feat(settings): 外部カレンダー連携設定と安全なCSV出力

### DIFF
--- a/apps/product/messages/en/settings.json
+++ b/apps/product/messages/en/settings.json
@@ -311,7 +311,7 @@
         "dataControls": "Data Controls",
         "dataControlsDesc": "Export, import, and backup settings",
         "integrations": "Integrations",
-        "integrationsDesc": "AI providers and external service connections",
+        "integrationsDesc": "Google Calendar and iCal feeds",
         "profile": "Profile",
         "profileDesc": "Name and email",
         "display": "Display",
@@ -427,17 +427,90 @@
         "description": "Issue API keys and configure Webhooks from the developer portal.",
         "openPortal": "Open Developer Portal (Coming Soon)"
       },
+      "googleCalendar": {
+        "title": "Google Calendar",
+        "description": "Choose which Google calendars to import into Dayopt. You can connect more than one Google account.",
+        "connect": "Connect Google account",
+        "addAccount": "Add Google account",
+        "checkingAvailability": "Checking...",
+        "unavailable": "Google Calendar connection is not available in this environment.",
+        "loading": "Loading Google Calendar connections",
+        "loadError": "Google Calendar connections could not be loaded",
+        "empty": "Connect a Google account to choose calendars for import.",
+        "unknownAccount": "Google account",
+        "lastSync": "Last sync: {value}",
+        "neverSynced": "Never",
+        "calendars": "Calendars to import",
+        "loadingCalendars": "Loading calendars",
+        "calendarLoadError": "Calendars could not be loaded",
+        "noCalendars": "No calendars are available for this account.",
+        "unnamedCalendar": "Unnamed calendar",
+        "primary": "Primary",
+        "apply": "Apply",
+        "applying": "Applying...",
+        "syncNow": "Sync now",
+        "syncing": "Syncing...",
+        "reconnect": "Reconnect",
+        "reconnectToChoose": "Reconnect this account before choosing calendars.",
+        "disconnect": "Disconnect",
+        "disconnecting": "Disconnecting...",
+        "disconnectSuccess": "Google account disconnected",
+        "disconnectFailed": "Google account could not be disconnected",
+        "status": {
+          "connected": "Connected",
+          "reauthRequired": "Reconnect required",
+          "issue": "Needs attention"
+        },
+        "errors": {
+          "reauthRequired": "Google access has expired. Reconnect the same Google account.",
+          "rateLimited": "Google Calendar is temporarily rate limited. Try again later.",
+          "providerUnavailable": "Google Calendar is temporarily unavailable. Try again later.",
+          "encryptionKeyInvalid": "This connection cannot be read securely. Reconnect the account.",
+          "partialFailure": "Some calendars could not be synced. Review the selection and try again.",
+          "generic": "This connection has a sync issue. Try again or reconnect it."
+        },
+        "outcomes": {
+          "synced": "Google Calendar synced",
+          "reauthRequired": "Reconnect this Google account before syncing",
+          "encryptionKeyInvalid": "This connection cannot be read securely. Reconnect it.",
+          "partialFailure": "Some calendars could not be synced",
+          "notConfigured": "Google Calendar connection is not configured",
+          "updateFailed": "Calendar selection could not be applied",
+          "syncFailed": "Google Calendar could not be synced"
+        },
+        "disconnectDialog": {
+          "title": "Disconnect this Google account?",
+          "description": "Dayopt will try to revoke Google access, then permanently delete its local token and connection. Referenced historical timeblocks will remain."
+        },
+        "callback": {
+          "connected": "Google account connected",
+          "accessDenied": "Google Calendar access was not granted",
+          "accountMismatch": "Choose the same Google account that needs to be reconnected",
+          "proRequired": "A Pro plan is required to connect Google Calendar",
+          "rateLimited": "Too many connection attempts. Try again later.",
+          "reconnectTargetInvalid": "This connection can no longer be reconnected. Refresh and try again.",
+          "unavailable": "Google Calendar connection is temporarily unavailable",
+          "genericError": "Google Calendar could not be connected"
+        }
+      },
       "icalFeed": {
         "title": "iCal Feed",
         "description": "Add this URL to Google Calendar or Apple Calendar to view your Dayopt schedule as read-only.",
         "feedUrl": "Feed URL",
         "copy": "Copy",
-        "copied": "Copied!",
+        "copied": "Copied",
+        "copyFailed": "Feed URL could not be copied",
+        "loading": "Loading iCal feed URL",
+        "loadError": "iCal feed URL could not be loaded",
+        "generate": "Generate URL",
+        "generating": "Generating...",
         "regenerate": "Regenerate URL",
+        "regenerating": "Regenerating...",
         "regenerateConfirmTitle": "Regenerate feed URL?",
         "regenerateConfirmDescription": "The current URL will stop working. Any calendars using it will need to be updated.",
         "regenerateSuccess": "New feed URL generated",
-        "noToken": "Click \"Regenerate URL\" to generate a feed URL"
+        "regenerateFailed": "Feed URL could not be generated",
+        "noToken": "Generate a private feed URL to subscribe from another calendar app."
       }
     },
     "legal": {

--- a/apps/product/messages/ja/settings.json
+++ b/apps/product/messages/ja/settings.json
@@ -311,7 +311,7 @@
         "dataControls": "データ管理",
         "dataControlsDesc": "エクスポート、インポート、バックアップ設定",
         "integrations": "連携",
-        "integrationsDesc": "AIプロバイダーと外部サービス連携",
+        "integrationsDesc": "Google CalendarとiCalフィード",
         "profile": "プロフィール",
         "profileDesc": "名前、メール",
         "display": "表示",
@@ -427,17 +427,90 @@
         "description": "APIキーの発行やWebhookの設定は開発者ポータルから行える。",
         "openPortal": "開発者ポータルを開く（準備中）"
       },
+      "googleCalendar": {
+        "title": "Google カレンダー",
+        "description": "Dayoptに取り込むGoogle カレンダーを選べます。複数のGoogle アカウントを接続できます。",
+        "connect": "Google アカウントを接続",
+        "addAccount": "Google アカウントを追加",
+        "checkingAvailability": "確認中...",
+        "unavailable": "この環境ではGoogle カレンダーに接続できません。",
+        "loading": "Google カレンダーの接続を読み込み中",
+        "loadError": "Google カレンダーの接続を読み込めませんでした",
+        "empty": "Google アカウントを接続すると、取り込むカレンダーを選べます。",
+        "unknownAccount": "Google アカウント",
+        "lastSync": "最終同期: {value}",
+        "neverSynced": "未同期",
+        "calendars": "取り込むカレンダー",
+        "loadingCalendars": "カレンダーを読み込み中",
+        "calendarLoadError": "カレンダーを読み込めませんでした",
+        "noCalendars": "このアカウントで利用できるカレンダーはありません。",
+        "unnamedCalendar": "名前のないカレンダー",
+        "primary": "メイン",
+        "apply": "適用",
+        "applying": "適用中...",
+        "syncNow": "今すぐ同期",
+        "syncing": "同期中...",
+        "reconnect": "再接続",
+        "reconnectToChoose": "カレンダーを選ぶ前に、このアカウントを再接続してください。",
+        "disconnect": "接続を解除",
+        "disconnecting": "解除中...",
+        "disconnectSuccess": "Google アカウントの接続を解除しました",
+        "disconnectFailed": "Google アカウントの接続を解除できませんでした",
+        "status": {
+          "connected": "接続済み",
+          "reauthRequired": "再接続が必要",
+          "issue": "確認が必要"
+        },
+        "errors": {
+          "reauthRequired": "Googleへのアクセスが期限切れです。同じGoogle アカウントを再接続してください。",
+          "rateLimited": "Google カレンダーの利用が一時的に制限されています。時間をおいてお試しください。",
+          "providerUnavailable": "Google カレンダーを一時的に利用できません。時間をおいてお試しください。",
+          "encryptionKeyInvalid": "この接続を安全に読み取れません。アカウントを再接続してください。",
+          "partialFailure": "一部のカレンダーを同期できませんでした。選択を確認して、もう一度お試しください。",
+          "generic": "この接続で同期の問題が発生しています。もう一度試すか、再接続してください。"
+        },
+        "outcomes": {
+          "synced": "Google カレンダーを同期しました",
+          "reauthRequired": "同期する前にGoogle アカウントを再接続してください",
+          "encryptionKeyInvalid": "この接続を安全に読み取れません。再接続してください。",
+          "partialFailure": "一部のカレンダーを同期できませんでした",
+          "notConfigured": "Google カレンダー接続が設定されていません",
+          "updateFailed": "カレンダーの選択を適用できませんでした",
+          "syncFailed": "Google カレンダーを同期できませんでした"
+        },
+        "disconnectDialog": {
+          "title": "このGoogle アカウントの接続を解除しますか？",
+          "description": "Googleへのアクセス解除を試みた後、Dayopt内のトークンと接続を完全に削除します。参照済みの過去のタイムブロックは残ります。"
+        },
+        "callback": {
+          "connected": "Google アカウントを接続しました",
+          "accessDenied": "Google カレンダーへのアクセスが許可されませんでした",
+          "accountMismatch": "再接続が必要なものと同じGoogle アカウントを選んでください",
+          "proRequired": "Google カレンダーとの接続にはProプランが必要です",
+          "rateLimited": "接続の試行回数が多すぎます。時間をおいてお試しください。",
+          "reconnectTargetInvalid": "この接続は再接続できなくなりました。更新して、もう一度お試しください。",
+          "unavailable": "Google カレンダーに一時的に接続できません",
+          "genericError": "Google カレンダーに接続できませんでした"
+        }
+      },
       "icalFeed": {
         "title": "iCalフィード",
         "description": "このURLをGoogle CalendarやApple Calendarに追加すると、Dayoptのスケジュールを読み取り専用で表示できます。",
         "feedUrl": "フィードURL",
         "copy": "コピー",
         "copied": "コピーしました",
+        "copyFailed": "フィードURLをコピーできませんでした",
+        "loading": "iCalフィードURLを読み込み中",
+        "loadError": "iCalフィードURLを読み込めませんでした",
+        "generate": "URLを生成",
+        "generating": "生成中...",
         "regenerate": "URLを再生成",
+        "regenerating": "再生成中...",
         "regenerateConfirmTitle": "フィードURLを再生成しますか？",
         "regenerateConfirmDescription": "現在のURLは無効になります。このURLを使用しているカレンダーは更新が必要です。",
         "regenerateSuccess": "新しいフィードURLを生成しました",
-        "noToken": "フィードURLを生成するには「URLを再生成」をクリックしてください"
+        "regenerateFailed": "フィードURLを生成できませんでした",
+        "noToken": "他のカレンダーアプリから購読するための非公開フィードURLを生成できます。"
       }
     },
     "legal": {

--- a/apps/product/src/app/[locale]/(app)/settings/[category]/page.tsx
+++ b/apps/product/src/app/[locale]/(app)/settings/[category]/page.tsx
@@ -1,17 +1,24 @@
 'use client';
 
 import { useParams, useSearchParams } from 'next/navigation';
-import { useEffect } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
 import { ArrowLeft } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
 import { AppHeader } from '@/components/shell/AppHeader';
+import {
+  parseCalendarCallbackResult,
+  removeCalendarCallbackParams,
+  type CalendarCallbackError,
+} from '@/features/external-calendar';
 import { isValidCategory, SETTINGS_CATEGORIES, SettingsContent } from '@/features/settings';
 import { MEDIA_QUERIES } from '@/lib/breakpoints';
 import { useHasMounted } from '@/lib/hooks/useHasMounted';
 import { useMediaQuery } from '@/lib/hooks/useMediaQuery';
 import { useShellStore } from '@/lib/stores/useShellStore';
+import { toast } from '@/lib/toast';
+import { api } from '@/lib/trpc';
 import { Button } from '@dayopt/components';
 import { Link, useRouter } from '@dayopt/i18n/navigation';
 
@@ -31,6 +38,8 @@ export default function SettingsCategoryPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const openSettings = useShellStore((s) => s.openSettings);
+  const utils = api.useUtils();
+  const processedCallback = useRef<string | null>(null);
 
   const category = params?.category ?? 'general';
   const isValid = isValidCategory(category);
@@ -38,14 +47,62 @@ export default function SettingsCategoryPage() {
   const settingsIndexHref = rawReturnTo
     ? `/settings${buildSettingsReturnQuery(normalizeSettingsReturnPath(rawReturnTo))}`
     : '/settings';
+  const calendarParam = searchParams.get('calendar');
+  const reasonParam = searchParams.get('reason');
+  const searchParamsString = searchParams.toString();
+  const callbackResult = useMemo(() => {
+    const callbackParams = new URLSearchParams();
+    if (calendarParam) callbackParams.set('calendar', calendarParam);
+    if (reasonParam) callbackParams.set('reason', reasonParam);
+    return parseCalendarCallbackResult(callbackParams);
+  }, [calendarParam, reasonParam]);
 
-  // PC: ホームにリダイレクトし、設定モーダルを開く
+  // OAuth callback の feedback / cache 更新を PC redirect より先に一元処理する。
   useEffect(() => {
-    if (hasMounted && !isMobile && isValid) {
+    if (!hasMounted || !isValid) return;
+
+    if (callbackResult) {
+      const callbackKey = `${calendarParam ?? ''}:${reasonParam ?? ''}`;
+      if (processedCallback.current === callbackKey) return;
+      processedCallback.current = callbackKey;
+
+      if (callbackResult.type === 'connected') {
+        toast.success(t('settings.integrations.googleCalendar.callback.connected'));
+      } else {
+        toast.error(calendarCallbackErrorMessage(t, callbackResult.error));
+      }
+      void utils.externalCalendar.listConnections.invalidate();
+
+      if (!isMobile) {
+        openSettings('integrations');
+        router.replace('/');
+        return;
+      }
+
+      const cleanParams = removeCalendarCallbackParams(new URLSearchParams(searchParamsString));
+      const query = cleanParams.size > 0 ? `?${cleanParams.toString()}` : '';
+      router.replace(`/settings/integrations${query}`);
+      return;
+    }
+
+    if (!isMobile) {
       openSettings(category);
       router.replace('/');
     }
-  }, [hasMounted, isMobile, isValid, category, openSettings, router]);
+  }, [
+    callbackResult,
+    calendarParam,
+    category,
+    hasMounted,
+    isMobile,
+    isValid,
+    openSettings,
+    reasonParam,
+    router,
+    searchParamsString,
+    t,
+    utils.externalCalendar.listConnections,
+  ]);
 
   if (!isValid) {
     return null;
@@ -75,4 +132,26 @@ export default function SettingsCategoryPage() {
       <SettingsContent category={category} />
     </>
   );
+}
+
+function calendarCallbackErrorMessage(
+  t: ReturnType<typeof useTranslations>,
+  error: CalendarCallbackError,
+): string {
+  switch (error) {
+    case 'access_denied':
+      return t('settings.integrations.googleCalendar.callback.accessDenied');
+    case 'account_mismatch':
+      return t('settings.integrations.googleCalendar.callback.accountMismatch');
+    case 'pro_required':
+      return t('settings.integrations.googleCalendar.callback.proRequired');
+    case 'rate_limited':
+      return t('settings.integrations.googleCalendar.callback.rateLimited');
+    case 'reconnect_target_invalid':
+      return t('settings.integrations.googleCalendar.callback.reconnectTargetInvalid');
+    case 'unavailable':
+      return t('settings.integrations.googleCalendar.callback.unavailable');
+    case 'generic':
+      return t('settings.integrations.googleCalendar.callback.genericError');
+  }
 }

--- a/apps/product/src/app/[locale]/(app)/settings/__tests__/routing.test.tsx
+++ b/apps/product/src/app/[locale]/(app)/settings/__tests__/routing.test.tsx
@@ -10,6 +10,11 @@ const mockReplace = vi.fn();
 const mockPush = vi.fn();
 const mockOpenSettings = vi.fn();
 const mockLogout = vi.fn();
+const { mockInvalidateConnections, mockToastSuccess, mockToastError } = vi.hoisted(() => ({
+  mockInvalidateConnections: vi.fn(),
+  mockToastSuccess: vi.fn(),
+  mockToastError: vi.fn(),
+}));
 
 vi.mock('next/navigation', () => ({
   useParams: () => ({ category: mockCategory }),
@@ -38,13 +43,18 @@ vi.mock('@dayopt/i18n/navigation', async () => {
 vi.mock('@/features/settings/constants', () => ({
   SETTINGS_CATEGORIES: [
     { id: 'profile', labelKey: 'settings.category.profile', icon: () => <span>icon</span> },
+    {
+      id: 'integrations',
+      labelKey: 'settings.category.integrations',
+      icon: () => <span>icon</span>,
+    },
     { id: 'billing', labelKey: 'settings.category.billing', icon: () => <span>icon</span> },
   ],
 }));
 
 vi.mock('@/features/settings', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/features/settings')>()),
-  isValidCategory: (category: string) => ['profile', 'billing'].includes(category),
+  isValidCategory: (category: string) => ['profile', 'integrations', 'billing'].includes(category),
   SettingsContent: ({ category }: { category: string }) => <div>{category}</div>,
 }));
 
@@ -91,12 +101,21 @@ vi.mock('@dayopt/components', async (importOriginal) => ({
 
 vi.mock('@/lib/trpc', () => ({
   api: {
+    useUtils: () => ({
+      externalCalendar: {
+        listConnections: { invalidate: mockInvalidateConnections },
+      },
+    }),
     billing: {
       getOverview: {
         useQuery: () => ({ data: null, isLoading: false }),
       },
     },
   },
+}));
+
+vi.mock('@/lib/toast', () => ({
+  toast: { success: mockToastSuccess, error: mockToastError },
 }));
 
 vi.mock('@/components/shell/AppHeader', () => ({
@@ -182,6 +201,39 @@ describe('settings route hydration guards', () => {
 
     expect(mockOpenSettings).toHaveBeenCalledWith('billing');
     expect(mockReplace).toHaveBeenCalledWith('/');
+  });
+
+  it('handles a desktop calendar callback before opening Integrations', () => {
+    mockHasMounted = true;
+    mockCategory = 'integrations';
+    mockSearchParams = new URLSearchParams('calendar=connected');
+
+    render(<SettingsCategoryPage />);
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      'settings.integrations.googleCalendar.callback.connected',
+    );
+    expect(mockInvalidateConnections).toHaveBeenCalled();
+    expect(mockOpenSettings).toHaveBeenCalledWith('integrations');
+    expect(mockReplace).toHaveBeenCalledWith('/');
+  });
+
+  it('cleans only calendar callback params on mobile', () => {
+    mockHasMounted = true;
+    mockIsMobile = true;
+    mockCategory = 'integrations';
+    mockSearchParams = new URLSearchParams(
+      'returnTo=%2Fweek%3Fdate%3D2026-08-01&calendar=error&reason=account_mismatch&panel=review',
+    );
+
+    render(<SettingsCategoryPage />);
+
+    expect(mockToastError).toHaveBeenCalledWith(
+      'settings.integrations.googleCalendar.callback.accountMismatch',
+    );
+    expect(mockReplace).toHaveBeenCalledWith(
+      '/settings/integrations?returnTo=%2Fweek%3Fdate%3D2026-08-01&panel=review',
+    );
   });
 
   it('preserves the mobile settings return path from category pages', () => {

--- a/apps/product/src/app/api/integrations/google-calendar/__tests__/callback-route.test.ts
+++ b/apps/product/src/app/api/integrations/google-calendar/__tests__/callback-route.test.ts
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const getUser = vi.hoisted(() => vi.fn());
 const createClient = vi.hoisted(() => vi.fn());
 const saveConnection = vi.hoisted(() => vi.fn());
+const getReconnectTarget = vi.hoisted(() => vi.fn());
+const reconnectExistingConnection = vi.hoisted(() => vi.fn());
 const captureUnexpectedError = vi.hoisted(() => vi.fn());
 const checkProAccessForUser = vi.hoisted(() => vi.fn());
 const rateLimit = vi.hoisted(() => vi.fn());
@@ -19,7 +21,11 @@ vi.mock('@/lib/supabase/server', () => ({ createClient }));
 vi.mock('@/lib/sentry', () => ({ captureUnexpectedError }));
 vi.mock('@/lib/billing/enforcement', () => ({ checkProAccessForUser }));
 vi.mock('@/lib/rate-limit/upstash', () => ({ calendarConnectRateLimit: { limit: rateLimit } }));
-vi.mock('@/features/external-calendar/server/connection-service', () => ({ saveConnection }));
+vi.mock('@/features/external-calendar/server/connection-service', () => ({
+  saveConnection,
+  getReconnectTarget,
+  reconnectExistingConnection,
+}));
 
 import { GET } from '../callback/route';
 
@@ -87,6 +93,11 @@ describe('google calendar callback route', () => {
     getUser.mockResolvedValue({ data: { user: { id: USER_ID } }, error: null });
     createClient.mockResolvedValue({ auth: { getUser } });
     saveConnection.mockResolvedValue(undefined);
+    getReconnectTarget.mockResolvedValue({
+      id: '00000000-0000-4000-8000-0000000000c1',
+      providerAccountId: 'google-sub-123',
+    });
+    reconnectExistingConnection.mockResolvedValue('updated');
     checkProAccessForUser.mockResolvedValue('allowed');
     rateLimit.mockResolvedValue({ success: true });
     vi.stubGlobal(
@@ -314,7 +325,7 @@ describe('google calendar callback route', () => {
     );
 
     const location = new URL(response.headers.get('location') ?? '');
-    expect(location.pathname).toBe('/ja/settings/account');
+    expect(location.pathname).toBe('/ja/settings/integrations');
     expect(location.searchParams.get('calendar')).toBe('connected');
   });
 
@@ -344,7 +355,7 @@ describe('google calendar callback route', () => {
 
     const location = new URL(response.headers.get('location') ?? '');
     expect(location.host).toBe('app.dayopt.app');
-    expect(location.pathname).toBe('/en/settings/account');
+    expect(location.pathname).toBe('/en/settings/integrations');
   });
 
   it('token 交換が拒否されたら接続を保存しない', async () => {
@@ -367,5 +378,50 @@ describe('google calendar callback route', () => {
 
     const failure = await GET(withCookie(request({ state: 'forged-state' })));
     expect(failure.cookies.get('__Host-dayopt-calendar-connect')?.maxAge).toBe(0);
+  });
+
+  it('再接続は同じ Google sub の既存行だけを条件付き更新する', async () => {
+    const connectionId = '00000000-0000-4000-8000-0000000000c1';
+    const response = await GET(withCookie(request(), { reconnectConnectionId: connectionId }));
+
+    expect(reasonOf(response)).toBeNull();
+    expect(getReconnectTarget).toHaveBeenCalledWith(USER_ID, connectionId);
+    expect(reconnectExistingConnection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectionId,
+        userId: USER_ID,
+        providerAccountId: 'google-sub-123',
+      }),
+    );
+    expect(saveConnection).not.toHaveBeenCalled();
+  });
+
+  it('別の Google sub を選んだ再接続は保存しない', async () => {
+    const connectionId = '00000000-0000-4000-8000-0000000000c1';
+    getReconnectTarget.mockResolvedValue({ id: connectionId, providerAccountId: 'expected-sub' });
+
+    const response = await GET(withCookie(request(), { reconnectConnectionId: connectionId }));
+
+    expect(reasonOf(response)).toBe('account_mismatch');
+    expect(reconnectExistingConnection).not.toHaveBeenCalled();
+    expect(saveConnection).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['対象が削除済み', null, 'updated'],
+    [
+      '条件付き UPDATE が 0 行',
+      { id: '00000000-0000-4000-8000-0000000000c1', providerAccountId: 'google-sub-123' },
+      'missing',
+    ],
+  ])('%s なら接続を新規作成しない', async (_label, target, updateOutcome) => {
+    const connectionId = '00000000-0000-4000-8000-0000000000c1';
+    getReconnectTarget.mockResolvedValue(target);
+    reconnectExistingConnection.mockResolvedValue(updateOutcome);
+
+    const response = await GET(withCookie(request(), { reconnectConnectionId: connectionId }));
+
+    expect(reasonOf(response)).toBe('reconnect_target_invalid');
+    expect(saveConnection).not.toHaveBeenCalled();
   });
 });

--- a/apps/product/src/app/api/integrations/google-calendar/__tests__/start-route.test.ts
+++ b/apps/product/src/app/api/integrations/google-calendar/__tests__/start-route.test.ts
@@ -7,6 +7,7 @@ const createClient = vi.hoisted(() => vi.fn());
 const rateLimit = vi.hoisted(() => vi.fn());
 const checkProAccessForUser = vi.hoisted(() => vi.fn());
 const captureUnexpectedError = vi.hoisted(() => vi.fn());
+const getReconnectTarget = vi.hoisted(() => vi.fn());
 const envMock = vi.hoisted(() => ({
   GOOGLE_CALENDAR_CLIENT_ID: 'client-id.apps.googleusercontent.com',
   GOOGLE_CALENDAR_CLIENT_SECRET: 'client-secret',
@@ -22,6 +23,7 @@ vi.mock('@/lib/rate-limit/upstash', () => ({
 }));
 vi.mock('@/lib/billing/enforcement', () => ({ checkProAccessForUser }));
 vi.mock('@/lib/sentry', () => ({ captureUnexpectedError }));
+vi.mock('@/features/external-calendar/server/connection-service', () => ({ getReconnectTarget }));
 
 import { GET } from '../start/route';
 
@@ -45,6 +47,10 @@ describe('google calendar start route', () => {
     createClient.mockResolvedValue({ auth: { getUser }, from });
     rateLimit.mockResolvedValue({ success: true });
     checkProAccessForUser.mockResolvedValue('allowed');
+    getReconnectTarget.mockResolvedValue({
+      id: '00000000-0000-4000-8000-0000000000c1',
+      providerAccountId: 'google-sub-123',
+    });
   });
 
   it('env が未設定なら 503 で止まり Google へ飛ばさない', async () => {
@@ -101,7 +107,7 @@ describe('google calendar start route', () => {
       'openid email https://www.googleapis.com/auth/calendar.readonly',
     );
     expect(location.searchParams.get('access_type')).toBe('offline');
-    expect(location.searchParams.get('prompt')).toBe('consent');
+    expect(location.searchParams.get('prompt')).toBe('consent select_account');
     expect(location.searchParams.get('code_challenge_method')).toBe('S256');
     expect(location.searchParams.get('code_challenge')).toBeTruthy();
     // allowlist の文字列がそのまま渡り、request から組み立て直されていない
@@ -121,6 +127,35 @@ describe('google calendar start route', () => {
     // verifier は cookie にだけ入り、URL には出ない
     expect(flowState.verifier).toBeTruthy();
     expect(location.searchParams.get('code_verifier')).toBeNull();
+  });
+
+  it('本人の reauth_required 接続だけを再接続 cookie に保存する', async () => {
+    const connectionId = '00000000-0000-4000-8000-0000000000c1';
+    const response = await GET(
+      request(
+        `https://app.dayopt.app/api/integrations/google-calendar/start?locale=ja&reconnectConnectionId=${connectionId}`,
+      ),
+    );
+
+    expect(getReconnectTarget).toHaveBeenCalledWith(USER_ID, connectionId);
+    const cookie = response.cookies.get('__Host-dayopt-calendar-connect');
+    const flowState = JSON.parse(decodeURIComponent(cookie?.value ?? '{}'));
+    expect(flowState).toMatchObject({ locale: 'ja', reconnectConnectionId: connectionId });
+  });
+
+  it.each([
+    ['not-a-uuid', false],
+    ['00000000-0000-4000-8000-0000000000c1', true],
+  ])('不正または存在しない再接続対象 %s は 400', async (connectionId, validUuid) => {
+    if (validUuid) getReconnectTarget.mockResolvedValue(null);
+
+    const response = await GET(
+      request(
+        `https://app.dayopt.app/api/integrations/google-calendar/start?reconnectConnectionId=${connectionId}`,
+      ),
+    );
+
+    expect(response.status).toBe(400);
   });
 
   it('http の localhost では __Host- prefix を落とす', async () => {

--- a/apps/product/src/app/api/integrations/google-calendar/callback/route.ts
+++ b/apps/product/src/app/api/integrations/google-calendar/callback/route.ts
@@ -10,7 +10,11 @@ import {
   normalizeLocale,
   parseConnectFlowCookie,
 } from '@/features/external-calendar/server/connect-flow';
-import { saveConnection } from '@/features/external-calendar/server/connection-service';
+import {
+  getReconnectTarget,
+  reconnectExistingConnection,
+  saveConnection,
+} from '@/features/external-calendar/server/connection-service';
 import {
   exchangeAuthorizationCode,
   GoogleOAuthError,
@@ -33,15 +37,14 @@ export const dynamic = 'force-dynamic';
 /**
  * Settings への戻り先。
  *
- * `integrations` カテゴリは Step 6 まで存在せず、未知カテゴリは空ページになるため
- * 当面は `account` へ返す。PC では settings ページが query を落とすので、この query を
- * Step 6 の UI トリガに使わないこと。
+ * locale-aware な Integrations 設定へ返す。PC / mobile の query 処理は設定ページの
+ * Composition Layer が一元管理する。
  */
 function settingsRedirect(requestUrl: URL, locale: string, result: string, reason?: string): URL {
   const query = new URLSearchParams({ calendar: result });
   if (reason) query.set('reason', reason);
 
-  const path = getSafeRedirectPath(`/${locale}/settings/account?${query.toString()}`, '/week');
+  const path = getSafeRedirectPath(`/${locale}/settings/integrations?${query.toString()}`, '/week');
   return new URL(path, requestUrl);
 }
 
@@ -186,14 +189,28 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     const idToken = parseIdToken(tokens.id_token);
 
-    await saveConnection({
+    const connectionInput = {
       userId: user.id,
       providerAccountId: idToken.sub,
       providerAccountEmail: idToken.email ?? null,
       grantedScopes,
       refreshToken: tokens.refresh_token,
       encryptionKey: env.CALENDAR_TOKEN_ENCRYPTION_KEY ?? '',
-    });
+    };
+
+    if (flowState.reconnectConnectionId) {
+      const target = await getReconnectTarget(user.id, flowState.reconnectConnectionId);
+      if (!target) return fail('reconnect_target_invalid');
+      if (target.providerAccountId !== idToken.sub) return fail('account_mismatch');
+
+      const outcome = await reconnectExistingConnection({
+        ...connectionInput,
+        connectionId: flowState.reconnectConnectionId,
+      });
+      if (outcome === 'missing') return fail('reconnect_target_invalid');
+    } else {
+      await saveConnection(connectionInput);
+    }
   } catch (error) {
     if (error instanceof GoogleOAuthError) {
       logger.warn('[calendar-callback] google oauth exchange failed');

--- a/apps/product/src/app/api/integrations/google-calendar/start/route.ts
+++ b/apps/product/src/app/api/integrations/google-calendar/start/route.ts
@@ -5,6 +5,7 @@ import {
   normalizeLocale,
   setConnectFlowCookie,
 } from '@/features/external-calendar/server/connect-flow';
+import { getReconnectTarget } from '@/features/external-calendar/server/connection-service';
 import {
   buildAuthorizationUrl,
   generatePkcePair,
@@ -17,6 +18,7 @@ import { logger } from '@/lib/logger';
 import { calendarConnectRateLimit } from '@/lib/rate-limit/upstash';
 import { captureUnexpectedError } from '@/lib/sentry';
 import { createClient } from '@/lib/supabase/server';
+import { z } from 'zod';
 
 /** AES-256-GCM に node:crypto が要る。Edge では動かない。 */
 export const runtime = 'nodejs';
@@ -98,6 +100,32 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     );
   }
 
+  const reconnectParam = requestUrl.searchParams.get('reconnectConnectionId');
+  const reconnectConnectionId = reconnectParam ? z.string().uuid().safeParse(reconnectParam) : null;
+
+  if (reconnectConnectionId && !reconnectConnectionId.success) {
+    return NextResponse.json({ error: 'Reconnect target is invalid' }, { status: 400 });
+  }
+
+  if (reconnectConnectionId?.success) {
+    try {
+      const target = await getReconnectTarget(user.id, reconnectConnectionId.data);
+      if (!target) {
+        return NextResponse.json({ error: 'Reconnect target is invalid' }, { status: 400 });
+      }
+    } catch (error) {
+      captureUnexpectedError(
+        error instanceof Error ? error : new Error('failed to load reconnect target'),
+        {
+          feature: 'external_calendar',
+          operation: 'load_reconnect_target',
+          route: '/api/integrations/google-calendar/start',
+        },
+      );
+      return NextResponse.json({ error: 'Failed to start reconnection' }, { status: 500 });
+    }
+  }
+
   const state = generateState();
   const { verifier, challenge } = generatePkcePair();
   const locale = normalizeLocale(requestUrl.searchParams.get('locale') ?? undefined);
@@ -106,7 +134,19 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     buildAuthorizationUrl({ redirectUri, state, codeChallenge: challenge }),
   );
 
-  setConnectFlowCookie(response, { state, verifier, locale, userId: user.id }, secure);
+  setConnectFlowCookie(
+    response,
+    {
+      state,
+      verifier,
+      locale,
+      userId: user.id,
+      ...(reconnectConnectionId?.success
+        ? { reconnectConnectionId: reconnectConnectionId.data }
+        : {}),
+    },
+    secure,
+  );
 
   return response;
 }

--- a/apps/product/src/features/external-calendar/components/GoogleCalendarSettings.tsx
+++ b/apps/product/src/features/external-calendar/components/GoogleCalendarSettings.tsx
@@ -1,0 +1,342 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import { useLocale, useTranslations } from 'next-intl';
+
+import { ConfirmDialog } from '@/components/ui/overlays/confirm-dialog';
+import { useHasMounted } from '@/lib/hooks/useHasMounted';
+import { toast } from '@/lib/toast';
+import { api } from '@/lib/trpc';
+
+import {
+  GoogleCalendarConnectionView,
+  GoogleCalendarSettingsView,
+  type GoogleCalendarOption,
+} from './GoogleCalendarSettingsView';
+
+type ConnectionSummary = {
+  id: string;
+  provider: string;
+  provider_account_email: string | null;
+  status: string;
+  last_synced_at: string | null;
+  last_sync_error: string | null;
+};
+
+type SyncOutcome =
+  | 'synced'
+  | 'skipped_reauth_required'
+  | 'reauth_required'
+  | 'encryption_key_invalid'
+  | 'partial_failure'
+  | 'not_configured';
+
+export function GoogleCalendarSettings() {
+  const locale = useLocale();
+  const hasMounted = useHasMounted();
+  const origin = hasMounted ? window.location.origin : null;
+  const connections = api.externalCalendar.listConnections.useQuery(undefined, {
+    retry: false,
+    refetchOnMount: 'always',
+  });
+  const availability = api.externalCalendar.getConnectionAvailability.useQuery(
+    { origin: origin ?? 'https://invalid.local' },
+    { enabled: origin !== null, retry: false },
+  );
+
+  const startConnection = () => {
+    if (!availability.data?.available) return;
+    const query = new URLSearchParams({ locale });
+    window.location.assign(`/api/integrations/google-calendar/start?${query.toString()}`);
+  };
+
+  const connectionRows = (connections.data ?? []) as ConnectionSummary[];
+  return (
+    <GoogleCalendarSettingsView
+      loading={connections.isLoading}
+      error={connections.isError}
+      availabilityLoading={origin === null || availability.isLoading}
+      available={availability.data?.available === true}
+      hasConnections={connectionRows.length > 0}
+      onRetry={() => void connections.refetch()}
+      onConnect={startConnection}
+    >
+      {connectionRows.map((connection) => (
+        <GoogleCalendarConnection
+          key={connection.id}
+          connection={connection}
+          origin={origin}
+          reconnectAvailable={availability.data?.available === true}
+        />
+      ))}
+    </GoogleCalendarSettingsView>
+  );
+}
+
+function GoogleCalendarConnection({
+  connection,
+  origin,
+  reconnectAvailable,
+}: {
+  connection: ConnectionSummary;
+  origin: string | null;
+  reconnectAvailable: boolean;
+}) {
+  const locale = useLocale();
+  const t = useTranslations('settings.integrations.googleCalendar');
+  const utils = api.useUtils();
+  const storedNeedsReauth = connection.status === 'reauth_required';
+  const [draftSelection, setDraftSelection] = useState<{
+    connectionId: string;
+    serverSelectionKey: string;
+    ids: string[];
+  } | null>(null);
+  const [disconnectOpen, setDisconnectOpen] = useState(false);
+
+  const syncStatus = api.externalCalendar.getSyncStatus.useQuery(
+    { connectionId: connection.id },
+    { retry: false },
+  );
+  const providerCalendars = api.externalCalendar.listProviderCalendars.useQuery(
+    { connectionId: connection.id },
+    { enabled: !storedNeedsReauth, retry: false },
+  );
+
+  // calendarList の取得中に token 失効を検知すると service が行を reauth_required に更新して
+  // CONFLICT を返す。listConnections の次回 refetch を待たず、その場で再接続導線へ収束させる。
+  const needsReauth = storedNeedsReauth || providerCalendars.error?.data?.code === 'CONFLICT';
+
+  const calendars = useMemo(
+    () => (providerCalendars.data ?? []) as GoogleCalendarOption[],
+    [providerCalendars.data],
+  );
+  const serverSelectedIds = useMemo(
+    () => calendars.filter((calendar) => calendar.selected).map((calendar) => calendar.id),
+    [calendars],
+  );
+  const serverSelectionKey = [...serverSelectedIds].sort().join('\u0000');
+
+  const draftIsCurrent =
+    draftSelection?.connectionId === connection.id &&
+    draftSelection.serverSelectionKey === serverSelectionKey;
+  const selectedIds = draftIsCurrent ? draftSelection.ids : serverSelectedIds;
+  const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+  const selectionDirty = !sameStringSet(selectedIds, serverSelectedIds);
+
+  const updateSelection = api.externalCalendar.updateSelectedCalendars.useMutation({
+    retry: false,
+    onMutate: async (input) => {
+      const queryInput = { connectionId: connection.id };
+      await Promise.all([
+        utils.externalCalendar.listProviderCalendars.cancel(queryInput),
+        utils.externalCalendar.getSyncStatus.cancel(queryInput),
+      ]);
+      const previousProvider = utils.externalCalendar.listProviderCalendars.getData(queryInput);
+      const previousStatus = utils.externalCalendar.getSyncStatus.getData(queryInput);
+      const nextIds = new Set(input.calendars.map((calendar) => calendar.providerCalendarId));
+
+      utils.externalCalendar.listProviderCalendars.setData(queryInput, (current) =>
+        current?.map((calendar) => ({ ...calendar, selected: nextIds.has(calendar.id) })),
+      );
+      utils.externalCalendar.getSyncStatus.setData(queryInput, (current) =>
+        current
+          ? {
+              ...current,
+              calendars: input.calendars.map((calendar) => ({
+                provider_calendar_id: calendar.providerCalendarId,
+                calendar_name: calendar.calendarName ?? null,
+                last_synced_at:
+                  current.calendars.find(
+                    (row) => row.provider_calendar_id === calendar.providerCalendarId,
+                  )?.last_synced_at ?? null,
+              })),
+            }
+          : current,
+      );
+      return { previousProvider, previousStatus };
+    },
+    onSuccess: (result) => showSyncOutcomeToast(t, result.outcome),
+    onError: (_error, _input, context) => {
+      const queryInput = { connectionId: connection.id };
+      // UI cache の暫定復元のみ。DB の選択保存と同期は transaction ではないため、
+      // settled の refetch で必ず server の実結果へ収束させる。
+      utils.externalCalendar.listProviderCalendars.setData(queryInput, context?.previousProvider);
+      utils.externalCalendar.getSyncStatus.setData(queryInput, context?.previousStatus);
+      toast.error(t('outcomes.updateFailed'));
+    },
+    onSettled: async () => {
+      setDraftSelection(null);
+      const queryInput = { connectionId: connection.id };
+      await Promise.all([
+        utils.externalCalendar.listConnections.invalidate(),
+        utils.externalCalendar.listProviderCalendars.invalidate(queryInput),
+        utils.externalCalendar.getSyncStatus.invalidate(queryInput),
+      ]);
+    },
+  });
+
+  const syncNow = api.externalCalendar.syncNow.useMutation({
+    retry: false,
+    onSuccess: (result) => showSyncOutcomeToast(t, result.outcome),
+    onError: () => toast.error(t('outcomes.syncFailed')),
+    onSettled: async () => {
+      const queryInput = { connectionId: connection.id };
+      await Promise.all([
+        utils.externalCalendar.listConnections.invalidate(),
+        utils.externalCalendar.getSyncStatus.invalidate(queryInput),
+      ]);
+    },
+  });
+
+  const disconnect = api.externalCalendar.disconnect.useMutation({
+    retry: false,
+    onMutate: async () => {
+      // 破壊操作は楽観的に消さない。進行中の一覧 fetch だけ止め、settled 後に server を正とする。
+      await utils.externalCalendar.listConnections.cancel();
+    },
+    onSuccess: () => {
+      setDisconnectOpen(false);
+      toast.success(t('disconnectSuccess'));
+    },
+    onError: () => toast.error(t('disconnectFailed')),
+    onSettled: async () => {
+      const queryInput = { connectionId: connection.id };
+      await Promise.all([
+        utils.externalCalendar.listConnections.invalidate(),
+        utils.externalCalendar.listProviderCalendars.invalidate(queryInput),
+        utils.externalCalendar.getSyncStatus.invalidate(queryInput),
+      ]);
+    },
+  });
+
+  const currentConnection = syncStatus.data?.connection ?? connection;
+  const currentStatus = needsReauth ? 'reauth_required' : currentConnection.status;
+  const reconnect = () => {
+    if (!origin) return;
+    const query = new URLSearchParams({ locale, reconnectConnectionId: connection.id });
+    window.location.assign(`/api/integrations/google-calendar/start?${query.toString()}`);
+  };
+
+  const apply = () => {
+    updateSelection.mutate({
+      connectionId: connection.id,
+      calendars: calendars
+        .filter((calendar) => selectedSet.has(calendar.id))
+        .map((calendar) => ({ providerCalendarId: calendar.id, calendarName: calendar.name })),
+    });
+  };
+
+  return (
+    <>
+      <GoogleCalendarConnectionView
+        email={currentConnection.provider_account_email}
+        lastSyncedLabel={formatLastSync(currentConnection.last_synced_at, locale, t('neverSynced'))}
+        statusLabel={statusLabel(t, currentStatus)}
+        statusVariant={currentStatus === 'active' ? 'success' : 'warning'}
+        persistedError={persistedErrorMessage(t, currentConnection.last_sync_error)}
+        needsReauth={needsReauth}
+        reconnectAvailable={reconnectAvailable}
+        calendars={calendars}
+        selectedCalendarIds={selectedSet}
+        calendarsLoading={providerCalendars.isLoading}
+        calendarsError={providerCalendars.isError || syncStatus.isError}
+        applying={updateSelection.isPending}
+        syncing={syncNow.isPending}
+        disconnecting={disconnect.isPending}
+        selectionDirty={selectionDirty}
+        onToggleCalendar={(calendarId, checked) => {
+          const next = new Set(selectedIds);
+          if (checked) next.add(calendarId);
+          else next.delete(calendarId);
+          setDraftSelection({
+            connectionId: connection.id,
+            serverSelectionKey,
+            ids: [...next],
+          });
+        }}
+        onRetryCalendars={() => {
+          void Promise.all([providerCalendars.refetch(), syncStatus.refetch()]);
+        }}
+        onApply={apply}
+        onSync={() => syncNow.mutate({ connectionId: connection.id })}
+        onReconnect={reconnect}
+        onDisconnect={() => setDisconnectOpen(true)}
+      />
+
+      <ConfirmDialog
+        open={disconnectOpen}
+        onClose={() => setDisconnectOpen(false)}
+        onConfirm={async () => {
+          await disconnect.mutateAsync({ connectionId: connection.id }).catch(() => undefined);
+        }}
+        title={t('disconnectDialog.title')}
+        description={t('disconnectDialog.description')}
+        confirmLabel={t('disconnect')}
+        loadingLabel={t('disconnecting')}
+        variant="destructive"
+      />
+    </>
+  );
+}
+
+function sameStringSet(left: string[], right: string[]): boolean {
+  if (left.length !== right.length) return false;
+  const rightSet = new Set(right);
+  return left.every((value) => rightSet.has(value));
+}
+
+function formatLastSync(value: string | null, locale: string, fallback: string): string {
+  if (!value) return fallback;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return fallback;
+  return new Intl.DateTimeFormat(locale, { dateStyle: 'medium', timeStyle: 'short' }).format(date);
+}
+
+function statusLabel(t: ReturnType<typeof useTranslations>, status: string): string {
+  if (status === 'active') return t('status.connected');
+  if (status === 'reauth_required') return t('status.reauthRequired');
+  return t('status.issue');
+}
+
+function persistedErrorMessage(
+  t: ReturnType<typeof useTranslations>,
+  error: string | null,
+): string | null {
+  if (!error) return null;
+  switch (error) {
+    case 'reauth_required':
+      return t('errors.reauthRequired');
+    case 'rate_limited':
+      return t('errors.rateLimited');
+    case 'provider_unavailable':
+      return t('errors.providerUnavailable');
+    case 'encryption_key_invalid':
+      return t('errors.encryptionKeyInvalid');
+    case 'partial_failure':
+      return t('errors.partialFailure');
+    default:
+      return t('errors.generic');
+  }
+}
+
+function showSyncOutcomeToast(t: ReturnType<typeof useTranslations>, outcome: SyncOutcome): void {
+  switch (outcome) {
+    case 'synced':
+      toast.success(t('outcomes.synced'));
+      break;
+    case 'skipped_reauth_required':
+    case 'reauth_required':
+      toast.error(t('outcomes.reauthRequired'));
+      break;
+    case 'encryption_key_invalid':
+      toast.error(t('outcomes.encryptionKeyInvalid'));
+      break;
+    case 'partial_failure':
+      toast.error(t('outcomes.partialFailure'));
+      break;
+    case 'not_configured':
+      toast.error(t('outcomes.notConfigured'));
+      break;
+  }
+}

--- a/apps/product/src/features/external-calendar/components/GoogleCalendarSettingsView.stories.tsx
+++ b/apps/product/src/features/external-calendar/components/GoogleCalendarSettingsView.stories.tsx
@@ -1,0 +1,184 @@
+import type { ReactNode } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { fn } from 'storybook/test';
+
+import {
+  GoogleCalendarConnectionView,
+  GoogleCalendarSettingsView,
+  type GoogleCalendarConnectionViewProps,
+} from './GoogleCalendarSettingsView';
+
+const ACTIONS = {
+  onToggleCalendar: fn(),
+  onRetryCalendars: fn(),
+  onApply: fn(),
+  onSync: fn(),
+  onReconnect: fn(),
+  onDisconnect: fn(),
+};
+
+const ACTIVE_CONNECTION: GoogleCalendarConnectionViewProps = {
+  email: 'work@example.com',
+  lastSyncedLabel: 'Aug 2, 2026, 10:30 AM',
+  statusLabel: 'Connected',
+  statusVariant: 'success',
+  persistedError: null,
+  needsReauth: false,
+  reconnectAvailable: true,
+  calendars: [
+    { id: 'primary', name: 'Work', primary: true, selected: true },
+    { id: 'focus', name: 'Focus time', primary: false, selected: false },
+  ],
+  selectedCalendarIds: new Set(['primary']),
+  calendarsLoading: false,
+  calendarsError: false,
+  applying: false,
+  syncing: false,
+  disconnecting: false,
+  selectionDirty: false,
+  ...ACTIONS,
+};
+
+function SettingsState({
+  loading = false,
+  error = false,
+  available = true,
+  availabilityLoading = false,
+  children,
+}: {
+  loading?: boolean;
+  error?: boolean;
+  available?: boolean;
+  availabilityLoading?: boolean;
+  children?: ReactNode;
+}) {
+  return (
+    <GoogleCalendarSettingsView
+      loading={loading}
+      error={error}
+      available={available}
+      availabilityLoading={availabilityLoading}
+      hasConnections={Boolean(children)}
+      onRetry={fn()}
+      onConnect={fn()}
+    >
+      {children}
+    </GoogleCalendarSettingsView>
+  );
+}
+
+function MultipleAccountsState() {
+  return (
+    <SettingsState>
+      <GoogleCalendarConnectionView {...ACTIVE_CONNECTION} />
+      <GoogleCalendarConnectionView
+        {...ACTIVE_CONNECTION}
+        email="personal@example.com"
+        lastSyncedLabel="Aug 2, 2026, 9:45 AM"
+        calendars={[
+          { id: 'personal', name: 'Personal', primary: true, selected: true },
+          { id: 'family', name: 'Family', primary: false, selected: true },
+        ]}
+        selectedCalendarIds={new Set(['personal', 'family'])}
+      />
+    </SettingsState>
+  );
+}
+
+function ReauthorizationRequiredState() {
+  return (
+    <SettingsState>
+      <GoogleCalendarConnectionView
+        {...ACTIVE_CONNECTION}
+        statusLabel="Reconnect required"
+        statusVariant="warning"
+        persistedError="Google access has expired. Reconnect the same Google account."
+        needsReauth
+        calendars={[]}
+        selectedCalendarIds={new Set()}
+      />
+    </SettingsState>
+  );
+}
+
+function PersistedSyncErrorState() {
+  return (
+    <SettingsState>
+      <GoogleCalendarConnectionView
+        {...ACTIVE_CONNECTION}
+        statusLabel="Needs attention"
+        statusVariant="warning"
+        persistedError="Some calendars could not be synced. Review the selection and try again."
+      />
+    </SettingsState>
+  );
+}
+
+const meta = {
+  title: 'Product/Features/ExternalCalendar/GoogleCalendarSettings',
+  component: GoogleCalendarSettingsView,
+  args: {
+    loading: false,
+    error: false,
+    availabilityLoading: false,
+    available: true,
+    hasConnections: false,
+    onRetry: fn(),
+    onConnect: fn(),
+  },
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-2xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof GoogleCalendarSettingsView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const AvailableDisconnected: Story = {
+  render: () => <SettingsState />,
+};
+
+export const Unavailable: Story = {
+  render: () => <SettingsState available={false} />,
+};
+
+export const MultipleAccounts: Story = {
+  render: () => <MultipleAccountsState />,
+};
+
+export const ReauthorizationRequired: Story = {
+  render: () => <ReauthorizationRequiredState />,
+};
+
+export const PersistedSyncError: Story = {
+  render: () => <PersistedSyncErrorState />,
+};
+
+export const Loading: Story = {
+  render: () => <SettingsState loading availabilityLoading />,
+};
+
+export const QueryError: Story = {
+  render: () => <SettingsState error />,
+};
+
+export const AllPatterns: Story = {
+  render: () => (
+    <div className="space-y-8">
+      <SettingsState />
+      <SettingsState available={false} />
+      <MultipleAccountsState />
+      <ReauthorizationRequiredState />
+      <PersistedSyncErrorState />
+      <SettingsState loading availabilityLoading />
+      <SettingsState error />
+    </div>
+  ),
+};

--- a/apps/product/src/features/external-calendar/components/GoogleCalendarSettingsView.tsx
+++ b/apps/product/src/features/external-calendar/components/GoogleCalendarSettingsView.tsx
@@ -1,0 +1,246 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import {
+  Badge,
+  Button,
+  Checkbox,
+  InlineBanner,
+  Skeleton,
+  type BadgeProps,
+} from '@dayopt/components';
+import { CalendarSync, Plus, RefreshCw, Unplug } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+import { SectionCard } from '@/components/ui/display/SectionCard';
+import { ErrorState } from '@/components/ui/feedback/ErrorState';
+
+export type GoogleCalendarOption = {
+  id: string;
+  name: string | null;
+  primary: boolean;
+  selected: boolean;
+};
+
+export type GoogleCalendarConnectionViewProps = {
+  email: string | null;
+  lastSyncedLabel: string;
+  statusLabel: string;
+  statusVariant: BadgeProps['variant'];
+  persistedError: string | null;
+  needsReauth: boolean;
+  reconnectAvailable: boolean;
+  calendars: GoogleCalendarOption[];
+  selectedCalendarIds: ReadonlySet<string>;
+  calendarsLoading: boolean;
+  calendarsError: boolean;
+  applying: boolean;
+  syncing: boolean;
+  disconnecting: boolean;
+  selectionDirty: boolean;
+  onToggleCalendar: (calendarId: string, checked: boolean) => void;
+  onRetryCalendars: () => void;
+  onApply: () => void;
+  onSync: () => void;
+  onReconnect: () => void;
+  onDisconnect: () => void;
+};
+
+type GoogleCalendarSettingsViewProps = {
+  loading: boolean;
+  error: boolean;
+  availabilityLoading: boolean;
+  available: boolean;
+  hasConnections: boolean;
+  onRetry: () => void;
+  onConnect: () => void;
+  children?: ReactNode;
+};
+
+export function GoogleCalendarSettingsView({
+  loading,
+  error,
+  availabilityLoading,
+  available,
+  hasConnections,
+  onRetry,
+  onConnect,
+  children,
+}: GoogleCalendarSettingsViewProps) {
+  const t = useTranslations('settings.integrations.googleCalendar');
+  const connectLabel = hasConnections ? t('addAccount') : t('connect');
+
+  return (
+    <SectionCard
+      title={t('title')}
+      actions={
+        <Button
+          size="sm"
+          onClick={onConnect}
+          disabled={availabilityLoading || !available}
+          loading={availabilityLoading}
+          loadingText={t('checkingAvailability')}
+        >
+          <Plus className="size-4" />
+          {connectLabel}
+        </Button>
+      }
+    >
+      <p className="text-muted-foreground mb-4 text-sm">{t('description')}</p>
+
+      {!availabilityLoading && !available ? (
+        <InlineBanner visible message={t('unavailable')} />
+      ) : null}
+
+      {loading ? (
+        <div className="space-y-3 py-4" aria-label={t('loading')}>
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-24 w-full" />
+        </div>
+      ) : error ? (
+        <ErrorState title={t('loadError')} onRetry={onRetry} size="sm" />
+      ) : hasConnections ? (
+        <div className="mt-4 space-y-4">{children}</div>
+      ) : (
+        <p className="text-muted-foreground py-4 text-sm">{t('empty')}</p>
+      )}
+    </SectionCard>
+  );
+}
+
+export function GoogleCalendarConnectionView({
+  email,
+  lastSyncedLabel,
+  statusLabel,
+  statusVariant,
+  persistedError,
+  needsReauth,
+  reconnectAvailable,
+  calendars,
+  selectedCalendarIds,
+  calendarsLoading,
+  calendarsError,
+  applying,
+  syncing,
+  disconnecting,
+  selectionDirty,
+  onToggleCalendar,
+  onRetryCalendars,
+  onApply,
+  onSync,
+  onReconnect,
+  onDisconnect,
+}: GoogleCalendarConnectionViewProps) {
+  const t = useTranslations('settings.integrations.googleCalendar');
+
+  return (
+    <article className="border-border rounded-2xl border p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium">{email ?? t('unknownAccount')}</p>
+          <p className="text-muted-foreground mt-1 text-xs">
+            {t('lastSync', { value: lastSyncedLabel })}
+          </p>
+        </div>
+        <Badge variant={statusVariant}>{statusLabel}</Badge>
+      </div>
+
+      {needsReauth ? (
+        <div className="mt-4">
+          <InlineBanner
+            visible
+            message={persistedError ?? t('errors.reauthRequired')}
+            action={{
+              label: t('reconnect'),
+              onClick: onReconnect,
+              disabled: !reconnectAvailable,
+            }}
+          />
+        </div>
+      ) : persistedError ? (
+        <div className="mt-4">
+          <InlineBanner visible message={persistedError} />
+        </div>
+      ) : null}
+
+      <div className="mt-4">
+        <p className="text-muted-foreground mb-2 text-xs font-medium tracking-wide uppercase">
+          {t('calendars')}
+        </p>
+        {needsReauth ? (
+          <p className="text-muted-foreground py-3 text-sm">{t('reconnectToChoose')}</p>
+        ) : calendarsLoading ? (
+          <div className="space-y-2 py-2" aria-label={t('loadingCalendars')}>
+            <Skeleton className="h-8 w-full" />
+            <Skeleton className="h-8 w-full" />
+          </div>
+        ) : calendarsError ? (
+          <ErrorState title={t('calendarLoadError')} onRetry={onRetryCalendars} size="sm" />
+        ) : calendars.length === 0 ? (
+          <p className="text-muted-foreground py-3 text-sm">{t('noCalendars')}</p>
+        ) : (
+          <div className="divide-border divide-y">
+            {calendars.map((calendar) => {
+              const label = calendar.name ?? t('unnamedCalendar');
+              return (
+                <label
+                  key={calendar.id}
+                  className="flex min-h-11 cursor-pointer items-center gap-3 py-2 text-sm"
+                >
+                  <Checkbox
+                    checked={selectedCalendarIds.has(calendar.id)}
+                    disabled={applying}
+                    onCheckedChange={(checked) => onToggleCalendar(calendar.id, checked === true)}
+                    aria-label={label}
+                  />
+                  <span className="min-w-0 flex-1 truncate">{label}</span>
+                  {calendar.primary ? <Badge variant="outline">{t('primary')}</Badge> : null}
+                </label>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center gap-2">
+        <Button
+          size="sm"
+          onClick={onApply}
+          disabled={needsReauth || calendarsLoading || calendarsError || !selectionDirty || syncing}
+          loading={applying}
+          loadingText={t('applying')}
+        >
+          {t('apply')}
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onSync}
+          disabled={needsReauth || applying}
+          loading={syncing}
+          loadingText={t('syncing')}
+        >
+          <RefreshCw className="size-4" />
+          {t('syncNow')}
+        </Button>
+        {needsReauth ? (
+          <Button variant="outline" size="sm" onClick={onReconnect} disabled={!reconnectAvailable}>
+            <CalendarSync className="size-4" />
+            {t('reconnect')}
+          </Button>
+        ) : null}
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onDisconnect}
+          disabled={disconnecting || applying || syncing}
+          className="text-destructive"
+        >
+          <Unplug className="size-4" />
+          {t('disconnect')}
+        </Button>
+      </div>
+    </article>
+  );
+}

--- a/apps/product/src/features/external-calendar/components/__tests__/GoogleCalendarSettings.test.tsx
+++ b/apps/product/src/features/external-calendar/components/__tests__/GoogleCalendarSettings.test.tsx
@@ -1,0 +1,240 @@
+import { act, render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type SelectionInput = {
+  connectionId: string;
+  calendars: Array<{ providerCalendarId: string; calendarName?: string | null }>;
+};
+
+type SelectionContext = {
+  previousProvider: typeof PREVIOUS_PROVIDER;
+  previousStatus: typeof PREVIOUS_STATUS;
+};
+
+type UpdateMutationOptions = {
+  onMutate: (input: SelectionInput) => Promise<SelectionContext>;
+  onError: (error: unknown, input: SelectionInput, context?: SelectionContext) => void;
+  onSettled: () => Promise<void>;
+};
+
+type SimpleMutationOptions = {
+  onMutate?: () => Promise<void>;
+  onSettled: () => Promise<void>;
+};
+
+const CONNECTION_ID = '00000000-0000-4000-8000-0000000000c1';
+const QUERY_INPUT = { connectionId: CONNECTION_ID };
+const PREVIOUS_PROVIDER = [
+  { id: 'primary', name: 'Primary', primary: true, selected: true },
+  { id: 'focus', name: 'Focus', primary: false, selected: false },
+];
+const PREVIOUS_STATUS = {
+  connection: {
+    id: CONNECTION_ID,
+    provider: 'google',
+    provider_account_email: 'user@example.com',
+    status: 'active',
+    last_synced_at: null,
+    last_sync_error: null,
+  },
+  calendars: [{ provider_calendar_id: 'primary', calendar_name: 'Primary', last_synced_at: null }],
+};
+
+const mocks = vi.hoisted(() => ({
+  updateOptions: null as UpdateMutationOptions | null,
+  syncOptions: null as SimpleMutationOptions | null,
+  disconnectOptions: null as SimpleMutationOptions | null,
+  updateMutate: vi.fn(),
+  syncMutate: vi.fn(),
+  disconnectMutate: vi.fn(),
+  disconnectMutateAsync: vi.fn(),
+  listCancel: vi.fn(),
+  listInvalidate: vi.fn(),
+  listSetData: vi.fn(),
+  providerCancel: vi.fn(),
+  providerGetData: vi.fn(),
+  providerSetData: vi.fn(),
+  providerInvalidate: vi.fn(),
+  statusCancel: vi.fn(),
+  statusGetData: vi.fn(),
+  statusSetData: vi.fn(),
+  statusInvalidate: vi.fn(),
+}));
+
+vi.mock('next-intl', () => ({
+  useLocale: () => 'ja',
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('@/lib/hooks/useHasMounted', () => ({
+  useHasMounted: () => true,
+}));
+
+vi.mock('@/lib/toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/lib/trpc', () => ({
+  api: {
+    useUtils: () => ({
+      externalCalendar: {
+        listConnections: {
+          cancel: mocks.listCancel,
+          invalidate: mocks.listInvalidate,
+          setData: mocks.listSetData,
+        },
+        listProviderCalendars: {
+          cancel: mocks.providerCancel,
+          getData: mocks.providerGetData,
+          setData: mocks.providerSetData,
+          invalidate: mocks.providerInvalidate,
+        },
+        getSyncStatus: {
+          cancel: mocks.statusCancel,
+          getData: mocks.statusGetData,
+          setData: mocks.statusSetData,
+          invalidate: mocks.statusInvalidate,
+        },
+      },
+    }),
+    externalCalendar: {
+      listConnections: {
+        useQuery: () => ({
+          data: [PREVIOUS_STATUS.connection],
+          isLoading: false,
+          isError: false,
+          refetch: vi.fn(),
+        }),
+      },
+      getConnectionAvailability: {
+        useQuery: () => ({ data: { available: true }, isLoading: false }),
+      },
+      getSyncStatus: {
+        useQuery: () => ({ data: PREVIOUS_STATUS, isError: false, refetch: vi.fn() }),
+      },
+      listProviderCalendars: {
+        useQuery: () => ({
+          data: PREVIOUS_PROVIDER,
+          error: null,
+          isLoading: false,
+          isError: false,
+          refetch: vi.fn(),
+        }),
+      },
+      updateSelectedCalendars: {
+        useMutation: (options: UpdateMutationOptions) => {
+          mocks.updateOptions = options;
+          return { mutate: mocks.updateMutate, isPending: false };
+        },
+      },
+      syncNow: {
+        useMutation: (options: SimpleMutationOptions) => {
+          mocks.syncOptions = options;
+          return { mutate: mocks.syncMutate, isPending: false };
+        },
+      },
+      disconnect: {
+        useMutation: (options: SimpleMutationOptions) => {
+          mocks.disconnectOptions = options;
+          return {
+            mutate: mocks.disconnectMutate,
+            mutateAsync: mocks.disconnectMutateAsync,
+            isPending: false,
+          };
+        },
+      },
+    },
+  },
+}));
+
+import { GoogleCalendarSettings } from '../GoogleCalendarSettings';
+
+describe('GoogleCalendarSettings mutation contracts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.updateOptions = null;
+    mocks.syncOptions = null;
+    mocks.disconnectOptions = null;
+    mocks.providerGetData.mockReturnValue(PREVIOUS_PROVIDER);
+    mocks.statusGetData.mockReturnValue(PREVIOUS_STATUS);
+    for (const invalidate of [
+      mocks.listInvalidate,
+      mocks.providerInvalidate,
+      mocks.statusInvalidate,
+    ]) {
+      invalidate.mockResolvedValue(undefined);
+    }
+    mocks.listCancel.mockResolvedValue(undefined);
+    mocks.providerCancel.mockResolvedValue(undefined);
+    mocks.statusCancel.mockResolvedValue(undefined);
+  });
+
+  it('選択更新を snapshot し、失敗時に rollback して settled で authoritative refetch する', async () => {
+    render(<GoogleCalendarSettings />);
+    const input: SelectionInput = {
+      connectionId: CONNECTION_ID,
+      calendars: [{ providerCalendarId: 'focus', calendarName: 'Focus' }],
+    };
+
+    let context: SelectionContext | undefined;
+    await act(async () => {
+      context = await mocks.updateOptions?.onMutate(input);
+    });
+
+    expect(mocks.providerCancel).toHaveBeenCalledWith(QUERY_INPUT);
+    expect(mocks.statusCancel).toHaveBeenCalledWith(QUERY_INPUT);
+    expect(context).toEqual({
+      previousProvider: PREVIOUS_PROVIDER,
+      previousStatus: PREVIOUS_STATUS,
+    });
+
+    const providerUpdater = mocks.providerSetData.mock.calls[0]?.[1] as (
+      current: typeof PREVIOUS_PROVIDER,
+    ) => typeof PREVIOUS_PROVIDER;
+    expect(providerUpdater(PREVIOUS_PROVIDER).map((calendar) => calendar.selected)).toEqual([
+      false,
+      true,
+    ]);
+
+    act(() => {
+      mocks.updateOptions?.onError(new Error('failed'), input, context);
+    });
+    expect(mocks.providerSetData).toHaveBeenNthCalledWith(2, QUERY_INPUT, PREVIOUS_PROVIDER);
+    expect(mocks.statusSetData).toHaveBeenNthCalledWith(2, QUERY_INPUT, PREVIOUS_STATUS);
+
+    await act(async () => {
+      await mocks.updateOptions?.onSettled();
+    });
+    expect(mocks.listInvalidate).toHaveBeenCalledOnce();
+    expect(mocks.providerInvalidate).toHaveBeenCalledWith(QUERY_INPUT);
+    expect(mocks.statusInvalidate).toHaveBeenCalledWith(QUERY_INPUT);
+  });
+
+  it('手動同期は settled 後に connection と sync status を再取得する', async () => {
+    render(<GoogleCalendarSettings />);
+
+    await act(async () => {
+      await mocks.syncOptions?.onSettled();
+    });
+
+    expect(mocks.listInvalidate).toHaveBeenCalledOnce();
+    expect(mocks.statusInvalidate).toHaveBeenCalledWith(QUERY_INPUT);
+  });
+
+  it('切断は一覧を楽観削除せず、settled 後に全関連 query を再取得する', async () => {
+    render(<GoogleCalendarSettings />);
+
+    await act(async () => {
+      await mocks.disconnectOptions?.onMutate?.();
+    });
+    expect(mocks.listCancel).toHaveBeenCalledOnce();
+    expect(mocks.listSetData).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await mocks.disconnectOptions?.onSettled();
+    });
+    expect(mocks.listInvalidate).toHaveBeenCalledOnce();
+    expect(mocks.providerInvalidate).toHaveBeenCalledWith(QUERY_INPUT);
+    expect(mocks.statusInvalidate).toHaveBeenCalledWith(QUERY_INPUT);
+  });
+});

--- a/apps/product/src/features/external-calendar/components/__tests__/GoogleCalendarSettingsView.test.tsx
+++ b/apps/product/src/features/external-calendar/components/__tests__/GoogleCalendarSettingsView.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+import {
+  GoogleCalendarConnectionView,
+  GoogleCalendarSettingsView,
+  type GoogleCalendarConnectionViewProps,
+} from '../GoogleCalendarSettingsView';
+
+const CONNECTION_PROPS: GoogleCalendarConnectionViewProps = {
+  email: 'user@example.com',
+  lastSyncedLabel: 'neverSynced',
+  statusLabel: 'status.connected',
+  statusVariant: 'success',
+  persistedError: null,
+  needsReauth: false,
+  reconnectAvailable: true,
+  calendars: [],
+  selectedCalendarIds: new Set(),
+  calendarsLoading: false,
+  calendarsError: false,
+  applying: false,
+  syncing: false,
+  disconnecting: false,
+  selectionDirty: false,
+  onToggleCalendar: vi.fn(),
+  onRetryCalendars: vi.fn(),
+  onApply: vi.fn(),
+  onSync: vi.fn(),
+  onReconnect: vi.fn(),
+  onDisconnect: vi.fn(),
+};
+
+describe('GoogleCalendarSettingsView', () => {
+  it('未接続でも接続 CTA を表示する', async () => {
+    const onConnect = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <GoogleCalendarSettingsView
+        loading={false}
+        error={false}
+        availabilityLoading={false}
+        available
+        hasConnections={false}
+        onRetry={vi.fn()}
+        onConnect={onConnect}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'connect' }));
+    expect(onConnect).toHaveBeenCalledOnce();
+  });
+
+  it('複数接続があってもアカウント追加 CTA を常に表示する', () => {
+    render(
+      <GoogleCalendarSettingsView
+        loading={false}
+        error={false}
+        availabilityLoading={false}
+        available
+        hasConnections
+        onRetry={vi.fn()}
+        onConnect={vi.fn()}
+      >
+        <GoogleCalendarConnectionView {...CONNECTION_PROPS} email="first@example.com" />
+        <GoogleCalendarConnectionView {...CONNECTION_PROPS} email="second@example.com" />
+      </GoogleCalendarSettingsView>,
+    );
+
+    expect(screen.getByRole('button', { name: 'addAccount' })).toBeEnabled();
+    expect(screen.getByText('first@example.com')).toBeInTheDocument();
+    expect(screen.getByText('second@example.com')).toBeInTheDocument();
+  });
+
+  it('利用できない環境では接続と再接続を無効にする', () => {
+    render(
+      <GoogleCalendarSettingsView
+        loading={false}
+        error={false}
+        availabilityLoading={false}
+        available={false}
+        hasConnections
+        onRetry={vi.fn()}
+        onConnect={vi.fn()}
+      >
+        <GoogleCalendarConnectionView
+          {...CONNECTION_PROPS}
+          needsReauth
+          reconnectAvailable={false}
+          persistedError="errors.reauthRequired"
+        />
+      </GoogleCalendarSettingsView>,
+    );
+
+    expect(screen.getByRole('button', { name: 'addAccount' })).toBeDisabled();
+    for (const button of screen.getAllByRole('button', { name: 'reconnect' })) {
+      expect(button).toBeDisabled();
+    }
+  });
+
+  it('選択の適用中は後発編集と競合する操作を無効にする', () => {
+    render(
+      <GoogleCalendarConnectionView
+        {...CONNECTION_PROPS}
+        calendars={[{ id: 'work', name: 'Work', primary: true, selected: true }]}
+        selectedCalendarIds={new Set(['work'])}
+        selectionDirty
+        applying
+      />,
+    );
+
+    expect(screen.getByRole('checkbox', { name: 'Work' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'syncNow' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'disconnect' })).toBeDisabled();
+  });
+
+  it('手動同期中は選択の適用と切断を無効にする', () => {
+    render(
+      <GoogleCalendarConnectionView
+        {...CONNECTION_PROPS}
+        calendars={[{ id: 'work', name: 'Work', primary: true, selected: true }]}
+        selectedCalendarIds={new Set()}
+        selectionDirty
+        syncing
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'apply' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'disconnect' })).toBeDisabled();
+  });
+});

--- a/apps/product/src/features/external-calendar/index.ts
+++ b/apps/product/src/features/external-calendar/index.ts
@@ -1,0 +1,7 @@
+export {
+  parseCalendarCallbackResult,
+  removeCalendarCallbackParams,
+  type CalendarCallbackError,
+} from './lib/calendar-callback-result';
+
+export { GoogleCalendarSettings } from './components/GoogleCalendarSettings';

--- a/apps/product/src/features/external-calendar/lib/__tests__/calendar-callback-result.test.ts
+++ b/apps/product/src/features/external-calendar/lib/__tests__/calendar-callback-result.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  parseCalendarCallbackResult,
+  removeCalendarCallbackParams,
+} from '../calendar-callback-result';
+
+describe('parseCalendarCallbackResult', () => {
+  it('接続成功を固定結果へ変換する', () => {
+    expect(parseCalendarCallbackResult(new URLSearchParams('calendar=connected'))).toEqual({
+      type: 'connected',
+    });
+  });
+
+  it('表示可能な reason だけを固定エラーへ変換する', () => {
+    expect(
+      parseCalendarCallbackResult(new URLSearchParams('calendar=error&reason=account_mismatch')),
+    ).toEqual({ type: 'error', error: 'account_mismatch' });
+  });
+
+  it('未知の provider reason を UI に露出しない', () => {
+    expect(
+      parseCalendarCallbackResult(new URLSearchParams('calendar=error&reason=raw-provider-detail')),
+    ).toEqual({ type: 'error', error: 'generic' });
+  });
+
+  it('callback でなければ null', () => {
+    expect(parseCalendarCallbackResult(new URLSearchParams('calendar=pending'))).toBeNull();
+  });
+});
+
+describe('removeCalendarCallbackParams', () => {
+  it('calendar / reason だけを削除し、他の query を保持する', () => {
+    const result = removeCalendarCallbackParams(
+      new URLSearchParams(
+        'returnTo=%2Fweek%3Fdate%3D2026-08-01&calendar=error&reason=x&panel=review',
+      ),
+    );
+
+    expect(result.toString()).toBe('returnTo=%2Fweek%3Fdate%3D2026-08-01&panel=review');
+  });
+});

--- a/apps/product/src/features/external-calendar/lib/calendar-callback-result.ts
+++ b/apps/product/src/features/external-calendar/lib/calendar-callback-result.ts
@@ -1,0 +1,50 @@
+export type CalendarCallbackError =
+  | 'access_denied'
+  | 'account_mismatch'
+  | 'pro_required'
+  | 'rate_limited'
+  | 'reconnect_target_invalid'
+  | 'unavailable'
+  | 'generic';
+
+type CalendarCallbackResult =
+  { type: 'connected' } | { type: 'error'; error: CalendarCallbackError };
+
+type SearchParamsReader = Pick<URLSearchParams, 'get'>;
+
+const CALLBACK_ERROR_GROUPS: Readonly<Record<string, CalendarCallbackError>> = {
+  access_denied: 'access_denied',
+  account_mismatch: 'account_mismatch',
+  pro_required: 'pro_required',
+  rate_limited: 'rate_limited',
+  reconnect_target_invalid: 'reconnect_target_invalid',
+  unsupported_environment: 'unavailable',
+  token_endpoint_unreachable: 'unavailable',
+  token_exchange_rejected: 'unavailable',
+};
+
+/**
+ * OAuth callback の query を、UI に表示してよい固定コードだけへ畳み込む。
+ * provider 由来や未知の reason をそのまま表示しない。
+ */
+export function parseCalendarCallbackResult(
+  searchParams: SearchParamsReader,
+): CalendarCallbackResult | null {
+  const calendar = searchParams.get('calendar');
+  if (calendar === 'connected') return { type: 'connected' };
+  if (calendar !== 'error') return null;
+
+  const reason = searchParams.get('reason');
+  return {
+    type: 'error',
+    error: reason ? (CALLBACK_ERROR_GROUPS[reason] ?? 'generic') : 'generic',
+  };
+}
+
+/** OAuth callback 専用の query だけを除き、returnTo など他の query は保持する。 */
+export function removeCalendarCallbackParams(searchParams: URLSearchParams): URLSearchParams {
+  const next = new URLSearchParams(searchParams);
+  next.delete('calendar');
+  next.delete('reason');
+  return next;
+}

--- a/apps/product/src/features/external-calendar/schemas/__tests__/google.test.ts
+++ b/apps/product/src/features/external-calendar/schemas/__tests__/google.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { connectFlowStateSchema } from '../google';
+
+const BASE_FLOW = {
+  state: 'state-value',
+  verifier: 'verifier-value',
+  locale: 'ja',
+  userId: '00000000-0000-4000-8000-0000000000a1',
+};
+
+describe('connectFlowStateSchema', () => {
+  it('従来の connect cookie を引き続き受け入れる', () => {
+    expect(connectFlowStateSchema.safeParse(BASE_FLOW).success).toBe(true);
+  });
+
+  it('UUID の reconnectConnectionId を任意で受け入れる', () => {
+    expect(
+      connectFlowStateSchema.safeParse({
+        ...BASE_FLOW,
+        reconnectConnectionId: '00000000-0000-4000-8000-0000000000c1',
+      }).success,
+    ).toBe(true);
+    expect(
+      connectFlowStateSchema.safeParse({ ...BASE_FLOW, reconnectConnectionId: 'not-a-uuid' })
+        .success,
+    ).toBe(false);
+  });
+});

--- a/apps/product/src/features/external-calendar/schemas/google.ts
+++ b/apps/product/src/features/external-calendar/schemas/google.ts
@@ -70,6 +70,7 @@ export const connectFlowStateSchema = z.object({
   verifier: z.string().min(1).max(255),
   locale: z.string().min(1).max(16),
   userId: z.string().uuid(),
+  reconnectConnectionId: z.string().uuid().optional(),
 });
 
 export type ConnectFlowState = z.infer<typeof connectFlowStateSchema>;

--- a/apps/product/src/features/external-calendar/server/__tests__/connection-service.test.ts
+++ b/apps/product/src/features/external-calendar/server/__tests__/connection-service.test.ts
@@ -44,9 +44,11 @@ vi.mock('@/lib/logger', () => ({
 
 import {
   disconnect,
+  getReconnectTarget,
   getSyncStatus,
   listConnections,
   listProviderCalendars,
+  reconnectExistingConnection,
   updateSelectedCalendars,
 } from '../connection-service';
 
@@ -57,6 +59,8 @@ type Recorder = { table: string; chain: Array<{ method: string; args: unknown[] 
 
 type Config = {
   connection?: { data_generation?: number; status: string; refresh_token_enc: string } | null;
+  reconnectTarget?: { id: string; provider_account_id: string } | null;
+  reconnectUpdate?: { id: string } | null;
   childRows?: Array<{ provider_calendar_id: string }>;
 };
 
@@ -66,7 +70,15 @@ function setupServiceRoleDb(config: Config) {
   function resolve(recorder: Recorder): { data: unknown; error: unknown } {
     const methods = recorder.chain.map((entry) => entry.method);
     if (recorder.table === 'calendar_connections') {
-      if (methods.includes('maybeSingle')) return { data: config.connection ?? null, error: null };
+      if (methods.includes('maybeSingle')) {
+        if (methods.includes('update'))
+          return { data: config.reconnectUpdate ?? null, error: null };
+        const select = recorder.chain.find((entry) => entry.method === 'select')?.args[0];
+        if (select === 'id, provider_account_id') {
+          return { data: config.reconnectTarget ?? null, error: null };
+        }
+        return { data: config.connection ?? null, error: null };
+      }
       return { data: null, error: null }; // update / delete
     }
     if (recorder.table === 'calendar_connection_calendars') {
@@ -167,6 +179,84 @@ describe('getSyncStatus', () => {
     await expect(getSyncStatus(supabase, USER_ID, CONNECTION_ID)).rejects.toMatchObject({
       code: 'CONNECTION_NOT_FOUND',
     });
+  });
+});
+
+describe('reconnect contract', () => {
+  it('対象読取を id / user / provider / reauth_required で限定する', async () => {
+    const { calls } = setupServiceRoleDb({
+      reconnectTarget: { id: CONNECTION_ID, provider_account_id: 'google-sub-123' },
+    });
+
+    await expect(getReconnectTarget(USER_ID, CONNECTION_ID)).resolves.toEqual({
+      id: CONNECTION_ID,
+      providerAccountId: 'google-sub-123',
+    });
+
+    const query = findWith(calls, 'calendar_connections', 'maybeSingle');
+    if (!query) throw new Error('reconnect target query not found');
+    expect(query.chain.filter((entry) => entry.method === 'eq').map((entry) => entry.args)).toEqual(
+      [
+        ['id', CONNECTION_ID],
+        ['user_id', USER_ID],
+        ['provider', 'google'],
+        ['status', 'reauth_required'],
+      ],
+    );
+  });
+
+  it('再接続は安定 sub を含む条件付き UPDATE だけを実行する', async () => {
+    const { calls } = setupServiceRoleDb({ reconnectUpdate: { id: CONNECTION_ID } });
+
+    await expect(
+      reconnectExistingConnection({
+        connectionId: CONNECTION_ID,
+        userId: USER_ID,
+        providerAccountId: 'google-sub-123',
+        providerAccountEmail: 'user@example.com',
+        grantedScopes: ['calendar.readonly'],
+        refreshToken: 'new-refresh-token',
+        encryptionKey: 'encryption-key',
+      }),
+    ).resolves.toBe('updated');
+
+    const update = findWith(calls, 'calendar_connections', 'update');
+    if (!update) throw new Error('reconnect update not found');
+    expect(argsOf(update, 'update')[0]).toEqual({
+      provider_account_email: 'user@example.com',
+      granted_scopes: ['calendar.readonly'],
+      refresh_token_enc: 'enc',
+      status: 'active',
+      last_sync_error: null,
+    });
+    expect(
+      update.chain.filter((entry) => entry.method === 'eq').map((entry) => entry.args),
+    ).toEqual([
+      ['id', CONNECTION_ID],
+      ['user_id', USER_ID],
+      ['provider', 'google'],
+      ['provider_account_id', 'google-sub-123'],
+      ['status', 'reauth_required'],
+    ]);
+    expect(findWith(calls, 'calendar_connections', 'upsert')).toBeUndefined();
+  });
+
+  it('切断との競合で更新行が無ければ missing とし、新規行を作らない', async () => {
+    const { calls } = setupServiceRoleDb({ reconnectUpdate: null });
+
+    await expect(
+      reconnectExistingConnection({
+        connectionId: CONNECTION_ID,
+        userId: USER_ID,
+        providerAccountId: 'google-sub-123',
+        providerAccountEmail: null,
+        grantedScopes: ['calendar.readonly'],
+        refreshToken: 'new-refresh-token',
+        encryptionKey: 'encryption-key',
+      }),
+    ).resolves.toBe('missing');
+
+    expect(findWith(calls, 'calendar_connections', 'upsert')).toBeUndefined();
   });
 });
 

--- a/apps/product/src/features/external-calendar/server/__tests__/router.test.ts
+++ b/apps/product/src/features/external-calendar/server/__tests__/router.test.ts
@@ -11,6 +11,8 @@ const disconnect = vi.hoisted(() => vi.fn());
 const syncConnection = vi.hoisted(() => vi.fn());
 const rateLimit = vi.hoisted(() => vi.fn());
 const isBillingEnforced = vi.hoisted(() => vi.fn(() => false));
+const isGoogleCalendarConfigured = vi.hoisted(() => vi.fn());
+const resolveRedirectUri = vi.hoisted(() => vi.fn());
 
 vi.mock('../connection-service', () => ({
   listConnections,
@@ -20,6 +22,7 @@ vi.mock('../connection-service', () => ({
   disconnect,
 }));
 vi.mock('../sync-service', () => ({ syncConnection }));
+vi.mock('../google-oauth', () => ({ isGoogleCalendarConfigured, resolveRedirectUri }));
 vi.mock('@/lib/rate-limit/upstash', () => ({
   calendarSyncNowRateLimit: { limit: rateLimit },
   // protectedProcedure が毎リクエスト参照する。ここでは常に成功させる。
@@ -48,6 +51,10 @@ beforeEach(() => {
   listProviderCalendars.mockResolvedValue([]);
   updateSelectedCalendars.mockResolvedValue(undefined);
   disconnect.mockResolvedValue(undefined);
+  isGoogleCalendarConfigured.mockReturnValue(true);
+  resolveRedirectUri.mockReturnValue(
+    'https://app.dayopt.app/api/integrations/google-calendar/callback',
+  );
 });
 
 describe('externalCalendarRouter — 認可', () => {
@@ -63,6 +70,38 @@ describe('externalCalendarRouter — 認可', () => {
   it('未認証（userId なし）は listConnections で弾かれる', async () => {
     const unauth = createCaller(createMockContext({}));
     await expect(unauth.listConnections()).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+  });
+});
+
+describe('externalCalendarRouter — connection availability', () => {
+  it('設定と redirect origin が一致すると available=true', async () => {
+    await expect(
+      caller().getConnectionAvailability({ origin: 'https://app.dayopt.app' }),
+    ).resolves.toEqual({ available: true });
+  });
+
+  it('設定不足または protocol の違う redirect は available=false', async () => {
+    isGoogleCalendarConfigured.mockReturnValue(false);
+    await expect(
+      caller().getConnectionAvailability({ origin: 'https://app.dayopt.app' }),
+    ).resolves.toEqual({ available: false });
+
+    isGoogleCalendarConfigured.mockReturnValue(true);
+    resolveRedirectUri.mockReturnValue(
+      'http://app.dayopt.app/api/integrations/google-calendar/callback',
+    );
+    await expect(
+      caller().getConnectionAvailability({ origin: 'https://app.dayopt.app' }),
+    ).resolves.toEqual({ available: false });
+  });
+
+  it('origin 以外や http(s) 以外は BAD_REQUEST', async () => {
+    await expect(
+      caller().getConnectionAvailability({ origin: 'https://app.dayopt.app/path' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    await expect(
+      caller().getConnectionAvailability({ origin: 'ftp://app.dayopt.app' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
   });
 });
 

--- a/apps/product/src/features/external-calendar/server/connection-service.ts
+++ b/apps/product/src/features/external-calendar/server/connection-service.ts
@@ -71,6 +71,15 @@ type SaveConnectionInput = {
   encryptionKey: string;
 };
 
+type ReconnectTarget = {
+  id: string;
+  providerAccountId: string;
+};
+
+type ReconnectExistingConnectionInput = SaveConnectionInput & {
+  connectionId: string;
+};
+
 /**
  * 接続を保存する。
  *
@@ -99,6 +108,71 @@ export async function saveConnection(input: SaveConnectionInput): Promise<void> 
     // error にトークンは含まれないが、message をそのまま外へ出さない。
     throw new Error(`failed to save calendar connection: ${error.code ?? 'unknown'}`);
   }
+}
+
+/**
+ * 再接続対象を本人・provider・状態まで限定して読む。
+ *
+ * `provider_account_id` は Google の安定識別子であり、callback で検証済み `sub` と比較する
+ * ためだけに server 内で扱う。UI や cookie には載せない。
+ */
+export async function getReconnectTarget(
+  userId: string,
+  connectionId: string,
+): Promise<ReconnectTarget | null> {
+  const db = createCalendarConnectionDbClient();
+  const { data, error } = await db
+    .from(databaseTables.calendarConnections)
+    .select('id, provider_account_id')
+    .eq('id', connectionId)
+    .eq('user_id', userId)
+    .eq('provider', GOOGLE_PROVIDER)
+    .eq('status', 'reauth_required')
+    .maybeSingle();
+
+  if (error) {
+    throw new ExternalCalendarServiceError('FETCH_FAILED', 'failed to load reconnect target', {
+      cause: error,
+    });
+  }
+  if (!data) return null;
+  return { id: data.id, providerAccountId: data.provider_account_id };
+}
+
+/**
+ * 既存の再接続対象だけを更新する。
+ *
+ * generic upsert を使うと、callback と切断が競合した際に削除済み接続を再作成できてしまう。
+ * そのため id / owner / provider / Google sub / reauth 状態を一つの UPDATE で guard し、
+ * 更新行が無ければ再接続失敗として扱う。これにより切断が常に最終的に勝つ。
+ */
+export async function reconnectExistingConnection(
+  input: ReconnectExistingConnectionInput,
+): Promise<'updated' | 'missing'> {
+  const db = createCalendarConnectionDbClient();
+  const { data, error } = await db
+    .from(databaseTables.calendarConnections)
+    .update({
+      provider_account_email: input.providerAccountEmail,
+      granted_scopes: input.grantedScopes,
+      refresh_token_enc: encryptToken(input.refreshToken, input.encryptionKey),
+      status: 'active',
+      last_sync_error: null,
+    })
+    .eq('id', input.connectionId)
+    .eq('user_id', input.userId)
+    .eq('provider', GOOGLE_PROVIDER)
+    .eq('provider_account_id', input.providerAccountId)
+    .eq('status', 'reauth_required')
+    .select('id')
+    .maybeSingle();
+
+  if (error) {
+    throw new ExternalCalendarServiceError('UPDATE_FAILED', 'failed to reconnect calendar', {
+      cause: error,
+    });
+  }
+  return data ? 'updated' : 'missing';
 }
 
 // =============================================================================

--- a/apps/product/src/features/external-calendar/server/google-oauth.ts
+++ b/apps/product/src/features/external-calendar/server/google-oauth.ts
@@ -121,7 +121,7 @@ export function generateState(): string {
   return randomBytes(ENTROPY_BYTES).toString('base64url');
 }
 
-/** 同意画面の URL。`prompt=consent` で refresh token を確実に取りに行く。 */
+/** 同意画面の URL。refresh token を取り直し、接続する Google アカウントを毎回選ばせる。 */
 export function buildAuthorizationUrl(params: {
   redirectUri: string;
   state: string;
@@ -134,7 +134,7 @@ export function buildAuthorizationUrl(params: {
   url.searchParams.set('response_type', 'code');
   url.searchParams.set('scope', GOOGLE_AUTHORIZATION_SCOPES.join(' '));
   url.searchParams.set('access_type', 'offline');
-  url.searchParams.set('prompt', 'consent');
+  url.searchParams.set('prompt', 'consent select_account');
   // `include_granted_scopes` は付けない。付けると、この client が過去にそのユーザーへ
   // 得ていた scope まで今回の認可へ畳み込まれ、保存する refresh token が本機能に必要な
   // 範囲を超えた権限を持ちうる。callback は calendar.readonly の有無しか見ないので、

--- a/apps/product/src/features/external-calendar/server/router.ts
+++ b/apps/product/src/features/external-calendar/server/router.ts
@@ -12,17 +12,31 @@ import {
   listProviderCalendars,
   updateSelectedCalendars,
 } from './connection-service';
+import { isGoogleCalendarConfigured, resolveRedirectUri } from './google-oauth';
 import { syncConnection } from './sync-service';
 
 /**
  * 外部カレンダー接続の tRPC router（overview.md §7-2）。
  *
- * 読み取り 3 本は protectedProcedure、provider を叩く / 書き込む 3 本は proProcedure
+ * 読み取り 4 本は protectedProcedure、provider を叩く / 書き込む 3 本は proProcedure
  * （課金ゲート。`BILLING_ENFORCED` off の間は素通り）。ghost 用 `listEvents` / `dismiss` は
  * 次 project の予約席なのでここには置かない。
  */
 
 const connectionIdInput = z.object({ connectionId: z.string().uuid() });
+
+const connectionAvailabilityInput = z.object({
+  origin: z
+    .string()
+    .url()
+    .refine(
+      (value) => {
+        const url = new URL(value);
+        return (url.protocol === 'http:' || url.protocol === 'https:') && url.origin === value;
+      },
+      { message: 'origin must be an http(s) origin without a path' },
+    ),
+});
 
 const updateSelectedCalendarsInput = z.object({
   connectionId: z.string().uuid(),
@@ -60,6 +74,19 @@ async function enforceSyncNowRateLimit(userId: string): Promise<void> {
 }
 
 export const externalCalendarRouter = createTRPCRouter({
+  getConnectionAvailability: protectedProcedure
+    .meta({ description: '現在の origin で Google カレンダー接続を開始できるか' })
+    .input(connectionAvailabilityInput)
+    .query(({ input }) => {
+      if (!isGoogleCalendarConfigured()) return { available: false };
+
+      const requestUrl = new URL(input.origin);
+      const redirectUri = resolveRedirectUri(requestUrl);
+      return {
+        available: redirectUri !== null && new URL(redirectUri).origin === requestUrl.origin,
+      };
+    }),
+
   listConnections: protectedProcedure
     .meta({ description: '外部カレンダー接続一覧' })
     .query(async ({ ctx }) => {

--- a/apps/product/src/features/settings/components/DataSettings.tsx
+++ b/apps/product/src/features/settings/components/DataSettings.tsx
@@ -36,45 +36,11 @@ import {
 
 import { LabeledRow } from '@/components/ui/display/LabeledRow';
 import { SectionCard } from '@/components/ui/display/SectionCard';
+import { timeblockRowsToCsv } from '../lib/timeblock-csv-export';
 import { InfoBox } from './InfoBox';
 
 type ExportFormat = 'json' | 'csv';
 type ExportRange = 'all' | 'custom';
-
-const CSV_COLUMNS = [
-  'kind',
-  'id',
-  'title',
-  'note',
-  'tag_id',
-  'plan_id',
-  'start_at',
-  'end_at',
-  'source',
-  'skipped_at',
-  'created_at',
-  'updated_at',
-  'deleted_at',
-] as const;
-
-/**
- * plans / recordsをCSV文字列に変換
- * RFC 4180準拠: ダブルクォートでフィールドをエスケープ
- */
-function timeblockRowsToCsv(rows: Record<string, unknown>[]): string {
-  const escapeCsvField = (value: unknown): string => {
-    if (value == null) return '';
-    const str = String(value);
-    if (str.includes(',') || str.includes('"') || str.includes('\n')) {
-      return `"${str.replace(/"/g, '""')}"`;
-    }
-    return str;
-  };
-
-  const header = CSV_COLUMNS.join(',');
-  const csvRows = rows.map((row) => CSV_COLUMNS.map((col) => escapeCsvField(row[col])).join(','));
-  return [header, ...csvRows].join('\n');
-}
 
 /**
  * データ管理設定コンポーネント

--- a/apps/product/src/features/settings/components/ICalFeedSettings.stories.tsx
+++ b/apps/product/src/features/settings/components/ICalFeedSettings.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { fn } from 'storybook/test';
+
+import { ICalFeedSettingsView } from './ICalFeedSettings';
+
+const BASE_ARGS = {
+  feedUrl: 'https://app.dayopt.app/api/v1/calendar/example-private-token.ics',
+  loading: false,
+  error: false,
+  regenerating: false,
+  copied: false,
+  onRetry: fn(),
+  onCopy: fn(),
+  onGenerate: fn(),
+};
+
+const meta = {
+  title: 'Product/Features/Settings/ICalFeedSettings',
+  component: ICalFeedSettingsView,
+  args: BASE_ARGS,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-2xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ICalFeedSettingsView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const TokenAvailable: Story = {};
+
+export const TokenMissing: Story = {
+  args: { feedUrl: null },
+};
+
+export const Loading: Story = {
+  args: { feedUrl: null, loading: true },
+};
+
+export const QueryError: Story = {
+  args: { feedUrl: null, error: true },
+};
+
+export const AllPatterns: Story = {
+  render: () => (
+    <div className="space-y-8">
+      <ICalFeedSettingsView {...BASE_ARGS} />
+      <ICalFeedSettingsView {...BASE_ARGS} feedUrl={null} />
+      <ICalFeedSettingsView {...BASE_ARGS} feedUrl={null} loading />
+      <ICalFeedSettingsView {...BASE_ARGS} feedUrl={null} error />
+    </div>
+  ),
+};

--- a/apps/product/src/features/settings/components/ICalFeedSettings.tsx
+++ b/apps/product/src/features/settings/components/ICalFeedSettings.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Button, Input, Skeleton } from '@dayopt/components';
+import { Check, Copy, RefreshCw } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+import { LabeledRow } from '@/components/ui/display/LabeledRow';
+import { SectionCard } from '@/components/ui/display/SectionCard';
+import { ErrorState } from '@/components/ui/feedback/ErrorState';
+import { ConfirmDialog } from '@/components/ui/overlays/confirm-dialog';
+import { useHasMounted } from '@/lib/hooks/useHasMounted';
+import { toast } from '@/lib/toast';
+import { api } from '@/lib/trpc';
+
+type ICalFeedSettingsViewProps = {
+  feedUrl: string | null;
+  loading: boolean;
+  error: boolean;
+  regenerating: boolean;
+  copied: boolean;
+  onRetry: () => void;
+  onCopy: () => void;
+  onGenerate: () => void;
+};
+
+export function ICalFeedSettingsView({
+  feedUrl,
+  loading,
+  error,
+  regenerating,
+  copied,
+  onRetry,
+  onCopy,
+  onGenerate,
+}: ICalFeedSettingsViewProps) {
+  const t = useTranslations('settings.integrations.icalFeed');
+
+  return (
+    <SectionCard title={t('title')}>
+      <p className="text-muted-foreground mb-4 text-sm">{t('description')}</p>
+      {loading ? (
+        <div className="space-y-3 py-2" aria-label={t('loading')}>
+          <Skeleton className="h-9 w-full" />
+          <Skeleton className="h-9 w-32" />
+        </div>
+      ) : error ? (
+        <ErrorState title={t('loadError')} onRetry={onRetry} size="sm" />
+      ) : feedUrl ? (
+        <>
+          <LabeledRow label={t('feedUrl')}>
+            <div className="flex max-w-full items-center gap-2">
+              <Input
+                value={feedUrl}
+                readOnly
+                className="min-w-0 font-mono text-xs sm:w-80"
+                aria-label={t('feedUrl')}
+              />
+              <Button variant="outline" size="sm" icon onClick={onCopy} aria-label={t('copy')}>
+                {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+              </Button>
+            </div>
+          </LabeledRow>
+          <div className="mt-3">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onGenerate}
+              loading={regenerating}
+              loadingText={t('regenerating')}
+            >
+              <RefreshCw className="size-4" />
+              {t('regenerate')}
+            </Button>
+          </div>
+        </>
+      ) : (
+        <div className="space-y-3">
+          <p className="text-muted-foreground text-sm">{t('noToken')}</p>
+          <Button
+            size="sm"
+            onClick={onGenerate}
+            loading={regenerating}
+            loadingText={t('generating')}
+          >
+            {t('generate')}
+          </Button>
+        </div>
+      )}
+    </SectionCard>
+  );
+}
+
+export function ICalFeedSettings() {
+  const t = useTranslations('settings.integrations.icalFeed');
+  const utils = api.useUtils();
+  const hasMounted = useHasMounted();
+  const origin = hasMounted ? window.location.origin : null;
+  const [copied, setCopied] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const tokenQuery = api.userSettings.getICalToken.useQuery(undefined, {
+    retry: false,
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: 'always',
+    meta: { persist: false },
+  });
+
+  const regenerate = api.userSettings.regenerateICalToken.useMutation({
+    retry: false,
+    onSuccess: () => {
+      setConfirmOpen(false);
+      toast.success(t('regenerateSuccess'));
+    },
+    onError: () => toast.error(t('regenerateFailed')),
+    onSettled: async () => {
+      await utils.userSettings.getICalToken.invalidate();
+      await tokenQuery.refetch();
+    },
+  });
+
+  const token = tokenQuery.data?.token ?? null;
+  const feedUrl = origin && token ? `${origin}/api/v1/calendar/${token}.ics` : null;
+  const generate = () => {
+    if (token) setConfirmOpen(true);
+    else regenerate.mutate();
+  };
+
+  const copy = async () => {
+    if (!feedUrl) return;
+    try {
+      await navigator.clipboard.writeText(feedUrl);
+      setCopied(true);
+      toast.success(t('copied'));
+      window.setTimeout(() => setCopied(false), 2_000);
+    } catch {
+      toast.error(t('copyFailed'));
+    }
+  };
+
+  return (
+    <>
+      <ICalFeedSettingsView
+        feedUrl={feedUrl}
+        loading={
+          tokenQuery.isLoading || tokenQuery.isFetching || (token !== null && origin === null)
+        }
+        error={tokenQuery.isError}
+        regenerating={regenerate.isPending}
+        copied={copied}
+        onRetry={() => void tokenQuery.refetch()}
+        onCopy={() => void copy()}
+        onGenerate={generate}
+      />
+      <ConfirmDialog
+        open={confirmOpen}
+        onClose={() => setConfirmOpen(false)}
+        onConfirm={async () => {
+          await regenerate.mutateAsync().catch(() => undefined);
+        }}
+        title={t('regenerateConfirmTitle')}
+        description={t('regenerateConfirmDescription')}
+        confirmLabel={t('regenerate')}
+        loadingLabel={t('regenerating')}
+        variant="warning"
+      />
+    </>
+  );
+}

--- a/apps/product/src/features/settings/components/IntegrationsSettings.tsx
+++ b/apps/product/src/features/settings/components/IntegrationsSettings.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { GoogleCalendarSettings } from '@/features/external-calendar';
+
+/** 外部サービスの接続面を Settings が Composition Layer として束ねる。 */
+export function IntegrationsSettings() {
+  return (
+    <div className="space-y-6 sm:space-y-8">
+      <GoogleCalendarSettings />
+    </div>
+  );
+}

--- a/apps/product/src/features/settings/components/IntegrationsSettings.tsx
+++ b/apps/product/src/features/settings/components/IntegrationsSettings.tsx
@@ -2,11 +2,14 @@
 
 import { GoogleCalendarSettings } from '@/features/external-calendar';
 
+import { ICalFeedSettings } from './ICalFeedSettings';
+
 /** 外部サービスの接続面を Settings が Composition Layer として束ねる。 */
 export function IntegrationsSettings() {
   return (
     <div className="space-y-6 sm:space-y-8">
       <GoogleCalendarSettings />
+      <ICalFeedSettings />
     </div>
   );
 }

--- a/apps/product/src/features/settings/components/Settings.docs.mdx
+++ b/apps/product/src/features/settings/components/Settings.docs.mdx
@@ -4,17 +4,18 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 # Settings
 
-profile、display、data、billing、accountを扱うsettings dialog component群。Storybookではcategory navigation、desktop / mobile layout、form stateを確認する。
+profile、display、data、integrations、billing、accountを扱うsettings dialog component群。Storybookではcategory navigation、desktop / mobile layout、form stateを確認する。
 
 ## Categories
 
-| Category | 主な表示                        |
-| -------- | ------------------------------- |
-| Profile  | profileとidentity               |
-| Display  | theme、timezone、日付・時間表示 |
-| Data     | exportとdata control            |
-| Billing  | Free / Pro、Checkout、Portal    |
-| Account  | password、MFA、account deletion |
+| Category     | 主な表示                              |
+| ------------ | ------------------------------------- |
+| Profile      | profileとidentity                     |
+| Display      | theme、timezone、日付・時間表示       |
+| Data         | exportとdata control                  |
+| Integrations | Google Calendar importとiCal feed URL |
+| Billing      | Free / Pro、Checkout、Portal          |
+| Account      | password、MFA、account deletion       |
 
 ## Visual states
 
@@ -22,6 +23,8 @@ profile、display、data、billing、accountを扱うsettings dialog component�
 - category list / selected category
 - loading / saved / validation error
 - billingのFree / trialing / active / past_due / canceled
+- Google Calendarの未接続 / 複数接続 / 再認証 / 同期エラー / 接続不可
+- iCal feed URLの有無 / loading / error
 - destructive account actionのconfirmation
 
 category定義の正本は`features/settings/constants.ts`、外部挙動はroot `docs/product/specs/settings.md`を参照する。router、DB、feature DAGはStorybookへ複製しない。

--- a/apps/product/src/features/settings/components/SettingsContent.tsx
+++ b/apps/product/src/features/settings/components/SettingsContent.tsx
@@ -15,11 +15,21 @@ const categoryComponents: Record<
   profile: lazy(() => import('./ProfileSettings').then((m) => ({ default: m.ProfileSettings }))),
   display: lazy(() => import('./DisplaySettings').then((m) => ({ default: m.DisplaySettings }))),
   data: lazy(() => import('./DataSettings').then((m) => ({ default: m.DataSettings }))),
+  integrations: lazy(() =>
+    import('./IntegrationsSettings').then((m) => ({ default: m.IntegrationsSettings })),
+  ),
   billing: lazy(() => import('./BillingSettings').then((m) => ({ default: m.BillingSettings }))),
   account: lazy(() => import('./AccountSettings').then((m) => ({ default: m.AccountSettings }))),
 };
 
-const VALID_CATEGORIES = new Set<string>(['profile', 'display', 'data', 'billing', 'account']);
+const VALID_CATEGORIES = new Set<string>([
+  'profile',
+  'display',
+  'data',
+  'integrations',
+  'billing',
+  'account',
+]);
 
 /**
  * 文字列が有効な設定カテゴリかチェックする型ガード

--- a/apps/product/src/features/settings/components/SettingsDialog.stories.tsx
+++ b/apps/product/src/features/settings/components/SettingsDialog.stories.tsx
@@ -40,6 +40,9 @@ const DIALOG_MOCKS = {
   'profile.get': MOCK_PROFILE,
   'tags.list': { data: [] },
   'statistics.getTagStats': { counts: {} },
+  'externalCalendar.getConnectionAvailability': { available: false },
+  'externalCalendar.listConnections': [],
+  'userSettings.getICalToken': { token: null },
 };
 
 // ─────────────────────────────────────────────────────────
@@ -125,6 +128,16 @@ export const DisplayCategory: Story = {
 export const DataCategory: Story = {
   render: () => {
     useShellStore.setState({ activeSheet: { type: 'settings', category: 'data' } });
+    return <SettingsDialog />;
+  },
+};
+
+/**
+ * 連携設定カテゴリ
+ */
+export const IntegrationsCategory: Story = {
+  render: () => {
+    useShellStore.setState({ activeSheet: { type: 'settings', category: 'integrations' } });
     return <SettingsDialog />;
   },
 };

--- a/apps/product/src/features/settings/components/SettingsSidebar.stories.tsx
+++ b/apps/product/src/features/settings/components/SettingsSidebar.stories.tsx
@@ -24,7 +24,7 @@ import { SettingsSidebar } from './SettingsSidebar';
  *
  * PC: button で store のカテゴリを切替（URL変更なし）。
  * Mobile: Link でページ遷移（pathname からアクティブカテゴリを判定）。
- * 5カテゴリ（プロフィール・表示・データ・課金・アカウント）を表示。
+ * 6カテゴリ（プロフィール・表示・データ・連携・課金・アカウント）を表示。
  */
 const meta = {
   title: 'Product/Features/Settings/SettingsSidebar',
@@ -82,6 +82,18 @@ export const DataActive: Story = {
   decorators: [
     (Story) => {
       useShellStore.setState({ activeSheet: { type: 'settings', category: 'data' } });
+      return <Story />;
+    },
+  ],
+};
+
+/**
+ * 連携設定カテゴリ選択中
+ */
+export const IntegrationsActive: Story = {
+  decorators: [
+    (Story) => {
+      useShellStore.setState({ activeSheet: { type: 'settings', category: 'integrations' } });
       return <Story />;
     },
   ],

--- a/apps/product/src/features/settings/components/__tests__/DataSettings.csv-export.test.tsx
+++ b/apps/product/src/features/settings/components/__tests__/DataSettings.csv-export.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const refetchExport = vi.hoisted(() => vi.fn());
+const createObjectURL = vi.hoisted(() => vi.fn());
+const revokeObjectURL = vi.hoisted(() => vi.fn());
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('@/lib/toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/lib/trpc', () => ({
+  api: {
+    user: {
+      exportData: {
+        useQuery: () => ({ refetch: refetchExport, isLoading: false, isFetching: false }),
+      },
+      deleteBlocks: {
+        useMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+      },
+      deleteAllData: {
+        useMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+      },
+    },
+    billing: {
+      getOverview: {
+        useQuery: () => ({ data: null, isLoading: false }),
+      },
+    },
+  },
+}));
+
+import { DataSettings } from '../DataSettings';
+
+describe('DataSettings CSV export', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    refetchExport.mockResolvedValue({
+      data: {
+        data: {
+          plans: [
+            {
+              id: 'plan-1',
+              title: '=HYPERLINK("https://example.com")',
+              note: '+1+1',
+              start_at: '2026-08-01T00:00:00.000Z',
+            },
+          ],
+          records: [
+            {
+              id: 'record-1',
+              title: 'Completed',
+              note: '@SUM(A1:A2)',
+              start_at: '2026-08-01T01:00:00.000Z',
+            },
+          ],
+        },
+      },
+    });
+    Object.defineProperty(window.URL, 'createObjectURL', {
+      configurable: true,
+      value: createObjectURL.mockReturnValue('blob:dayopt-export'),
+    });
+    Object.defineProperty(window.URL, 'revokeObjectURL', {
+      configurable: true,
+      value: revokeObjectURL,
+    });
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => undefined);
+  });
+
+  it('exportData の plan / record を安全な CSV Blob としてダウンロードする', async () => {
+    const user = userEvent.setup();
+    render(<DataSettings />);
+
+    const formatSelect = screen.getAllByRole('combobox')[0];
+    if (!formatSelect) throw new Error('format select not found');
+    await user.click(formatSelect);
+    await user.click(await screen.findByRole('option', { name: 'formatCsv' }));
+    await user.click(screen.getByRole('button', { name: 'exportButton' }));
+
+    await waitFor(() => expect(createObjectURL).toHaveBeenCalledTimes(1));
+    const blob = createObjectURL.mock.calls[0]?.[0];
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe('text/csv;charset=utf-8');
+
+    const csv = await blob.text();
+    expect(csv).toContain('plan,plan-1,"\'=HYPERLINK(""https://example.com"")",\'+1+1');
+    expect(csv).toContain("record,record-1,Completed,'@SUM(A1:A2)");
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:dayopt-export');
+  });
+});

--- a/apps/product/src/features/settings/components/__tests__/ICalFeedSettings.test.tsx
+++ b/apps/product/src/features/settings/components/__tests__/ICalFeedSettings.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const tokenState = vi.hoisted(() => ({ value: 'private-token' as string | null }));
+const queryState = vi.hoisted(() => ({ isLoading: false, isFetching: false, isError: false }));
+const regenerate = vi.hoisted(() => vi.fn());
+const regenerateAsync = vi.hoisted(() => vi.fn());
+const refetch = vi.hoisted(() => vi.fn());
+const invalidate = vi.hoisted(() => vi.fn());
+const queryOptions = vi.hoisted(
+  () =>
+    ({ current: null }) as {
+      current: null | {
+        retry: boolean;
+        refetchOnMount: string;
+        refetchOnWindowFocus: string;
+        meta: { persist: boolean };
+      };
+    },
+);
+const mutationOptions = vi.hoisted(
+  () =>
+    ({ current: null }) as {
+      current: null | {
+        onSuccess: () => void;
+        onError: () => void;
+        onSettled: () => Promise<void>;
+      };
+    },
+);
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('@/lib/toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/lib/trpc', () => ({
+  api: {
+    useUtils: () => ({ userSettings: { getICalToken: { invalidate } } }),
+    userSettings: {
+      getICalToken: {
+        useQuery: (_input: undefined, options: NonNullable<typeof queryOptions.current>) => {
+          queryOptions.current = options;
+          return {
+            data: { token: tokenState.value },
+            ...queryState,
+            refetch,
+          };
+        },
+      },
+      regenerateICalToken: {
+        useMutation: (options: NonNullable<typeof mutationOptions.current>) => {
+          mutationOptions.current = options;
+          return {
+            mutate: regenerate,
+            mutateAsync: regenerateAsync,
+            isPending: false,
+          };
+        },
+      },
+    },
+  },
+}));
+
+import { ICalFeedSettings } from '../ICalFeedSettings';
+
+describe('ICalFeedSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tokenState.value = 'private-token';
+    queryState.isLoading = false;
+    queryState.isFetching = false;
+    queryState.isError = false;
+    queryOptions.current = null;
+    mutationOptions.current = null;
+    regenerateAsync.mockResolvedValue({ token: 'new-token' });
+    refetch.mockResolvedValue({ data: { token: tokenState.value } });
+    invalidate.mockResolvedValue(undefined);
+  });
+
+  it('既存 token の再生成は確認するまで mutation を呼ばない', async () => {
+    const user = userEvent.setup();
+    render(<ICalFeedSettings />);
+
+    await user.click(screen.getByRole('button', { name: 'regenerate' }));
+
+    expect(regenerate).not.toHaveBeenCalled();
+    const dialog = screen.getByRole('alertdialog');
+    expect(within(dialog).getByText('regenerateConfirmDescription')).toBeInTheDocument();
+    await user.click(within(dialog).getByRole('button', { name: 'regenerate' }));
+    expect(regenerateAsync).toHaveBeenCalledOnce();
+  });
+
+  it('token が無い legacy 状態では確認なしで生成する', async () => {
+    tokenState.value = null;
+    const user = userEvent.setup();
+    render(<ICalFeedSettings />);
+
+    await user.click(screen.getByRole('button', { name: 'generate' }));
+
+    expect(regenerate).toHaveBeenCalledOnce();
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+
+  it('bearer token を永続化せず、mount / focus で常に authoritative refetch する', () => {
+    render(<ICalFeedSettings />);
+
+    expect(queryOptions.current).toMatchObject({
+      retry: false,
+      refetchOnMount: 'always',
+      refetchOnWindowFocus: 'always',
+      meta: { persist: false },
+    });
+  });
+
+  it('cached token の再取得中は古い URL と操作を表示しない', () => {
+    queryState.isFetching = true;
+    render(<ICalFeedSettings />);
+
+    expect(screen.getByLabelText('loading')).toBeInTheDocument();
+    expect(screen.queryByRole('textbox', { name: 'feedUrl' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'copy' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'regenerate' })).not.toBeInTheDocument();
+  });
+
+  it('現在 origin の完全な feed URL を表示して clipboard へコピーする', async () => {
+    const user = userEvent.setup();
+    const writeText = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+    render(<ICalFeedSettings />);
+    const expected = `${window.location.origin}/api/v1/calendar/private-token.ics`;
+
+    expect(screen.getByRole('textbox', { name: 'feedUrl' })).toHaveValue(expected);
+    await user.click(screen.getByRole('button', { name: 'copy' }));
+    expect(writeText).toHaveBeenCalledWith(expected);
+  });
+
+  it('再生成後は query を再取得し、旧 URL ではなく新 token を表示する', async () => {
+    const { rerender } = render(<ICalFeedSettings />);
+    tokenState.value = 'new-token';
+    refetch.mockResolvedValue({ data: { token: 'new-token' } });
+
+    mutationOptions.current?.onSuccess();
+    await mutationOptions.current?.onSettled();
+    rerender(<ICalFeedSettings />);
+
+    expect(invalidate).toHaveBeenCalledOnce();
+    expect(refetch).toHaveBeenCalledOnce();
+    expect(screen.getByRole('textbox', { name: 'feedUrl' })).toHaveValue(
+      `${window.location.origin}/api/v1/calendar/new-token.ics`,
+    );
+  });
+});

--- a/apps/product/src/features/settings/constants.ts
+++ b/apps/product/src/features/settings/constants.ts
@@ -2,6 +2,7 @@ import {
   CreditCard,
   Database,
   Monitor,
+  Plug,
   Settings as SettingsIcon,
   User,
   type LucideIcon,
@@ -21,7 +22,7 @@ interface SettingsCategoryMeta {
 }
 
 /**
- * 設定カテゴリの定義（5カテゴリ）
+ * 設定カテゴリの定義（6カテゴリ）
  */
 export const SETTINGS_CATEGORIES: readonly SettingsCategoryMeta[] = [
   {
@@ -41,6 +42,12 @@ export const SETTINGS_CATEGORIES: readonly SettingsCategoryMeta[] = [
     icon: Database,
     labelKey: 'settings.dialog.categories.data',
     descKey: 'settings.dialog.categories.dataDesc',
+  },
+  {
+    id: 'integrations',
+    icon: Plug,
+    labelKey: 'settings.dialog.categories.integrations',
+    descKey: 'settings.dialog.categories.integrationsDesc',
   },
   {
     id: 'billing',

--- a/apps/product/src/features/settings/lib/__tests__/timeblock-csv-export.test.ts
+++ b/apps/product/src/features/settings/lib/__tests__/timeblock-csv-export.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  escapeTimeblockCsvField,
+  TIMEBLOCK_CSV_COLUMNS,
+  timeblockRowsToCsv,
+} from '../timeblock-csv-export';
+
+describe('escapeTimeblockCsvField', () => {
+  it.each([
+    ['=', '=SUM(A1:A2)', "'=SUM(A1:A2)"],
+    ['+', '+1+1', "'+1+1"],
+    ['-', '-2+3', "'-2+3"],
+    ['@', '@SUM(A1)', "'@SUM(A1)"],
+    ['tab', '\t=1+1', "'\t=1+1"],
+    ['carriage return', '\r=1+1', '"\'\r=1+1"'],
+  ])('%s で始まる値を文字列として扱う', (_label, input, expected) => {
+    expect(escapeTimeblockCsvField(input)).toBe(expected);
+  });
+
+  it.each([
+    ['ordinary', 'Plan', 'Plan'],
+    ['comma', 'Plan, record', '"Plan, record"'],
+    ['quote', 'Say "hello"', '"Say ""hello"""'],
+    ['line feed', 'first\nsecond', '"first\nsecond"'],
+    ['carriage return', 'first\rsecond', '"first\rsecond"'],
+    ['null', null, ''],
+  ])('%s の CSV field escaping を保つ', (_label, input, expected) => {
+    expect(escapeTimeblockCsvField(input)).toBe(expected);
+  });
+});
+
+describe('timeblockRowsToCsv', () => {
+  it('header・列順・LF record separator を固定する', () => {
+    const csv = timeblockRowsToCsv([
+      { kind: 'plan', id: 'plan-1', title: '=2+2', note: null },
+      { kind: 'record', id: 'record-1', title: 'Done', note: 'line 1\rline 2' },
+    ]);
+
+    const lines = csv.split('\n');
+    expect(lines[0]).toBe(TIMEBLOCK_CSV_COLUMNS.join(','));
+    expect(lines[1]?.startsWith("plan,plan-1,'=2+2,,")).toBe(true);
+    expect(csv).toContain('record,record-1,Done,"line 1\rline 2",');
+    expect(csv).not.toContain('\r\n');
+  });
+});

--- a/apps/product/src/features/settings/lib/timeblock-csv-export.ts
+++ b/apps/product/src/features/settings/lib/timeblock-csv-export.ts
@@ -1,0 +1,42 @@
+export const TIMEBLOCK_CSV_COLUMNS = [
+  'kind',
+  'id',
+  'title',
+  'note',
+  'tag_id',
+  'plan_id',
+  'start_at',
+  'end_at',
+  'source',
+  'skipped_at',
+  'created_at',
+  'updated_at',
+  'deleted_at',
+] as const;
+
+const SPREADSHEET_FORMULA_PREFIX = /^[=+\-@\t\r]/;
+const CSV_QUOTING_CHARACTER = /[,"\n\r]/;
+
+/**
+ * Spreadsheet が数式として解釈する先頭文字を、明示的な文字列へ変換する。
+ * CSV を Excel / Google Sheets で開いた時に title / note 等が実行可能な式にならないための境界。
+ */
+export function escapeTimeblockCsvField(value: unknown): string {
+  if (value == null) return '';
+
+  const text = String(value);
+  const neutralized = SPREADSHEET_FORMULA_PREFIX.test(text) ? `'${text}` : text;
+  if (CSV_QUOTING_CHARACTER.test(neutralized)) {
+    return `"${neutralized.replace(/"/g, '""')}"`;
+  }
+  return neutralized;
+}
+
+/** plans / records を、固定列順と LF 区切りの CSV 文字列へ変換する。 */
+export function timeblockRowsToCsv(rows: Record<string, unknown>[]): string {
+  const header = TIMEBLOCK_CSV_COLUMNS.join(',');
+  const csvRows = rows.map((row) =>
+    TIMEBLOCK_CSV_COLUMNS.map((column) => escapeTimeblockCsvField(row[column])).join(','),
+  );
+  return [header, ...csvRows].join('\n');
+}

--- a/apps/product/src/lib/types/settings.ts
+++ b/apps/product/src/lib/types/settings.ts
@@ -1,8 +1,9 @@
 /**
- * 設定カテゴリの識別子（5カテゴリ）
+ * 設定カテゴリの識別子（6カテゴリ）
  *
  * lib/stores/useShellStore および lib/components/shell から参照されるため lib/types に配置。
  * lib/ → features/* の import は DAG 違反になるため features/settings への移動は不可。
  * features/settings からは features/settings/types/index.ts 経由で re-export している。
  */
-export type SettingsCategory = 'profile' | 'display' | 'data' | 'billing' | 'account';
+export type SettingsCategory =
+  'profile' | 'display' | 'data' | 'integrations' | 'billing' | 'account';

--- a/docs/product/specs/settings.md
+++ b/docs/product/specs/settings.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_verified: 2026-07-24
+last_verified: 2026-08-02
 code: apps/product/src/features/settings
 public_docs:
   - data-export
@@ -10,14 +10,18 @@ lp:
 
 # Settings（設定）
 
-ユーザー設定全般。プロフィール、表示、データ管理、課金、アカウントをカテゴリ別ページで提供する。
+ユーザー設定全般。プロフィール、表示、データ管理、連携、課金、アカウントをカテゴリ別ページで提供する。
 
 ## 現在の振る舞い
 
-- `/settings/[category]` のカテゴリ別ルーティング（`profile` / `display` / `data` / `billing` / `account`）
+- `/settings/[category]` のカテゴリ別ルーティング（`profile` / `display` / `data` / `integrations` / `billing` / `account`）
+- 連携設定では複数の Google アカウントを接続でき、取り込むカレンダーの選択、手動同期、再接続、切断を行える
+- Google OAuth の callback は連携設定へ戻り、成功・失敗を通知する。未知の provider エラー詳細は表示しない
+- Google 連携に必要な設定や redirect URI が現在の origin で利用できない場合、接続・再接続操作を無効にする
+- iCal フィードの非公開 URL を表示・コピーできる。URL の再生成は既存 URL を即時無効にするため、確認後に行う
 - 通知は独立カテゴリとして提供していない。将来追加する場合も「計画に仕える」opt-in の合図に限定し、streak 煽り・re-engagement push は作らない（[strategy.md §4-7](../../business/strategy.md)）
 - 課金設定は Stripe Customer Portal と連携する（[Billing](./billing.md) 参照）
-- データエクスポート（CSV/JSON）は Pro 機能
+- データエクスポート（CSV/JSON）は Pro 機能。CSV は先頭が `=` / `+` / `-` / `@` / tab / carriage return の値を文字列として出力し、表計算ソフトで数式として実行させない
 
 ## 関連する意思決定
 

--- a/docs/projects/external-calendar-import/overview.md
+++ b/docs/projects/external-calendar-import/overview.md
@@ -1,6 +1,6 @@
 ---
 status: active
-last_verified: 2026-07-24
+last_verified: 2026-08-02
 code: apps/product/src/features/external-calendar/server/sync-service.ts
 ---
 
@@ -35,7 +35,7 @@ Phase 1 から継承する拘束（本書で再決定しない）:
 4. Vercel cron + 手動 syncNow で実行
 5. Settings に Integrations カテゴリ（接続・カレンダー選択・状態表示・切断）
 
-骨格に含めないもの: ghost 表示・変換 UX（次 project、§12 にスケッチ）、Outlook 実装（adapter interface だけ切る、§7-4）、webhook push channel、iCal export の URL 表示 UI。
+骨格に含めないもの: ghost 表示・変換 UX（次 project、§12 にスケッチ）、Outlook 実装（adapter interface だけ切る、§7-4）、webhook push channel。Step 6 の Settings 出荷面には、既存 iCal export URL の管理 UI と CSV export の安全化も同じ機能まとまりとして含める。
 
 ## 3. スコープ — 「連携ができる」の定義
 
@@ -137,8 +137,8 @@ Supabase Auth の Google provider に scope を足す案は却下する。理由
 ### 5-2. Connect フロー
 
 - Route handler 2 本: `apps/product/src/app/api/integrations/google-calendar/start/route.ts` / `.../callback/route.ts`。redirect flow は tRPC 化できないため、`/api/auth/*` と同列の「REST 維持」例外として `.claude/rules/architecture.md` の一覧に追記する
-- `start`: session 必須 + billing gate（`canAccessProFeatures` + `isBillingEnforced` を route 内で適用）。`state`（random）と PKCE `code_verifier` を signed HTTP-only cookie（10 分 TTL）に保存して Google へ redirect。confidential client なので token 交換には client_secret を併用し、PKCE は上乗せ防御
-- Auth URL params: `access_type=offline`・`prompt=consent`（refresh token を確実に取得）。**`include_granted_scopes` は付けない** — 付けると同一 client が過去に得ていた scope まで畳み込まれ、保存する refresh token が本機能に必要な範囲を超えた権限を持ちうる。callback は `calendar.readonly` の有無しか検査しないため余分な scope は素通りする。必要な scope は最初から全部要求しており incremental auth は使わない（Step 2 レビュー指摘）
+- `start`: session 必須 + billing gate（`canAccessProFeatures` + `isBillingEnforced` を route 内で適用）。`state`（random）と PKCE `code_verifier` を `__Host-` HTTP-only cookie（10 分 TTL）に保存して Google へ redirect。confidential client なので token 交換には client_secret を併用し、PKCE は上乗せ防御
+- Auth URL params: `access_type=offline`・`prompt=consent select_account`（refresh token を確実に取得し、接続する Google アカウントを毎回選ばせる）。**`include_granted_scopes` は付けない** — 付けると同一 client が過去に得ていた scope まで畳み込まれ、保存する refresh token が本機能に必要な範囲を超えた権限を持ちうる。callback は `calendar.readonly` の有無しか検査しないため余分な scope は素通りする。必要な scope は最初から全部要求しており incremental auth は使わない（Step 2 レビュー指摘）
 - `callback`: state/PKCE 検証 → code 交換 → id_token から `sub` / `email` を取得 → `calendar_connections` を upsert → 初回はカレンダー選択へ誘導する Settings へ redirect
 - API client は **googleapis SDK を入れず素の `fetch` + zod パース**。必要な endpoint は token / calendarList.list / events.list / revoke の 4 つだけで、依存追加規律（1 機能のために大きなライブラリを入れない）に従う
 
@@ -148,7 +148,7 @@ Supabase Auth の Google provider に scope を足す案は却下する。理由
 
 ### 5-4. 再認証
 
-token 交換・API 呼び出しで `invalid_grant` を検知したら `status = 'reauth_required'` に更新し、同期対象から外す。Settings UI に再接続バナーを出し、connect フローの再実行で `active` に戻す。
+token 交換・API 呼び出しで `invalid_grant` を検知したら `status = 'reauth_required'` に更新し、同期対象から外す。Settings UI に再接続バナーを出す。再接続は connection id を HttpOnly flow cookie に保持し、callback で検証済み Google `sub` が保存済み `provider_account_id` と一致する場合だけ、既存行を条件付き UPDATE して `active` に戻す。generic upsert は使わず、切断との競合で更新行が無ければ失敗させる。
 
 ### 5-5. Operational TODO（コードの blocker にしない）
 
@@ -214,21 +214,24 @@ features/external-calendar/
 
 ### 7-2. tRPC surface（Router → Service の 3 層、`handleServiceError`）
 
-| procedure                 | gate               | 内容                                           |
-| ------------------------- | ------------------ | ---------------------------------------------- |
-| `listConnections`         | protectedProcedure | 接続一覧。解約後も自分の接続状態は見える       |
-| `getSyncStatus`           | protectedProcedure | connection + calendars の last_synced / error  |
-| `listProviderCalendars`   | **proProcedure**   | オンデマンドで provider の calendarList を取得 |
-| `updateSelectedCalendars` | **proProcedure**   | child table 差し替え + 即時 sync kick          |
-| `syncNow`                 | **proProcedure**   | rate-limited、sync-service 直呼び              |
-| `disconnect`              | protectedProcedure | 解約済みユーザーも必ず切断できる               |
+| procedure                   | gate               | 内容                                           |
+| --------------------------- | ------------------ | ---------------------------------------------- |
+| `getConnectionAvailability` | protectedProcedure | 現在の origin が設定済み redirect と一致するか |
+| `listConnections`           | protectedProcedure | 接続一覧。解約後も自分の接続状態は見える       |
+| `getSyncStatus`             | protectedProcedure | connection + calendars の last_synced / error  |
+| `listProviderCalendars`     | **proProcedure**   | オンデマンドで provider の calendarList を取得 |
+| `updateSelectedCalendars`   | **proProcedure**   | child table 差し替え + 即時 sync kick          |
+| `syncNow`                   | **proProcedure**   | rate-limited、sync-service 直呼び              |
+| `disconnect`                | protectedProcedure | 解約済みユーザーも必ず切断できる               |
 
 connect start/callback は route handler（§5-2）。ghost 用の `listEvents` / `dismiss` は次 project で追加する（予約席としてここに記す）。ルーターは `lib/trpc/root.ts` に集約。
 
 ### 7-3. Settings UI
 
 - `features/settings/constants.ts` の `SETTINGS_CATEGORIES` に第 6 カテゴリ `integrations` を追加し、`SettingsContent.tsx` に `IntegrationsSettings` を合成する。settings は composition feature なので external-calendar の **barrel** から import する（deep import 禁止）
-- コンポーネント実体は `features/external-calendar/components/`: 未接続 = connect ボタン（`/api/integrations/google-calendar/start` へ）。接続済み = アカウント email・カレンダー checklist・最終同期 + status/error・今すぐ同期・切断・`reauth_required` 時の再接続バナー
+- コンポーネント実体は `features/external-calendar/components/`: 未接続 = connect ボタン（`/api/integrations/google-calendar/start` へ）。接続済み = 複数アカウントの email・カレンダー checklist・最終同期 + status/error・今すぐ同期・切断・`reauth_required` 時の同一アカウント再接続バナー
+- `getConnectionAvailability` は設定値を返さず boolean だけを返す。現在の origin が redirect URI allowlist と一致しない Preview や、credentials 未設定環境では接続・追加・再接続 CTA を無効にする
+- Settings 所有の iCal セクションは既存 token から feed URL を表示・コピーし、再生成時だけ確認する。CSV export は危険な数式 prefix を文字列化する。iCal route の query/window と JSON restore の仕様は変えない
 - i18n: **orphan 状態の `settings.integrations` キー（en/ja）を接続し、不足分を追加**する（i18n skill / glossary 準拠）
 - Storybook: AllPatterns story 必須（未接続 / 接続済み / reauth_required / エラー）
 
@@ -328,12 +331,12 @@ disconnect は次の 3 段で行う:
 | 1    | Migration: 新 2 テーブル + RLS/GRANT/trigger 一式、`supabase/schemas` 宣言ミラー、`pnpm rls:snapshot` 再生成                                                                    | [hours]       | 1-2     |
 | 2    | OAuth connect: env 4 変数（redirect URI allowlist を含む）、token 暗号 helper、start/callback route、feature scaffold + eslint.config.mjs DAG 追加。GCP 設定は operational TODO | [hours]       | 4-6     |
 | 3    | Provider adapter（google）+ sync-service（full/incremental/410/tombstone/prune）+ Vitest（dismissed 不可侵・prune anti-join の regression test 必須）                           | [minutes]     | 2       |
-| 4    | tRPC router + service（§7-2 の 6 procedure、proProcedure 付与）                                                                                                                 | [minutes]     | 1       |
+| 4    | tRPC router + service（§7-2 の 7 procedure、proProcedure 付与）                                                                                                                 | [minutes]     | 1       |
 | 5    | Vercel cron: vercel.json + `/api/cron/calendar-sync`（CRON_SECRET 検証・時間予算・課金フィルタ hook）                                                                           | [hours]       | 1       |
-| 6    | Settings UI: integrations カテゴリ + コンポーネント + i18n（orphan キー接続）+ Storybook                                                                                        | [minutes]     | 1-2     |
-| 7    | Hardening + 完了処理: reauth_required UX、Sentry capture 整備、`summary.md` + `status: done`、user docs は docs-writing skill で提案                                            | [minutes]     | 1       |
+| 6    | Settings UI: integrations カテゴリ + Google 接続/再接続 UI + iCal URL 管理 + CSV export 安全化 + i18n + Storybook                                                               | [minutes]     | 3       |
+| 7    | Hardening + 完了処理: Sentry capture 整備、`summary.md` + `status: done`、user docs は docs-writing skill で提案                                                                | [minutes]     | 1       |
 
-計 10-11 commits。マイルストーン「連携ができる」は Step 6 で到達し、Step 7 で締める。auth / RLS / OAuth / cron を扱うため、Step 1・2・5 は `risk-reviewer`、挙動変更は `behavior-verifier` の自動委任対象。
+計 11-12 commits。マイルストーン「連携ができる」は Step 6 で到達し、Step 7 で締める。auth / RLS / OAuth / cron を扱うため、Step 1・2・5 は `risk-reviewer`、挙動変更は `behavior-verifier` の自動委任対象。
 
 ## 14. 完了条件（Definition of Done）
 

--- a/scripts/ai-review/invariants.md
+++ b/scripts/ai-review/invariants.md
@@ -51,6 +51,16 @@ ai-review が「**あるべき検査の不在**」を判定するための正本
 - 外部 OAuth では `openid` scope を要求し、ユーザーの同定は id_token 側で行う
   （メールアドレスの一致で同定しない）
 - token 暗号化の鍵は起動時に長さを検証する（32 bytes 以上）
+- 外部カレンダーの再接続は、callback で検証した Google `sub` が保存済み
+  `provider_account_id` と一致する既存の `reauth_required` 行だけを条件付き更新する。
+  generic upsert で削除済み接続を復活させず、切断との競合では切断を勝たせる
+- iCal feed token は URL を知るだけで購読できる bearer-style credential として扱い、client query を
+  永続 cache へ保存しない。Settings を開く時と focus 復帰時は再取得し、取得中の cached URL は操作させない
+
+## Export
+
+- CSV に出す外部入力由来の文字列は、先頭が `=` / `+` / `-` / `@` / tab / carriage return
+  の場合に文字列として neutralize してから CSV field escaping を行う
 
 ## MCP の DB 書き込み境界
 


### PR DESCRIPTION
## Summary

- add the sixth Settings category for Integrations and expose multi-account Google Calendar connection, calendar selection, sync, reconnect, and confirmed disconnect flows
- add iCal feed URL display, copy, generation, and confirmed regeneration without changing the feed route contract
- neutralize spreadsheet formula prefixes in exported CSV while preserving the existing columns, quoting, and ordinary values

Closes #1708
Closes #1710
Closes #1778

## Behavior and security contracts

- reconnect is bound to the authenticated owner, existing `reauth_required` connection, provider, and verified Google `sub`; guarded UPDATE wins safely against disconnect/delete races
- connection availability returns only a boolean and requires an exact HTTP(S) origin compatible with the configured redirect allowlist
- selection updates snapshot and optimistically update provider/status caches, roll back on error, and converge through settled invalidation
- Apply, manual sync, and disconnect are mutually guarded so in-flight sync/update work cannot recreate removed selection data
- disconnect is confirmed and never removes the connection optimistically
- iCal bearer tokens are excluded from persisted query cache, refetched on mount/focus, and cached URLs are hidden while authoritative data is loading
- CSV fields beginning with `=`, `+`, `-`, `@`, tab, or carriage return receive a leading apostrophe before normal CSV quoting

## Verification

- `LC_ALL=C pnpm check` with Node 24.18.1
  - Product: 283 files / 2,629 tests
  - Web: 37 files / 260 tests
  - scripts: 20 files / 256 tests
- `pnpm build`
- `pnpm build-storybook`
- `pnpm docs:check`
- `pnpm api:spec:check`
- Storybook AllPatterns visual check for Google Calendar and iCal: content rendered, no overlay, no console/page errors
- read-only reviews: architecture-guard GO, behavior-verifier GO, risk-reviewer GO
- real CSV import into Google Sheets: all dangerous-prefix cells were `stringValue`, with no formula values
- LibreOffice Calc conversion to XLSX: zero formula cells; dangerous and ordinary values remained strings

## Preview and residual validation

- Product Preview deployed successfully, but `/ja/settings/integrations` redirects to Vercel Authentication in the available headless browser. The authenticated Google OAuth and live iCal subscription flows therefore remain unverified in Preview; no env/secret changes are made in this PR. If credentials/redirect allowlist are absent as tracked by #1461, the disabled state is expected.
- Microsoft Excel is not installed in the execution environment, so the Excel-specific formula-bar smoke test remains unverified. Google Sheets plus LibreOffice/XLSX provide the available cross-engine evidence.
- #1709 production secrets/hardening is intentionally excluded.

Google Sheets evidence: https://docs.google.com/spreadsheets/d/1jJRNUd3njqRyBva5qZu0OVmeSQxT8mTkRVp3E38s420/edit
