### PR TITLE
docs(mcp): Plan Track Learnの設計正本と現行境界を復元する

### DIFF
--- a/docs/engineering/log/2026-07-29-mcp-2026-07-28-conformance.md
+++ b/docs/engineering/log/2026-07-29-mcp-2026-07-28-conformance.md
@@ -1,0 +1,29 @@
+---
+status: frozen
+date: 2026-07-29
+code:
+  - apps/product/src/app/api/mcp
+  - apps/product/package.json
+---
+
+# MCP 2026-07-28 conformanceの履歴
+
+Issue [#1716](https://github.com/Dayopt/dayopt/issues/1716)では、当時のintegration source branchにMCP specification `2026-07-28`向けのofficial conformance harnessを追加した。
+
+当時の記録は次のとおりである。
+
+- conformance suite: `@modelcontextprotocol/conformance@0.2.0-alpha.10`
+- `server-stateless`: 24 / 28 pass
+- suite専用diagnostic toolを必要とする4件: expected failure
+- `tools-list`: 2 / 2 pass
+- warning: 0
+
+production registryへtest専用toolを追加せず、4件のexact failure IDをbaselineとして扱った。
+
+## 2026-08-03 reconciliation
+
+段階導入の候補7では、integration sourceをそのままmergeせず、現行SDKで動く最小のdark releaseを最新`main`へ選択的に移植した。その結果、現在の`main`は`@modelcontextprotocol/sdk` `^1.30.0`を使う一方、当時のv2 runtimeとconformance harness、`pnpm test:mcp:conformance` commandを含まない。
+
+したがって、2026-07-29の結果は設計判断と試験方法の履歴としては有効だが、現在の`main`が同じsuiteを通る証拠としては使わない。closed beta候補では、exact SHAに対して現在の公式suiteを再実行できるharnessを用意し直す必要がある。
+
+現在の判定基準は[Step 6 protocol verification](../../projects/mcp-plan-track-learn/step-6-conformance.md)を正本とする。

--- a/docs/product/log/2026-07-23-mcp-client-confirmed-direct-write.md
+++ b/docs/product/log/2026-07-23-mcp-client-confirmed-direct-write.md
@@ -1,0 +1,33 @@
+---
+status: frozen
+date: 2026-07-23
+code: apps/product/src/app/api/mcp
+---
+
+# MCPの操作確認はclientへ委ね、Dayoptは正規データへ直接反映する
+
+## 背景・当時の前提
+
+外部AIからDayoptのPlan → Track → Learnを完結するには、Plan / Recordを読むだけでなく、正規データを変更できる必要がある。当初はDayopt内にproposalとapproval URLを持つ案も検討したが、対応AI client自身がtool実行前の確認UIや承認方針を持てる。
+
+## 決定と理由
+
+- write scopeを持つMCP clientからのtool callを操作要求として扱い、Dayoptの正規データへ直接反映する
+- 操作ごとの確認はclientの責任とし、Dayoptは確認が行われた事実を独立には検証しない
+- Dayoptは現在の接続、scope、Pro entitlement、ドメイン制約、競合制御、冪等性、成功mutationの監査を保証する
+- `confirmed: true`のようなclient自己申告fieldは受け付けない。確認の証明にならず、誤った安全感だけを作るため
+
+この責任分界なら、clientごとの自然な確認体験を維持しながら、Dayoptは自ら検証できる認可とデータ整合性へ責任を集中できる。
+
+## 却下した選択肢と、なぜ捨てたか
+
+- Dayopt内proposal / approval URL / 承認状態機械 — 二重の確認体験と期限・revoke後状態を増やし、client側確認がある一般的なMCP接続面を複雑にする
+- `confirmed` booleanをtool inputへ追加 — clientの自己申告にすぎず、承認主体・時刻・対象payloadを証明できない
+- scopeなしのgeneric mutation — 最小権限、tool discovery、監査、domain validationを崩す
+
+## 影響
+
+- Plan / Recordごとのtyped write toolとscopeを使う
+- apply transactionでconnection、token、entitlementを再検証し、正規データ変更とidempotency receiptを一括commitする
+- global / client gateでwriteを一時停止し、connection revokeでtoken familyを恒久停止できるようにする
+- tool名、scope、response schemaは3 clientの実機検証を通して公開契約として確定する

--- a/docs/projects/mcp-plan-track-learn/overview.md
+++ b/docs/projects/mcp-plan-track-learn/overview.md
@@ -1,0 +1,143 @@
+---
+status: active
+last_verified: 2026-08-03
+code:
+  - apps/product/src/app/api/mcp
+  - apps/product/src/app/api/oauth
+  - apps/product/src/lib/mcp
+  - apps/product/src/lib/oauth-server
+  - apps/product/src/features/timeblock
+  - supabase/schemas/017_tables_oauth.sql
+  - supabase/schemas/040_functions.sql
+---
+
+# mcp-plan-track-learn — 外部AIからPlan → Track → Learnを完結する
+
+## Goal
+
+Dayopt MCPは、ユーザーの予定、実績、時間上の制約、レビューを外部AIへ正確に提供し、権限を持つAI clientから受けた操作だけをDayoptの正規データへ安全に反映する標準接続面である。
+
+最終的なプロダクト価値は、外部AIから次の一周を完結できることにある。
+
+1. **Plan** — 予定、タグ、制約を読み、Planを作成・更新する
+2. **Track** — 実績をRecordとして記録・更新する
+3. **Learn** — PlanとRecordの差をレビューし、次のPlanへ反映する
+
+## Responsibility boundary
+
+write scopeを持つ対応clientからのtool callは、Dayoptの正規データへ直接反映する。操作ごとの確認はclientが担う。Dayoptはclientが確認した事実を検証せず、次を保証する。
+
+- 接続、resource、scope、Pro entitlementが現在も有効である
+- 同時書き込み、時間重複、古いversion、再送を安全に扱う
+- 成功した変更をpayload-free receiptとして追跡できる
+- global / client gateでwriteを一時停止し、connection revokeで対象familyを恒久停止できる
+
+Dayopt内にproposal、approval URL、承認状態機械は作らない。`confirmed: true`のような自己申告fieldも受け付けない。判断の背景は[操作確認をclientへ委ねる決定](../../product/log/2026-07-23-mcp-client-confirmed-direct-write.md)に記録する。
+
+## Current state
+
+2026-08-03時点で、段階導入8候補のうち候補1〜7が`main`へ入っている。MCP / OAuth endpoint、read tool、write tool、安全なDB command、retention用DB RPC、外部接続maintenance routeまでdark release済みである。
+
+ただし、closed betaはまだ完了していない。
+
+- #1754の最新manifestではProductionのglobal write gateはOFF、enabled clientは空。外部操作前にはlive値を再確認する
+- ChatGPT、Claude、Cursorの実機Plan → Track → Learnは未検証
+- 候補8の旧経路cleanupは未実施
+- 現在の`main`には公式conformance suiteの再実行commandがない
+- SettingsはMCP URLの表示だけで、connection一覧とuser-facing revoke導線がない
+- client gateはwrite scopeを一時的に隠すだけで、既存connection / token familyをrevokeしない。gateを再び開くと古い接続がwrite能力を取り戻し得る
+- maintenance dispatcherはOAuth code、access / refresh token、connection、mutation receiptのdue flagを完了判定へ含めていない
+- Productionでwriteを有効にしたclientはまだない
+
+実行状況のappend-only ledgerは[#1754](https://github.com/Dayopt/dayopt/issues/1754)、残りの手順は[Step 6 execution checklist](./step-6-execution-checklist.md)を正本とする。
+
+## Public tool and scope contract
+
+`tools/list`は、現在の接続が実行できるtoolだけを返す。scopeを後から増やす場合は再authorizationと再接続を行う。
+
+| Scope              | Tools                                                                    |
+| ------------------ | ------------------------------------------------------------------------ |
+| `read:entries`     | `entries.list`, `plans.list`, `plans.get`, `records.list`, `records.get` |
+| `read:tags`        | `tags.list`                                                              |
+| `read:constraints` | `constraints.get`                                                        |
+| `read:stats`       | `review.get`                                                             |
+| `write:plans`      | `plans.create`, `plans.update`                                           |
+| `delete:plans`     | `plans.trash.list`, `plans.delete`, `plans.restore`                      |
+| `write:records`    | `records.create`, `records.update`                                       |
+| `delete:records`   | `records.trash.list`, `records.delete`, `records.restore`                |
+
+公開metadataは一般提供する4つのread scopeだけを広告する。write / delete scopeはclosed betaの対象clientにだけ発行する。write / delete scopeは`read:entries`を必須とする。
+
+## OAuth and connection contract
+
+- 対応client IDは`claude-ai`、`chatgpt`、`cursor`のstatic allowlistとする
+- public clientはPKCE S256を必須とする
+- authorization request、code exchange、access token、refresh tokenを正規化済みresourceとconnectionへbindする
+- resource URIはURLとしてparseし、configured originと正規化比較する。userinfo、query、fragment、非default port、想定外pathを拒否する
+- redirect URIはclientごとの登録値と厳密一致させる
+- authorization codeは一回限りとし、交換をtransaction化する
+- refreshでscopeとresourceを拡大しない。rotationのreuseを検知したfamilyは失効する
+- connection revoke RPC、再認証期限、scope喪失、client gate、entitlement喪失を次のrequestとwrite transactionで再検証する
+- codeとtokenの平文、Authorization header、raw tool inputをlogやreceiptへ保存しない
+
+credentialなし、形式不正、無効token、scope不足、一時的な認可障害は別のHTTP結果として扱う。一時障害を再authorization loopへ変換しない。
+
+## Mutation contract
+
+- generic JSON executorではなく、Plan / Recordごとのtyped commandを使う
+- create/update/delete/restoreは`operationId`を冪等性keyとする。同じclientとoperation IDで同じ要求が再送された場合はreceiptを再生し、別payloadへの使い回しは拒否する
+- update/delete/restoreは`expectedUpdatedAt`を必須にし、古い画面やAIが新しい変更を上書きしないようexact versionで比較する
+- connection、token、resource、scope、reauth期限、client gate、global gate、entitlementをtransaction内で再検証する
+- Plan同士、Record同士の時間重複はDB exclusion constraintを最終防衛線にする。通常UIとMCPが同時に書いても片方だけが成立する
+- mutationとreceiptは同じtransactionでcommitする。失敗したmutationの本文は監査用に保存しない
+- `plans.delete`と`records.delete`はsoft deleteであり、restore可能とする
+- MCPから作るPlan / RecordはAPI由来として識別する。Recordだけが完了済みPlanへの`planId`を持てる
+
+## Read consistency and product convergence
+
+- `plans.list` / `records.list` / `get`は安定したresource IDとversionを返す
+- `tags.list`、`constraints.get`、`review.get`は最小限のprojectionだけを返す
+- `constraints.get`と`review.get`の複数readは、user revisionとtimezoneが変わっていない一貫した時点に揃える。互換用`entries.list`はbest-effortな複数readであり、同じsnapshot保証を持たない
+- DBとserverにはuser revision境界があるが、現在のProduct UIはrevisionをpollしていない。Calendar、Inspector、Reviewの外部変更追従と20秒SLAはStep 6の未完了項目とする
+- legacy text outputは外部由来のtitle、noteなどをuntrusted dataとして警告付きで囲む。`structuredContent`は構造化するだけで同じ囲みを持たないため、3 clientがモデルへの指示として誤採用しないことを別に実機確認する
+- `deleteAllData`、account削除、connection revokeにはMCP authorityと競合しないDB command境界がある。OAuth / receipt retentionの実行と完了判定は未完成である
+
+## Delivery
+
+| Step | Outcome                                                      | State       |
+| ---- | ------------------------------------------------------------ | ----------- |
+| 1    | OAuth connection、resource binding、revoke、scope filtering  | done        |
+| 2    | DB overlap防止、typed command、exact version、通常UI cutover | done        |
+| 3    | transaction内再認可、idempotency receipt、write gate         | done        |
+| 4    | Plan / Record read・create・update・delete・restore          | done        |
+| 5    | tags、constraints、review、consistent read、local E2E        | done        |
+| 6    | 3 client実機検証、旧経路cleanup、Production beta             | in progress |
+
+## Completion boundary
+
+このProjectは、次をすべて満たした時に完了する。
+
+- 旧input、旧RPC、旧connectionの利用が0である証拠を取り、候補8を安全に完了する
+- isolated ephemeral PreviewでChatGPT、Claude、Cursorの3 clientが同じ公開契約を扱える
+- 各clientでPlan → Track → Learn、再送、revoke、並列refresh、UIとの同時書き込みを確認する
+- responseのID、時刻、timezone、Plan / Record関係、外部由来情報が3 clientで同じ意味になる
+- Settingsから自分のconnectionを確認・revokeでき、解除後のtoken familyが復活しない
+- client停止時に既存write connectionを恒久失効する仕組みを実装するか、一時停止と個別revokeを組み合わせた運用契約を固定する
+- retention backlog、account削除、停止手順、監視がProduction運用に耐える
+- 明示承認したclientだけを1 clientずつ有効にし、問題時に即時停止できる
+
+## Reversibility
+
+- runtime allowlistを空にすれば、新しいwrite scopeの利用を止められる
+- durable client gateをOFFにすると、そのclientのwrite scopeを一時的に除外できる。既存connection / tokenは失効しない
+- global gateをOFFにすると、全clientの新しいwriteを停止できる
+- 恒久停止にはconnection revokeを使い、同じfamilyのtokenが失効したことを確認する
+- gate再開で停止前のconnectionが復活しない契約が必要なら、Production beta前にDB commandを追加する
+- schema cleanupのような破壊的変更は、削除前のzero-use証拠とforward restoration migrationを用意して別の明示承認境界で行う
+
+## Deferred scope
+
+- Dynamic Client Registration
+- Dayopt内proposal / approval UI
+- 汎用タスク管理や会議自動生成
+- durableな個別resource URLが決まる前の一時的なdeep link公開

--- a/docs/projects/mcp-plan-track-learn/step-6-client-beta.md
+++ b/docs/projects/mcp-plan-track-learn/step-6-client-beta.md
@@ -1,0 +1,154 @@
+---
+status: current
+last_verified: 2026-08-03
+code:
+  - apps/product/src/app/api/mcp
+  - apps/product/src/app/api/oauth
+  - apps/product/src/features/settings
+  - apps/product/src/features/timeblock
+  - apps/product/src/app/api/cron/external-connection-maintenance
+---
+
+# Step 6 — Client beta verification
+
+## Goal
+
+ChatGPT、Claude、Cursorから、同じ公開契約でDayoptのPlan → Track → Learnを完結できることを、Productionと分離した一時Previewで確認する。その証拠が揃ったclientだけを、Productionで1 clientずつ有効にする。
+
+## Current state
+
+2026-08-03時点の状態は次のとおりである。
+
+- MCP / OAuth appは候補7まで`main`へ入り、Productionへdark release済み
+- global write gateはOFF、enabled clientは空
+- local integrationでは3 client ID、scope filter、retry、refresh、revoke、同時書き込みを検証済み
+- 実client UI、実network、実OAuth callbackを通したE2Eは未実施
+- 旧経路cleanupの候補8と、現在のcandidateに対するofficial conformance再実行が未完了
+- Settingsのconnection一覧 / revoke UI、client停止時の恒久失効、OAuth / receipt retentionのcomplete判定が未実装
+
+したがって「実装済み」ではあるが「closed betaを提供できる」状態ではない。
+
+## Customer contract
+
+- Dayoptは、接続時にユーザーが許可したscopeのtoolだけをclientへ見せる
+- AIがwrite toolを呼んだ場合、Dayoptの正規データを直接変更する
+- 操作確認のUIと方針はclientが担い、Dayoptは確認済みという自己申告を要求しない
+- revoke、scope喪失、entitlement喪失、期限切れ、gate停止後は古いtool listを使った呼び出しも拒否する
+- client gateは閉じている間だけwrite scopeを除外する。再開時に古いconnectionを復活させないには、connection revokeまたは追加のDB commandが必要である
+- 同じoperationの再送は二重作成せず、異なるpayloadへのoperation ID再利用は拒否する
+- UIとAIが同じ時間帯へ同時に書いた場合、DB制約により片方だけが成功する
+
+## Preview environment
+
+Persistent Stagingは作らない。client betaごとに破棄可能なephemeral PR Previewを使う。
+
+- Supabase branchはProductionと別ref、`with_data: false`、non-persistentとする
+- seed、public signup、email signupを止めてからsynthetic userを作る
+- Vercelはstable branch aliasをissuer、resource、redirect URIに共通利用する
+- deployment固有URLをOAuth identityに使わない
+- Upstash、OAuth redirect、test identityはPreview専用にする
+- Productionのcookie、token、service-role key、Stripe live secret、実ユーザーデータを持ち込まない
+- runtime write allowlistとDB gateは、read-only確認が終わるまで空・OFFを維持する
+
+環境identity、branch、resource、Supabase refが一致しない場合は即座に停止する。
+
+## Client test matrix
+
+各clientは別connectionを使い、同じsynthetic scenarioと同じtool schemaで検証する。
+
+| Area               | Required result                                                                                                         |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| OAuth discovery    | issuer、resource、authorization endpoint、token endpointがPreview identityと一致する                                    |
+| Consent            | client名、要求scope、resourceが正しく表示され、未許可scopeは付与されない                                                |
+| Tool discovery     | granted scopeで使えるtoolだけが列挙される                                                                               |
+| Plan               | constraints / tags / existing Planを読み、Planをcreate / updateできる                                                   |
+| Track              | Planを参照したRecordをcreateし、必要な修正をupdateできる                                                                |
+| Learn              | `review.get`でPlanとRecordの差を読み、次のPlanへ反映できる                                                              |
+| Retry              | response欠落を想定した同一operation再送でreceiptがreplayされ、二重作成されない                                          |
+| Parallel refresh   | 同一refresh tokenの競合時に、許容grace内の勝者を維持できる                                                              |
+| Refresh reuse      | grace外のreuseでfamilyが失効し、再接続へ進める                                                                          |
+| Revoke             | Settingsから対象connectionだけを失効でき、同じtoken familyが復活せず、別connectionは維持される                          |
+| Authorization loss | downgrade、scope撤回、reauth期限、client停止後のcached writeを拒否する                                                  |
+| UI race            | 通常UIとMCPのPlan作成、Record作成を同時実行し、重複する要求の片方だけが成功する                                         |
+| UI convergence     | Calendar、Inspector、Reviewが外部変更を20秒以内に反映する                                                               |
+| Retention          | OAuth code、access / refresh token、connection、receiptを含む全due flagがfalseになり、aggregate以外の機微情報を返さない |
+| Delete all data    | 明示承認したsynthetic userだけを削除し、MCP / Calendarから再生成されない                                                |
+| Stop control       | global / client gateで即時停止し、対象connectionを恒久revokeできる。gate再開で停止対象が復活しない                      |
+| Untrusted content  | legacy textと`structuredContent`の両方で、外部由来自由文をモデルへの指示として誤採用しない                              |
+
+## Response usability contract
+
+AIが安全に後続操作へつなげられるよう、3 clientで次を確認する。
+
+- Plan / Recordは安定した`id`を返し、listで得たIDをget / update / deleteへそのまま渡せる
+- `startAt`、`endAt`、`createdAt`、`updatedAt`はRFC 3339のabsolute timeとしてoffsetを失わない
+- ユーザーtimezoneを明示的なcontextとして扱い、serverやclient端末のtimezoneを暗黙に使わない
+- Recordの`planId`から対応Planを辿れる
+- `source`でDayopt内作成と外部由来を区別できる
+- field名、nullability、時刻の意味が3 clientで一致する
+- 永続的なroute契約がない間はstable IDをlocatorの正とし、一時的なdeep linkを公開しない
+- 外部カレンダーの非公開情報を露出せず、自由テキストをuntrusted dataとして扱う
+
+現在のpublic Plan / Record schemaは`externalCalendarEventId`を公開しない。legacy textにはuntrusted noticeとdelimiterがある一方、同じpayloadの`structuredContent`は構造化されるだけでdelimiterを持たない。各clientがどちらをモデルへ渡すかを観測し、自由文を指示として誤採用する場合は公開前にserver contractまたはclient対応を修正する。
+
+既存fieldで満たせる項目は実装を増やさない。timezone、locator、外部eventとの対応付けが必要だと実機検証で分かった場合だけ、privacy境界を確認した最小のcontract変更を別PRで行う。
+
+## Evidence manifest
+
+clientごとに`docs/engineering/log/YYYY-MM-DD-mcp-beta-<client>-<run>.md`を作る。結果はappend-onlyとし、再試験は新しいrunへ分ける。
+
+```yaml
+status: current
+last_verified: YYYY-MM-DD
+client: claude-ai | chatgpt | cursor
+client_version: '<version>'
+environment: preview
+authorization_server: 'https://<stable-branch-alias>'
+resource: 'https://<stable-branch-alias>'
+deployment_sha: '<exact-sha>'
+db_identity:
+  environment: preview
+  origin: 'https://<stable-branch-alias>'
+  supabase_project_ref: '<non-secret-ref>'
+gate_revision: '<opaque-revision>'
+synthetic_subject_label: '<non-identifying-label>'
+destructive_test_authority: '<approval-record-reference-or-none>'
+started_at: 'YYYY-MM-DDTHH:MM:SSZ'
+ended_at: 'YYYY-MM-DDTHH:MM:SSZ'
+result: pass | fail | blocked
+```
+
+manifest本文には、test matrix各行のstatusと、HTTP status、件数、時刻、最終画面状態だけを書く。次は保存しない。
+
+- OAuth code、access token、refresh token、PKCE verifier
+- cookie、Authorization header、callback query
+- service-role key、DB password、Webhook secret
+- user ID、operation ID、Customer ID
+- Plan、Record、reviewの本文
+- raw HARや無加工の画面録画
+
+画面録画が必要な場合はrepo外の制限された場所へ置き、Step 6判定後30日以内に削除する。
+
+## Per-client pass condition
+
+1 clientをpassにするには、次をすべて満たす。
+
+- exact candidate SHAでprotocol verificationがpassしている
+- matrixの全項目がpassし、blockedが残っていない
+- mutation件数とreceipt件数が一致する
+- DB statusが返すOAuth / receiptを含む全retention due flagがfalseである。現在のmaintenance summaryの`complete`だけでは判定しない
+- client gate / global gateの一時停止と、connection revokeによる恒久停止の両方をrehearseしている
+- Settingsのconnection一覧 / revokeと、structured contentのuntrusted data testがpassしている
+- failure時の顧客影響と再接続手順がSettings / docsと一致する
+
+clientは`claude-ai`、`chatgpt`、`cursor`の順序を固定しない。最初に互換性が確認できた1 clientからProduction betaへ進めるが、Project完了には3 clientすべてのpassが必要である。
+
+## Completion boundary
+
+- 3 clientすべてに独立したpass manifestがある
+- Plan → Track → Learnが同じ公開契約で完結する
+- 20秒以内のUI convergenceとnegative caseを実測している
+- retention、account削除、revoke、gate停止が実環境で成立する
+- Production betaの対象client、運用担当、停止判断、監視が決まっている
+
+Production migration、release、write gate変更、credential rotate / revokeはこの文書だけでは承認されない。対象と環境を指定した明示承認を別に得る。

--- a/docs/projects/mcp-plan-track-learn/step-6-conformance.md
+++ b/docs/projects/mcp-plan-track-learn/step-6-conformance.md
@@ -1,0 +1,80 @@
+---
+status: current
+last_verified: 2026-08-03
+code:
+  - apps/product/package.json
+  - apps/product/src/app/api/mcp/_protocol-handler.ts
+  - apps/product/src/app/api/mcp/__tests__
+---
+
+# Step 6 — MCP protocol verification
+
+## Purpose
+
+DayoptのMCP endpointが、実装者の読み合わせだけでなく、再現可能なprotocol試験と3 clientの実機試験の両方を通ることを確認する。
+
+## Current main contract
+
+現在の`main`は次の構成である。
+
+- `@modelcontextprotocol/sdk` `^1.30.0`
+- `WebStandardStreamableHTTPServerTransport`
+- requestごとにserverとtransportを作るstateless構成
+- JSON responseを有効にした単一のStreamable HTTP経路
+- server-side session storageなし
+
+repo testは、protocol handler、route、server、tool registryを通して少なくとも次を固定している。
+
+- 認証済みrequestだけがMCP contextを作れる
+- token、connection、client、resource、scopeが同じcontextへbindされる
+- `tools/list`はeffective scopeでfilterされる
+- tool registryの名前とscopeがexact setで一致する
+- credentialなし、形式不正、無効token、scope不足、一時的な認可障害を分ける
+- request size、rate limit、JSON-RPC batch拒否をMCP処理より前で強制する
+
+これらはDayopt固有の安全境界を検証するが、公式conformance suiteの代替ではない。
+
+## Historical evidence and current gap
+
+[2026-07-29の履歴](../../engineering/log/2026-07-29-mcp-2026-07-28-conformance.md)では、integration source branch上のofficial alpha suiteが`server-stateless` 24 / 28、`tools-list` 2 / 2を通った。
+
+そのharnessとv2 runtimeは候補7の選択的移植に含めなかった。現在の`main`には同じ結果を再現するcommandがないため、過去の数字を現在のrelease proofとして扱わない。
+
+## Required release evidence
+
+closed beta候補のexact SHAで次を満たす。
+
+1. 現在の公式conformance suiteと対象MCP specificationのversionを固定する
+2. repo内の1 commandで、外部networkへ公開せずにsuiteを再実行できるようにする
+3. `server-stateless`と`tools-list`の結果、warning、既知failure IDを保存する
+4. 既知failureがsuite専用diagnostic toolだけに由来することを確認する
+5. baselineにないfailure、warning、未実行testを失敗として扱う
+6. suite更新時は、expected failureが実際に実行されていることを人が確認する
+7. ChatGPT、Claude、Cursorの実機でOAuth discovery、resource indicator、tool discovery、tool callを確認する
+
+test専用toolをproduction registryへ追加しない。conformanceを通すために認可、rate limit、request size、untrusted data境界を弱めない。
+
+## Evidence record
+
+検証結果には次だけを保存する。
+
+- candidate SHA
+- Node、SDK、suite、specのversion
+- 実行command
+- suite別のpass / failure / warning件数
+- expected failure IDと理由
+- 実行日時と担当者
+
+token、Authorization header、OAuth code、PKCE verifier、user ID、operation ID、Plan / Record本文、raw HARは保存しない。
+
+## Release boundary
+
+次の状態ではwrite gateを開かない。
+
+- 現在のcandidate SHAでofficial conformanceを再実行できない
+- baseline外のfailureまたはwarningがある
+- expected failureが未実行・skipされているだけか判別できない
+- 3 clientのいずれかでresource indicator、OAuth discovery、tool listの意味が一致しない
+- repo testとofficial suiteのどちらかが失敗する
+
+protocol conformanceが通っても、正規データ変更の安全性やclient UIの確認体験までは証明しない。残りは[client beta verification](./step-6-client-beta.md)で検証する。

--- a/docs/projects/mcp-plan-track-learn/step-6-execution-checklist.md
+++ b/docs/projects/mcp-plan-track-learn/step-6-execution-checklist.md
@@ -1,0 +1,188 @@
+---
+status: current
+last_verified: 2026-08-03
+code:
+  - docs/projects/mcp-plan-track-learn/overview.md
+  - docs/projects/mcp-plan-track-learn/step-6-conformance.md
+  - docs/projects/mcp-plan-track-learn/step-6-client-beta.md
+  - supabase/migrations
+---
+
+# Step 6 — Rollout execution checklist
+
+## Source of truth
+
+- 設計と完了条件: このproject directory
+- 実行順、candidate manifest、Production確認: GitHub Issue [#1754](https://github.com/Dayopt/dayopt/issues/1754)
+- 実clientの証跡: `docs/engineering/log/YYYY-MM-DD-mcp-beta-<client>-<run>.md`
+
+Issue本文の割合や「次の1件」は古くなるため、完了判断にはchecklistと最新のappend-only commentを使う。secret、個人情報、raw requestはどの正本にも残さない。
+
+## Rollout status
+
+段階導入は7 / 8候補まで完了している。
+
+| Candidate | Outcome                                               | Evidence               | State   |
+| --------- | ----------------------------------------------------- | ---------------------- | ------- |
+| 1         | additive DB expand、gate OFF                          | PR #1764 / `ce8c4cd7d` | done    |
+| 2         | Timeblock通常UI command compatibility                 | PR #1765 / `ee44c0fd6` | done    |
+| 3         | retention、account削除、外部依存compatibility         | PR #1766 / `ed4a61013` | done    |
+| 4         | OAuth CHECKを`NOT VALID`で追加                        | PR #1769 / `566ca7982` | done    |
+| 5         | read-only preflight後にOAuth CHECKをvalidate          | PR #1780 / `f1dc397a0` | done    |
+| 6         | Plan / Record ACLをauthenticated SELECT onlyへcutover | PR #1781 / `468cd2495` | done    |
+| 7         | MCP / OAuth appを全write gate OFFでdark release       | PR #1799 / `51bb34479` | done    |
+| 8         | 旧input、旧RPC、旧connectionのzero-use後cleanup       | 未着手                 | pending |
+
+その後、PR #1801でlocal OAuth identity seed、PR #1802でSettingsと初回OAuth challengeのread scopeを調整した。この抽出branchのbaseは、PR #1802までを含む`159304471`である。
+
+## Next sequence
+
+### 1. Candidate 8 scopeを現在のmainから再定義する
+
+- [ ] latest `origin/main`から専用branchを作る
+- [ ] 旧ブランチのmigrationやcommitを機械的にcherry-pickしない
+- [ ] repo内の旧input型、旧route、旧RPC caller、compatibility testを列挙する
+- [ ] Productionをread-onlyで確認し、旧input、旧connection、旧RPC利用の観測期間と件数を記録する
+- [ ] `soft_delete_plan`、`soft_delete_record`、`confirm_day_plans_to_records`のauthenticated compatibilityが本当に不要か確認する
+- [ ] service-role recovery surfaceを残すか削除するかを、運用手順と一緒に明示する
+- [ ] drop / revoke対象と残す対象をobject signature単位で固定する
+
+観測窓、対象object、顧客影響が曖昧なままcleanup migrationを書かない。利用0の証拠はtargetごとに必要であり、「repo callerが0」だけでProduction traffic 0とはみなさない。
+
+### 2. Candidate 8をephemeral Previewでrehearseする
+
+- [ ] Productionと別refのdata-less、non-persistent Supabase branchを使う
+- [ ] exact candidate SHAと期待migration terminalをmanifestへ固定する
+- [ ] global gate OFF、enabled client空、runtime allowlist空を確認する
+- [ ] cleanup前の旧app互換またはdrain完了条件を確認する
+- [ ] cleanup後に新appのread、通常UI mutation、service-role recoveryが意図どおり動く
+- [ ] authenticatedから撤去した能力が`42501`等の期待結果で拒否される
+- [ ] rollbackではなくforward restoration migrationをrehearseする
+- [ ] migration lock、開始・終了時刻、最大待機を記録する
+- [ ] `pnpm docs:check`、DB integration、RLS snapshot、typecheck、lint、boundariesを通す
+
+Candidate 8は破壊的変更を含む。PR merge、Production migration、Production cleanupには対象と環境を指定した明示承認が必要である。
+
+### 3. Current candidateでprotocol verificationを戻す
+
+protocol試験の前に、次のrepo-side blockerも閉じる。
+
+- [ ] Settingsに認証済みuser自身のconnection一覧と個別revoke導線を追加し、別user / 別connectionを変更できないことを検証する
+- [ ] client gate OFFが一時停止にすぎない現状を維持するか、対象clientの既存write connectionを同じtransactionで恒久失効するDB commandを追加するかを決める
+- [ ] 一時停止を維持する場合は、gate再開前に対象connectionを個別revokeし、同じtoken familyが復活しない運用をrehearseする
+- [ ] maintenance dispatcherがauthorization code、access token、refresh token、connection、mutation receiptのdue flagを完了判定へ含める
+- [ ] 各due itemのbounded cleanupを実行し、期限超過をfail closedで報告する
+- [ ] legacy textと`structuredContent`のuntrusted data扱いを3 clientで確認できるtest scenarioを用意する
+
+- [ ] 現在のofficial conformance suiteとspec versionを選ぶ
+- [ ] exact candidate SHAを1 commandで検証できるharnessを追加する
+- [ ] repo testとofficial suiteを両方passさせる
+- [ ] expected failureはID、理由、実行済みであることを記録する
+- [ ] baseline外のfailure、warning、skipがない
+
+詳細は[protocol verification](./step-6-conformance.md)に従う。
+
+### 4. Client beta用ephemeral Previewを作る
+
+- [ ] Candidate 8とprotocol verificationを含むexact SHAを使う
+- [ ] seedとsignupを止めたdata-less branchを使う
+- [ ] synthetic userを1件だけ用意し、credentialをrepoやIssueへ書かない
+- [ ] stable branch alias、authorization server、resource、redirect URIを同じoriginへ揃える
+- [ ] Preview専用Upstashとsecretだけを使う
+- [ ] DB environment identityとSupabase project refをapp起動前に確認する
+- [ ] read-only connectionでread toolだけが見える
+- [ ] cached write callがgate OFFで正規データを変更しない
+
+過去のPR #1760 Previewは準備記録であり、再利用しない。Persistent Stagingも作らない。
+
+### 5. Three-client matrixを実行する
+
+- [ ] ChatGPT
+- [ ] Claude
+- [ ] Cursor
+
+各clientで[client beta verification](./step-6-client-beta.md)の全matrixを実行し、別々のevidence logを作る。1 clientの成功を他clientへ転用しない。
+
+### 6. Production beta checkpoint
+
+次を揃えてから、顧客挙動を変える承認を求める。
+
+- [ ] Candidate 8と最新appがProductionへ反映済み
+- [ ] exact Production SHAとDB migration terminalが一致する
+- [ ] 今回有効にするclientのPreview evidenceがpassしている
+- [ ] DB statusのOAuth / receiptを含む全retention due flagがfalseである。maintenance summaryの`complete`だけに依存しない
+- [ ] account削除とconnection revokeの実環境rehearsalがpassしている
+- [ ] Settingsのconnection一覧 / revokeと、client停止後の恒久失効がpassしている
+- [ ] 監視、担当者、停止条件、顧客案内、再接続手順が決まっている
+- [ ] global / client / runtimeの各gateを閉じる手順をrehearseしている
+
+有効化は1 clientずつ行う。
+
+1. durable client gateを開く
+2. runtime allowlistへclientを追加する
+3. global gateを開く
+4. 新しいconnectionで再authorizationする
+5. client matrixの代表flowを再実行する
+6. 監視期間を終えてから次のclientへ進む
+
+現在のclient gateだけでは旧connectionを失効できない。Production betaでは、対象connectionを明示revokeして同じtoken familyの失効を確認する。将来、client停止commandが恒久失効をtransaction化した場合だけ、そのcommandを正本に切り替える。
+
+## Candidate manifest
+
+Candidate 8と以後のrelease候補では、最低限次をIssueへappend-onlyで残す。
+
+```yaml
+candidate: '<name>'
+base_main_sha: '<sha>'
+candidate_head_sha: '<sha>'
+expected_migration_terminal: '<timestamp-or-none>'
+actual_migration_terminal: '<timestamp-or-none>'
+supabase_preview_project_ref: '<non-secret-ref>'
+stable_branch_alias: '<hostname>'
+global_write_gate: 'off'
+enabled_client_ids: []
+runtime_write_allowlist: []
+old_surface_usage: '<observation-window-and-aggregate>'
+forward_restoration_rehearsal: pass | fail | pending
+verified_at: 'YYYY-MM-DDTHH:MM:SSZ'
+operator: '<name-or-handle>'
+```
+
+## Stop conditions
+
+次のいずれかで作業を止める。
+
+- issuer、resource、branch alias、DB identity、Supabase refが一致しない
+- Production credentialまたは実ユーザーデータがPreviewへ入った
+- write gate OFFでwrite toolが列挙または実行された
+- 旧surfaceの利用が1件でも残る状態でCandidate 8を適用しようとしている
+- mutationとreceiptの件数が一致しない
+- UIとMCPの競合で重複Planまたは重複Recordが成立する
+- retention期限超過backlogが残る
+- Calendar、Inspector、Reviewが20秒以内に収束しない
+- baseline外のprotocol failureまたはwarningがある
+- client gateを閉じている間、またはconnection revoke後に新しいwriteが成立する
+- gate再開で、恒久停止したはずの旧connectionがwrite能力を取り戻す
+- DB statusにOAuth / receiptのdue flagがあるのにmaintenanceがcompleteを返す
+
+## Stop and roll forward
+
+write異常時は次の順に閉じる。
+
+1. global gateをOFFにする
+2. durable client gateをOFFにしてwrite scopeを一時除外する
+3. runtime allowlistから対象clientを外す
+4. 恒久停止が必要なconnectionを明示revokeし、同じtoken familyの失効を確認する
+
+schema cleanup後の問題は、確認済みのforward restoration migrationで復旧する。削除済みconnectionを復活させず、必要なclientは再authorizationする。
+
+Production credential混入時はPreview appとcronを隔離し、影響credentialをrotateまたはrevokeする。Production migration、release、gate変更、credential rotate / revokeは、対象と環境を指定した明示承認なしに実行しない。
+
+## Completion
+
+- Candidate 8がzero-use evidence付きで完了している
+- 現在のcandidateでofficial conformanceを再実行できる
+- ChatGPT、Claude、Cursorのevidenceが最終的にすべてpassしている
+- Productionで承認したclientだけが有効である
+- Plan → Track → Learn、停止、retention、削除、監視が一周している
+- #1754の古い進捗文を現状へ更新し、完了証拠を添えてcloseできる


### PR DESCRIPTION
## 概要

MCP Plan → Track → Learn の設計正本を `docs/projects/mcp-plan-track-learn/` へ復元し、候補7まで `main` へ入った現在地に合わせて Step 6（closed beta）の残作業境界を現行化する。docs のみの変更で、コードの挙動は変えない。

## 追加したファイル

| ファイル | 役割 |
| --- | --- |
| `docs/projects/mcp-plan-track-learn/overview.md` | Project の設計正本（責任分界、public tool / scope 契約、OAuth・mutation 契約、完了条件、Reversibility） |
| `docs/projects/mcp-plan-track-learn/step-6-conformance.md` | protocol 検証の現行境界と release evidence 要件 |
| `docs/projects/mcp-plan-track-learn/step-6-client-beta.md` | 3 client 実機検証の customer 契約、test matrix、evidence manifest |
| `docs/projects/mcp-plan-track-learn/step-6-execution-checklist.md` | 候補8 cleanup 以降の実行手順 |
| `docs/engineering/log/2026-07-29-mcp-2026-07-28-conformance.md` | 2026-07-29 conformance 結果の履歴と、現行 `main` との乖離の記録 |
| `docs/product/log/2026-07-23-mcp-client-confirmed-direct-write.md` | 操作確認を client へ委ね正規データへ直接反映する決定 |

## 記録した現行境界

過去の integration source branch と現在の `main` は別物であることを明示した。とくに次を「未完了」として固定する。

- 2026-07-29 の conformance 結果（`server-stateless` 24 / 28）は当時の v2 runtime のもので、現行 `main` に再実行 command がない。**過去の数字を release proof として使わない**
- client gate は write scope を一時的に隠すだけで、既存 connection / token family を revoke しない。gate 再開で古い接続が write 能力を取り戻し得る
- maintenance dispatcher が OAuth code / token / connection / receipt の due flag を完了判定へ含めていない
- Settings に connection 一覧と user-facing revoke 導線がない
- 3 client の実機 Plan → Track → Learn は未検証、候補8 の旧経路 cleanup は未着手

## 検証

- `pnpm docs:check` pass（リンク切れ・metadata 契約・命名規約・log 凍結ガードすべて違反なし）
- `overview.md` の scope → tool 表を `apps/product/src/app/api/mcp/_tools/registry.ts` と突合し、19 tool すべての `requiredScope` が一致することを確認
- `@modelcontextprotocol/sdk` `^1.30.0` の記述が `apps/product/package.json` と一致することを確認

## 関連

実行状況の append-only ledger は #1754 を正本とする。
