### PR TITLE
ci: Actions棚卸しのquick winsとDeno型検査・merge gateページング

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -304,7 +304,7 @@ gh pr merge <PR番号> --merge --delete-branch
 
 策定日: 2026-08-04
 
-**PR の review thread は全件 resolve してから merge する。** `branch:finish` が機械的に強制する: GraphQL `reviewThreads` の `isResolved=false` が 1 件でもあれば merge を停止し、取得失敗・100 件超も停止に倒す（fail closed）。
+**PR の review thread は全件 resolve してから merge する。** `branch:finish` が機械的に強制する: GraphQL `reviewThreads` を全ページ走査し、`isResolved=false` が 1 件でもあれば merge を停止する。取得失敗・20 ページ（2000 件）超は停止に倒す（fail closed、#1831 でページング対応）。
 
 「解決」は次の 3 択のいずれか。いずれの場合も thread を resolve して閉じる:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,61 @@ jobs:
             exit 1
           fi
 
+      # ── supabase/functions/** の Deno 型検査（#1822）───────────────
+      # tsconfig / typecheck lane の対象外（別ランタイム）のため、import 欠落等が
+      # すり抜けていた（2026-08-04 incident）。supabase/functions/** を触った PR
+      # でだけ走らせる。判定は Impact summary と同じ gh api の変更ファイル一覧を使う。
+      - name: supabase/functions/** 変更の有無を確認
+        id: functions-changed
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # 取得と判定を分離する。gh を grep への pipeline に入れると、gh の失敗や
+          # grep -q 早期終了の SIGPIPE が else（changed=false）へ倒れて fail open に
+          # なる。取得失敗は step 失敗（continue-on-error で outputs.changed 空）に
+          # して、下流の `!= 'false'` 判定で実行側に倒す。判定は herestring で行い
+          # pipe を排除する。既知の限界: files API は 3,000 件で silent truncation
+          # する（finish-branch.sh が件数照合するのと同じ理由）。3,000 件超の PR は
+          # 現実的に発生しないため許容する
+          files="$(gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[] | .filename, (.previous_filename // empty)')"
+          if grep -q '^supabase/functions/' <<<"$files"; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # 変更ファイル取得に失敗した場合（continue-on-error で outputs.changed が
+      # 空のまま）は fail closed で実行側に倒す。workflow_dispatch は
+      # pull_request context が無く上の step 自体が skip される（outputs.changed
+      # も空）ため、同じ条件で常に実行される。
+      - name: Deno インストール
+        if: steps.functions-changed.outputs.changed != 'false'
+        env:
+          # supabase/config.toml の deno_version = 2 系の最新安定版を pin する。
+          # org の Actions 許可リストに denoland/setup-deno が無いため、
+          # gitleaks（docs-guard.yml）と同じく公式バイナリを直接取得し sha256 検証する。
+          # sha256 は https://github.com/denoland/deno/releases/download/v2.9.4/deno-x86_64-unknown-linux-gnu.zip.sha256sum の実測値。
+          DENO_VERSION: '2.9.4'
+          DENO_SHA256: 'c24f955d9fbfe0ea5ae2b501c8e71ae76e31e4c9782390a54a284b3364fda725'
+        run: |
+          curl -sSLO "https://github.com/denoland/deno/releases/download/v${DENO_VERSION}/deno-x86_64-unknown-linux-gnu.zip"
+          echo "${DENO_SHA256}  deno-x86_64-unknown-linux-gnu.zip" | sha256sum -c -
+          unzip -q deno-x86_64-unknown-linux-gnu.zip -d "$RUNNER_TEMP/deno-bin"
+          echo "$RUNNER_TEMP/deno-bin" >> "$GITHUB_PATH"
+
+      # import map（npm:/jsr: specifier）の解決でネットワークアクセスが要る。
+      # deno.json の import はすべて exact version 固定（npm:pkg@x.y.z）のため
+      # lock file の追加検証価値が薄く、`deno check` は失敗時に lock を書かない
+      # （実測: type error があると deno.lock が生成されない）ため運用に乗せづらい。
+      # `--no-lock` で明示的に無効化し、ローカル実行（pnpm functions:check）でも
+      # 未追跡の deno.lock が supabase/functions/ に生成されないようにする。
+      - name: deno check (supabase/functions)
+        if: steps.functions-changed.outputs.changed != 'false'
+        run: pnpm functions:check
+
   unit:
     name: "\U0001F4E6 Unit Tests"
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,6 +3,10 @@ name: Integration Tests
 on:
   pull_request:
     branches: [main]
+    # ready_for_review を明示する（ci.yml と同じ根拠）。既定 types に含まれないため、
+    # これが無いと draft → ready の変換で再発火せず、draft 時の skipped が残ったまま
+    # merge できてしまう（.claude/rules/workflow.md §2 段階 CI）。
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - '.nvmrc'
       - 'package.json'
@@ -49,6 +53,12 @@ permissions:
 jobs:
   integration:
     name: Integration Tests
+    # 重量層: draft の間は走らせない（2 段階 CI、ci.yml の e2e / web job と同じ扱い）。
+    # Supabase 起動込みで 1 run ≈ 4 課金分と単価が全 job 中最も高く、draft push の
+    # たびに走らせる必要はない。`draft != true` の形なのは workflow_dispatch では
+    # pull_request context が null になるためで、この形なら手動実行は常に走る。
+    # skipped のまま残る check は branch:finish の畳み込みが正しく扱う。
+    if: github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -31,7 +31,11 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: process.env.CI ? 'pnpm build && pnpm start:e2e' : 'pnpm dev:e2e',
+    // CI では build を含めない。ci.yml の web job が直前 step で `pnpm build:web` を
+    // 実行済みで、ここに build を書くと同一 job 内で next build が二重に走る
+    // （実測で発覚、2026-08-05）。build 無しで起動した場合は next start が
+    // .next 不在で即 fail するので、壊れ方は「静かに古い build を使う」ではなく明示的。
+    command: process.env.CI ? 'pnpm start:e2e' : 'pnpm dev:e2e',
     url: 'http://localhost:3001',
     reuseExistingServer: !process.env.CI,
     timeout: (process.env.CI ? 240 : 120) * 1000,

--- a/docs/engineering/infra.md
+++ b/docs/engineering/infra.md
@@ -264,12 +264,13 @@ GitHub Code QualityはOrganization / Repositoryの両方で無効にし、PR品�
 - Required checksはrepository rulesetと`.github/workflows/ci.yml`を正とし、Code Quality由来のcheckを追加しない
 - セキュリティ静的解析はGitHub CodeQLを継続する
 - **自動の外部レビューは Codex（`chatgpt-codex-connector[bot]`）だけにする。** 2026-08-03 に Gemini の ai-review を撤去し、Copilot も外した（直近マージ 10 PR の実測で review / comment がともに 0 件。原因は org の Copilot seat が 0 で、automatic review が実際には機能していなかったこと）。したがって「外部の目」は Codex の 1 系統だけで、実装・テスト・内部レビューはすべて Claude 系という前提で品質設計する
-- Copilot を再開する場合は、org の Copilot seat 割り当てから必要（Settings → Copilot → Access）。seat が 0 のままでは workflow が登録されていてもレビューは出ない
+- **repo ruleset「Copilot automatic first review」は 2026-08-05 に削除した。** 上記の「外した」後も ruleset 自体は active で残っており、seat 付与後に復活したのか直近 PR（#1832）へ実際にレビューを投稿し、PR ごとに約 3 課金分の Actions 実行を発生させていた。private 化後の課金源かつ Codex 一本化方針と二重のため ruleset ごと削除。再開する場合は org の Copilot seat 割り当て（Settings → Copilot → Access）と ruleset の再作成の両方が必要
 - カバレッジ閾値が必要になった場合はVitest / CIで直接管理する
 - Code Qualityを再評価する場合は、有効化前にbilling impactと既存品質ゲートとの差分を確認する
 
 判断と2026-07-21時点の外部設定証跡は[判断ログ](./log/2026-07-21-github-code-quality-disabled.md)に記録する。
 
+- Edge Function（`supabase/functions/**`）の型検査は Static Checks job の `deno check` step（`pnpm functions:check`）が担う。tsconfig / `pnpm typecheck` の対象外（別ランタイム）で、`supabase/functions/**` を変更した PR でだけ走る（#1822）
 - `Production Contract`は安全なdummy値だけを使い、Product / WebのProduction build gateがResend、Upstash、Web Turnstileを要求することを検査する
 - `Production Config Audit`はtrusted base revisionのscriptだけを実行し、Vercel APIからenvのkey / target / typeだけを検査する。secret値は取得・出力せず、PR codeへVercel tokenを渡さない
 - `RESEND_API_KEY`と`RESEND_WEBHOOK_SECRET`はProductionだけをtargetにし、Preview / Developmentへの設定をaudit failureにする
@@ -297,8 +298,10 @@ main ruleset の required status checks は `ci.yml` の 4 job（`🔍 Static Ch
   merge gate と Production Release の affected-aware 化が完了した後、#1817（Phase 4）で
   Impact Resolver を呼ぶ形に限って解禁する
 - **未解決の review thread が 1 件でもあると `branch:finish` は停止する**（2026-08-04）。
-  GraphQL `reviewThreads` の `isResolved` を数え、取得失敗・100 件超も停止に倒す。
-  解決の 3 択は `.claude/rules/workflow.md` §レビュー指摘の必須解決
+  GraphQL `reviewThreads` を `pageInfo.hasNextPage` / `endCursor` で全ページ走査して
+  `isResolved` を数える（2026-08-05、#1831。旧実装は first:100 の 1 ページのみで、
+  101 件・未解決 0 の PR #1820 を偽陰性で止めた）。取得失敗・20 ページ（2000 件）超は
+  従来どおり停止に倒す（fail closed）。解決の 3 択は `.claude/rules/workflow.md` §レビュー指摘の必須解決
 - `Production Release` は merge 後の証跡であり、required check にはしない
 - **Storybook browser suite（`pnpm test-storybook` / `test-storybook:dark`）は CI に載っていない。**
   `@dayopt/product` の vitest project（`--project storybook` / `storybook-dark`）として実体はあるが、

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "types:generate:local": "supabase gen types typescript --local > apps/product/src/lib/database/generated/database.types.ts",
     "auth-email:sync": "tsx scripts/sync-auth-email-templates.ts",
     "auth-email:check": "tsx scripts/sync-auth-email-templates.ts --check",
+    "functions:check": "deno check --no-lock --config supabase/functions/deno.json supabase/functions",
     "lint:i18n": "pnpm --filter @dayopt/product lint:i18n",
     "i18n:add-locale": "pnpm --filter @dayopt/product i18n:add-locale",
     "docs:check": "tsx scripts/docs-guard/index.ts",

--- a/scripts/__tests__/finish-branch.test.ts
+++ b/scripts/__tests__/finish-branch.test.ts
@@ -78,13 +78,14 @@ function vercelChecks(): RollupEntry[] {
 function threadsPayload(
   threads: Array<{ isResolved: boolean; path?: string; author?: string }>,
   hasNextPage = false,
+  endCursor: string | null = null,
 ): unknown {
   return {
     data: {
       repository: {
         pullRequest: {
           reviewThreads: {
-            pageInfo: { hasNextPage },
+            pageInfo: { hasNextPage, endCursor },
             nodes: threads.map((thread) => ({
               isResolved: thread.isResolved,
               path: thread.path ?? 'src/example.ts',
@@ -97,6 +98,11 @@ function threadsPayload(
       },
     },
   };
+}
+
+/** N 件の resolve 済み thread を作る（ページング境界の件数合わせ用） */
+function resolvedThreads(count: number): Array<{ isResolved: boolean }> {
+  return Array.from({ length: count }, () => ({ isResolved: true }));
 }
 
 function runScript(
@@ -114,12 +120,22 @@ function runScript(
     filesUnavailable?: boolean;
     /** 一覧を部分的に出力した後で失敗させる（pagination 途中失敗の再現） */
     filesPartialFailure?: boolean;
-    /** レビュー thread の状態。省略時は 0 件（gate を通す） */
+    /** レビュー thread の状態（1 ページ目のみ）。省略時は 0 件（gate を通す） */
     threads?: Array<{ isResolved: boolean; path?: string; author?: string }>;
     /** thread 取得 API を失敗させる（fail closed 経路の検証） */
     threadsUnavailable?: boolean;
-    /** reviewThreads が 100 件を超えている状態にする */
+    /** reviewThreads の 1 ページ目が hasNextPage: true で終わり、2 ページ目を用意しない状態にする */
     threadsTruncated?: boolean;
+    /**
+     * reviewThreads を複数ページに分けてレスポンスを組み立てる。指定時は `threads` /
+     * `threadsTruncated` より優先する。各要素が 1 ページ分。`hasNextPage` を省略した
+     * 要素は「最後の要素以外は true、最後は false」として扱う（20 ページ上限の
+     * テストのように全ページ true にしたい場合だけ明示する）。
+     */
+    threadPages?: Array<{
+      threads?: Array<{ isResolved: boolean; path?: string; author?: string }>;
+      hasNextPage?: boolean;
+    }>;
   } = {},
 ): { status: number | null; stderr: string } {
   // repo 直下ではなく os の temp に作る。プロセスが afterEach 前に落ちると untracked な
@@ -162,13 +178,34 @@ function runScript(
         ].join('\n')}\n`,
   );
 
-  // レビュー thread の GraphQL レスポンス。threadsUnavailable は実在しない path を
-  // 指させて cat を失敗させる（API 不通の再現）。
-  const threadsPath = join(temporaryDirectory, 'threads.json');
-  writeFileSync(
-    threadsPath,
-    JSON.stringify(threadsPayload(options.threads ?? [], options.threadsTruncated ?? false)),
-  );
+  // レビュー thread の GraphQL レスポンス（ページ単位）。gh スタブは cursor 引数
+  // （page-N.json の N）でページを選ぶため、実際のディレクトリに 1..N の
+  // page-*.json を並べる。threadsUnavailable は実在しないディレクトリを指させて
+  // cat を失敗させる（API 不通の再現）。
+  const threadsDirectory = join(temporaryDirectory, 'threads');
+  mkdirSync(threadsDirectory);
+
+  const pages =
+    options.threadPages ??
+    ([
+      { threads: options.threads ?? [], hasNextPage: options.threadsTruncated ?? false },
+    ] satisfies Array<{
+      threads: Array<{ isResolved: boolean; path?: string; author?: string }>;
+      hasNextPage: boolean;
+    }>);
+
+  pages.forEach((page, index) => {
+    const pageNumber = index + 1;
+    const isLast = index === pages.length - 1;
+    const hasNextPage = page.hasNextPage ?? !isLast;
+    // 次ページの cursor はそのページ番号の文字列にする。gh スタブはこの値を
+    // そのまま `page-<cursor>.json` の解決に使う。
+    const endCursor = hasNextPage ? String(pageNumber + 1) : null;
+    writeFileSync(
+      join(threadsDirectory, `page-${pageNumber}.json`),
+      JSON.stringify(threadsPayload(page.threads ?? [], hasNextPage, endCursor)),
+    );
+  });
 
   // `gh` だけ差し替える。git は temp repo 上で本物を動かす（worktree / show-ref の判定を
   // 実挙動に任せる方が、stub の作り込みより契約に近い）。
@@ -186,16 +223,30 @@ case "$1" in
     ;;
   api)
     shift
-    case "$*" in
-      graphql*) cat "$FINISH_BRANCH_THREADS_JSON" ;;
-      *pulls/123/files*)
-        cat "$FINISH_BRANCH_PR_FILES"
-        if [[ "\${FINISH_BRANCH_FILES_EXIT:-0}" != "0" ]]; then exit 1; fi
-        ;;
-      *compare*) echo "$FINISH_BRANCH_COMPARE" ;;
-      *full_name*) echo "Dayopt/dayopt" ;;
-      *) exit 2 ;;
-    esac
+    if [[ "\${1:-}" == graphql ]]; then
+      # cursor 引数（-f cursor=VALUE）を argv から拾う。無ければ 1 ページ目。
+      cursor=""
+      for arg in "$@"; do
+        case "$arg" in
+          cursor=*) cursor="\${arg#cursor=}" ;;
+        esac
+      done
+      if [[ -n "$cursor" ]]; then
+        cat "$FINISH_BRANCH_THREADS_DIR/page-\${cursor}.json"
+      else
+        cat "$FINISH_BRANCH_THREADS_DIR/page-1.json"
+      fi
+    else
+      case "$*" in
+        *pulls/123/files*)
+          cat "$FINISH_BRANCH_PR_FILES"
+          if [[ "\${FINISH_BRANCH_FILES_EXIT:-0}" != "0" ]]; then exit 1; fi
+          ;;
+        *compare*) echo "$FINISH_BRANCH_COMPARE" ;;
+        *full_name*) echo "Dayopt/dayopt" ;;
+        *) exit 2 ;;
+      esac
+    fi
     ;;
   *) exit 2 ;;
 esac
@@ -224,9 +275,9 @@ esac
       FINISH_BRANCH_PR_FILES: options.filesUnavailable
         ? join(temporaryDirectory, 'missing-files.txt')
         : filesPath,
-      FINISH_BRANCH_THREADS_JSON: options.threadsUnavailable
-        ? join(temporaryDirectory, 'missing-threads.json')
-        : threadsPath,
+      FINISH_BRANCH_THREADS_DIR: options.threadsUnavailable
+        ? join(temporaryDirectory, 'missing-threads-dir')
+        : threadsDirectory,
       FINISH_BRANCH_FILES_EXIT: options.filesPartialFailure ? '1' : '0',
     },
   });
@@ -900,13 +951,51 @@ describe('レビュー thread の必須解決 gate', () => {
     expect(status).toBe(1);
   });
 
-  it('thread が 100 件を超えていたら止める（全件確認できないため）', () => {
+  it('101 件（2 ページ）を全走査し、全 resolve 済みなら merge へ進む', () => {
+    // PR #1820 の実測（thread 101 件・未解決 0 件）を再現する。旧実装は
+    // first: 100 の 1 ページ目で hasNextPage=true を見た時点で即停止していた
+    // （issue #1831）。2 ページ目まで走査して初めて「未解決 0 件」と判定できる。
     const { status, stderr } = runScript(greenRollup(), {
-      threads: [{ isResolved: true }],
-      threadsTruncated: true,
+      threadPages: [{ threads: resolvedThreads(100) }, { threads: resolvedThreads(1) }],
     });
-    expect(stderr).toContain('100 件を超えて');
+    expect(stderr).toContain('未解決のレビュー thread はありません');
+    expect(status).toBe(0);
+  });
+
+  it('101 件のうち 2 ページ目に未解決が 1 件あれば止める', () => {
+    // 1 ページ目だけ見て判定を打ち切っていないことを、2 ページ目側の未解決で確認する。
+    const { status, stderr } = runScript(greenRollup(), {
+      threadPages: [
+        { threads: resolvedThreads(100) },
+        { threads: [{ isResolved: false, path: 'scripts/git/finish-branch.sh' }] },
+      ],
+    });
+    expect(stderr).toContain('未解決のレビュー thread が 1 件');
+    expect(stderr).toContain('scripts/git/finish-branch.sh');
     expect(status).toBe(1);
+  });
+
+  it('ページ数が上限（20 ページ）を超えるほど残っていれば止める', () => {
+    // 暴走防止の上限は件数（100 件超）ではなくページ数。first:100 × 20 ページ
+    // 尽くしてもなお hasNextPage が true な場合だけ「全件確認できない」で止める。
+    const { status, stderr } = runScript(greenRollup(), {
+      threadPages: Array.from({ length: 20 }, () => ({
+        threads: resolvedThreads(1),
+        hasNextPage: true,
+      })),
+    });
+    expect(stderr).toContain('20 ページ');
+    expect(stderr).toContain('全件を確認できません');
+    expect(status).toBe(1);
+  });
+
+  it('ちょうど 20 ページ目で hasNextPage: false なら全件確認できたとして進む', () => {
+    // 上限ぎりぎり（2,000 件）でも「確認できないから停止」に倒れないことを確認する。
+    const { status, stderr } = runScript(greenRollup(), {
+      threadPages: Array.from({ length: 20 }, () => ({ threads: resolvedThreads(1) })),
+    });
+    expect(stderr).toContain('未解決のレビュー thread はありません');
+    expect(status).toBe(0);
   });
 });
 

--- a/scripts/git/finish-branch.sh
+++ b/scripts/git/finish-branch.sh
@@ -444,60 +444,144 @@ if [[ "$PR_STATE" == "OPEN" ]]; then
   #
   # thread の resolve 状態は GraphQL の reviewThreads にしか無い（REST には出ない）。
   # 取得に失敗した場合は「未確認のまま通す」ではなく停止に倒す（fail closed）。
-  # first: 100 を超える場合も全件を確認できないため停止する。
+  #
+  # **`reviewThreads` は `pageInfo` の `hasNextPage` / `endCursor` で全ページを走査する。**
+  # 旧実装は first: 100 を 1 回だけ引き、hasNextPage が true なら「全件確認できない」
+  # として即停止していた。PR #1820（thread 101 件・未解決 0 件）が実際にこれで
+  # 止まり、手動フォールバックを強いられた（issue #1831）。暴走防止の上限は件数
+  # ではなくページ数 MAX_THREAD_PAGES に置く（first:100 × 20 = 最大 2000 件）。
+  # この上限に達してもなお hasNextPage が true の場合だけ「全件確認できない」と
+  # して停止する。
   step "レビュー thread の解決状態を確認"
 
   NAME_WITH_OWNER="$(gh api "repos/{owner}/{repo}" --jq '.full_name' 2>/dev/null || true)"
-  THREADS_JSON=""
+
+  MAX_THREAD_PAGES=20
+  THREAD_FETCH_FAILED=false
+  THREAD_PAGES_TRUNCATED=false
+  THREAD_PAGE_JSONS=()
+
   if [[ "$NAME_WITH_OWNER" == */* ]]; then
-    THREADS_JSON="$(gh api graphql \
-      -f query='query($owner: String!, $name: String!, $number: Int!) {
-        repository(owner: $owner, name: $name) {
-          pullRequest(number: $number) {
-            reviewThreads(first: 100) {
-              pageInfo { hasNextPage }
-              nodes {
-                isResolved
-                path
-                comments(first: 1) { nodes { author { login } } }
+    THREAD_OWNER="${NAME_WITH_OWNER%%/*}"
+    THREAD_NAME="${NAME_WITH_OWNER##*/}"
+    THREAD_CURSOR=""
+    THREAD_PAGE=0
+
+    while true; do
+      THREAD_PAGE=$((THREAD_PAGE + 1))
+
+      # 1 ページ目は cursor 変数を持たないクエリを使う（従来の shape を変えない）。
+      # 2 ページ目以降は `after: $cursor` を持つ別クエリで続きを取る。
+      if [[ -z "$THREAD_CURSOR" ]]; then
+        THREAD_PAGE_JSON="$(gh api graphql \
+          -f query='query($owner: String!, $name: String!, $number: Int!) {
+            repository(owner: $owner, name: $name) {
+              pullRequest(number: $number) {
+                reviewThreads(first: 100) {
+                  pageInfo { hasNextPage endCursor }
+                  nodes {
+                    isResolved
+                    path
+                    comments(first: 1) { nodes { author { login } } }
+                  }
+                }
               }
             }
-          }
-        }
-      }' \
-      -f owner="${NAME_WITH_OWNER%%/*}" \
-      -f name="${NAME_WITH_OWNER##*/}" \
-      -F number="$PR_NUMBER" 2>/dev/null || true)"
+          }' \
+          -f owner="$THREAD_OWNER" \
+          -f name="$THREAD_NAME" \
+          -F number="$PR_NUMBER" 2>/dev/null || true)"
+      else
+        THREAD_PAGE_JSON="$(gh api graphql \
+          -f query='query($owner: String!, $name: String!, $number: Int!, $cursor: String!) {
+            repository(owner: $owner, name: $name) {
+              pullRequest(number: $number) {
+                reviewThreads(first: 100, after: $cursor) {
+                  pageInfo { hasNextPage endCursor }
+                  nodes {
+                    isResolved
+                    path
+                    comments(first: 1) { nodes { author { login } } }
+                  }
+                }
+              }
+            }
+          }' \
+          -f owner="$THREAD_OWNER" \
+          -f name="$THREAD_NAME" \
+          -F number="$PR_NUMBER" \
+          -f cursor="$THREAD_CURSOR" 2>/dev/null || true)"
+      fi
+
+      # このページの hasNextPage / endCursor だけを取り出す。reviewThreads 自体が
+      # null（pullRequest が見つからない等）なら select が空を返し、fail closed に倒す。
+      THREAD_PAGE_INFO="$(printf '%s' "$THREAD_PAGE_JSON" | jq -r '
+        .data.repository.pullRequest.reviewThreads
+        | select(. != null)
+        | "\(.pageInfo.hasNextPage) \(.pageInfo.endCursor // "")"' 2>/dev/null || true)"
+
+      if [[ -z "$THREAD_PAGE_INFO" ]]; then
+        THREAD_FETCH_FAILED=true
+        break
+      fi
+
+      THREAD_HAS_NEXT="${THREAD_PAGE_INFO%% *}"
+      THREAD_NEXT_CURSOR="${THREAD_PAGE_INFO#* }"
+
+      if [[ "$THREAD_HAS_NEXT" != "true" && "$THREAD_HAS_NEXT" != "false" ]]; then
+        # hasNextPage が欠落した等、想定外の形。停止はするが誤診断のメッセージを出さない。
+        THREAD_FETCH_FAILED=true
+        break
+      fi
+
+      THREAD_PAGE_JSONS+=("$THREAD_PAGE_JSON")
+
+      if [[ "$THREAD_HAS_NEXT" != "true" ]]; then
+        break
+      fi
+
+      if [[ "$THREAD_PAGE" -ge "$MAX_THREAD_PAGES" ]]; then
+        THREAD_PAGES_TRUNCATED=true
+        break
+      fi
+
+      THREAD_CURSOR="$THREAD_NEXT_CURSOR"
+    done
+  else
+    THREAD_FETCH_FAILED=true
   fi
 
-  # 「未解決件数」と「100 件超フラグ」を 1 回の jq で取り出す。JSON が想定形で
-  # なければ（pullRequest が null 等）ここが空になり、fail closed で停止する。
-  THREAD_STATS="$(printf '%s' "$THREADS_JSON" | jq -r '
-    .data.repository.pullRequest.reviewThreads
-    | "\([.nodes[] | select(.isResolved | not)] | length) \(.pageInfo.hasNextPage)"' 2>/dev/null || true)"
-
-  if [[ -z "$THREAD_STATS" ]]; then
+  if [[ "$THREAD_FETCH_FAILED" == true ]]; then
     error "レビュー thread の状態を取得できませんでした。マージを中止します（fail closed）。"
     error "gh の認証とネットワークを確認して再実行してください。"
     exit 1
   fi
 
-  UNRESOLVED_THREADS="${THREAD_STATS%% *}"
-  THREADS_TRUNCATED="${THREAD_STATS##* }"
-
-  if [[ "$THREADS_TRUNCATED" == "true" ]]; then
-    error "レビュー thread が 100 件を超えており全件を確認できません。マージを中止します。"
-    exit 1
-  elif [[ "$THREADS_TRUNCATED" != "false" ]]; then
-    # hasNextPage が欠落した等、想定外の形。停止はするが誤診断のメッセージを出さない。
-    error "レビュー thread の取得結果が想定外の形です。マージを中止します（fail closed）。"
+  if [[ "$THREAD_PAGES_TRUNCATED" == true ]]; then
+    error "レビュー thread が ${MAX_THREAD_PAGES} ページ（最大 $((MAX_THREAD_PAGES * 100)) 件）を超えており全件を確認できません。マージを中止します。"
     exit 1
   fi
 
+  # 全ページの nodes を 1 つの配列へ結合する。個々のページの失敗は上の
+  # THREAD_FETCH_FAILED で既に停止しているため、ここでの失敗は
+  # 「配列を組み立てられない」想定外の形が混入した場合のみで、同じく fail closed にする。
+  # 配列展開は bash 3.2 + set -u の空配列 unbound 対策で ${arr[@]+...} 形にする
+  # （現経路では空で到達しないが、将来の経路追加で壊れないよう既存パターンに揃える）。
+  ALL_THREADS_JSON="$(printf '%s\n' ${THREAD_PAGE_JSONS[@]+"${THREAD_PAGE_JSONS[@]}"} | jq -s '
+    [.[] | .data.repository.pullRequest.reviewThreads.nodes[]]' 2>/dev/null || true)"
+
+  if [[ -z "$ALL_THREADS_JSON" ]]; then
+    error "レビュー thread の状態を取得できませんでした。マージを中止します（fail closed）。"
+    error "gh の認証とネットワークを確認して再実行してください。"
+    exit 1
+  fi
+
+  UNRESOLVED_THREADS="$(printf '%s' "$ALL_THREADS_JSON" | jq -r '[.[] | select(.isResolved | not)] | length')"
+
   if [[ "$UNRESOLVED_THREADS" != "0" ]]; then
     error "未解決のレビュー thread が $UNRESOLVED_THREADS 件あります。マージを中止します。"
-    printf '%s' "$THREADS_JSON" | jq -r '
-      .data.repository.pullRequest.reviewThreads.nodes[]
+    printf '%s' "$ALL_THREADS_JSON" | jq -r '
+      .[]
       | select(.isResolved | not)
       | "    - \(.path // "(general)")（\(.comments.nodes[0].author.login // "unknown")）"' >&2 || true
     error "解決は 3 択: fix を積む / 反論を reply / issue 化して番号を reply。いずれも thread を resolve してから再実行してください。"

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -1,11 +1,14 @@
 {
   "compilerOptions": {
     "jsx": "react-jsx",
-    "jsxImportSource": "react"
+    "jsxImportSource": "react",
+    "jsxImportSourceTypes": "@types/react",
+    "types": ["@types/react"]
   },
   "imports": {
     "@supabase/supabase-js": "npm:@supabase/supabase-js@2.49.1",
     "react": "npm:react@18.3.1",
+    "@types/react": "npm:@types/react@18.3.31",
     "@react-email/components": "npm:@react-email/components@0.0.22",
     "standardwebhooks": "npm:standardwebhooks@1.0.0",
     "resend": "npm:resend@4.0.0"

--- a/supabase/functions/send-auth-email/index.ts
+++ b/supabase/functions/send-auth-email/index.ts
@@ -248,11 +248,14 @@ Deno.serve(async (req) => {
       }
     }
   } catch (error) {
+    // catch 変数は unknown。auth hook のエラー契約（http_code / message）に
+    // 載せる 2 プロパティだけを取り出す
+    const { code, message } = error as { code?: number; message?: string };
     return new Response(
       JSON.stringify({
         error: {
-          http_code: error.code,
-          message: error.message,
+          http_code: code,
+          message,
         },
       }),
       {


### PR DESCRIPTION
## 背景

9月のprivate化を前にCI/CDを棚卸しした（実測: PR 1本 ≈ 24-31課金分）。epic #1812の設計（Impact Resolver / Phase 3-6）は維持したまま、epic未収載の無駄と独立issueをquick winsとして1 PRに束ねる。

## 変更内容

### 課金削減（quick wins）
- **integration.yml**: draftガード + `ready_for_review` type追加。server系PRのdraft pushごとの約4課金分（全job中最高単価）をready後1回に寄せる
- **web E2E job**: PlaywrightのwebServerがCIで`pnpm build`を再実行し、同一job内でnext buildが2回走っていたのを解消（webServerはstart専用に）

### Closes #1822 — supabase/functionsのDeno型検査
- static jobにpath gate付き`deno check`を追加（`supabase/functions/**`を触ったPRのみ実行、取得失敗は実行側に倒すfail closed）
- org許可リストに`denoland/setup-deno`が無いため、docs-guardのgitleaksと同じpinned version + sha256検証の直接DL方式（2.9.4、公開sha256sumと独立照合済み）
- ローカル用`pnpm functions:check`追加
- 導入により実バグ1件を検出・修正: send-auth-emailのcatch変数narrowing欠落（レスポンスshape不変）
- 検出力実証: import 1行削除でfailすることを実機確認済み

### Closes #1831 — branch:finishのreview threadページング
- `reviewThreads`を`pageInfo.hasNextPage`/`endCursor`で全ページ走査。PR #1820（101件・未解決0）型の偽陰性を解消
- fail closedは全経路維持。上限はページ数20（=2000件）
- 101件2ページ通過 / 2ページ目未解決検出 / 20ページ境界両側をtestで固定（bash 3.2実機でpass）

### 運用（PR外で実施済み）
- repo ruleset「Copilot automatic first review」を削除（約3課金分/PR、Codex一本化方針と二重だった）。infra.mdに記録

## 検証
- typecheck / lint / lint:boundaries / docs:check: pass
- test:scripts: 331/331 pass
- deno check: 全ファイルpass（ローカル実機 2.9.4）
- push前反証レビュー: risk-reviewer実施。medium 1件（functions-changed gateのfail open）を修正済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)