### PR TITLE
ci: Impact Resolverを追加しmerge gateをaffected-aware化する

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -254,6 +254,7 @@ Actions 課金は **PR ごとの固定費が支配的**（2026-07-25 実測）:
 - **ready 後に走る重量層**: E2E / Web E2E / Production Config Audit
 - flow は「draft で push を重ねる（軽量層のみ）→ ready 化 → 重量層 green を確認 → `pnpm branch:finish`」。`branch:finish` は draft を拒否する（既存挙動）
 - ready 後にさらに push すると重量層も再走する。レビュー指摘の対応が続くなら `gh pr ready --undo` で draft に戻してから積む
+- **外部レビューは draft のまま `@codex review` コメントで回す**（2026-08-04 に PR #1818 で実測）。Codex の自動レビューは「review 用に open」「draft を ready 化」で発火するため、これを待つとレビュー 1 ラウンドごとに ready 化が要り、そのたびに重量層が丸ごと再走する。`@codex review` は PR の状態に依存しない独立トリガーで、draft のまま 👀 → レビュー投稿まで通る。指摘が尽きてから ready 化すれば、重量層は merge 前の 1 回に収まる
 - **draft skip を使う workflow は `types` に `ready_for_review` を明示する。** `pull_request` / `pull_request_target` の既定 types は `opened / synchronize / reopened` だけで、これが無いと ready 化で再発火せず、draft 時の `skipped` が残ったまま「重量層を一度も走らせずに merge できる」状態になる（2026-08-03、PR #1810 で実測）
 - draft を忘れて ready で作っても機能的な regression は無い（全 push で全層が走る従来挙動に戻り、課金だけ増える）
 
@@ -311,6 +312,8 @@ gh pr merge <PR番号> --merge --delete-branch
 1. **fix を積む** — 指摘どおり修正コミットを push して resolve
 2. **反論を reply** — 採用しない根拠を thread に書いて resolve（黙って resolve しない）
 3. **issue 化** — エッジケース等を別 issue へ切り出し、issue 番号を reply して resolve
+
+レビューを起こすタイミングは §2 段階 CI の `@codex review`（draft のまま回す）に従う。
 
 外部レビュー（Codex）の指摘は的中率が高い実績があるため、既定は 1。2 を選ぶ時は根拠を必ず書く（後から「なぜ見送ったか」を thread だけで追えるようにする）。3 は P2 のエッジケースや scope 外の改善が対象で、起票は dispatch skill の規約に従う。
 

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -300,6 +300,22 @@ gh pr merge <PR番号> --merge --delete-branch
 - revert は対象を見極める。マージコミット自体を戻す場合は `git revert -m 1 <merge-sha>`、個別コミットを戻す場合は通常の `git revert <sha>`
 - マージ済みブランチは GitHub が自動削除（`deleteBranchOnMerge: true`）。ローカルでは `git branch -d` がマージを検出して安全に削除できる（squash 時代の `-D` 強制は不要になる）
 
+### レビュー指摘の必須解決
+
+策定日: 2026-08-04
+
+**PR の review thread は全件 resolve してから merge する。** `branch:finish` が機械的に強制する: GraphQL `reviewThreads` の `isResolved=false` が 1 件でもあれば merge を停止し、取得失敗・100 件超も停止に倒す（fail closed）。
+
+「解決」は次の 3 択のいずれか。いずれの場合も thread を resolve して閉じる:
+
+1. **fix を積む** — 指摘どおり修正コミットを push して resolve
+2. **反論を reply** — 採用しない根拠を thread に書いて resolve（黙って resolve しない）
+3. **issue 化** — エッジケース等を別 issue へ切り出し、issue 番号を reply して resolve
+
+外部レビュー（Codex）の指摘は的中率が高い実績があるため、既定は 1。2 を選ぶ時は根拠を必ず書く（後から「なぜ見送ったか」を thread だけで追えるようにする）。3 は P2 のエッジケースや scope 外の改善が対象で、起票は dispatch skill の規約に従う。
+
+このルールの狙いは「指摘の黙殺を構造的に不可能にする」こと。resolve の作業自体を目的化しない — 中身のない「対応済み」reply で resolve するのは 2 の違反にあたる。
+
 ## Worktree 運用
 
 策定日: 2026-07-10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,21 @@ jobs:
 
       - uses: ./.github/actions/setup
 
+      # Impact Resolver（scripts/ci/impact.mjs）の判定結果を Step Summary に出す。
+      # merge gate（branch:finish）が同じ判定で必須 Vercel context を決めるため、
+      # PR 上で「何が affected と判定されたか」を可視化する（#1813）。
+      # 表示専用で gate ではないので、失敗しても static job は落とさない。
+      # job を新設しないのは課金が job 単位で切り上げられるため（本 workflow 冒頭コメント）。
+      - name: Impact summary
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename' \
+            | node scripts/ci/impact.mjs --stdin --summary >> "$GITHUB_STEP_SUMMARY"
+
       # 独立した static チェックを 1 step 内の shell background lane で並列実行する（#1422）。
       # 2026-06-25 GA の native `parallel` 構文は hosted runner 未対応（workflow parse error）
       # だったため、確実に動く `&` / `wait` 方式を採用。install は共有し、重い ESLint / knip /

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # rename は移動元（previous_filename）も影響範囲に含める（finish-branch.sh と同じ規則）
           gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-            --jq '.[].filename' \
+            --jq '.[] | .filename, (.previous_filename // empty)' \
             | node scripts/ci/impact.mjs --stdin --summary >> "$GITHUB_STEP_SUMMARY"
 
       # 独立した static チェックを 1 step 内の shell background lane で並列実行する（#1422）。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# pull-requests: read は Impact summary step（static job）が PR の変更ファイル一覧を
+# 取得するために要る。permissions を明示宣言すると未宣言スコープは none になるため、
+# contents: read だけだと files API が 403 で静かに落ちる（continue-on-error のため
+# job は成功し、summary だけが出ない）。
 permissions:
   contents: read
+  pull-requests: read
 
 # private repo の Actions 課金は job ごとに 1 分単位で切り上げられるため、
 # job 数を絞り checkout + setup の重複を減らす構成にしている。

--- a/docs/engineering/infra.md
+++ b/docs/engineering/infra.md
@@ -235,9 +235,19 @@ main ruleset の required status checks は `ci.yml` の 4 job（`🔍 Static Ch
 | `Vercel – web`            | Vercel GitHub App | Web の Preview build が成功すること                        |
 
 - `Vercel – product` / `Vercel – web` の区切り文字は en dash（U+2013）で、hyphen ではない
+- **`branch:finish` はこの 2 context を無条件には要求しない（2026-08-04、#1813）。**
+  `scripts/ci/impact.mjs`（Impact Resolver）が PR の変更ファイルから affected な app を判定し、
+  affected な project の context だけを success 必須にする。unaffected な project の context
+  欠落は正常。変更ファイル一覧の取得失敗・未知 path・判定不能は両方必須へ倒す（fail closed）。
+  判定仕様は [ci-monorepo-refactor overview §5](../projects/ci-monorepo-refactor/overview.md)
 - Vercel の check context は **project 名に由来する**。project を rename すると required check が一致しなくなり、
   全 PR が merge 不能になる。rename する場合は ruleset を先に更新する
-- 同じ理由で、Ignored Build Step を設定すると status 自体が付かなくなる。設定しない
+- 同じ理由で、Ignored Build Step を設定すると status 自体が付かなくなる。**現時点では設定しない**。
+  merge gate と Production Release の affected-aware 化が完了した後、#1817（Phase 4）で
+  Impact Resolver を呼ぶ形に限って解禁する
+- **未解決の review thread が 1 件でもあると `branch:finish` は停止する**（2026-08-04）。
+  GraphQL `reviewThreads` の `isResolved` を数え、取得失敗・100 件超も停止に倒す。
+  解決の 3 択は `.claude/rules/workflow.md` §レビュー指摘の必須解決
 - `Production Release` は merge 後の証跡であり、required check にはしない
 - **Storybook browser suite（`pnpm test-storybook` / `test-storybook:dark`）は CI に載っていない。**
   `@dayopt/product` の vitest project（`--project storybook` / `storybook-dark`）として実体はあるが、

--- a/docs/projects/ci-monorepo-refactor/overview.md
+++ b/docs/projects/ci-monorepo-refactor/overview.md
@@ -104,6 +104,8 @@ Phase 1 の Step Summary 表示は既存 static job 内の 1 step に相乗り�
 Impact Resolver → merge gate 対応 → Production Release 対応 → Vercel skip 有効化 → CI / E2E 整理
 ```
 
+補足（2026-08-04 リスクレビューでの検出）: product の Vercel project は 2026-08-01 から標準機能の **Skip deployments（Root Directory 外の変更で skip）が Enabled** のまま（[当時のログ](../../engineering/log/2026-08-01-vercel-root-directory-flip-product.md)の残タスク未消化）。この機能は workspace 依存グラフを見ないため、`packages/**` のみの PR では Impact Resolver が `product=true` で context を要求する一方、Vercel は deployment を skip して context が付かず、**fail closed で merge が止まりうる**（安全側だが可用性の問題）。merge gate の affected-aware 化が main に入った後、最初の `packages/**` 限定 PR で `Vercel – product` context が付くかを確認し、付かなければ同トグルを Disabled に戻す。
+
 ## 9. 非目標
 
 - CI をすべて 1 workflow へ統合すること

--- a/docs/projects/ci-monorepo-refactor/overview.md
+++ b/docs/projects/ci-monorepo-refactor/overview.md
@@ -1,0 +1,119 @@
+---
+status: active
+last_verified: 2026-08-04
+code: scripts/ci
+---
+
+# ci-monorepo-refactor — 影響範囲に応じて検証・build・release を実行する
+
+モノレポの CI/CD が Product / Web を常に一組として扱っている状態を解消し、変更の影響を受ける app だけを検証・build・release する構成へ移行する。進捗と残作業は epic [#1812](https://github.com/Dayopt/dayopt/issues/1812) が正本で、本書は設計（なぜこの形か・判定仕様・Phase 構成・移行順序）の正本。**大規模判定**（blast radius が CI / merge gate / release 横断、Phase 5 構成）。
+
+---
+
+## 1. Goal
+
+変更ファイルと workspace 依存グラフから影響範囲を**一度だけ**判定し、その結果を CI、merge gate、Vercel、Production Release で共有する。
+
+## 2. 現状の問題（2026-08-04 検証済み）
+
+- [ci.yml](../../../.github/workflows/ci.yml) の `Web Build & E2E` は paths フィルタを持たず、Web を触らない PR でも ready 後に必ず走る
+- Web build は 3 重: Actions の `pnpm build:web` + Playwright webServer の `pnpm build && pnpm start:e2e`（[playwright.config.ts](../../../apps/web/playwright.config.ts) の CI 分岐）+ Vercel preview
+- Vercel の Product / Web project は、各 app へ影響しない変更でも両方 deployment を作る
+- [finish-branch.sh](../../../scripts/git/finish-branch.sh) は `REQUIRED_CONTEXTS=("Vercel – product" "Vercel – web")` を無条件に要求し、片方の deployment を skip すると merge できない
+- [production-release.mjs](../../../scripts/production-release.mjs) は `RELEASE_PROJECTS` 両方の同一 SHA candidate を待つため、片方だけ変更した release でも両方の build が必要
+- [integration.yml](../../../.github/workflows/integration.yml) は 28 行の手書き paths を持ち、影響判定の規則が workflow ごとに散らばっている
+- Product E2E は認証・service role が必要な重要 spec を CI で skip している（#1808）。中核 journey の未完成分は #1809
+
+## 3. 期待する挙動
+
+| 変更                       | Product               | Web                   | Production       |
+| -------------------------- | --------------------- | --------------------- | ---------------- |
+| `apps/product/**` のみ     | verify / build        | skip                  | Product のみ更新 |
+| `apps/web/**` のみ         | skip                  | build / preview smoke | Web のみ更新     |
+| Web/Product 共通 package   | 両方                  | 両方                  | 両方更新         |
+| docs / agent Markdown のみ | skip                  | skip                  | no-op            |
+| DB / server contract       | integration + Product | skip                  | Product のみ更新 |
+
+## 4. 設計原則
+
+1. **影響判定を一か所に集約する。** `scripts/ci/impact.mjs` を正本とし、GitHub Actions の手書き paths、Vercel の skip、merge gate、release が別々の規則を持たない
+2. **Vercel の skip は最適化であり、正しさの基準にはしない。** Dayopt 側で `web=true` なのに `Vercel – web` が無い場合は fail closed。`web=false` なら Web context が無くても正常
+3. **Draft は軽く、Ready 後に重い検証を行う**（[workflow.md §2 段階 CI](../../../.claude/rules/workflow.md) の既存方針を維持）
+4. **build は配信環境で一度だけ行う。** Product / Web の本番相当 build は Vercel を正とし、Actions 内の重複 build を撤去する
+5. **E2E は存在確認ではなく中核 journey を守る。** Product は Local Supabase で実データ操作、Web は Vercel Preview URL で最小 smoke。重要 spec の skip を green として扱わない
+6. **DB migration は artifact rollback と分離する。** expand / contract で後方互換期間を確保する
+
+## 5. Impact Resolver の判定仕様
+
+出力（JSON、キーは固定）:
+
+```json
+{
+  "product": true,
+  "web": false,
+  "integration": true,
+  "productJourney": true,
+  "webPreviewSmoke": false,
+  "docsOnly": false
+}
+```
+
+判定規則:
+
+- **docsOnly** — 変更ファイルの**全て**が docs 系パターン（`docs/**`、`.claude/**/*.md`、`.codex/**/*.md`、`.agents/**/*.md`、`AGENTS.md`、`CLAUDE.md`、`README.md`）に該当する時のみ true。[ci.yml](../../../.github/workflows/ci.yml) の paths-ignore と同一規則
+- **product** — `apps/product/**`、`packages/**`（product は全 7 package に依存）、`supabase/**`、root 設定（`package.json` / `pnpm-lock.yaml` / `pnpm-workspace.yaml` / `turbo.json` / `tsconfig.base.json` / `.nvmrc`）のいずれかに触れた時 true
+- **web** — `apps/web/**`、`packages/**` のうち web が依存するもの（`packages/domain` 以外）、root 設定に触れた時 true
+- **integration** — [integration.yml](../../../.github/workflows/integration.yml) の現行 paths と同一集合（server contract / DB / migration / MCP / tRPC 境界）
+- **productJourney** — `product` が true かつコード変更を含む時 true（E2E spec / config 自体の変更も含む）
+- **webPreviewSmoke** — `web` と同値
+- **未知の path は fail closed** — どの規則にも該当しないファイル（新しい root ファイル等）は「全て affected」として扱う。判定漏れが検証漏れに化けるのを防ぐ
+
+依存グラフは pnpm workspace の manifest（`dependencies` / `devDependencies` の `@dayopt/*`）から実行時に解決する。ハードコードした対応表は持たない（package 追加時に判定が自動追従する）。
+
+## 6. Phase 構成と PR の対応
+
+Step 分割は作業単位、PR は機能のまとまり（[workflow.md §PR 粒度](../../../.claude/rules/workflow.md)）。
+
+| PR  | 内容                                                                                                                  | 分割理由                                                                                                                                                      |
+| --- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A   | Phase 1（Impact Resolver + test + Step Summary）+ Phase 2（merge gate の affected-aware 化）+ マージルール gate（§7） | merge gate は resolver の最初の消費者。`finish-branch.sh` はローカル実行なので merge-base diff から impact をその場で再計算でき、CI artifact の受け渡しが不要 |
+| B   | Phase 3（Production Release の affected-aware 化）                                                                    | production release 経路は独立して検証・revert したい変更                                                                                                      |
+| C   | Phase 4（Vercel skip 有効化 + Config Audit への metadata 監査追加）                                                   | 外部設定変更が主体。B より先に出さない（§8）                                                                                                                  |
+| D   | Phase 5（CI 重複整理: Actions の Web build 削除、Web E2E → Preview smoke 化）                                         | #1808 / #1809 の Local Supabase 基盤・journey 完成に依存                                                                                                      |
+| E   | Phase 6（計測後に Unit を `turbo --affected` 化）                                                                     | 現行 full Unit の時間と検出内容を基準計測してから。現状 [turbo.json](../../../turbo.json) に `test:run` の inputs / 依存定義が無く、turbo.json 整備が前提     |
+
+Phase 1 の Step Summary 表示は既存 static job 内の 1 step に相乗りさせる（job 新設は課金分 +1/run になるため）。
+
+## 7. マージルール — レビュー thread の必須解決
+
+`branch:finish` に「未解決 review thread 0 件」の gate を追加する。GraphQL の `reviewThreads` で `isResolved=false` を数え、1 件でもあれば merge を停止して一覧を表示する。
+
+「解決」は次の 3 択のいずれか:
+
+1. 指摘どおり fix を積んで resolve
+2. 反論・根拠を reply して resolve
+3. 別 issue へ切り出し、issue 番号を reply して resolve
+
+外部レビュー（Codex）の的中率実績を踏まえ、黙殺での merge を機械的に塞ぐ。運用ルールの正本は [workflow.md](../../../.claude/rules/workflow.md) §マージ方式 に置く。
+
+## 8. 移行順序（安全制約）
+
+**`branch:finish` と Production Release を affected-aware にする前に、Vercel の Skip deployment を有効化しない。** 現在は両 Vercel context と同一 SHA の両 candidate を要求しているため、先に skip すると merge / release が停止する。
+
+```text
+Impact Resolver → merge gate 対応 → Production Release 対応 → Vercel skip 有効化 → CI / E2E 整理
+```
+
+## 9. 非目標
+
+- CI をすべて 1 workflow へ統合すること
+- Vercel Preview で Production DB を使った変更系 E2E を行うこと
+- すべての Unit / Static を即座に affected 化すること
+- migration をアプリの Instant Rollback で戻せるようにすること
+- Vercel の判定だけを信頼して merge / release を決めること
+
+## 10. 関連
+
+- epic: #1812（進捗の正本）
+- #1808 — CI に Local Supabase を立てて認証必須 E2E を実行する
+- #1809 — critical-path journey の残り 2 段を完成させる

--- a/scripts/__tests__/finish-branch.test.ts
+++ b/scripts/__tests__/finish-branch.test.ts
@@ -108,6 +108,8 @@ function runScript(
     files?: string[];
     /** 変更ファイル一覧 API を失敗させる（fail closed 経路の検証） */
     filesUnavailable?: boolean;
+    /** 一覧を部分的に出力した後で失敗させる（pagination 途中失敗の再現） */
+    filesPartialFailure?: boolean;
     /** レビュー thread の状態。省略時は 0 件（gate を通す） */
     threads?: Array<{ isResolved: boolean; path?: string; author?: string }>;
     /** thread 取得 API を失敗させる（fail closed 経路の検証） */
@@ -173,7 +175,10 @@ case "$1" in
     shift
     case "$*" in
       graphql*) cat "$FINISH_BRANCH_THREADS_JSON" ;;
-      *pulls/123/files*) cat "$FINISH_BRANCH_PR_FILES" ;;
+      *pulls/123/files*)
+        cat "$FINISH_BRANCH_PR_FILES"
+        if [[ "\${FINISH_BRANCH_FILES_EXIT:-0}" != "0" ]]; then exit 1; fi
+        ;;
       *compare*) echo "$FINISH_BRANCH_COMPARE" ;;
       *full_name*) echo "Dayopt/dayopt" ;;
       *) exit 2 ;;
@@ -209,6 +214,7 @@ esac
       FINISH_BRANCH_THREADS_JSON: options.threadsUnavailable
         ? join(temporaryDirectory, 'missing-threads.json')
         : threadsPath,
+      FINISH_BRANCH_FILES_EXIT: options.filesPartialFailure ? '1' : '0',
     },
   });
 
@@ -769,6 +775,22 @@ describe('affected-aware な Vercel context 要求（Impact Resolver 連携）',
     );
     expect(stderr).toContain('影響判定を実行できませんでした');
     expect(stderr).toContain('必須 check「Vercel – web」');
+    expect(status).toBe(1);
+  });
+
+  it('一覧が部分的に取れて失敗した場合も両方を必須にする（pagination 途中失敗）', () => {
+    // `gh api --paginate` はページごとに stdout へ流すため、後半ページの失敗は
+    // 「部分的な一覧 + 非 0 終了」になる。部分出力を「取得成功」と扱うと、
+    // 後半ページにだけ含まれる app の context を要求しないまま merge できてしまう。
+    const { status, stderr } = runScript(
+      [
+        checkRun('CI', 'SUCCESS', '2026-08-04T10:00:00Z'),
+        statusContext('Vercel – web', 'SUCCESS', '2026-08-04T10:01:00Z'),
+      ],
+      { files: ['apps/web/src/app/page.tsx'], filesPartialFailure: true },
+    );
+    expect(stderr).toContain('影響判定を実行できませんでした');
+    expect(stderr).toContain('必須 check「Vercel – product」');
     expect(status).toBe(1);
   });
 

--- a/scripts/__tests__/finish-branch.test.ts
+++ b/scripts/__tests__/finish-branch.test.ts
@@ -74,9 +74,47 @@ function vercelChecks(): RollupEntry[] {
   ];
 }
 
+/** レビュー thread の GraphQL レスポンスを組み立てる（shape は gh api graphql の実出力） */
+function threadsPayload(
+  threads: Array<{ isResolved: boolean; path?: string; author?: string }>,
+  hasNextPage = false,
+): unknown {
+  return {
+    data: {
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            pageInfo: { hasNextPage },
+            nodes: threads.map((thread) => ({
+              isResolved: thread.isResolved,
+              path: thread.path ?? 'src/example.ts',
+              comments: {
+                nodes: [{ author: { login: thread.author ?? 'chatgpt-codex-connector' } }],
+              },
+            })),
+          },
+        },
+      },
+    },
+  };
+}
+
 function runScript(
   rollup: RollupEntry[],
-  options: { compare?: string; isDraft?: boolean } = {},
+  options: {
+    compare?: string;
+    isDraft?: boolean;
+    /** PR の変更ファイル一覧。省略時は product / web 両方に触れる形（従来テストの前提を維持） */
+    files?: string[];
+    /** 変更ファイル一覧 API を失敗させる（fail closed 経路の検証） */
+    filesUnavailable?: boolean;
+    /** レビュー thread の状態。省略時は 0 件（gate を通す） */
+    threads?: Array<{ isResolved: boolean; path?: string; author?: string }>;
+    /** thread 取得 API を失敗させる（fail closed 経路の検証） */
+    threadsUnavailable?: boolean;
+    /** reviewThreads が 100 件を超えている状態にする */
+    threadsTruncated?: boolean;
+  } = {},
 ): { status: number | null; stderr: string } {
   // repo 直下ではなく os の temp に作る。プロセスが afterEach 前に落ちると untracked な
   // ディレクトリが repo に残り、まさにこのスクリプトの dirty ゲートが以後の掃除を止める。
@@ -100,6 +138,23 @@ function runScript(
     }),
   );
 
+  // PR の変更ファイル一覧（impact 判定の入力）。既定は product / web 両方に触れる形。
+  const filesPath = join(temporaryDirectory, 'files.txt');
+  writeFileSync(
+    filesPath,
+    options.filesUnavailable
+      ? ''
+      : `${(options.files ?? ['apps/product/src/app.ts', 'apps/web/src/page.tsx']).join('\n')}\n`,
+  );
+
+  // レビュー thread の GraphQL レスポンス。threadsUnavailable は実在しない path を
+  // 指させて cat を失敗させる（API 不通の再現）。
+  const threadsPath = join(temporaryDirectory, 'threads.json');
+  writeFileSync(
+    threadsPath,
+    JSON.stringify(threadsPayload(options.threads ?? [], options.threadsTruncated ?? false)),
+  );
+
   // `gh` だけ差し替える。git は temp repo 上で本物を動かす（worktree / show-ref の判定を
   // 実挙動に任せる方が、stub の作り込みより契約に近い）。
   const ghStub = join(binDirectory, 'gh');
@@ -115,9 +170,12 @@ case "$1" in
     esac
     ;;
   api)
-    # up-to-date gate: compare の .status だけを返す
-    case "\${2:-}" in
+    shift
+    case "$*" in
+      graphql*) cat "$FINISH_BRANCH_THREADS_JSON" ;;
+      *pulls/123/files*) cat "$FINISH_BRANCH_PR_FILES" ;;
       *compare*) echo "$FINISH_BRANCH_COMPARE" ;;
+      *full_name*) echo "Dayopt/dayopt" ;;
       *) exit 2 ;;
     esac
     ;;
@@ -145,6 +203,12 @@ esac
       PATH: `${binDirectory}:${process.env.PATH ?? ''}`,
       FINISH_BRANCH_PR_JSON: payloadPath,
       FINISH_BRANCH_COMPARE: options.compare ?? 'ahead',
+      FINISH_BRANCH_PR_FILES: options.filesUnavailable
+        ? join(temporaryDirectory, 'missing-files.txt')
+        : filesPath,
+      FINISH_BRANCH_THREADS_JSON: options.threadsUnavailable
+        ? join(temporaryDirectory, 'missing-threads.json')
+        : threadsPath,
     },
   });
 
@@ -272,6 +336,9 @@ case "$1" in
       exit 2
     fi
     case "$*" in
+      *graphql*) echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false},"nodes":[]}}}}}' ;;
+      *full_name*) echo "Dayopt/dayopt" ;;
+      *pulls/123/files*) printf 'apps/product/src/x.ts\napps/web/src/y.ts\n' ;;
       *compare*) echo ahead ;;
       */merge*) exit "\${FINISH_BRANCH_MERGE_EXIT:-0}" ;;
       *) exit 0 ;;
@@ -630,6 +697,134 @@ describe('畳み込みで緩めてはいけない判定', () => {
       statusContext('Vercel – product', 'FAILURE', '2026-07-30T10:01:00Z'),
     ]);
     expect(stderr).toContain('失敗している check');
+    expect(status).toBe(1);
+  });
+});
+
+describe('affected-aware な Vercel context 要求（Impact Resolver 連携）', () => {
+  it('product のみの変更なら Vercel – web が無くても merge へ進む', () => {
+    // Vercel skip 導入後の通常状態。unaffected な project の context 欠落は正常。
+    const { status, stderr } = runScript(
+      [
+        checkRun('CI', 'SUCCESS', '2026-08-04T10:00:00Z'),
+        statusContext('Vercel – product', 'SUCCESS', '2026-08-04T10:01:00Z'),
+      ],
+      { files: ['apps/product/src/features/tags/ui/TagList.tsx'] },
+    );
+    expect(stderr).toContain('必須 Vercel context: Vercel – product');
+    expect(stderr).not.toContain('必須 check「Vercel – web」');
+    expect(status).toBe(0);
+  });
+
+  it('product のみの変更でも Vercel – product の欠落は止める', () => {
+    // affected な project の context 欠落は従来どおり fail closed。
+    const { status, stderr } = runScript([checkRun('CI', 'SUCCESS', '2026-08-04T10:00:00Z')], {
+      files: ['apps/product/src/features/tags/ui/TagList.tsx'],
+    });
+    expect(stderr).toContain('必須 check「Vercel – product」');
+    expect(status).toBe(1);
+  });
+
+  it('web のみの変更なら Vercel – product が無くても merge へ進む', () => {
+    const { status, stderr } = runScript(
+      [
+        checkRun('CI', 'SUCCESS', '2026-08-04T10:00:00Z'),
+        statusContext('Vercel – web', 'SUCCESS', '2026-08-04T10:01:00Z'),
+      ],
+      { files: ['apps/web/src/app/page.tsx'] },
+    );
+    expect(stderr).toContain('必須 Vercel context: Vercel – web');
+    expect(status).toBe(0);
+  });
+
+  it('docs のみの変更なら Vercel context を要求しない', () => {
+    const { status, stderr } = runScript(
+      [checkRun('🛡️ docs & secrets guard', 'SUCCESS', '2026-08-04T10:00:00Z')],
+      { files: ['docs/product/specs/calendar.md', 'AGENTS.md'] },
+    );
+    expect(stderr).toContain('Vercel context は要求しません');
+    expect(status).toBe(0);
+  });
+
+  it('共通 package の変更は両方の context を要求する', () => {
+    const { status, stderr } = runScript(
+      [
+        checkRun('CI', 'SUCCESS', '2026-08-04T10:00:00Z'),
+        statusContext('Vercel – product', 'SUCCESS', '2026-08-04T10:01:00Z'),
+      ],
+      { files: ['packages/config/src/env.ts'] },
+    );
+    expect(stderr).toContain('必須 check「Vercel – web」');
+    expect(status).toBe(1);
+  });
+
+  it('変更ファイル一覧を取得できなければ両方を必須にする（fail closed）', () => {
+    // files API 不通で「影響なし」に倒れると、build 未検証のまま merge できてしまう。
+    const { status, stderr } = runScript(
+      [
+        checkRun('CI', 'SUCCESS', '2026-08-04T10:00:00Z'),
+        statusContext('Vercel – product', 'SUCCESS', '2026-08-04T10:01:00Z'),
+      ],
+      { filesUnavailable: true },
+    );
+    expect(stderr).toContain('影響判定を実行できませんでした');
+    expect(stderr).toContain('必須 check「Vercel – web」');
+    expect(status).toBe(1);
+  });
+
+  it('未知の path は両方を必須にする（fail closed）', () => {
+    const { status, stderr } = runScript(
+      [
+        checkRun('CI', 'SUCCESS', '2026-08-04T10:00:00Z'),
+        statusContext('Vercel – product', 'SUCCESS', '2026-08-04T10:01:00Z'),
+      ],
+      { files: ['mystery.config.xyz'] },
+    );
+    expect(stderr).toContain('必須 check「Vercel – web」');
+    expect(status).toBe(1);
+  });
+});
+
+describe('レビュー thread の必須解決 gate', () => {
+  const greenRollup = () => [checkRun('CI', 'SUCCESS', '2026-08-04T10:00:00Z'), ...vercelChecks()];
+
+  it('未解決 thread が 1 件でもあれば止め、一覧を表示する', () => {
+    const { status, stderr } = runScript(greenRollup(), {
+      threads: [
+        { isResolved: true, path: 'src/resolved.ts' },
+        {
+          isResolved: false,
+          path: 'scripts/git/finish-branch.sh',
+          author: 'chatgpt-codex-connector',
+        },
+      ],
+    });
+    expect(stderr).toContain('未解決のレビュー thread が 1 件');
+    expect(stderr).toContain('scripts/git/finish-branch.sh');
+    expect(status).toBe(1);
+  });
+
+  it('全 thread が resolve 済みなら merge へ進む', () => {
+    const { status, stderr } = runScript(greenRollup(), {
+      threads: [{ isResolved: true }, { isResolved: true }],
+    });
+    expect(stderr).toContain('未解決のレビュー thread はありません');
+    expect(status).toBe(0);
+  });
+
+  it('thread の取得に失敗したら止める（fail closed）', () => {
+    // 「未確認のまま通す」を許すと、API 障害のたびに gate が消える。
+    const { status, stderr } = runScript(greenRollup(), { threadsUnavailable: true });
+    expect(stderr).toContain('レビュー thread の状態を取得できませんでした');
+    expect(status).toBe(1);
+  });
+
+  it('thread が 100 件を超えていたら止める（全件確認できないため）', () => {
+    const { status, stderr } = runScript(greenRollup(), {
+      threads: [{ isResolved: true }],
+      threadsTruncated: true,
+    });
+    expect(stderr).toContain('100 件を超えて');
     expect(status).toBe(1);
   });
 });

--- a/scripts/__tests__/finish-branch.test.ts
+++ b/scripts/__tests__/finish-branch.test.ts
@@ -106,6 +106,10 @@ function runScript(
     isDraft?: boolean;
     /** PR の変更ファイル一覧。省略時は product / web 両方に触れる形（従来テストの前提を維持） */
     files?: string[];
+    /** rename の移動元（previous_filename）。API は移動先を filename で返す */
+    previousFiles?: string[];
+    /** PR の changedFiles 申告値。省略時は files の件数（= 一致して gate を通る） */
+    changedFilesCount?: number;
     /** 変更ファイル一覧 API を失敗させる（fail closed 経路の検証） */
     filesUnavailable?: boolean;
     /** 一覧を部分的に出力した後で失敗させる（pagination 途中失敗の再現） */
@@ -126,6 +130,9 @@ function runScript(
   const binDirectory = join(temporaryDirectory, 'bin');
   mkdirSync(binDirectory);
 
+  const changedFiles = options.files ?? ['apps/product/src/app.ts', 'apps/web/src/page.tsx'];
+  const previousFiles = options.previousFiles ?? [];
+
   const payloadPath = join(temporaryDirectory, 'pr.json');
   writeFileSync(
     payloadPath,
@@ -137,16 +144,22 @@ function runScript(
       mergeable: 'MERGEABLE',
       mergeStateStatus: 'CLEAN',
       statusCheckRollup: rollup,
+      changedFiles: options.changedFilesCount ?? changedFiles.length,
     }),
   );
 
   // PR の変更ファイル一覧（impact 判定の入力）。既定は product / web 両方に触れる形。
+  // 実際の gh は `F<TAB>filename` / `P<TAB>previous_filename` の形で出す（rename の
+  // 移動元を落とさず、かつ「ファイル件数」を数えられるようにするため）。
   const filesPath = join(temporaryDirectory, 'files.txt');
   writeFileSync(
     filesPath,
     options.filesUnavailable
       ? ''
-      : `${(options.files ?? ['apps/product/src/app.ts', 'apps/web/src/page.tsx']).join('\n')}\n`,
+      : `${[
+          ...changedFiles.map((file) => `F\t${file}`),
+          ...previousFiles.map((file) => `P\t${file}`),
+        ].join('\n')}\n`,
   );
 
   // レビュー thread の GraphQL レスポンス。threadsUnavailable は実在しない path を
@@ -325,6 +338,7 @@ function runScriptOnRepo(scenario: RepoScenario) {
         scenario.prState === 'OPEN'
           ? [checkRun('CI', 'SUCCESS', '2026-07-30T10:00:00Z'), ...vercelChecks()]
           : [],
+      changedFiles: 2,
     }),
   );
 
@@ -344,7 +358,7 @@ case "$1" in
     case "$*" in
       *graphql*) echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false},"nodes":[]}}}}}' ;;
       *full_name*) echo "Dayopt/dayopt" ;;
-      *pulls/123/files*) printf 'apps/product/src/x.ts\napps/web/src/y.ts\n' ;;
+      *pulls/123/files*) printf 'F\\tapps/product/src/x.ts\\nF\\tapps/web/src/y.ts\\n' ;;
       *compare*) echo ahead ;;
       */merge*) exit "\${FINISH_BRANCH_MERGE_EXIT:-0}" ;;
       *) exit 0 ;;
@@ -775,6 +789,51 @@ describe('affected-aware な Vercel context 要求（Impact Resolver 連携）',
     );
     expect(stderr).toContain('影響判定を実行できませんでした');
     expect(stderr).toContain('必須 check「Vercel – web」');
+    expect(status).toBe(1);
+  });
+
+  it('rename では移動元の app の context も必須にする', () => {
+    // API は移動先を filename、移動元を previous_filename で返す。移動先だけを見ると
+    // apps/product → docs の rename が docs-only 判定になり、ファイルが消えた側の
+    // build を検証しないまま merge できてしまう。
+    const { status, stderr } = runScript([checkRun('CI', 'SUCCESS', '2026-08-04T10:00:00Z')], {
+      files: ['docs/moved.md'],
+      previousFiles: ['apps/product/src/moved.ts'],
+    });
+    expect(stderr).toContain('必須 check「Vercel – product」');
+    expect(status).toBe(1);
+  });
+
+  it('rename の移動元は件数に数えない（changedFiles と一致させる）', () => {
+    // previous_filename を件数に含めると申告件数と食い違い、正常な rename PR が
+    // truncation 扱いで止まる（fail closed の過剰発動）。
+    const { status, stderr } = runScript(
+      [
+        checkRun('CI', 'SUCCESS', '2026-08-04T10:00:00Z'),
+        statusContext('Vercel – product', 'SUCCESS', '2026-08-04T10:01:00Z'),
+      ],
+      {
+        files: ['apps/product/src/moved.ts'],
+        previousFiles: ['apps/product/src/old.ts'],
+        changedFilesCount: 1,
+      },
+    );
+    expect(stderr).not.toContain('truncation');
+    expect(status).toBe(0);
+  });
+
+  it('取得件数が PR の申告件数に足りなければ両方を必須にする（3,000 件上限などの truncation）', () => {
+    // files endpoint は --paginate でも 3,000 件で打ち切られ、その状態で成功終了する。
+    // 打ち切りを完全な一覧と扱うと、後半にだけ現れる app の context が要求されない。
+    const { status, stderr } = runScript(
+      [
+        checkRun('CI', 'SUCCESS', '2026-08-04T10:00:00Z'),
+        statusContext('Vercel – web', 'SUCCESS', '2026-08-04T10:01:00Z'),
+      ],
+      { files: ['apps/web/src/page.tsx'], changedFilesCount: 3000 },
+    );
+    expect(stderr).toContain('truncation');
+    expect(stderr).toContain('必須 check「Vercel – product」');
     expect(status).toBe(1);
   });
 

--- a/scripts/__tests__/impact.test.ts
+++ b/scripts/__tests__/impact.test.ts
@@ -144,6 +144,18 @@ describe('app とその依存', () => {
     });
   });
 
+  it('.npmrc は両方を要求する（pnpm の依存解決設定は install 結果を変える）', () => {
+    // auto-install-peers / strict-peer-dependencies は両 app の install 結果＝build
+    // 対象を左右する。lockfile の diff を伴わない単独変更がありうるため、中立に倒すと
+    // install 起因の build 失敗を検証しないまま merge できる。
+    expectImpact(['.npmrc'], {
+      product: true,
+      web: true,
+      productJourney: true,
+      webPreviewSmoke: true,
+    });
+  });
+
   it('docs と product の混在は docsOnly=false', () => {
     expectImpact(['docs/README.md', 'apps/product/src/app/layout.tsx'], {
       product: true,

--- a/scripts/__tests__/impact.test.ts
+++ b/scripts/__tests__/impact.test.ts
@@ -1,0 +1,255 @@
+import { spawnSync } from 'node:child_process';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+// @ts-expect-error -- .mjs に型定義は無いが、contract test は実装そのものを読む
+import { formatSummary, readWorkspaceGraph, resolveImpact } from '../ci/impact.mjs';
+
+/**
+ * Impact Resolver は merge gate / release / CI が共有する影響判定の正本。
+ * 判定を誤ると「必要な検証を skip してマージする」方向に倒れるため、
+ * 変更ファイル fixture のテーブルで期待値を固定する。
+ */
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+
+type Impact = {
+  product: boolean;
+  web: boolean;
+  integration: boolean;
+  productJourney: boolean;
+  webPreviewSmoke: boolean;
+  docsOnly: boolean;
+  unknown: string[];
+};
+
+/** 期待値を書きやすくする省略形。省略キーは false 扱い。 */
+function expectImpact(files: string[], expected: Partial<Impact>) {
+  const impact = resolveImpact(files) as Impact;
+  const full: Omit<Impact, 'unknown'> = {
+    product: false,
+    web: false,
+    integration: false,
+    productJourney: false,
+    webPreviewSmoke: false,
+    docsOnly: false,
+    ...expected,
+  };
+  expect({
+    product: impact.product,
+    web: impact.web,
+    integration: impact.integration,
+    productJourney: impact.productJourney,
+    webPreviewSmoke: impact.webPreviewSmoke,
+    docsOnly: impact.docsOnly,
+  }).toEqual(full);
+  return impact;
+}
+
+describe('workspace 依存グラフ', () => {
+  it('product は全 package、web は domain 以外に依存する（現在の manifest の固定）', () => {
+    // このテストが落ちたら manifest が変わったということ。期待値を現実に合わせて
+    // 更新すればよい（resolver 側は自動追従している）。
+    const graph = readWorkspaceGraph() as Map<string, Set<string>>;
+    expect(graph.get('packages/domain')).toEqual(new Set(['product']));
+    expect(graph.get('packages/config')).toEqual(new Set(['product', 'web']));
+    expect(graph.get('packages/i18n')).toEqual(new Set(['product', 'web']));
+    expect(graph.get('packages/components')).toEqual(new Set(['product', 'web']));
+  });
+});
+
+describe('docs のみの変更', () => {
+  it.each([
+    [['docs/business/strategy.md']],
+    [['AGENTS.md', 'CLAUDE.md', 'README.md']],
+    [['.claude/rules/workflow.md', '.codex/rules/README.md', '.agents/skills/dispatch/SKILL.md']],
+    [['docs/projects/ci-monorepo-refactor/overview.md', 'docs/README.md']],
+  ])('%j は docsOnly=true で app build を要求しない', (files) => {
+    expectImpact(files, { docsOnly: true });
+  });
+
+  it('rls-snapshot.md は docsOnly でも integration を要求する', () => {
+    // integration.yml の paths に含まれる docs ファイル。docsOnly の shortcut で
+    // integration まで消してはいけない。
+    expectImpact(['docs/engineering/data/db/rls-snapshot.md'], {
+      docsOnly: true,
+      integration: true,
+    });
+  });
+});
+
+describe('app とその依存', () => {
+  it('apps/product のみ → product 側だけ', () => {
+    expectImpact(['apps/product/src/components/Button.tsx'], {
+      product: true,
+      productJourney: true,
+    });
+  });
+
+  it('apps/product の server 境界 → integration も要求する', () => {
+    expectImpact(['apps/product/src/features/tags/server/router.ts'], {
+      product: true,
+      productJourney: true,
+      integration: true,
+    });
+  });
+
+  it('apps/web のみ → web 側だけ', () => {
+    expectImpact(['apps/web/src/app/page.tsx', 'apps/web/content/blog/en/hello.mdx'], {
+      web: true,
+      webPreviewSmoke: true,
+    });
+  });
+
+  it('packages/domain → product のみ（web は依存しない）', () => {
+    expectImpact(['packages/domain/src/plan.ts'], {
+      product: true,
+      productJourney: true,
+      integration: true, // packages/domain/** は integration.yml の paths に含まれる
+    });
+  });
+
+  it('共通 package（config）→ 両方', () => {
+    expectImpact(['packages/config/src/env.ts'], {
+      product: true,
+      web: true,
+      productJourney: true,
+      webPreviewSmoke: true,
+    });
+  });
+
+  it('supabase/migrations → product + integration', () => {
+    expectImpact(['supabase/migrations/20260804000000_add_table.sql'], {
+      product: true,
+      productJourney: true,
+      integration: true,
+    });
+  });
+
+  it('root の build 入力（pnpm-lock.yaml）→ 両方 + integration', () => {
+    expectImpact(['pnpm-lock.yaml'], {
+      product: true,
+      web: true,
+      productJourney: true,
+      webPreviewSmoke: true,
+      integration: true, // integration.yml の paths に含まれる
+    });
+  });
+
+  it('docs と product の混在は docsOnly=false', () => {
+    expectImpact(['docs/README.md', 'apps/product/src/app/layout.tsx'], {
+      product: true,
+      productJourney: true,
+    });
+  });
+});
+
+describe('中立 path（app 成果物に影響しない）', () => {
+  it.each([
+    [['scripts/git/finish-branch.sh', 'scripts/__tests__/finish-branch.test.ts']],
+    [['.claude/hooks/pre-tool-guard.sh', '.claude/settings.json']],
+    [['.github/workflows/ci.yml']],
+    [['.husky/pre-push', '.vscode/settings.json']],
+    [['apps/storybook/.storybook/main.ts']],
+    [['eslint.config.mjs', '.prettierrc', 'vitest.scripts.config.ts']],
+  ])('%j は app build を要求しない', (files) => {
+    expectImpact(files, {});
+  });
+
+  it('.github の integration 対象（setup action）は integration を要求する', () => {
+    expectImpact(['.github/actions/setup/action.yml'], { integration: true });
+  });
+});
+
+describe('fail closed', () => {
+  it('未知の root ファイルは全 affected に倒す', () => {
+    const impact = expectImpact(['mystery.config.xyz'], {
+      product: true,
+      web: true,
+      integration: true,
+      productJourney: true,
+      webPreviewSmoke: true,
+    });
+    expect(impact.unknown).toEqual(['mystery.config.xyz']);
+  });
+
+  it('未知の packages ディレクトリも全 affected に倒す', () => {
+    // manifest の無い package（作りかけ・rename 直後）を「影響なし」と
+    // 誤判定しないこと。
+    expectImpact(['packages/brand-new/src/index.ts'], {
+      product: true,
+      web: true,
+      integration: true,
+      productJourney: true,
+      webPreviewSmoke: true,
+    });
+  });
+
+  it('docs と未知の混在を docsOnly と誤判定しない', () => {
+    expectImpact(['docs/README.md', 'mystery.config.xyz'], {
+      product: true,
+      web: true,
+      integration: true,
+      productJourney: true,
+      webPreviewSmoke: true,
+    });
+  });
+
+  it('空の変更一覧は判定不能として全 affected に倒す', () => {
+    // 「影響なし」と「ファイル一覧を取得できなかった」を区別できないため、
+    // 空入力を green に流さない。
+    expectImpact([], {
+      product: true,
+      web: true,
+      integration: true,
+      productJourney: true,
+      webPreviewSmoke: true,
+    });
+  });
+});
+
+describe('CLI', () => {
+  it('--stdin で newline 区切りの一覧を受け、JSON を返す', () => {
+    const result = spawnSync('node', [join(rootDir, 'scripts/ci/impact.mjs'), '--stdin'], {
+      input: 'apps/product/src/foo.ts\ndocs/README.md\n',
+      encoding: 'utf8',
+    });
+    expect(result.status).toBe(0);
+    const impact = JSON.parse(result.stdout) as Impact;
+    expect(impact.product).toBe(true);
+    expect(impact.web).toBe(false);
+    expect(impact.docsOnly).toBe(false);
+  });
+
+  it('--summary は Markdown を返し、未知 path の警告を含む', () => {
+    const result = spawnSync(
+      'node',
+      [join(rootDir, 'scripts/ci/impact.mjs'), '--stdin', '--summary'],
+      {
+        input: 'mystery.config.xyz\n',
+        encoding: 'utf8',
+      },
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('## Impact Resolver');
+    expect(result.stdout).toContain('未知の path');
+  });
+});
+
+describe('formatSummary', () => {
+  it('全キーを表に含める', () => {
+    const summary = formatSummary(resolveImpact(['apps/product/src/foo.ts'])) as string;
+    for (const key of [
+      'product',
+      'web',
+      'integration',
+      'productJourney',
+      'webPreviewSmoke',
+      'docsOnly',
+    ]) {
+      expect(summary).toContain(key);
+    }
+  });
+});

--- a/scripts/__tests__/impact.test.ts
+++ b/scripts/__tests__/impact.test.ts
@@ -1,11 +1,17 @@
 import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
 // @ts-expect-error -- .mjs に型定義は無いが、contract test は実装そのものを読む
-import { formatSummary, readWorkspaceGraph, resolveImpact } from '../ci/impact.mjs';
+import {
+  PRODUCT_BUILD_SCRIPTS,
+  formatSummary,
+  readWorkspaceGraph,
+  resolveImpact,
+} from '../ci/impact.mjs';
 
 /**
  * Impact Resolver は merge gate / release / CI が共有する影響判定の正本。
@@ -160,6 +166,53 @@ describe('中立 path（app 成果物に影響しない）', () => {
 
   it('.github の integration 対象（setup action）は integration を要求する', () => {
     expectImpact(['.github/actions/setup/action.yml'], { integration: true });
+  });
+});
+
+describe('Vercel の build が実行する root script', () => {
+  it.each([['scripts/check-client-bundle-secrets.mjs'], ['scripts/check-bundle-budget.ts']])(
+    '%s は product を要求する（scripts/ の中立扱いより優先）',
+    (file) => {
+      // これらは apps/product/vercel.json の buildCommand（verify:bundle）が直接実行する。
+      // 中立に倒すと product=false になり、変更した当の検証を走らせないまま merge できる。
+      expectImpact([file], { product: true, productJourney: true });
+    },
+  );
+
+  it('build に関与しない scripts/ は従来どおり中立', () => {
+    expectImpact(['scripts/git/finish-branch.sh'], {});
+  });
+
+  it('PRODUCT_BUILD_SCRIPTS が product の build 定義と一致する（drift 検出）', () => {
+    // 手で書いた集合は、buildCommand や verify:bundle に script が足された時に腐る。
+    // manifest から導出した実際の参照集合と突き合わせて、追加漏れを機械的に捕まえる。
+    const vercelConfig = JSON.parse(
+      readFileSync(join(rootDir, 'apps/product/vercel.json'), 'utf8'),
+    ) as { buildCommand: string };
+    const packageJson = JSON.parse(
+      readFileSync(join(rootDir, 'apps/product/package.json'), 'utf8'),
+    ) as { scripts: Record<string, string> };
+
+    // buildCommand から `pnpm <script>` を再帰展開し、root scripts/ への参照を集める
+    const expandCommand = (command: string, seen = new Set<string>()): string[] => {
+      const expanded = [command];
+      for (const [, name] of command.matchAll(/pnpm\s+([\w:-]+)/g)) {
+        if (seen.has(name)) continue;
+        seen.add(name);
+        const script = packageJson.scripts[name];
+        if (script) expanded.push(...expandCommand(script, seen));
+      }
+      return expanded;
+    };
+
+    const referenced = new Set(
+      expandCommand(vercelConfig.buildCommand)
+        .flatMap((command) => [...command.matchAll(/\.\.\/\.\.\/(scripts\/[\w./-]+)/g)])
+        .map(([, path]) => path),
+    );
+
+    expect(referenced.size).toBeGreaterThan(0);
+    expect([...referenced].sort()).toEqual([...(PRODUCT_BUILD_SCRIPTS as Set<string>)].sort());
   });
 });
 

--- a/scripts/ci/impact.mjs
+++ b/scripts/ci/impact.mjs
@@ -118,6 +118,20 @@ const ROOT_BUILD_FILES = new Set([
   'eslint.config.packages.mjs',
 ]);
 
+// ─── Vercel の build が実行する root script ───────────────────────────
+// `apps/product/vercel.json` の buildCommand が `pnpm verify:bundle` を呼び、それが
+// root の `scripts/` を直接実行する。`scripts/` 全体を中立に倒すと、この検証スクリプト
+// 自体を変更した PR が product=false になり、**変更した当の検証を一度も走らせないまま**
+// merge できてしまう（Vercel build がその PR で走らないため）。
+// 追加漏れ（drift）は `scripts/__tests__/impact.test.ts` が manifest から導出して検査する。
+export const PRODUCT_BUILD_SCRIPTS = new Set([
+  'scripts/check-client-bundle-secrets.mjs',
+  'scripts/check-bundle-budget.ts',
+]);
+
+// web の buildCommand（`pnpm generate:search-index && pnpm build`）が呼ぶのは
+// `apps/web/scripts/generate-search-index.ts` で、`apps/web/` prefix で既に拾える。
+
 // ─── 中立（appの成果物に影響しない既知の path）──────────────────────
 // ここに入れてよいのは「app の build 成果物・runtime 挙動を変えない」ものだけ。
 // 迷ったら入れない（未知扱い = fail closed の側に倒れる）。
@@ -302,6 +316,12 @@ export function resolveImpact(changedFiles, options = {}) {
       web = true;
       mark('product', file);
       mark('web', file);
+      continue;
+    }
+    // isNeutralPath より先に見る（どちらも scripts/ に該当するため）
+    if (PRODUCT_BUILD_SCRIPTS.has(file)) {
+      product = true;
+      mark('product', file);
       continue;
     }
     if (isNeutralPath(file)) continue;

--- a/scripts/ci/impact.mjs
+++ b/scripts/ci/impact.mjs
@@ -1,0 +1,386 @@
+#!/usr/bin/env node
+
+/**
+ * Impact Resolver — 変更ファイル一覧から「どの検証・build・release が必要か」を判定する。
+ *
+ * CI の手書き paths、merge gate（finish-branch.sh）、Production Release、Vercel の
+ * Ignored Build Step が**同じ規則**を共有するための単一の正本
+ * （docs/projects/ci-monorepo-refactor/overview.md §5）。
+ *
+ * 使い方:
+ *   printf '%s\n' file1 file2 | node scripts/ci/impact.mjs --stdin
+ *   node scripts/ci/impact.mjs apps/product/src/foo.ts docs/README.md
+ *   ... --summary を付けると GITHUB_STEP_SUMMARY 向けの Markdown を出す
+ *
+ * 出力キーは固定: product / web / integration / productJourney / webPreviewSmoke / docsOnly。
+ *
+ * 判定の原則:
+ * - **未知の path は fail closed（全 affected）**。判定漏れが検証漏れに化けるのを防ぐ。
+ *   新しい root ファイルを足した時は本ファイルの分類へ明示的に追加する
+ * - workspace 依存グラフは pnpm manifest（dependencies / devDependencies の @dayopt/*）
+ *   から実行時に解決する。package 追加時に判定が自動追従し、対応表の腐りを防ぐ
+ * - 変更ファイルが 1 件も無い入力は判定不能として fail closed（全 affected）に倒す
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+
+/** 出力キー。消費側（finish-branch.sh / release / CI）はこの集合に依存する。 */
+export const IMPACT_KEYS = [
+  'product',
+  'web',
+  'integration',
+  'productJourney',
+  'webPreviewSmoke',
+  'docsOnly',
+];
+
+// ─── docs 系（app build に影響しない）────────────────────────────────
+// ci.yml の paths-ignore と同一規則。片方だけ直すと「CI は skip したのに
+// merge gate は build を要求する」ズレが出るため、変更時は両方を揃える。
+const DOCS_FILES = new Set(['AGENTS.md', 'CLAUDE.md', 'README.md']);
+
+function isDocsPath(file) {
+  if (DOCS_FILES.has(file)) return true;
+  if (file.startsWith('docs/')) return true;
+  if (
+    (file.startsWith('.claude/') || file.startsWith('.codex/') || file.startsWith('.agents/')) &&
+    file.endsWith('.md')
+  ) {
+    return true;
+  }
+  return false;
+}
+
+// ─── integration（server contract / DB 境界）────────────────────────
+// .github/workflows/integration.yml の paths と同一集合。あちらの手書き paths は
+// Phase 5 で本ファイルへの参照に置き換える予定（それまで二重管理。変更時は両方を揃える）。
+const INTEGRATION_GLOBS = [
+  '.nvmrc',
+  'package.json',
+  'pnpm-lock.yaml',
+  'apps/product/package.json',
+  '.github/actions/setup/action.yml',
+  '.github/workflows/integration.yml',
+  'apps/product/src/features/*/domain/**',
+  'apps/product/src/features/*/server/**',
+  'packages/domain/**',
+  'apps/product/src/lib/database/**',
+  'apps/product/src/lib/mcp/**',
+  'apps/product/src/lib/oauth-server/**',
+  'apps/product/src/lib/supabase/**',
+  'apps/product/src/lib/trpc/**',
+  'apps/product/src/app/api/mcp/**',
+  'supabase/migrations/**',
+  'apps/product/src/lib/test/integration/**',
+  'apps/product/src/lib/test/integration-setup.ts',
+  'apps/product/src/lib/test/trpc-test-helpers.ts',
+  'apps/product/vitest.config.integration.ts',
+  'scripts/generate-rls-snapshot.ts',
+  'docs/engineering/data/db/rls-snapshot.md',
+];
+
+/**
+ * Actions の paths と同じ意味論の最小 glob。`*` は 1 セグメント内、`**` は任意深さ。
+ * 依存を増やさないため自前実装（対象はこのファイル内の固定パターンのみ）。
+ */
+function globToRegExp(glob) {
+  const escaped = glob
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replaceAll('**', '\u0000')
+    .replaceAll('*', '[^/]*')
+    .replaceAll('\u0000', '.*');
+  return new RegExp(`^${escaped}$`);
+}
+
+const INTEGRATION_MATCHERS = INTEGRATION_GLOBS.map(globToRegExp);
+
+function isIntegrationPath(file) {
+  return INTEGRATION_MATCHERS.some((re) => re.test(file));
+}
+
+// ─── root 設定（両 app の build に影響する）──────────────────────────
+// turbo.json の globalDependencies と install / toolchain の入力を含める。
+const ROOT_BUILD_FILES = new Set([
+  'package.json',
+  'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+  'turbo.json',
+  'tsconfig.base.json',
+  '.nvmrc',
+  'eslint.config.packages.mjs',
+]);
+
+// ─── 中立（appの成果物に影響しない既知の path）──────────────────────
+// ここに入れてよいのは「app の build 成果物・runtime 挙動を変えない」ものだけ。
+// 迷ったら入れない（未知扱い = fail closed の側に倒れる）。
+function isNeutralPath(file) {
+  const prefixes = [
+    'scripts/', // CI / release / 開発補助。app へ bundle されない
+    '.github/', // workflow 定義（integration 対象の 2 path は先に判定済み）
+    '.claude/', // agent 設定・hooks
+    '.codex/',
+    '.agents/',
+    '.husky/',
+    '.vscode/',
+    'apps/storybook/', // 開発者向け。Vercel の product / web project に含まれない
+  ];
+  if (prefixes.some((p) => file.startsWith(p))) return true;
+  const rootNeutral = new Set([
+    '.gitignore',
+    '.gitattributes',
+    '.npmrc',
+    '.prettierrc',
+    '.prettierignore',
+    'commitlint.config.mjs',
+    'eslint.config.mjs',
+    'vitest.scripts.config.ts',
+    'LICENSE',
+  ]);
+  return rootNeutral.has(file);
+}
+
+// ─── workspace 依存グラフ ───────────────────────────────────────────
+
+/**
+ * `packages/<dir>` ごとに「どの app が（推移的に）依存しているか」を返す。
+ * 対応表をハードコードしない: manifest の @dayopt/* を辿るため、package の
+ * 追加・依存変更に自動追従する。
+ *
+ * @returns {Map<string, Set<'product' | 'web'>>} key は `packages/<dir>`
+ */
+export function readWorkspaceGraph(root = ROOT) {
+  const readManifest = (dir) => {
+    try {
+      return JSON.parse(readFileSync(join(root, dir, 'package.json'), 'utf8'));
+    } catch {
+      return null;
+    }
+  };
+
+  /** @type {Map<string, { dir: string, deps: string[] }>} name -> manifest 情報 */
+  const packagesByName = new Map();
+  for (const entry of readdirSync(join(root, 'packages'), { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const dir = `packages/${entry.name}`;
+    const manifest = readManifest(dir);
+    if (!manifest?.name) continue;
+    const deps = Object.keys({
+      ...manifest.dependencies,
+      ...manifest.devDependencies,
+    }).filter((name) => name.startsWith('@dayopt/'));
+    packagesByName.set(manifest.name, { dir, deps });
+  }
+
+  const reachableFrom = (appDir) => {
+    const manifest = readManifest(appDir);
+    const queue = Object.keys({
+      ...manifest?.dependencies,
+      ...manifest?.devDependencies,
+    }).filter((name) => name.startsWith('@dayopt/'));
+    const seen = new Set();
+    while (queue.length > 0) {
+      const name = queue.pop();
+      if (seen.has(name)) continue;
+      seen.add(name);
+      const pkg = packagesByName.get(name);
+      if (pkg) queue.push(...pkg.deps);
+    }
+    return seen;
+  };
+
+  const productDeps = reachableFrom('apps/product');
+  const webDeps = reachableFrom('apps/web');
+
+  const graph = new Map();
+  for (const [name, { dir }] of packagesByName) {
+    const apps = new Set();
+    if (productDeps.has(name)) apps.add('product');
+    if (webDeps.has(name)) apps.add('web');
+    graph.set(dir, apps);
+  }
+  return graph;
+}
+
+// ─── 判定本体 ───────────────────────────────────────────────────────
+
+const ALL_AFFECTED = {
+  product: true,
+  web: true,
+  integration: true,
+  productJourney: true,
+  webPreviewSmoke: true,
+  docsOnly: false,
+};
+
+/**
+ * @param {string[]} changedFiles repo-root 相対の変更ファイル一覧
+ * @param {{ graph?: Map<string, Set<string>> }} [options] test 用の依存グラフ注入
+ */
+export function resolveImpact(changedFiles, options = {}) {
+  const files = changedFiles.map((f) => f.trim()).filter(Boolean);
+
+  // 空入力は「判定できない」であって「影響なし」ではない。fail closed に倒す。
+  if (files.length === 0) {
+    return {
+      ...ALL_AFFECTED,
+      reasons: { product: '(判定不能: 変更ファイル一覧が空。fail closed)' },
+      unknown: [],
+    };
+  }
+
+  const graph = options.graph ?? readWorkspaceGraph();
+
+  let product = false;
+  let web = false;
+  let integration = false;
+  let docsOnly = true;
+  /** @type {Record<string, string>} 各キーを最初に true にしたファイル（説明用） */
+  const reasons = {};
+  /** @type {string[]} どの規則にも該当しなかったファイル */
+  const unknown = [];
+
+  const mark = (key, file) => {
+    if (!reasons[key]) reasons[key] = file;
+  };
+
+  for (const file of files) {
+    // integration は docs とも app とも独立に判定する（rls-snapshot.md のように
+    // docs パスが integration の対象になるものがあるため、先に見る）。
+    if (isIntegrationPath(file)) {
+      integration = true;
+      mark('integration', file);
+    }
+
+    if (isDocsPath(file)) continue; // docsOnly を維持
+
+    docsOnly = false;
+
+    if (file.startsWith('apps/product/')) {
+      product = true;
+      mark('product', file);
+      continue;
+    }
+    if (file.startsWith('apps/web/')) {
+      web = true;
+      mark('web', file);
+      continue;
+    }
+    if (file.startsWith('supabase/')) {
+      product = true;
+      integration = true;
+      mark('product', file);
+      mark('integration', file);
+      continue;
+    }
+    if (file.startsWith('packages/')) {
+      const dir = file.split('/').slice(0, 2).join('/');
+      const apps = graph.get(dir);
+      if (!apps) {
+        unknown.push(file); // 未知 package は fail closed
+        continue;
+      }
+      if (apps.has('product')) {
+        product = true;
+        mark('product', file);
+      }
+      if (apps.has('web')) {
+        web = true;
+        mark('web', file);
+      }
+      continue;
+    }
+    if (ROOT_BUILD_FILES.has(file)) {
+      product = true;
+      web = true;
+      mark('product', file);
+      mark('web', file);
+      continue;
+    }
+    if (isNeutralPath(file)) continue;
+
+    unknown.push(file);
+  }
+
+  if (unknown.length > 0) {
+    // 未知 path の fail closed。docsOnly も false にする（docs と未知の混在を
+    // 「docs のみ」と誤判定して build を skip しないため）。
+    return {
+      ...ALL_AFFECTED,
+      reasons: { ...reasons, product: reasons.product ?? unknown[0], web: reasons.web ?? unknown[0] },
+      unknown,
+    };
+  }
+
+  return {
+    product,
+    web,
+    integration,
+    // journey / smoke は現状 app 影響と同値。Phase 5 で E2E の実行判定に使う
+    // 独立キーとして先に固定しておく（消費側の contract を後から変えない）。
+    productJourney: product,
+    webPreviewSmoke: web,
+    docsOnly,
+    reasons,
+    unknown,
+  };
+}
+
+// ─── Markdown summary（GITHUB_STEP_SUMMARY 向け）────────────────────
+
+export function formatSummary(impact) {
+  const row = (key) => {
+    const value = impact[key] ? '✅ 必要' : '⬜ skip';
+    const reason = impact.reasons?.[key] ? ` — \`${impact.reasons[key]}\`` : '';
+    return `| ${key} | ${value}${reason} |`;
+  };
+  const lines = [
+    '## Impact Resolver',
+    '',
+    '| 対象 | 判定 |',
+    '| --- | --- |',
+    ...IMPACT_KEYS.map((key) =>
+      key === 'docsOnly' ? `| docsOnly | ${impact.docsOnly ? '✅' : '⬜'} |` : row(key),
+    ),
+  ];
+  if (impact.unknown?.length > 0) {
+    lines.push(
+      '',
+      `⚠️ 未知の path を検出したため fail closed（全 affected）: ${impact.unknown
+        .map((f) => `\`${f}\``)
+        .join(', ')}`,
+      '分類は `scripts/ci/impact.mjs` に追加する。',
+    );
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+// ─── CLI ────────────────────────────────────────────────────────────
+
+async function readStdinLines() {
+  let data = '';
+  for await (const chunk of process.stdin) data += chunk;
+  return data.split('\n');
+}
+
+const isDirectRun =
+  process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isDirectRun) {
+  const args = process.argv.slice(2);
+  const useStdin = args.includes('--stdin');
+  const summary = args.includes('--summary');
+  const fileArgs = args.filter((a) => !a.startsWith('--'));
+
+  const files = useStdin ? await readStdinLines() : fileArgs;
+  const impact = resolveImpact(files);
+
+  if (summary) {
+    process.stdout.write(formatSummary(impact));
+  } else {
+    process.stdout.write(`${JSON.stringify(impact, null, 2)}\n`);
+  }
+}

--- a/scripts/ci/impact.mjs
+++ b/scripts/ci/impact.mjs
@@ -18,7 +18,11 @@
  * - **未知の path は fail closed（全 affected）**。判定漏れが検証漏れに化けるのを防ぐ。
  *   新しい root ファイルを足した時は本ファイルの分類へ明示的に追加する
  * - workspace 依存グラフは pnpm manifest（dependencies / devDependencies の @dayopt/*）
- *   から実行時に解決する。package 追加時に判定が自動追従し、対応表の腐りを防ぐ
+ *   から実行時に解決する。package 追加時に判定が自動追従し、対応表の腐りを防ぐ。
+ *   読むのは**本ファイルを実行している checkout の manifest**（merge gate では通常
+ *   main checkout）。PR 側の manifest 変更は直接見ないが、新しい依存 edge を作る
+ *   変更は manifest ファイル自体（apps/** または packages/**）に触れるため、その
+ *   ファイルの分類で当該 app が affected になり、判定漏れにはならない
  * - 変更ファイルが 1 件も無い入力は判定不能として fail closed（全 affected）に倒す
  */
 

--- a/scripts/ci/impact.mjs
+++ b/scripts/ci/impact.mjs
@@ -108,6 +108,10 @@ function isIntegrationPath(file) {
 
 // ─── root 設定（両 app の build に影響する）──────────────────────────
 // turbo.json の globalDependencies と install / toolchain の入力を含める。
+// `.npmrc` は pnpm の依存解決設定（auto-install-peers / strict-peer-dependencies）を
+// 持ち、両 app の install 結果＝build 対象を左右する。lockfile の diff を伴わない
+// 単独変更がありうるため、中立に倒すと install 起因の build 失敗を検証しないまま
+// merge できてしまう（product の build は Actions に無く Vercel だけが持つ）。
 const ROOT_BUILD_FILES = new Set([
   'package.json',
   'pnpm-lock.yaml',
@@ -115,6 +119,7 @@ const ROOT_BUILD_FILES = new Set([
   'turbo.json',
   'tsconfig.base.json',
   '.nvmrc',
+  '.npmrc',
   'eslint.config.packages.mjs',
 ]);
 
@@ -150,7 +155,6 @@ function isNeutralPath(file) {
   const rootNeutral = new Set([
     '.gitignore',
     '.gitattributes',
-    '.npmrc',
     '.prettierrc',
     '.prettierignore',
     'commitlint.config.mjs',

--- a/scripts/git/finish-branch.sh
+++ b/scripts/git/finish-branch.sh
@@ -107,7 +107,7 @@ fi
 # ── 1. PR 状態を取得 ────────────────────────────────────────────────
 step "PR #$PR_NUMBER の状態を確認"
 
-PR_JSON="$(gh pr view "$PR_NUMBER" --json state,isDraft,headRefName,headRefOid,mergeable,mergeStateStatus,statusCheckRollup 2>/dev/null || true)"
+PR_JSON="$(gh pr view "$PR_NUMBER" --json state,isDraft,headRefName,headRefOid,mergeable,mergeStateStatus,statusCheckRollup,changedFiles 2>/dev/null || true)"
 
 if [[ -z "$PR_JSON" ]]; then
   error "PR #$PR_NUMBER を取得できませんでした。番号とネットワークを確認してください。"
@@ -345,13 +345,41 @@ if [[ "$PR_STATE" == "OPEN" ]]; then
 
   IMPACT_PRODUCT="true"
   IMPACT_WEB="true"
+
+  # **rename では移動元（previous_filename）も影響範囲に含める。** 移動先だけを見ると
+  # `apps/product/foo.ts` → `docs/foo.ts` の rename が docs-only と判定され、ファイルが
+  # 消えた側の app の build を検証しないまま merge できる（fail-open）。
+  #
+  # 行頭マーカーで「ファイル本体（F）」と「rename 元（P）」を区別する。F の件数を
+  # PR の changedFiles と突き合わせ、取得漏れ（後述）を検出するために要る。
+  #
   # `|| true` で握り潰さない。`gh api --paginate` はページごとに stdout へ流すため、
   # 2 ページ目以降の失敗では「部分的なファイル一覧 + 非 0 終了」になる。終了コード
   # だけ潰すと不完全な一覧が「取得成功」として通り、後半ページにだけ含まれる
-  # app の context を要求しないまま merge できてしまう（fail-open）。
+  # app の context を要求しないまま merge できてしまう。
   # 失敗時は空へ明示リセットし、「取得不能 → 両方必須」の経路に合流させる。
-  if ! CHANGED_FILES="$(gh api --paginate "repos/{owner}/{repo}/pulls/$PR_NUMBER/files" --jq '.[].filename' 2>/dev/null)"; then
-    CHANGED_FILES=""
+  if ! CHANGED_FILES_RAW="$(gh api --paginate "repos/{owner}/{repo}/pulls/$PR_NUMBER/files" \
+    --jq '.[] | "F\t\(.filename)", (if .previous_filename then "P\t\(.previous_filename)" else empty end)' 2>/dev/null)"; then
+    CHANGED_FILES_RAW=""
+  fi
+
+  # **files endpoint は `--paginate` でも 3,000 件で打ち切られ、その状態で成功終了する。**
+  # 打ち切りを「完全な一覧」と扱うと、3,000 件目以降にだけ現れる app の context を
+  # 要求しないまま merge できる。PR の申告件数と取得件数の一致を要求し、ズレたら
+  # fail closed に倒す（3,000 件上限に限らず、あらゆる silent truncation を捕まえる）。
+  if [[ -n "$CHANGED_FILES_RAW" ]]; then
+    RETRIEVED_FILE_COUNT="$(printf '%s\n' "$CHANGED_FILES_RAW" | grep -c "$(printf '^F\t')" || true)"
+    PR_CHANGED_FILES="$(printf '%s' "$PR_JSON" | jq -r '.changedFiles // ""' 2>/dev/null || echo "")"
+    if ! [[ "$PR_CHANGED_FILES" =~ ^[0-9]+$ ]] || [[ "$RETRIEVED_FILE_COUNT" != "$PR_CHANGED_FILES" ]]; then
+      info "変更ファイル一覧が PR の申告件数と一致しません（取得 $RETRIEVED_FILE_COUNT / 申告 ${PR_CHANGED_FILES:-不明}）。truncation の可能性があるため fail closed にします。"
+      CHANGED_FILES_RAW=""
+    fi
+  fi
+
+  # マーカーを外して resolver へ渡す（先頭は "F<TAB>" / "P<TAB>" の 2 文字）
+  CHANGED_FILES=""
+  if [[ -n "$CHANGED_FILES_RAW" ]]; then
+    CHANGED_FILES="$(printf '%s\n' "$CHANGED_FILES_RAW" | sed "s/^[FP]$(printf '\t')//")"
   fi
   IMPACT_JSON=""
   if [[ -n "$CHANGED_FILES" ]] && command -v node >/dev/null 2>&1; then

--- a/scripts/git/finish-branch.sh
+++ b/scripts/git/finish-branch.sh
@@ -319,24 +319,63 @@ if [[ "$PR_STATE" == "OPEN" ]]; then
     exit 1
   fi
 
-  # **product の build は Vercel でしか検証されない。** Actions 側の無条件 build は
-  # 2026-08-03 に撤去し、Next build と bundle 検査（secret 混入 / JS budget /
-  # CSS budget）は `apps/product/vercel.json` の buildCommand へ移した
+  # **product / web の build は Vercel でしか検証されない。** Actions 側の無条件
+  # build は 2026-08-03 に撤去し、Next build と bundle 検査（secret 混入 /
+  # JS budget / CSS budget）は `apps/product/vercel.json` の buildCommand へ移した
   # （`.claude/rules/workflow.md` §build と bundle 検査は Vercel 側で走る）。
   #
-  # このため `Vercel – product` の status が **付かなかった場合**、上の「成功 1 件
+  # このため affected な project の context が **付かなかった場合**、上の「成功 1 件
   # 以上」は Static / Unit / Docs Guard だけで満たされ、build が一度も走らないまま
   # merge できてしまう（fail-open）。status が付かない経路は実在する: Vercel
   # integration の切断・障害、Ignored Build Step の設定、project rename。
   # private repo + Free plan では ruleset の required check を強制できないので、
   # 「あるはずの context が無い」ことをここで能動的に検出する。
   #
+  # **どの context を「あるはず」とするかは Impact Resolver が決める**
+  # （scripts/ci/impact.mjs。docs/projects/ci-monorepo-refactor/overview.md §5）。
+  # PR の変更ファイルから affected な app を判定し、affected な project の context
+  # だけを必須にする。unaffected な project の context 欠落は正常（Vercel の
+  # Skip deployment 導入後はこれが通常状態になる）。判定に失敗した場合
+  # （files API 不通 / node 不在 / 出力が解釈不能）は従来どおり両方を必須にする
+  # （fail closed。Vercel の判定ではなく Dayopt 側の判定を正とする設計原則）。
+  step "影響範囲を判定"
+
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  IMPACT_RESOLVER="$SCRIPT_DIR/../ci/impact.mjs"
+
+  IMPACT_PRODUCT="true"
+  IMPACT_WEB="true"
+  CHANGED_FILES="$(gh api --paginate "repos/{owner}/{repo}/pulls/$PR_NUMBER/files" --jq '.[].filename' 2>/dev/null || true)"
+  IMPACT_JSON=""
+  if [[ -n "$CHANGED_FILES" ]] && command -v node >/dev/null 2>&1; then
+    IMPACT_JSON="$(printf '%s\n' "$CHANGED_FILES" | node "$IMPACT_RESOLVER" --stdin 2>/dev/null || true)"
+  fi
+  if [[ -n "$IMPACT_JSON" ]]; then
+    IMPACT_PRODUCT="$(printf '%s' "$IMPACT_JSON" | jq -r '.product' 2>/dev/null || echo true)"
+    IMPACT_WEB="$(printf '%s' "$IMPACT_JSON" | jq -r '.web' 2>/dev/null || echo true)"
+  else
+    info "影響判定を実行できませんでした。fail closed で両方の Vercel context を必須にします。"
+  fi
+  # Resolver の出力が想定外（jq のエラー文字列・null 等）なら fail closed に倒す。
+  # 明示的な "false" だけが必須 context を外せる。
+  if [[ "$IMPACT_PRODUCT" != "false" ]]; then IMPACT_PRODUCT="true"; fi
+  if [[ "$IMPACT_WEB" != "false" ]]; then IMPACT_WEB="true"; fi
+
   # 区切り文字は en dash（U+2013）。hyphen ではない。
   # **存在だけでなく success を要求する。** GitHub の StatusState には `EXPECTED`
   # （status の到着待ち）があり、これは上の is_failed にも is_pending にも該当しない。
   # 「context はあるが EXPECTED のまま」を通すと、build 未完了のまま merge できる。
-  REQUIRED_CONTEXTS=("Vercel – product" "Vercel – web")
-  for required in "${REQUIRED_CONTEXTS[@]}"; do
+  REQUIRED_CONTEXTS=()
+  if [[ "$IMPACT_PRODUCT" == "true" ]]; then REQUIRED_CONTEXTS+=("Vercel – product"); fi
+  if [[ "$IMPACT_WEB" == "true" ]]; then REQUIRED_CONTEXTS+=("Vercel – web"); fi
+
+  if [[ ${#REQUIRED_CONTEXTS[@]} -eq 0 ]]; then
+    info "app へ影響しない変更のため Vercel context は要求しません（docs / scripts / CI 設定等）。"
+  else
+    info "必須 Vercel context: ${REQUIRED_CONTEXTS[*]}"
+  fi
+
+  for required in ${REQUIRED_CONTEXTS[@]+"${REQUIRED_CONTEXTS[@]}"}; do
     succeeded="$(printf '%s' "$ROLLUP" | jq -r --arg name "$required" '
       map(select(
           ((.name // .context // "")) == $name
@@ -360,6 +399,73 @@ if [[ "$PR_STATE" == "OPEN" ]]; then
       exit 1
     fi
   done
+
+  # ── レビュー thread の解決を要求する ────────────────────────────────
+  #
+  # 外部レビュー（Codex 等）の指摘 thread が未解決のまま merge できると、指摘の
+  # 黙殺が構造的に可能になる。「解決」は 3 択のいずれか: ① fix を積んで resolve、
+  # ② 反論・根拠を reply して resolve、③ 別 issue へ切り出し番号を reply して
+  # resolve（`.claude/rules/workflow.md` §レビュー指摘の必須解決）。
+  #
+  # thread の resolve 状態は GraphQL の reviewThreads にしか無い（REST には出ない）。
+  # 取得に失敗した場合は「未確認のまま通す」ではなく停止に倒す（fail closed）。
+  # first: 100 を超える場合も全件を確認できないため停止する。
+  step "レビュー thread の解決状態を確認"
+
+  NAME_WITH_OWNER="$(gh api "repos/{owner}/{repo}" --jq '.full_name' 2>/dev/null || true)"
+  THREADS_JSON=""
+  if [[ "$NAME_WITH_OWNER" == */* ]]; then
+    THREADS_JSON="$(gh api graphql \
+      -f query='query($owner: String!, $name: String!, $number: Int!) {
+        repository(owner: $owner, name: $name) {
+          pullRequest(number: $number) {
+            reviewThreads(first: 100) {
+              pageInfo { hasNextPage }
+              nodes {
+                isResolved
+                path
+                comments(first: 1) { nodes { author { login } } }
+              }
+            }
+          }
+        }
+      }' \
+      -f owner="${NAME_WITH_OWNER%%/*}" \
+      -f name="${NAME_WITH_OWNER##*/}" \
+      -F number="$PR_NUMBER" 2>/dev/null || true)"
+  fi
+
+  # 「未解決件数」と「100 件超フラグ」を 1 回の jq で取り出す。JSON が想定形で
+  # なければ（pullRequest が null 等）ここが空になり、fail closed で停止する。
+  THREAD_STATS="$(printf '%s' "$THREADS_JSON" | jq -r '
+    .data.repository.pullRequest.reviewThreads
+    | "\([.nodes[] | select(.isResolved | not)] | length) \(.pageInfo.hasNextPage)"' 2>/dev/null || true)"
+
+  if [[ -z "$THREAD_STATS" ]]; then
+    error "レビュー thread の状態を取得できませんでした。マージを中止します（fail closed）。"
+    error "gh の認証とネットワークを確認して再実行してください。"
+    exit 1
+  fi
+
+  UNRESOLVED_THREADS="${THREAD_STATS%% *}"
+  THREADS_TRUNCATED="${THREAD_STATS##* }"
+
+  if [[ "$THREADS_TRUNCATED" != "false" ]]; then
+    error "レビュー thread が 100 件を超えており全件を確認できません。マージを中止します。"
+    exit 1
+  fi
+
+  if [[ "$UNRESOLVED_THREADS" != "0" ]]; then
+    error "未解決のレビュー thread が $UNRESOLVED_THREADS 件あります。マージを中止します。"
+    printf '%s' "$THREADS_JSON" | jq -r '
+      .data.repository.pullRequest.reviewThreads.nodes[]
+      | select(.isResolved | not)
+      | "    - \(.path // "(general)")（\(.comments.nodes[0].author.login // "unknown")）"' >&2 || true
+    error "解決は 3 択: fix を積む / 反論を reply / issue 化して番号を reply。いずれも thread を resolve してから再実行してください。"
+    exit 1
+  fi
+
+  info "未解決のレビュー thread はありません。"
 
   # マージは REST を直叩きする。`gh pr merge` は「削除対象 branch が current」だと
   # **実行元の worktree を main へ切り替えてから** ローカル branch を削除するため、

--- a/scripts/git/finish-branch.sh
+++ b/scripts/git/finish-branch.sh
@@ -345,7 +345,14 @@ if [[ "$PR_STATE" == "OPEN" ]]; then
 
   IMPACT_PRODUCT="true"
   IMPACT_WEB="true"
-  CHANGED_FILES="$(gh api --paginate "repos/{owner}/{repo}/pulls/$PR_NUMBER/files" --jq '.[].filename' 2>/dev/null || true)"
+  # `|| true` で握り潰さない。`gh api --paginate` はページごとに stdout へ流すため、
+  # 2 ページ目以降の失敗では「部分的なファイル一覧 + 非 0 終了」になる。終了コード
+  # だけ潰すと不完全な一覧が「取得成功」として通り、後半ページにだけ含まれる
+  # app の context を要求しないまま merge できてしまう（fail-open）。
+  # 失敗時は空へ明示リセットし、「取得不能 → 両方必須」の経路に合流させる。
+  if ! CHANGED_FILES="$(gh api --paginate "repos/{owner}/{repo}/pulls/$PR_NUMBER/files" --jq '.[].filename' 2>/dev/null)"; then
+    CHANGED_FILES=""
+  fi
   IMPACT_JSON=""
   if [[ -n "$CHANGED_FILES" ]] && command -v node >/dev/null 2>&1; then
     IMPACT_JSON="$(printf '%s\n' "$CHANGED_FILES" | node "$IMPACT_RESOLVER" --stdin 2>/dev/null || true)"
@@ -450,8 +457,12 @@ if [[ "$PR_STATE" == "OPEN" ]]; then
   UNRESOLVED_THREADS="${THREAD_STATS%% *}"
   THREADS_TRUNCATED="${THREAD_STATS##* }"
 
-  if [[ "$THREADS_TRUNCATED" != "false" ]]; then
+  if [[ "$THREADS_TRUNCATED" == "true" ]]; then
     error "レビュー thread が 100 件を超えており全件を確認できません。マージを中止します。"
+    exit 1
+  elif [[ "$THREADS_TRUNCATED" != "false" ]]; then
+    # hasNextPage が欠落した等、想定外の形。停止はするが誤診断のメッセージを出さない。
+    error "レビュー thread の取得結果が想定外の形です。マージを中止します（fail closed）。"
     exit 1
   fi
 


### PR DESCRIPTION
## 概要

epic #1812 の Phase 1+2（close #1813）。CI/CD をモノレポの影響範囲に合わせる第一歩として、影響判定の単一の正本（Impact Resolver）を導入し、merge gate を affected-aware 化する。あわせてマージルール「レビュー thread の必須解決」を機械化する。

設計の正本: [docs/projects/ci-monorepo-refactor/overview.md](docs/projects/ci-monorepo-refactor/overview.md)

## 変更内容

### Phase 1 — Impact Resolver（`scripts/ci/impact.mjs`）

- 変更ファイル一覧から `{product, web, integration, productJourney, webPreviewSmoke, docsOnly}` を判定
- workspace 依存グラフは pnpm manifest（`@dayopt/*`）から実行時解決。対応表をハードコードしない
- **未知 path・空入力は fail closed（全 affected）**
- 変更ファイル fixture のテーブル駆動 test（28 cases）で判定を固定
- ci.yml static job に判定結果の Step Summary 表示を追加（表示専用・`continue-on-error`・job 新設なし）

### Phase 2 — merge gate の affected-aware 化（`scripts/git/finish-branch.sh`）

- 必須 Vercel context を無条件の 2 固定から、Impact Resolver の判定による条件付きへ変更
- affected な project の context 欠落 / EXPECTED / failure は従来どおり停止（fail closed）
- unaffected な project の context 欠落は正常扱い（#1817 の Vercel skip 有効化の前提）
- 変更ファイル一覧の取得失敗・判定不能は両方必須へ倒す

### マージルール — レビュー thread の必須解決

- GraphQL `reviewThreads` の `isResolved=false` が 1 件でもあれば merge を停止し一覧表示
- 取得失敗・100 件超も停止（fail closed）
- 解決の 3 択（fix / 反論 reply / issue 化）を `.claude/rules/workflow.md` §レビュー指摘の必須解決 に明文化

## この PR でやらないこと

- Vercel の Skip deployment 有効化（#1817。merge gate と release の対応が先。overview §8 の移行順序）
- Production Release の affected-aware 化（#1814）
- CI の Web 重複 build 整理（#1815）

## 検証

- `pnpm test:scripts` 248 tests pass（finish-branch 47 / impact 28 を含む）
- `pnpm lint` / `pnpm typecheck` / `pnpm lint:boundaries` / `pnpm docs:check` pass
- apps/product unit の 65 件 failure はローカル node26 の既知環境依存（localStorage 系。CI の node24 では pass）で本 diff と無関係

🤖 Generated with [Claude Code](https://claude.com/claude-code)
