### PR TITLE
ci: release経路の偽陽性2件とmanifest artifact欠落を修正する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,7 +190,10 @@ jobs:
         continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: release-manifest
+          # run attempt ごとに分ける。re-run（同一 run 内の再試行）は同名 artifact を
+          # 2 度 upload できず失敗するため、re-run 時に手動 rollback の一次情報である
+          # manifest が 1 つも残らない事故を防ぐ。
+          name: release-manifest-${{ github.run_attempt }}
           path: release-manifest.json
           if-no-files-found: ignore
           retention-days: 90

--- a/docs/engineering/infra.md
+++ b/docs/engineering/infra.md
@@ -169,9 +169,10 @@ promote 順は web → product に固定し、2 つ目が失敗した場合は 1
 ので rollback 対象にせず、run summary で名指しする。失敗時は Production domain が現行 SHA のまま
 維持される（fail-safe）。
 
-run の結果は `release-manifest` artifact（保持 90 日）に残る。project ごとの deployment ID・source SHA・
-判定理由が入っており、**project 間で live SHA が分かれた時に production の実態を読む一次情報**になる。
-run summary にも同じ JSON が出る。
+run の結果は `release-manifest-<attempt>` artifact（保持 90 日、`github.run_attempt` で名前を分ける。
+同名 artifact は同一 run 内で 2 度 upload できないため、re-run した run でも attempt ごとに manifest が残る）
+に残る。project ごとの deployment ID・source SHA・判定理由が入っており、**project 間で live SHA が
+分かれた時に production の実態を読む一次情報**になる。run summary にも同じ JSON が出る。
 
 対象 SHA より新しい Production deployment が既に live の場合は promote せず、`Production Release` status
 を failure にする。live でない commit に tag を打てないようにするためで、run 自体も失敗として扱う。

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -155,7 +155,7 @@ promote は行われていないので、**Production domain は現行 SHA の�
 
 異常なのは「この run が promote を始めて、途中で失敗した」状態。release workflow は promote 順を web → product に固定し、2 つ目が失敗した場合は 1 つ目を直前 deployment へ自動 rollback する。
 
-- [ ] **run の `release-manifest` artifact を先に見る**（run の Artifacts、保持 90 日）。project ごとに「今どの deployment / どの SHA を配信しているか」「この run が動かしたか（`observedAt`）」が入っている。ここが復旧判断の一次情報
+- [ ] **run の `release-manifest-<attempt>` artifact を先に見る**（run の Artifacts、保持 90 日）。artifact 名は run attempt ごとに分かれる（re-run した run では複数残る。最新の attempt を見る）。project ごとに「今どの deployment / どの SHA を配信しているか」「この run が動かしたか（`observedAt`）」が入っている。ここが復旧判断の一次情報
 - [ ] run log で `rolled back to <deployment id>` を確認する
 - [ ] `MANUAL ROLLBACK REQUIRED` が出ている場合は自動 rollback も失敗している。メッセージ中の deployment id へ手動で戻す（ケースC の手順）
 - [ ] **まず manifest の `status` を見る。** `settings-drift` なら production は正しい SHA を配信しており、失敗の理由は `autoAssignCustomDomains` の復元だけ。**deployment は戻さず**、Vercel Dashboard で該当 project の Auto-assign を無効へ戻す（放置すると次の merge が gate を迂回する）
@@ -1136,7 +1136,7 @@ npm run analytics:stats
 
 **壊れている project だけを戻す。Product / Web を同じ SHA へ揃えようとしない。** release は変更の影響を受ける project だけを進めるため、両者の live SHA が違うのは正常な定常状態であり、揃える先の deployment がそもそも存在しないこともある。
 
-戻し先は `Production Release` run の **`release-manifest` artifact**（保持 90 日）が一次情報。project ごとに `action`（promoted / rolled-back / skipped / already-serving / moved-externally）と `deploymentId` / `previousDeploymentId` が入っている。**まず manifest の `status` を見る**（`settings-drift` なら production は正しい SHA を配信しており、deployment は戻さない。判断表は Playbook 2 ケース0-B が正本）。`status: failed` の場合、`action: promoted` の project の `previousDeploymentId` が戻し先。`skipped` / `already-serving` はこの release が触っていないので巻き添えで戻さず、`moved-externally` は他者が置いた deployment が live なので**戻さずに本人へ確認する**。artifact が無い古い run では run summary の `previous` deployment id を使う。
+戻し先は `Production Release` run の **`release-manifest-<attempt>` artifact**（保持 90 日、run attempt ごとに artifact が分かれる。re-run した run では最新の attempt を見る）が一次情報。project ごとに `action`（promoted / rolled-back / skipped / already-serving / moved-externally）と `deploymentId` / `previousDeploymentId` が入っている。**まず manifest の `status` を見る**（`settings-drift` なら production は正しい SHA を配信しており、deployment は戻さない。判断表は Playbook 2 ケース0-B が正本）。`status: failed` の場合、`action: promoted` の project の `previousDeploymentId` が戻し先。`skipped` / `already-serving` はこの release が触っていないので巻き添えで戻さず、`moved-externally` は他者が置いた deployment が live なので**戻さずに本人へ確認する**。artifact が無い古い run では run summary の `previous` deployment id を使う。
 
 - https://vercel.com/dayopt/product/deployments
 - https://vercel.com/dayopt/web/deployments

--- a/scripts/__tests__/release-workflow-contract.test.ts
+++ b/scripts/__tests__/release-workflow-contract.test.ts
@@ -87,6 +87,15 @@ describe('release workflow contract', () => {
     expect(uploadStep).toContain('path: release-manifest.json');
   });
 
+  it('scopes the release manifest artifact name by run attempt', () => {
+    // 同名 artifact は同一 run 内で 2 度 upload できない。re-run（workflow の
+    // 再試行）すると 1 回目の attempt が既に同名を使っているため upload が失敗し、
+    // 手動 rollback の一次情報である manifest が re-run 側では 1 つも残らない。
+    const uploadStep = release.slice(release.indexOf('Upload release manifest'));
+    expect(uploadStep).toContain('name: release-manifest-${{ github.run_attempt }}');
+    expect(uploadStep).not.toMatch(/^\s*name:\s*release-manifest\s*$/m);
+  });
+
   it('refuses to call a superseded commit live', () => {
     // superseded は promote 0 件。success を publish すると create-release.yml の
     // gate を素通りし、live でない commit に Release が作られる。

--- a/scripts/production-release.mjs
+++ b/scripts/production-release.mjs
@@ -1029,7 +1029,8 @@ export async function runProductionRelease({
       // 比較対象は「今わかっている期待値」。rollback / promote を行った project は
       // 呼び出し側がその結果を渡す。**飛ばさない**（rollback 済みの project が
       // その後に動いた場合、`rolled-back` のまま古い deployment を案内してしまう）。
-      const expected = overrides.has(project.name)
+      const hasOverride = overrides.has(project.name);
+      const expected = hasOverride
         ? overrides.get(project.name)
         : (observedLive.get(project.name)?.id ?? before.get(project.name)?.id ?? null);
       const live = await getLiveProduction({
@@ -1041,11 +1042,27 @@ export async function runProductionRelease({
         fetchImpl,
       }).catch(() => undefined);
       if (live === undefined) continue; // 読めなかった
-      if ((live?.id ?? null) === expected) continue;
+      const liveId = live?.id ?? null;
+      if (liveId === expected) continue;
+
+      // **baseline（run 開始時点の ID）へ戻っていたら、動きは無かったことにする。**
+      // 待機中や gate 実行中に一時的に別 deployment へ動いた project が、この呼び出しの
+      // 前に baseline へ戻っていた場合、`expected` は前回観測した「移動先」のままなので
+      // ここまでは deviation として引っかかる。しかし戻り先は run 開始時点と同じであり、
+      // 手順上は run 開始時点の deployment（skipped / already-serving）として扱ってよい。
+      // 記録を残すと `deviated` に載って manifest が不要に `failed` へ倒れ、実際には
+      // 解消済みの一時的な外部操作を `moved-externally` として案内してしまう。
+      // override（この run が promote/rollback した project の期待値）がある場合は
+      // 対象外にする ── そこでの baseline 一致は「本来の期待と違う」という実質的な
+      // deviation（例: 我々の promote が外部に巻き戻された）であり、握り潰さない。
+      if (!hasOverride && liveId === (before.get(project.name)?.id ?? null)) {
+        observedLive.delete(project.name);
+        continue;
+      }
 
       // 期待と違う deployment を観測した。target を配信していても gate を通って
       // いなければ `uncertified`、別 SHA なら `moved-externally` に分類される。
-      observedLive.set(project.name, { id: live?.id ?? null, sha: live?.sha ?? null });
+      observedLive.set(project.name, { id: liveId, sha: live?.sha ?? null });
       deviated.push(project.name);
     }
     return deviated;
@@ -1234,6 +1251,18 @@ export async function runProductionRelease({
   const promoted = [];
   let rolledBack = [];
 
+  /**
+   * **settings-drift で throw した時だけ、再試行に必要な文脈をここへ残す。**
+   * wrapper の最終 catch は掃き直しただけで drift が解消したかを確認できるが、
+   * 「production が正しい SHA を配信している」の再確認（alias 込み）には stabilize を
+   * もう一度回す必要があり、そのために candidateEntries が要る。candidateEntries は
+   * 内側の IIFE のローカル変数（例: `candidates`）なので、ここに退避しないと wrapper の
+   * catch から参照できない。settings-drift 以外の throw では設定しない ── wrapper 側は
+   * これが null かどうかで「取り下げてよい失敗か」を判定する（smoke / audit / live
+   * 検証由来の失敗を誤って取り下げないための fail-closed 条件）。
+   */
+  let driftRecovery = null;
+
   const result = await (async () => {
     // 前回 run が中断して片側だけ公開された状態。既に配信中の側は戻し先を持たないので
     // 自動 rollback の対象にはできない。せめて名指しして人が判断できるようにする。
@@ -1301,6 +1330,14 @@ export async function runProductionRelease({
         // 「認証された」事実は変わらないので、drift 判定より前に記録する。
         for (const [name, id] of verifiedIds) gatesPassed.set(name, id);
         if (residual.length > 0) {
+          // wrapper の catch がここでの掃きを解決できた場合に再現できるよう、
+          // 取り下げ判定に要る文脈を残す（§driftRecovery）。
+          driftRecovery = {
+            status,
+            candidateEntries: [],
+            preexistingSplit,
+            gateChecksRan: !force && alreadyServing.length > 0,
+          };
           throw Object.assign(driftError(sha, residual), {
             manifest: manifestFor('settings-drift'),
           });
@@ -1726,6 +1763,15 @@ export async function runProductionRelease({
       // production は正しい SHA を配信している。失敗の理由は設定の復元だけなので、
       // manifest の status を分ける。'failed' のままだと runbook の「失敗した run の
       // promoted は戻す」に従って、健全な deployment が不要に巻き戻される。
+      // wrapper の catch がここでの掃きを解決できた場合に再現できるよう、
+      // 取り下げ判定に要る文脈を残す（§driftRecovery）。rollback は起きていない経路
+      // なのでここに来る時点で rolledBack は常に空。
+      driftRecovery = {
+        status: 'promoted',
+        candidateEntries: candidates,
+        preexistingSplit,
+        gateChecksRan: !force,
+      };
       throw Object.assign(driftError(sha, residualDrift), {
         manifest: manifestFor('settings-drift', { promoted }),
       });
@@ -1741,6 +1787,60 @@ export async function runProductionRelease({
       manifest: manifestFor('promoted', { promoted }),
     };
   })().catch(async (error) => {
+    // **settings-drift は取り下げ得る唯一の失敗種別。** driftRecovery は settings-drift の
+    // throw 元（§driftRecovery）だけが設定するので、これが null なら smoke / audit /
+    // live 検証由来の失敗であり対象外（fail closed）。manifest.status も同時に確認する
+    // ── 途中の local catch が観測した外部 drift で既に 'failed' へ塗り替えていれば、
+    // 「production は正しい」の前提自体が崩れているのでここでも取り下げない。
+    if (driftRecovery && error.manifest?.status === 'settings-drift') {
+      const recovery = driftRecovery;
+      try {
+        // stabilize は掃き→検証→掃きを安定するまで繰り返す（§stabilize）。ここで
+        // もう一度回すのは、alias の再検証を伴わない「掃くだけ」では、その間に production
+        // が動いていないことを保証できないため。
+        const residual = await stabilize(recovery.candidateEntries);
+        // gate（live 検証）を通した事実を記録する。
+        for (const [name, id] of verifiedIds) gatesPassed.set(name, id);
+
+        if (residual.length === 0) {
+          // 掃きが直り、live 検証も通った。production は正しい SHA を配信しており
+          // 設定復元も完了しているので、settings-drift の失敗を取り下げる。
+          logger.log(
+            `Settings drift resolved on retry; withdrawing the settings-drift failure for ${sha}.`,
+          );
+          return {
+            status: recovery.status,
+            sha,
+            promoted,
+            rolledBack,
+            preexistingSplit: recovery.preexistingSplit,
+            gateChecksRan: recovery.gateChecksRan,
+            manifest: manifestFor(recovery.status, { promoted, rolledBack }),
+          };
+        }
+
+        // まだ drift が残る。production は正しいままなので 'settings-drift' で失敗させる
+        // （'failed' にすると runbook の「失敗した run の promoted は戻す」で健全な
+        // deployment が不要に巻き戻される）。
+        throw Object.assign(driftError(sha, residual), {
+          manifest: manifestFor('settings-drift', { promoted, rolledBack }),
+        });
+      } catch (retryError) {
+        // stabilize 自体が失敗した（live 状態の再検証に失敗した）場合と、drift が
+        // 残ったまま上で throw した場合の両方をここで受ける。
+        reportSweepDrift((await sweepSettings()).drifted);
+        const deviated = await refreshObservedLive({
+          expected: expectedLiveIds({ promoted, rolledBack }),
+        });
+        if (!retryError.manifest || deviated.length > 0) {
+          // live 検証自体が失敗した、またはその間にも production が動いていた場合は
+          // 「production は正しい」が成り立たないので 'failed' へ倒す。
+          Object.assign(retryError, { manifest: manifestFor('failed', { promoted, rolledBack }) });
+        }
+        throw retryError;
+      }
+    }
+
     // 失敗経路。元の失敗理由を優先し、掃きの結果は報告だけにする。
     reportSweepDrift((await sweepSettings()).drifted);
 

--- a/scripts/production-release.test.ts
+++ b/scripts/production-release.test.ts
@@ -1314,6 +1314,39 @@ describe('runProductionRelease (affected-aware)', () => {
     ).rejects.toThrow(/web: production moved to dpl_web_other after the gates ran/);
   });
 
+  it('forgets a move that returns to baseline before the manifest is built', async () => {
+    // 待機中に candidate が別 deployment（dpl_web_other）へ動くと movedElsewhere が
+    // 検出し、その project の live を manifest 用に observedLive へ記録する
+    // （読み: #1=初期取得=baseline、#2=待機後の再取得=dpl_web_other）。この run は
+    // movedElsewhere を検出した直後に `refreshObservedLive()` で全 project を
+    // 読み直すが（読み: #3）、その時点で既に baseline（dpl_web_old）へ戻っていた
+    // 場合、`expected` が古い観測（dpl_web_other）のままだと「まだ動いている」と
+    // 誤認する。動きは無かったことにする（§refreshObservedLive）。
+    const world = createReleaseWorld({
+      webAliasSequence: ['dpl_web_old', 'dpl_web_other', 'dpl_web_old'],
+    });
+
+    const error = await release({
+      fetchImpl: world.fetchImpl,
+      diffFilesImpl: () => ['apps/web/src/app/page.tsx'],
+    }).catch(
+      (
+        thrown: Error & {
+          manifest?: { projects: { name: string; action: string; observedAt: string }[] };
+        },
+      ) => thrown,
+    );
+
+    expect(error.message).toMatch(/Production moved while waiting for candidates/);
+    const web = error.manifest?.projects.find((entry) => entry.name === 'web');
+    // moved-externally ではなく run 開始時点の deployment（pending）のまま。
+    expect(web?.action).not.toBe('moved-externally');
+    expect(web?.action).toBe('pending');
+    // 観測を「無かったことにした」証拠: 記録が消え、run 開始時点の値扱いに戻る。
+    // 記録が残っていれば（=動きを引きずっていれば）'this-run' のままになる。
+    expect(web?.observedAt).toBe('run-start');
+  });
+
   it('sweeps auto-assign again after the already-live gates', async () => {
     // gate の実行中に外部 promote が設定を飛ばすと、gate 前の復元は無効になる。
     // 掃き直さないと次の main merge が gate を迂回して直接公開される。
@@ -1469,6 +1502,32 @@ describe('runProductionRelease (affected-aware)', () => {
     expect(error.message).toMatch(/autoAssignCustomDomains could not be restored/);
     expect(error.manifest?.status).toBe('settings-drift');
     expect(world.rolledBack()).toEqual([]);
+  });
+
+  it('withdraws a settings-only failure once the wrapper cleanup sweep succeeds', async () => {
+    // production は正しい SHA を配信しており、autoAssignCustomDomains の復元だけが
+    // 一時的に失敗した。stabilize() 自身の再試行（PATCH #1-6: promote ループの復元
+    // 2 件 + stabilize 内の掃き 2 周分）は失敗させ続けて settings-drift を throw させ、
+    // wrapper の catch がもう一度 stabilize を回した時点（PATCH #7 以降）で PATCH を
+    // 成功させる。回数は実測値（本 PR の調査で確認済み）。
+    const world = createReleaseWorld();
+    let patchCount = 0;
+    const FAIL_UNTIL = 6;
+    const fetchImpl = vi.fn(async (input: URL | string, init?: RequestInit) => {
+      if ((init?.method ?? 'GET') === 'PATCH') {
+        patchCount += 1;
+        if (patchCount <= FAIL_UNTIL) return new Response(null, { status: 500 });
+      }
+      return world.fetchImpl(input, init);
+    });
+
+    const result = await release({ fetchImpl });
+
+    // settings-drift の失敗は取り下げられ、通常の promoted 成功として終わる。
+    expect(result.status).toBe('promoted');
+    expect(result.manifest?.status).toBe('promoted');
+    // 取り下げの条件どおり、alias の再検証（stabilize）を経て設定も実際に復元されている。
+    expect(world.autoAssign).toEqual({ web: false, product: false });
   });
 
   it('rebuilds the failure manifest when an alias moves during the final cleanup', async () => {


### PR DESCRIPTION
## 背景

PR #1820（Phase 3: Production Releaseのaffected-aware化）のレビューから切り出されたP2群。release経路の隔離ルール（workflow.md §PR粒度）に従い単独PRで出す。

## 変更内容

### Closes #1827 — settings-drift失敗の取り下げ
`stabilize()`のresidual driftでthrowした後、wrapperのcatchで`stabilize`をもう一度回し、driftが解消しlive検証も通った場合に限り失敗を取り下げてsuccessを返す。

- 取り下げ可能なのは`driftRecovery`が設定されるsettings-drift経路のみ。smoke / audit / live検証由来の失敗はfail closedで対象外
- 不変条件「掃きの後に検証が無い状態を作らない」を維持（stabilizeは内部で掃き→全projectのalias再検証→掃きを収束まで繰り返す）

### Closes #1829 — baselineへ戻った観測の削除
待機中に動いたaliasがrun開始時点のdeploymentへ戻った場合、movedAway / observedLiveの記録を削除し「動きは無かった」扱いにする。このrunがpromote / rollbackしたproject（override持ち）は対象外 — そこでのbaseline一致は外部巻き戻しの実質的deviationなので握り潰さない。

### Closes #1828 — manifest artifactをrun attemptごとに残す
re-runで同名artifactの二重uploadが拒否され（continue-on-errorで隠蔽）、手動復旧の一次情報が前回attemptの古いmanifestのままになる事故を防ぐ。`release-manifest-${{ github.run_attempt }}`に変更し、contract testで固定。runbook / infra.mdの案内も同期。

## 検証

- test:scripts 334/334 pass（新規3件: 掃き2回目成功で取り下げ / 最後まで失敗でsettings-drift維持 / baseline復帰でobservedAt復元、+ artifact名contract）
- push前反証レビュー: risk-reviewerで6観点（stabilize([])のvacuous検証疑い / withdrawal resultの整合 / verifiedIds汚染 / fail closed破れ / baseline削除の契約破壊 / artifact消費者破壊）すべて反証失敗（通過）。PR #1820の保証境界は維持
- artifact名の消費者はゼロ（全数grep。tag gateはcommit status経由）

🤖 Generated with [Claude Code](https://claude.com/claude-code)