### PR TITLE
fix(build): turbo経由のVercel buildへserver envを宣言してrelease停止を解消する

### DIFF
--- a/scripts/__tests__/turbo-build-env-contract.test.ts
+++ b/scripts/__tests__/turbo-build-env-contract.test.ts
@@ -1,0 +1,79 @@
+/**
+ * turbo.json の build env 宣言と production build gate の契約を固定する。
+ *
+ * Vercel は turborepo 検出時に `turbo run build` で build する（#1701 の
+ * Root Directory flip 以降）。Turborepo 2.x の strict env mode は、
+ * `tasks.build.env` に宣言しない env を build process から剥がすため、
+ * gate が要求する env の宣言漏れはそのまま production release の停止になる。
+ *
+ * - NEXT_PUBLIC_* は Next.js の framework inference で自動的に通るため宣言不要
+ * - それ以外の gate 必須 env は、exact 名または prefix wildcard（`XXX_*`）で
+ *   turbo.json に必ず載せる
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { REQUIRED_PRODUCT_OPERATIONAL_BUILD_ENV } from '../../apps/product/production-build-gate.mjs';
+import { REQUIRED_WEB_OPERATIONAL_BUILD_ENV } from '../../apps/web/production-build-gate.mjs';
+import { REQUIRED_SENTRY_BUILD_ENV } from '../../packages/observability/build-gate.mjs';
+
+const BUILD_GATE_PATHS = [
+  '../../packages/observability/build-gate.mjs',
+  '../../apps/product/production-build-gate.mjs',
+  '../../apps/web/production-build-gate.mjs',
+] as const;
+
+const turboConfig = JSON.parse(
+  readFileSync(fileURLToPath(new URL('../../turbo.json', import.meta.url)), 'utf8'),
+) as { tasks?: { build?: { env?: string[] } } };
+
+const buildEnvDeclarations = turboConfig.tasks?.build?.env ?? [];
+
+function isCoveredByBuildEnv(envName: string): boolean {
+  // Next.js package の build では turbo の framework inference が通す。
+  if (envName.startsWith('NEXT_PUBLIC_')) return true;
+
+  return buildEnvDeclarations.some((declared) =>
+    declared.endsWith('*') ? envName.startsWith(declared.slice(0, -1)) : envName === declared,
+  );
+}
+
+describe('turbo build env contract', () => {
+  it('build env宣言はexact名かprefix wildcardだけで構成する', () => {
+    expect(buildEnvDeclarations.length).toBeGreaterThan(0);
+    for (const declared of buildEnvDeclarations) {
+      // negation（`!XXX`）や中間 wildcard を混ぜると下の coverage 判定が
+      // 成立しなくなるため、宣言の形式ごと契約に含める。
+      expect(declared, declared).toMatch(/^[A-Z][A-Z0-9_]*\*?$/);
+    }
+  });
+
+  it.each([
+    { gate: 'Sentry production gate', requiredEnvNames: REQUIRED_SENTRY_BUILD_ENV },
+    {
+      gate: 'Product operational gate',
+      requiredEnvNames: REQUIRED_PRODUCT_OPERATIONAL_BUILD_ENV,
+    },
+    { gate: 'Web operational gate', requiredEnvNames: REQUIRED_WEB_OPERATIONAL_BUILD_ENV },
+  ])('$gateの必須envをturbo.jsonのbuild envがカバーする', ({ requiredEnvNames }) => {
+    const uncovered = requiredEnvNames.filter((envName: string) => !isCoveredByBuildEnv(envName));
+    expect(uncovered).toEqual([]);
+  });
+
+  it('gate実装が読むenvプロパティをturbo.jsonのbuild envがカバーする', () => {
+    // gate は VERCEL_ENV などを配列外で直接参照する。ソースを走査して
+    // `env.XXX` の形の参照をすべて拾い、宣言漏れを検出する。
+    for (const gatePath of BUILD_GATE_PATHS) {
+      const source = readFileSync(fileURLToPath(new URL(gatePath, import.meta.url)), 'utf8');
+      const referencedEnvNames = [...source.matchAll(/\benv\.([A-Z][A-Z0-9_]*)\b/gu)].map(
+        (match) => match[1]!,
+      );
+      expect(referencedEnvNames.length, gatePath).toBeGreaterThan(0);
+
+      const uncovered = referencedEnvNames.filter((envName) => !isCoveredByBuildEnv(envName));
+      expect(uncovered, gatePath).toEqual([]);
+    }
+  });
+});

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,37 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": [".next/**", "!.next/cache/**", "storybook-static/**", "dist/**"]
+      "outputs": [".next/**", "!.next/cache/**", "storybook-static/**", "dist/**"],
+      "env": [
+        "ANALYZE",
+        "ANTHROPIC_API_KEY",
+        "BILLING_ENFORCED",
+        "CALENDAR_TOKEN_ENCRYPTION_KEY",
+        "CI",
+        "CRON_SECRET",
+        "GOOGLE_CALENDAR_*",
+        "GOOGLE_SITE_VERIFICATION",
+        "MCP_*",
+        "OAUTH_*",
+        "PRIVACY_PROTECTION_MODE",
+        "RECOVERY_CODE_PEPPER",
+        "RESEND_*",
+        "SENTRY_*",
+        "SKIP_AUTH_IN_DEV",
+        "SLACK_*",
+        "STRIPE_*",
+        "SUPABASE_*",
+        "TURNSTILE_*",
+        "UPSTASH_*",
+        "VERCEL_BRANCH_URL",
+        "VERCEL_ENV",
+        "VERCEL_GIT_COMMIT_REF",
+        "VERCEL_GIT_COMMIT_SHA",
+        "VERCEL_TARGET_ENV",
+        "VERCEL_URL",
+        "YAHOO_VERIFICATION",
+        "YANDEX_VERIFICATION"
+      ]
     },
     "typecheck": {
       "dependsOn": ["^typecheck"],


### PR DESCRIPTION
## 原因

Vercel product project の Root Directory を `apps/product` へ flip（#1701 Phase 1、2026-08-01）した後、Vercel が turborepo を自動検出して `turbo run build` で build するようになった。Turborepo 2.x の strict env mode は `turbo.json` に宣言のない env を build process から剥がすため、`next.config.mjs` が呼ぶ production build gate が env を見失い fail closed で throw:

```
Error: Product Sentry production build requires: SENTRY_DSN, SENTRY_ORG, SENTRY_PROJECT, SENTRY_AUTH_TOKEN
```

Sentry gate を通しても次は operational gate（RESEND_* / UPSTASH_*）で落ちる。`NEXT_PUBLIC_*` は turbo の framework inference で通るため preview build は成功し、production だけが落ちる。結果、8/1 以降 main への全 push で release が失敗している（Production は 1b197d486 のまま稼働）。

## 変更内容

- **turbo.json**: `tasks.build.env` に build gate（`packages/observability/build-gate.mjs` / `apps/{product,web}/production-build-gate.mjs`）と `next.config.mjs` / env schema が読む server env を宣言。secret グループは prefix wildcard（`SENTRY_*` / `RESEND_*` / `UPSTASH_*` / `SUPABASE_*` / `STRIPE_*` / `GOOGLE_CALENDAR_*` / `MCP_*` / `OAUTH_*` / `SLACK_*` / `TURNSTILE_*`）、単発名（`RECOVERY_CODE_PEPPER` / `CALENDAR_TOKEN_ENCRYPTION_KEY` / `CRON_SECRET` / `BILLING_ENFORCED` 等）は個別に宣言
  - `VERCEL_ENV` / `VERCEL_GIT_COMMIT_SHA` / `VERCEL_TARGET_ENV` / `VERCEL_BRANCH_URL` / `VERCEL_GIT_COMMIT_REF` / `VERCEL_URL` は、strict mode で既定で通る保証が turbo docs に無いため明示宣言（CI provider 変数は既定で filter されると明記あり）
  - `MCP_*` / `OAUTH_*` / `VERCEL_TARGET_ENV` 等は未マージの #1754 branch の preview gate が読む名前を先回りでカバー
- **scripts/__tests__/turbo-build-env-contract.test.ts**: gate の必須 env 配列（`REQUIRED_*_BUILD_ENV`）と gate 実装が読む `env.XXX` 参照が turbo.json の宣言（exact / prefix wildcard / NEXT_PUBLIC_ framework inference）でカバーされることを契約として固定。宣言ドリフトの再発を CI で検出する

## 検証

- `pnpm test:scripts`: 21 files / 261 tests pass（新規 5 tests 含む）
- 負のテスト: `SENTRY_*` 宣言を一時的に外すと該当 case が fail することを確認
- `pnpm typecheck` / `pnpm lint` / `pnpm lint:boundaries` pass、turbo.json の JSON validity 確認済み

## 注意

**この修正は merge 後の main push（Vercel production build）で初めて実地検証される。** ローカルでは Vercel の strict env 環境を完全には再現できない。merge 後の deploy で build ログの gate 通過を確認すること。

Refs #1701

🤖 Generated with [Claude Code](https://claude.com/claude-code)