### PR TITLE
feat(timeblock): 作成時フィードフォワードでタグ別見積もり係数を提示し、Trial 期限を Billing 設定に出す

### DIFF
--- a/apps/product/messages/en/settings.json
+++ b/apps/product/messages/en/settings.json
@@ -629,7 +629,8 @@
             "unlimitedAI": "Unlimited AI + model selection"
           }
         }
-      }
+      },
+      "trialEndsAt": "Your trial runs through {date}"
     }
   }
 }

--- a/apps/product/messages/en/timeblock.json
+++ b/apps/product/messages/en/timeblock.json
@@ -189,7 +189,10 @@
         "unskipped": "Skip removed",
         "planCreated": "Plan added ✓"
       },
-      "migratedLocked": "Migrated past records cannot be edited"
+      "migratedLocked": "Migrated past records cannot be edited",
+      "feedforward": {
+        "recentActual": "Recent actuals for this tag are around {duration}"
+      }
     }
   }
 }

--- a/apps/product/messages/ja/settings.json
+++ b/apps/product/messages/ja/settings.json
@@ -629,7 +629,8 @@
             "unlimitedAI": "AI振り返り無制限 + モデル選択"
           }
         }
-      }
+      },
+      "trialEndsAt": "試用期間は {date} までです"
     }
   }
 }

--- a/apps/product/messages/ja/timeblock.json
+++ b/apps/product/messages/ja/timeblock.json
@@ -189,7 +189,10 @@
         "unskipped": "スキップを解除しました",
         "planCreated": "予定を追加しました ✓"
       },
-      "migratedLocked": "移行された過去の記録は編集できません"
+      "migratedLocked": "移行された過去の記録は編集できません",
+      "feedforward": {
+        "recentActual": "このタグの直近実績は {duration} 前後です"
+      }
     }
   }
 }

--- a/apps/product/src/features/calendar/components/views/shared/components/InlineTagPalette/InlineTagPalette.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/InlineTagPalette/InlineTagPalette.tsx
@@ -18,7 +18,7 @@ import { enUS, ja } from 'date-fns/locale';
 import { useLocale, useTranslations } from 'next-intl';
 
 import { getTagColorClasses, TagIcon, TagQuickSelector } from '@/features/tags';
-import { resolveTimeblockDestination } from '@/features/timeblock';
+import { EstimationFeedforward, resolveTimeblockDestination } from '@/features/timeblock';
 import { formatTimeString } from '@/lib/date';
 import { convertFromTimezone } from '@/lib/date/timezone';
 import { useUserPreferences } from '@/lib/hooks/useUserPreferences';
@@ -273,6 +273,18 @@ export function InlineTagPalette({ hourHeight, date }: InlineTagPaletteProps) {
         onTagHover={handleTagHover}
         anchorRef={highlightRef}
         timeLabel={pickerContextLabel}
+        hint={
+          // 作成時フィードフォワード。hover 中のタグ + ドラッグで決まった長さで引く。
+          // TagBadgeList の hover は onMouseEnter / onMouseLeave なので、これが出るのは
+          // pointer デバイスだけ。mobile の作成時は hover が発生せず出ない（既知の限界）。
+          hoveredTag ? (
+            <EstimationFeedforward
+              destination={destination}
+              tagId={hoveredTag.id}
+              draftMinutes={endMinutes - startMinutes}
+            />
+          ) : null
+        }
       />
     </>
   );

--- a/apps/product/src/features/settings/components/BillingSettings.stories.tsx
+++ b/apps/product/src/features/settings/components/BillingSettings.stories.tsx
@@ -100,8 +100,9 @@ function makeBillingMocks(
   billingInfo: BillingInfo,
   paymentMethod: PaymentMethod | null = null,
   invoices: InvoiceItem[] = [],
+  trialEndsAt: string | null = null,
 ) {
-  const overview: BillingOverview = { billingInfo, paymentMethod, invoices };
+  const overview: BillingOverview = { billingInfo, paymentMethod, invoices, trialEndsAt };
   return {
     'billing.getOverview': overview,
     'billing.getInfo': billingInfo,
@@ -151,10 +152,20 @@ export const ProPlan: Story = {
   },
 };
 
-/** トライアル中ユーザー（trialing）。カード情報・請求履歴なし */
+/** トライアル中ユーザー（trialing）。カード情報・請求履歴なし。試用期限を表示する */
 export const TrialingPlan: Story = {
   parameters: {
-    trpcMocks: makeBillingMocks(TRIALING_BILLING_INFO, null, []),
+    trpcMocks: makeBillingMocks(TRIALING_BILLING_INFO, null, [], '2026-08-21T00:00:00.000Z'),
+  },
+};
+
+/**
+ * trialing だが Stripe から試用期限を取得できなかった場合。
+ * Badge と説明文は従来どおり出て、期限の行だけが消える。
+ */
+export const TrialingPlanWithoutEndDate: Story = {
+  parameters: {
+    trpcMocks: makeBillingMocks(TRIALING_BILLING_INFO, null, [], null),
   },
 };
 

--- a/apps/product/src/features/settings/components/BillingSettings.tsx
+++ b/apps/product/src/features/settings/components/BillingSettings.tsx
@@ -116,6 +116,7 @@ export function BillingSettings() {
   });
 
   const subscriptionStatus = overview.data?.billingInfo.subscriptionStatus;
+  const trialEndsAt = overview.data?.trialEndsAt ?? null;
   const currentPlan = getPlanIdForSubscriptionStatus(subscriptionStatus);
   const canAccessPro = canUseEntitlement(currentPlan, entitlementKeys.proAccess);
 
@@ -280,6 +281,14 @@ export function BillingSettings() {
                   ? t('settings.subscription.proPlanDescription')
                   : t('settings.subscription.freePlanDescription')}
             </p>
+            {/* Stripe から期限を取れなかった場合は表示しない（Badge と説明文は従来どおり出る） */}
+            {subscriptionStatus === 'trialing' && trialEndsAt && (
+              <p className="text-muted-foreground text-base md:text-sm">
+                {t('settings.subscription.trialEndsAt', {
+                  date: dateFormatter.format(new Date(trialEndsAt)),
+                })}
+              </p>
+            )}
           </div>
           {canAccessPro && (
             <Button

--- a/apps/product/src/features/settings/server/__tests__/billing-router.test.ts
+++ b/apps/product/src/features/settings/server/__tests__/billing-router.test.ts
@@ -93,6 +93,7 @@ describe('billing-router', () => {
         },
         paymentMethod: { brand: 'visa', last4: '4242', expMonth: 12, expYear: 2027 },
         invoices: [],
+        trialEndsAt: null,
       };
       vi.mocked(billingServiceMock.getBillingOverview).mockResolvedValue(mockOverview);
 
@@ -113,6 +114,7 @@ describe('billing-router', () => {
         },
         paymentMethod: null,
         invoices: [],
+        trialEndsAt: null,
       };
       vi.mocked(billingServiceMock.getBillingOverview).mockResolvedValue(mockOverview);
 

--- a/apps/product/src/features/settings/server/__tests__/billing-service.test.ts
+++ b/apps/product/src/features/settings/server/__tests__/billing-service.test.ts
@@ -2,7 +2,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createChainableMock } from '@/lib/test/trpc-test-helpers';
 
-import { BillingServiceError, getBillingInfo, syncSubscriptionStatus } from '../billing-service';
+import {
+  BillingServiceError,
+  getBillingInfo,
+  getBillingOverview,
+  syncSubscriptionStatus,
+} from '../billing-service';
 
 const stripeMock = vi.hoisted(() => ({
   customers: {
@@ -10,7 +15,7 @@ const stripeMock = vi.hoisted(() => ({
     retrieve: vi.fn(),
   },
   checkout: { sessions: { create: vi.fn() } },
-  subscriptions: { list: vi.fn() },
+  subscriptions: { list: vi.fn(), retrieve: vi.fn() },
   billingPortal: { sessions: { create: vi.fn() } },
   paymentMethods: { retrieve: vi.fn() },
   invoices: { list: vi.fn() },
@@ -218,6 +223,92 @@ describe('billing-service', () => {
           ),
         ).resolves.toBeUndefined();
       }
+    });
+  });
+  describe('getBillingOverview の trialEndsAt', () => {
+    const TRIALING_PROFILE = {
+      id: 'user-1',
+      subscription_status: 'trialing',
+      stripe_customer_id: 'cus_test',
+      subscription_id: 'sub_test',
+    };
+
+    function stubCustomerAndInvoices() {
+      stripeMock.customers.retrieve.mockResolvedValue({
+        deleted: false,
+        invoice_settings: { default_payment_method: null },
+      });
+      stripeMock.invoices.list.mockResolvedValue({ data: [] });
+    }
+
+    it('trialing なら trial_end を ISO へ変換して返す', async () => {
+      stubCustomerAndInvoices();
+      // 2026-08-21T00:00:00Z の unix 秒
+      stripeMock.subscriptions.retrieve.mockResolvedValue({ trial_end: 1787270400 });
+
+      const overview = await getBillingOverview(createProfileSupabase(TRIALING_PROFILE), 'user-1');
+
+      expect(overview.trialEndsAt).toBe('2026-08-21T00:00:00.000Z');
+    });
+
+    it('trial_end が null なら trialEndsAt も null（Stripe の型は number | null）', async () => {
+      stubCustomerAndInvoices();
+      stripeMock.subscriptions.retrieve.mockResolvedValue({ trial_end: null });
+
+      const overview = await getBillingOverview(createProfileSupabase(TRIALING_PROFILE), 'user-1');
+
+      expect(overview.trialEndsAt).toBeNull();
+    });
+
+    it('trialing 以外では subscription を引かない（追加の Stripe 呼び出しをしない）', async () => {
+      stubCustomerAndInvoices();
+
+      const overview = await getBillingOverview(
+        createProfileSupabase({ ...TRIALING_PROFILE, subscription_status: 'active' }),
+        'user-1',
+      );
+
+      expect(overview.trialEndsAt).toBeNull();
+      expect(stripeMock.subscriptions.retrieve).not.toHaveBeenCalled();
+    });
+
+    it('Stripe が失敗しても支払い方法・請求書を巻き添えにせず trialEndsAt だけ null になる', async () => {
+      // この契約が壊れると「試用期限という付加情報」のために Billing 画面が丸ごと落ちる
+      stubCustomerAndInvoices();
+      stripeMock.invoices.list.mockResolvedValue({
+        data: [
+          {
+            id: 'in_1',
+            created: 1787270400,
+            amount_paid: 1000,
+            currency: 'jpy',
+            status: 'paid',
+            hosted_invoice_url: null,
+          },
+        ],
+      });
+      stripeMock.subscriptions.retrieve.mockRejectedValue(new Error('No such subscription'));
+
+      const overview = await getBillingOverview(createProfileSupabase(TRIALING_PROFILE), 'user-1');
+
+      expect(overview.trialEndsAt).toBeNull();
+      expect(overview.invoices).toHaveLength(1);
+    });
+
+    it('Stripe 顧客が無ければ Stripe を一切引かず trialEndsAt は null', async () => {
+      const overview = await getBillingOverview(
+        createProfileSupabase({
+          id: 'user-1',
+          subscription_status: 'free',
+          stripe_customer_id: null,
+          subscription_id: null,
+        }),
+        'user-1',
+      );
+
+      expect(overview.trialEndsAt).toBeNull();
+      expect(stripeMock.subscriptions.retrieve).not.toHaveBeenCalled();
+      expect(stripeMock.customers.retrieve).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/product/src/features/settings/server/billing-service.ts
+++ b/apps/product/src/features/settings/server/billing-service.ts
@@ -321,6 +321,11 @@ export interface BillingOverview {
   billingInfo: BillingInfo;
   paymentMethod: PaymentMethod | null;
   invoices: InvoiceItem[];
+  /**
+   * 試用期間の終了時刻（ISO 8601）。`trialing` 以外、subscription 未取得、
+   * Stripe 側の取得失敗ではすべて null になる。
+   */
+  trialEndsAt: string | null;
 }
 
 /**
@@ -356,18 +361,46 @@ export async function getBillingOverview(
 
   // Free ユーザーは Stripe 問い合わせ不要
   if (!billingInfo.stripeCustomerId) {
-    return { billingInfo, paymentMethod: null, invoices: [] };
+    return { billingInfo, paymentMethod: null, invoices: [], trialEndsAt: null };
   }
 
   const stripe = requireStripe();
 
   // Stripe API を並列実行
-  const [paymentMethod, invoiceList] = await Promise.all([
+  const [paymentMethod, invoiceList, trialEndsAt] = await Promise.all([
     getPaymentMethodByCustomerId(stripe, billingInfo.stripeCustomerId),
     getInvoicesByCustomerId(stripe, billingInfo.stripeCustomerId),
+    getTrialEndsAt(stripe, billingInfo),
   ]);
 
-  return { billingInfo, paymentMethod, invoices: invoiceList };
+  return { billingInfo, paymentMethod, invoices: invoiceList, trialEndsAt };
+}
+
+/**
+ * 試用期間の終了時刻を Stripe から取得する（内部用）。
+ *
+ * **この関数は決して reject しない。** 呼び出し元の `Promise.all` は支払い方法・請求書の
+ * 取得と束ねられており、ここで throw すると「試用期限という付加情報」のために
+ * 支払い方法・請求書という既存の表示ごと落ちる。試用期限が出ないのは許容できるが、
+ * Billing 画面が丸ごと壊れるのは許容できないので、失敗は null に畳む。
+ *
+ * 失敗しうる実例: subscription が既に削除されている、Stripe の一時的エラー、
+ * `subscription_status` が profiles 側だけ trialing のまま残っている不整合。
+ */
+async function getTrialEndsAt(stripe: Stripe, billingInfo: BillingInfo): Promise<string | null> {
+  if (billingInfo.subscriptionStatus !== 'trialing') return null;
+  if (!billingInfo.subscriptionId) return null;
+
+  try {
+    const subscription = await stripe.subscriptions.retrieve(billingInfo.subscriptionId);
+    // trial_end は unix 秒。trialing でも null になりうる（trial 無しで作られた場合）
+    return subscription.trial_end ? new Date(subscription.trial_end * 1000).toISOString() : null;
+  } catch (error) {
+    logger.error('Failed to fetch trial end from Stripe', {
+      errorType: error instanceof Error ? error.name : 'unknown',
+    });
+    return null;
+  }
 }
 
 /**

--- a/apps/product/src/features/tags/components/TagQuickSelector.tsx
+++ b/apps/product/src/features/tags/components/TagQuickSelector.tsx
@@ -66,6 +66,12 @@ interface TagQuickSelectorProps {
   anchorRef?: React.RefObject<HTMLDivElement | HTMLButtonElement | null>;
   /** ヘッダーに表示する日付・時間帯ラベル（例: "3/30 (日) 14:00 – 15:30"） */
   timeLabel?: string | undefined;
+  /**
+   * timeLabel の下に出す補助表示。呼び出し側が組み立てた ReactNode をそのまま描画する。
+   * tags feature は Layer 0 なので上位 feature の component を import できない。
+   * ノードで受け取ることで依存方向を保ったまま合成できる（例: 作成時フィードフォワード）。
+   */
+  hint?: React.ReactNode | undefined;
 }
 
 /**
@@ -206,6 +212,7 @@ export function TagQuickSelector({
   onTagHover,
   anchorRef,
   timeLabel,
+  hint,
 }: TagQuickSelectorProps) {
   const t = useTranslations('calendar');
   const isMobile = useIsMobile();
@@ -287,6 +294,7 @@ export function TagQuickSelector({
           <DrawerHeader>
             <DrawerTitle>{t('tagSelector.title')}</DrawerTitle>
             {timeLabel && <p className="text-muted-foreground text-sm">{timeLabel}</p>}
+            {hint}
           </DrawerHeader>
           <TagQuickSelectorContent
             onSelect={onSelect}
@@ -319,6 +327,7 @@ export function TagQuickSelector({
         <div className="min-w-0">
           <h2 className="font-medium">{t('tagSelector.title')}</h2>
           {timeLabel && <p className="text-muted-foreground truncate text-sm">{timeLabel}</p>}
+          {hint}
         </div>
         <Button
           type="button"

--- a/apps/product/src/features/timeblock/components/editor/EstimationFeedforward.stories.tsx
+++ b/apps/product/src/features/timeblock/components/editor/EstimationFeedforward.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { EstimationFeedforward } from './EstimationFeedforward';
+
+/** 直近 4 週の中央値が 1.5 倍のタグ（n=4）。 */
+const FACTORS = [
+  { tagId: 'tag-work', factor: 1.5, sampleCount: 4 },
+  { tagId: 'tag-learning', factor: 0.75, sampleCount: 6 },
+];
+
+const withFactors = { trpcMocks: { 'statistics.getTagEstimationFactors': FACTORS } };
+
+const meta = {
+  title: 'Product/Features/Timeblock/EstimationFeedforward',
+  component: EstimationFeedforward,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded', ...withFactors },
+  args: {
+    destination: 'plan',
+    tagId: 'tag-work',
+    draftMinutes: 30,
+  },
+} satisfies Meta<typeof EstimationFeedforward>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** 見積もりより長くかかる傾向のタグ（1.5 倍 × 30 分 = 45 分）。 */
+export const LongerThanPlanned: Story = {};
+
+/** 見積もりより短く終わる傾向のタグ（0.75 倍 × 60 分 = 45 分）。 */
+export const ShorterThanPlanned: Story = {
+  args: { tagId: 'tag-learning', draftMinutes: 60 },
+};
+
+/** 保存先が Record のときは出さない（過去の事実に見積もりの話は要らない）。 */
+export const RecordDestination: Story = {
+  args: { destination: 'record' },
+};
+
+/** タグ未選択では出さない。 */
+export const NoTag: Story = {
+  args: { tagId: null },
+};
+
+/** サンプルが 3 件未満のタグは server が返さないので出ない。 */
+export const InsufficientSamples: Story = {
+  args: { tagId: 'tag-life' },
+};
+
+/** 取得に失敗しても ErrorState を出さず、静かに消える。 */
+export const QueryFailed: Story = {
+  parameters: { trpcMocks: { 'statistics.getTagEstimationFactors': undefined } },
+};
+
+/** 全パターン一覧。何も出ないケースは高さ 0 になる。 */
+export const AllPatterns: Story = {
+  render: () => (
+    <div className="flex flex-col items-start gap-4">
+      <EstimationFeedforward destination="plan" tagId="tag-work" draftMinutes={30} />
+      <EstimationFeedforward destination="plan" tagId="tag-learning" draftMinutes={60} />
+      <EstimationFeedforward destination="plan" tagId="tag-work" draftMinutes={120} />
+      <EstimationFeedforward destination="record" tagId="tag-work" draftMinutes={30} />
+      <EstimationFeedforward destination="plan" tagId={null} draftMinutes={30} />
+      <EstimationFeedforward destination="plan" tagId="tag-life" draftMinutes={30} />
+    </div>
+  ),
+};

--- a/apps/product/src/features/timeblock/components/editor/EstimationFeedforward.tsx
+++ b/apps/product/src/features/timeblock/components/editor/EstimationFeedforward.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+/**
+ * 作成時フィードフォワード（ADR-026 の 1 点目）
+ *
+ * 「このタグの直近実績は 45m 前後です」を Plan の作成・編集時にだけ静かに出す。
+ * 警告色・アイコン・感嘆符を使わない。ユーザーの入力を書き換えることは無く、
+ * 読むかどうかはユーザーに委ねる（strategy §4-6 成績表化しない）。
+ *
+ * 出さない条件（どれか 1 つでも該当したら `null`）:
+ * - 保存先が Record（過去の事実の記録に見積もりの話は要らない）
+ * - タグ未選択
+ * - draft の長さが 0 以下
+ * - そのタグのサンプルが 3 件未満、または係数を取得できていない
+ */
+
+import { useTranslations } from 'next-intl';
+
+import { formatDurationMinutes } from '@/lib/date';
+
+import type { TimeblockDestination } from '../../domain/timeblock-destination';
+import { useTagEstimationFactors } from '../../hooks/useTagEstimationFactors';
+
+interface EstimationFeedforwardProps {
+  /** 保存先。`'plan'` のときだけ表示する。 */
+  destination: TimeblockDestination;
+  tagId: string | null;
+  /** draft の予定時間（分）。 */
+  draftMinutes: number;
+}
+
+export function EstimationFeedforward({
+  destination,
+  tagId,
+  draftMinutes,
+}: EstimationFeedforwardProps) {
+  const t = useTranslations('timeblock.editor.feedforward');
+  const { project } = useTagEstimationFactors();
+
+  if (destination !== 'plan') return null;
+
+  const projection = project(tagId, draftMinutes);
+  if (!projection) return null;
+
+  return (
+    <p className="text-muted-foreground text-xs" role="status">
+      {t('recentActual', { duration: formatDurationMinutes(projection.minutes) })}
+    </p>
+  );
+}

--- a/apps/product/src/features/timeblock/components/editor/TimeblockInspectorForm.tsx
+++ b/apps/product/src/features/timeblock/components/editor/TimeblockInspectorForm.tsx
@@ -19,7 +19,11 @@ import { useDebouncedCallback } from '@/lib/hooks/useDebounce';
 import { toast } from '@/lib/toast';
 import { Button } from '@dayopt/components';
 
-import { isPlanTimeEditable, type TimeblockDestination } from '../../domain/timeblock-destination';
+import {
+  isPlanTimeEditable,
+  resolveTimeblockDestination,
+  type TimeblockDestination,
+} from '../../domain/timeblock-destination';
 import {
   useCoalescedTimeblockSave,
   type TimeblockSavePatch,
@@ -45,6 +49,7 @@ import {
 } from '../../lib/timeblock-lane-conflict';
 import { getTimeblockMenuItems } from '../../lib/timeblock-menu-items';
 import { TagRow } from '../inspector/fields';
+import { EstimationFeedforward } from './EstimationFeedforward';
 import {
   isValidTimeModelRange,
   TimeblockEditor,
@@ -616,6 +621,17 @@ export function TimeblockInspectorForm({
           isWriteFrozen ||
           isMigrated
         }
+      />
+
+      {/*
+        保存先は kind ではなく end_at のルールで判定する。編集で end を過去へ動かした
+        瞬間に消え、未来へ戻せば再び出る。過去 Plan（end が過去）では出ない — 時間が
+        凍結されていて見積もりを直す余地が無いため。
+      */}
+      <EstimationFeedforward
+        destination={resolveTimeblockDestination(value.endAt)}
+        tagId={value.tagId}
+        draftMinutes={(value.endAt.getTime() - value.startAt.getTime()) / 60000}
       />
 
       {duplicateDraft ? (

--- a/apps/product/src/features/timeblock/components/editor/__tests__/EstimationFeedforward.test.tsx
+++ b/apps/product/src/features/timeblock/components/editor/__tests__/EstimationFeedforward.test.tsx
@@ -65,6 +65,19 @@ describe('EstimationFeedforward', () => {
     expect(screen.queryByRole('status')).not.toBeInTheDocument();
   });
 
+  it('draft の長さが負なら表示しない（start > end の不正入力中）', () => {
+    render(<EstimationFeedforward destination="plan" tagId="tag-a" draftMinutes={-30} />);
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('draft の長さが NaN なら表示しない（Invalid Date 由来）', () => {
+    // `NaN <= 0` は false なので、`<= 0` だけのガードでは「NaN 分」を描画してしまう
+    render(<EstimationFeedforward destination="plan" tagId="tag-a" draftMinutes={Number.NaN} />);
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
   it('query が失敗しても ErrorState を出さず静かに消える', () => {
     // 失敗時は data が undefined。受動的なヒントなのでエラー表示はしない
     // （`.claude/rules/quality.md` の ErrorState 必須ルールに対する明示的な例外）

--- a/apps/product/src/features/timeblock/components/editor/__tests__/EstimationFeedforward.test.tsx
+++ b/apps/product/src/features/timeblock/components/editor/__tests__/EstimationFeedforward.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { TagEstimationFactor } from '../../../domain/tag-estimation-factor';
+
+const queryResult = vi.hoisted(
+  () =>
+    ({ current: { data: undefined } }) as {
+      current: { data: TagEstimationFactor[] | undefined };
+    },
+);
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, values?: Record<string, unknown>) =>
+    `${key}:${String(values?.duration ?? '')}`,
+}));
+
+vi.mock('@/lib/trpc', () => ({
+  api: {
+    statistics: {
+      getTagEstimationFactors: {
+        useQuery: () => queryResult.current,
+      },
+    },
+  },
+}));
+
+const { EstimationFeedforward } = await import('../EstimationFeedforward');
+
+beforeEach(() => {
+  queryResult.current = {
+    data: [{ tagId: 'tag-a', factor: 1.5, sampleCount: 4 }],
+  };
+});
+
+describe('EstimationFeedforward', () => {
+  it('Plan の作成・編集時に、係数を掛けた実時間を提示する', () => {
+    render(<EstimationFeedforward destination="plan" tagId="tag-a" draftMinutes={30} />);
+
+    // 1.5 * 30 = 45 分
+    expect(screen.getByRole('status')).toHaveTextContent('recentActual:45m');
+  });
+
+  it('保存先が Record なら表示しない', () => {
+    render(<EstimationFeedforward destination="record" tagId="tag-a" draftMinutes={30} />);
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('タグ未選択なら表示しない', () => {
+    render(<EstimationFeedforward destination="plan" tagId={null} draftMinutes={30} />);
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('係数を持たないタグでは表示しない（n < 3 は server が返さない）', () => {
+    render(<EstimationFeedforward destination="plan" tagId="tag-unknown" draftMinutes={30} />);
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('draft の長さが 0 なら表示しない', () => {
+    render(<EstimationFeedforward destination="plan" tagId="tag-a" draftMinutes={0} />);
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('query が失敗しても ErrorState を出さず静かに消える', () => {
+    // 失敗時は data が undefined。受動的なヒントなのでエラー表示はしない
+    // （`.claude/rules/quality.md` の ErrorState 必須ルールに対する明示的な例外）
+    queryResult.current = { data: undefined };
+
+    render(<EstimationFeedforward destination="plan" tagId="tag-a" draftMinutes={30} />);
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});

--- a/apps/product/src/features/timeblock/components/editor/__tests__/TimeblockInspectorForm.test.tsx
+++ b/apps/product/src/features/timeblock/components/editor/__tests__/TimeblockInspectorForm.test.tsx
@@ -128,6 +128,22 @@ vi.mock('../TimeblockRelationshipSection', () => ({
   TimeblockRelationshipSection: () => null,
 }));
 
+// 作成時フィードフォワードは自身の test が挙動を固定する。ここでは配線
+// （どの destination / tagId / draftMinutes が渡るか）だけを見える化する。
+vi.mock('../EstimationFeedforward', () => ({
+  EstimationFeedforward: ({
+    destination,
+    tagId,
+    draftMinutes,
+  }: {
+    destination: 'plan' | 'record';
+    tagId: string | null;
+    draftMinutes: number;
+  }) => (
+    <output data-testid="feedforward-props">{`${destination}/${tagId ?? 'none'}/${draftMinutes}`}</output>
+  ),
+}));
+
 vi.mock('../TimeblockEditor', () => ({
   isValidTimeModelRange: ({ startAt, endAt }: { startAt: Date; endAt: Date }) =>
     startAt.getTime() < endAt.getTime(),
@@ -289,6 +305,23 @@ describe('TimeblockInspectorForm', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it('作成時フィードフォワードへ end ルール基準の保存先と draft の長さを渡す', () => {
+    render(<TimeblockInspectorForm kind="plan" plan={futurePlan} onDeleted={vi.fn()} />);
+
+    // 13:00-14:00（now は 12:00）→ plan / 60 分
+    expect(screen.getByTestId('feedforward-props')).toHaveTextContent(
+      `plan/${futurePlan.tag_id}/60`,
+    );
+  });
+
+  it('過去 Plan では保存先が record になりフィードフォワードが出ない', () => {
+    render(<TimeblockInspectorForm kind="plan" plan={pastPlan} onDeleted={vi.fn()} />);
+
+    // 保存先は kind ではなく end_at で決まる。過去 Plan は時間が凍結されていて
+    // 見積もりを直す余地が無いため、component 側が null を返す想定の入力になる。
+    expect(screen.getByTestId('feedforward-props')).toHaveTextContent(/^record\//);
   });
 
   it('未来Planの終了を現在以前へ変更せず、保存キューにも送らない', () => {

--- a/apps/product/src/features/timeblock/domain/__tests__/tag-estimation-factor.test.ts
+++ b/apps/product/src/features/timeblock/domain/__tests__/tag-estimation-factor.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  aggregateTagEstimationFactors,
+  MIN_ESTIMATION_SAMPLE_COUNT,
+  projectActualMinutes,
+  type TagEstimationPlanRow,
+  type TagEstimationRecordRow,
+} from '../tag-estimation-factor';
+
+function plan(overrides: Partial<TagEstimationPlanRow> & { id: string }): TagEstimationPlanRow {
+  return {
+    tag_id: 'tag-a',
+    planned_minutes: 60,
+    is_skipped: false,
+    ...overrides,
+  };
+}
+
+function record(
+  overrides: Partial<TagEstimationRecordRow> & { plan_id: string },
+): TagEstimationRecordRow {
+  return {
+    source: 'from_plan',
+    minutes: 60,
+    ...overrides,
+  };
+}
+
+describe('aggregateTagEstimationFactors', () => {
+  it('n >= 3 のタグだけ返す（ADR-026 の沈黙閾値）', () => {
+    const plans = [plan({ id: 'p1' }), plan({ id: 'p2' })];
+    const records = [record({ plan_id: 'p1' }), record({ plan_id: 'p2' })];
+
+    expect(aggregateTagEstimationFactors(plans, records)).toEqual([]);
+
+    const third = {
+      plans: [...plans, plan({ id: 'p3' })],
+      records: [...records, record({ plan_id: 'p3' })],
+    };
+    expect(aggregateTagEstimationFactors(third.plans, third.records)).toEqual([
+      { tagId: 'tag-a', factor: 1, sampleCount: 3 },
+    ]);
+  });
+
+  it('沈黙閾値は 3 件', () => {
+    expect(MIN_ESTIMATION_SAMPLE_COUNT).toBe(3);
+  });
+
+  it('平均ではなく中央値を取る（1 回の外れ値に引きずられない）', () => {
+    // 比: 1.0 / 1.0 / 10.0 → 平均 4.0、中央値 1.0
+    const plans = [plan({ id: 'p1' }), plan({ id: 'p2' }), plan({ id: 'p3' })];
+    const records = [
+      record({ plan_id: 'p1', minutes: 60 }),
+      record({ plan_id: 'p2', minutes: 60 }),
+      record({ plan_id: 'p3', minutes: 600 }),
+    ];
+
+    expect(aggregateTagEstimationFactors(plans, records)).toEqual([
+      { tagId: 'tag-a', factor: 1, sampleCount: 3 },
+    ]);
+  });
+
+  it('偶数件は中央 2 件の平均を取る', () => {
+    // 比: 1.0 / 1.0 / 2.0 / 2.0 → 中央 2 件は 1.0 と 2.0 → 1.5
+    const plans = ['p1', 'p2', 'p3', 'p4'].map((id) => plan({ id }));
+    const records = [
+      record({ plan_id: 'p1', minutes: 60 }),
+      record({ plan_id: 'p2', minutes: 60 }),
+      record({ plan_id: 'p3', minutes: 120 }),
+      record({ plan_id: 'p4', minutes: 120 }),
+    ];
+
+    expect(aggregateTagEstimationFactors(plans, records)).toEqual([
+      { tagId: 'tag-a', factor: 1.5, sampleCount: 4 },
+    ]);
+  });
+
+  it('1 Plan : N Record は合算して 1 つの比にする', () => {
+    // p1 は 30 分 + 30 分 = 60 分の実績 → 比 1.0（2 件と数えない）
+    const plans = [plan({ id: 'p1' }), plan({ id: 'p2' }), plan({ id: 'p3' })];
+    const records = [
+      record({ plan_id: 'p1', minutes: 30 }),
+      record({ plan_id: 'p1', minutes: 30 }),
+      record({ plan_id: 'p2', minutes: 60 }),
+      record({ plan_id: 'p3', minutes: 60 }),
+    ];
+
+    expect(aggregateTagEstimationFactors(plans, records)).toEqual([
+      { tagId: 'tag-a', factor: 1, sampleCount: 3 },
+    ]);
+  });
+
+  it('auto_migrated の Record は分子から除外する', () => {
+    // p3 の実績が auto_migrated だけ → p3 ごと分母から外れ、n=2 で沈黙する
+    const plans = [plan({ id: 'p1' }), plan({ id: 'p2' }), plan({ id: 'p3' })];
+    const records = [
+      record({ plan_id: 'p1' }),
+      record({ plan_id: 'p2' }),
+      record({ plan_id: 'p3', source: 'auto_migrated' }),
+    ];
+
+    expect(aggregateTagEstimationFactors(plans, records)).toEqual([]);
+  });
+
+  it('auto_migrated が混在する Plan は残りの Record だけで比を作る', () => {
+    const plans = [plan({ id: 'p1' }), plan({ id: 'p2' }), plan({ id: 'p3' })];
+    const records = [
+      record({ plan_id: 'p1' }),
+      record({ plan_id: 'p2' }),
+      record({ plan_id: 'p3', minutes: 60 }),
+      record({ plan_id: 'p3', minutes: 600, source: 'auto_migrated' }),
+    ];
+
+    expect(aggregateTagEstimationFactors(plans, records)).toEqual([
+      { tagId: 'tag-a', factor: 1, sampleCount: 3 },
+    ]);
+  });
+
+  it('skip した Plan は分母から除外する', () => {
+    const plans = [
+      plan({ id: 'p1' }),
+      plan({ id: 'p2' }),
+      plan({ id: 'p3', is_skipped: true }),
+      plan({ id: 'p4', is_skipped: true }),
+    ];
+    const records = ['p1', 'p2', 'p3', 'p4'].map((plan_id) => record({ plan_id }));
+
+    expect(aggregateTagEstimationFactors(plans, records)).toEqual([]);
+  });
+
+  it('記録が 1 件も無い Plan は分母から除外する（0 実績として潰さない）', () => {
+    const plans = ['p1', 'p2', 'p3', 'p4'].map((id) => plan({ id }));
+    const records = [record({ plan_id: 'p1' }), record({ plan_id: 'p2' })];
+
+    expect(aggregateTagEstimationFactors(plans, records)).toEqual([]);
+  });
+
+  it('planned_minutes が 0 以下の Plan は比が定義できないので除外する', () => {
+    const plans = [
+      plan({ id: 'p1' }),
+      plan({ id: 'p2' }),
+      plan({ id: 'p3' }),
+      plan({ id: 'p4', planned_minutes: 0 }),
+    ];
+    const records = ['p1', 'p2', 'p3', 'p4'].map((plan_id) => record({ plan_id }));
+
+    expect(aggregateTagEstimationFactors(plans, records)).toEqual([
+      { tagId: 'tag-a', factor: 1, sampleCount: 3 },
+    ]);
+  });
+
+  it('tag_id が null の Plan は返さない（作成時に引くキーが無い）', () => {
+    const plans = ['p1', 'p2', 'p3'].map((id) => plan({ id, tag_id: null }));
+    const records = ['p1', 'p2', 'p3'].map((plan_id) => record({ plan_id }));
+
+    expect(aggregateTagEstimationFactors(plans, records)).toEqual([]);
+  });
+
+  it('plan_id を持たない Record（予定外の記録）は分子に入れない', () => {
+    const plans = ['p1', 'p2', 'p3'].map((id) => plan({ id }));
+    const records = [
+      ...['p1', 'p2', 'p3'].map((plan_id) => record({ plan_id })),
+      record({ plan_id: null as unknown as string, minutes: 600 }),
+    ];
+
+    expect(aggregateTagEstimationFactors(plans, records)).toEqual([
+      { tagId: 'tag-a', factor: 1, sampleCount: 3 },
+    ]);
+  });
+
+  it('Plan 側のタグで束ねる（Record 側のタグは見ない）', () => {
+    const plans = [
+      ...['p1', 'p2', 'p3'].map((id) => plan({ id, tag_id: 'tag-a' })),
+      ...['p4', 'p5', 'p6'].map((id) => plan({ id, tag_id: 'tag-b', planned_minutes: 30 })),
+    ];
+    const records = [
+      ...['p1', 'p2', 'p3'].map((plan_id) => record({ plan_id, minutes: 90 })),
+      ...['p4', 'p5', 'p6'].map((plan_id) => record({ plan_id, minutes: 30 })),
+    ];
+
+    expect(aggregateTagEstimationFactors(plans, records)).toEqual([
+      { tagId: 'tag-a', factor: 1.5, sampleCount: 3 },
+      { tagId: 'tag-b', factor: 1, sampleCount: 3 },
+    ]);
+  });
+
+  it('sampleCount 降順・同数は tagId 昇順で安定ソートする', () => {
+    const plans = [
+      ...['a1', 'a2', 'a3'].map((id) => plan({ id, tag_id: 'tag-b' })),
+      ...['b1', 'b2', 'b3'].map((id) => plan({ id, tag_id: 'tag-a' })),
+      ...['c1', 'c2', 'c3', 'c4'].map((id) => plan({ id, tag_id: 'tag-c' })),
+    ];
+    const records = plans.map((p) => record({ plan_id: p.id }));
+
+    expect(aggregateTagEstimationFactors(plans, records).map((entry) => entry.tagId)).toEqual([
+      'tag-c',
+      'tag-a',
+      'tag-b',
+    ]);
+  });
+
+  it('空入力で空配列を返す', () => {
+    expect(aggregateTagEstimationFactors([], [])).toEqual([]);
+  });
+});
+
+describe('projectActualMinutes', () => {
+  it('係数を draft の予定時間に掛けて 5 分刻みに丸める', () => {
+    expect(projectActualMinutes(1.5, 30)).toBe(45);
+    expect(projectActualMinutes(1, 60)).toBe(60);
+    expect(projectActualMinutes(0.5, 60)).toBe(30);
+  });
+
+  it('端数は最も近い 5 分へ寄せる', () => {
+    // 1.1 * 30 = 33 → 35
+    expect(projectActualMinutes(1.1, 30)).toBe(35);
+    // 1.05 * 30 = 31.5 → 30
+    expect(projectActualMinutes(1.05, 30)).toBe(30);
+  });
+
+  it('0 分と表示しないよう下限を 5 分にする', () => {
+    expect(projectActualMinutes(0.01, 15)).toBe(5);
+    expect(projectActualMinutes(0, 60)).toBe(5);
+  });
+});

--- a/apps/product/src/features/timeblock/domain/index.ts
+++ b/apps/product/src/features/timeblock/domain/index.ts
@@ -8,6 +8,11 @@ export { aggregateHourlyDistribution } from './hourly-distribution';
 export { aggregateMonthlyTrend, getMonthlyStartDate } from './monthly-trend';
 export { calculateStreak } from './streak-calculator';
 
+// MIN_ESTIMATION_SAMPLE_COUNT / projectActualMinutes は barrel に出さない。
+// consumer（hook / test）が leaf を直接参照しており barrel 経由の consumer がいないため
+// （`.claude/rules/feature-boundaries.md` の「barrel 経由の consumer が実際にいるか」で判断）。
+export { aggregateTagEstimationFactors } from './tag-estimation-factor';
+export type { TagEstimationFactor } from './tag-estimation-factor';
 export { aggregateTagPlanCounts, aggregateTagStats } from './tag-stats';
 export { deriveTimePLReview } from './time-pl-review';
 export type { TimePLReview } from './time-pl-review';

--- a/apps/product/src/features/timeblock/domain/tag-estimation-factor.ts
+++ b/apps/product/src/features/timeblock/domain/tag-estimation-factor.ts
@@ -1,0 +1,123 @@
+/**
+ * タグ別見積もり係数（作成時フィードフォワードの燃料）の pure aggregation。
+ *
+ * ADR-026（`docs/product/log/2026-07-10-analytics-expression-policy.md`）の 3 点のうち
+ * 1 点目「タグ別見積もり係数」の定義をそのまま実装する:
+ *
+ * - Plan 1 件ごとに `Σ(Record duration) ÷ Plan duration` の比を **1 つ**作る（1 Plan : N Record は合算）
+ * - タグは **Plan 側の `tag_id`** で束ねる。作成時に draft のタグで引くため、計上キーと参照キーを一致させる
+ *   （Review 表示の「Record 側タグ優先」とは用途が異なる別の決定であり、矛盾ではない）
+ * - 直近 4 週の **中央値**。平均は 1 回の大事故に引きずられ、「静かに教える」トーンと相性が悪い
+ * - サンプル `n >= 3` 未満のタグは返さない（根拠の薄い数字を出さない）
+ *
+ * 期間の絞り込みは呼び出し側（server の fetcher）が `plans.start_at` に対して行う。
+ * この module は渡された行だけを見る。
+ */
+
+/** 集計対象の Plan 行。期間フィルタ適用後のものを渡す。 */
+export interface TagEstimationPlanRow {
+  id: string;
+  tag_id: string | null;
+  planned_minutes: number;
+  /** `plans.skipped_at != null` — やらなかった Plan は分母から外す。 */
+  is_skipped: boolean;
+}
+
+/** 集計対象の Record 行。`plan_id` で Plan に紐づくもの。 */
+export interface TagEstimationRecordRow {
+  plan_id: string | null;
+  source: string;
+  minutes: number;
+}
+
+/** タグ 1 件分の見積もり係数。 */
+export interface TagEstimationFactor {
+  tagId: string;
+  /** 実績 ÷ 予定 の中央値。1.0 で見積もりどおり、1.5 なら 1.5 倍かかっている。 */
+  factor: number;
+  /** 中央値の元になった Plan の件数。 */
+  sampleCount: number;
+}
+
+/**
+ * 移行で実体化しただけの Record。ユーザーが確定した実績ではないので分子から除外する
+ * （`domain/estimation-accuracy.ts` と同じ扱い）。
+ */
+const AUTO_MIGRATED_SOURCE = 'auto_migrated';
+
+/** ADR-026 の沈黙閾値。これ未満のタグは何も出さない。 */
+export const MIN_ESTIMATION_SAMPLE_COUNT = 3;
+
+/** 提示する実時間の丸め単位（分）。「45 分前後」の粒度に合わせる。 */
+const PROJECTION_STEP_MINUTES = 5;
+
+/** 偶数件は中央 2 件の平均を取る。入力は昇順にソート済みであること。 */
+function median(sortedValues: readonly number[]): number {
+  const middle = Math.floor(sortedValues.length / 2);
+  if (sortedValues.length % 2 === 1) return sortedValues[middle] as number;
+  return ((sortedValues[middle - 1] as number) + (sortedValues[middle] as number)) / 2;
+}
+
+/**
+ * Plan / Record 行からタグ別の見積もり係数を作る。
+ *
+ * 分母から外れるもの:
+ * - `is_skipped` の Plan（やらなかった）
+ * - `planned_minutes <= 0` の Plan（比が定義できない）
+ * - `tag_id` が null の Plan（作成時に引くキーが無いので提示先が存在しない）
+ * - 紐づく Record が 1 件も無い Plan（未記録。ゼロ実績として扱うと係数が 0 に潰れる）
+ *
+ * 分子から外れるもの:
+ * - `source = 'auto_migrated'` の Record
+ * - `plan_id` を持たない Record（予定外の記録。どの Plan の実績でもない）
+ */
+export function aggregateTagEstimationFactors(
+  plans: ReadonlyArray<TagEstimationPlanRow>,
+  records: ReadonlyArray<TagEstimationRecordRow>,
+): TagEstimationFactor[] {
+  const actualMinutesByPlanId = new Map<string, number>();
+  for (const record of records) {
+    if (record.plan_id == null || record.source === AUTO_MIGRATED_SOURCE) continue;
+    actualMinutesByPlanId.set(
+      record.plan_id,
+      (actualMinutesByPlanId.get(record.plan_id) ?? 0) + record.minutes,
+    );
+  }
+
+  const ratiosByTagId = new Map<string, number[]>();
+  for (const plan of plans) {
+    if (plan.is_skipped) continue;
+    if (plan.planned_minutes <= 0) continue;
+    if (plan.tag_id == null) continue;
+
+    const actualMinutes = actualMinutesByPlanId.get(plan.id);
+    if (actualMinutes == null) continue;
+
+    const ratios = ratiosByTagId.get(plan.tag_id) ?? [];
+    ratios.push(actualMinutes / plan.planned_minutes);
+    ratiosByTagId.set(plan.tag_id, ratios);
+  }
+
+  return Array.from(ratiosByTagId.entries())
+    .filter(([, ratios]) => ratios.length >= MIN_ESTIMATION_SAMPLE_COUNT)
+    .map(([tagId, ratios]) => ({
+      tagId,
+      factor: median([...ratios].sort((a, b) => a - b)),
+      sampleCount: ratios.length,
+    }))
+    .sort((a, b) => b.sampleCount - a.sampleCount || a.tagId.localeCompare(b.tagId));
+}
+
+/**
+ * 係数を draft の予定時間に掛けて、提示する実時間（分）を作る。
+ *
+ * 比率（1.5x）ではなく実時間で出すのは ADR-026 の決定。比は計器っぽく認知負荷が高く、
+ * 「45 分前後」は次の入力を直接助ける。
+ *
+ * 5 分刻みに丸め、下限は 5 分（0 分と表示しない）。
+ */
+export function projectActualMinutes(factor: number, draftMinutes: number): number {
+  const projected = factor * draftMinutes;
+  const rounded = Math.round(projected / PROJECTION_STEP_MINUTES) * PROJECTION_STEP_MINUTES;
+  return Math.max(PROJECTION_STEP_MINUTES, rounded);
+}

--- a/apps/product/src/features/timeblock/hooks/useTagEstimationFactors.ts
+++ b/apps/product/src/features/timeblock/hooks/useTagEstimationFactors.ts
@@ -45,7 +45,10 @@ export function useTagEstimationFactors(): TagEstimationFactors {
   return useMemo(
     () => ({
       project(tagId, draftMinutes) {
-        if (tagId == null || draftMinutes <= 0) return null;
+        // Number.isFinite を先に見る。`NaN <= 0` は false なので、`<= 0` だけだと
+        // Invalid Date 由来の NaN を素通りさせ「NaN 分」を描画してしまう。
+        // Inspector は時刻入力が壊れている間も draft の値をそのまま渡してくる。
+        if (tagId == null || !Number.isFinite(draftMinutes) || draftMinutes <= 0) return null;
         const entry = factorsByTagId.get(tagId);
         if (!entry) return null;
         return {

--- a/apps/product/src/features/timeblock/hooks/useTagEstimationFactors.ts
+++ b/apps/product/src/features/timeblock/hooks/useTagEstimationFactors.ts
@@ -1,0 +1,59 @@
+'use client';
+
+/**
+ * 作成時フィードフォワード用のタグ別見積もり係数を引く hook。
+ *
+ * 係数は**タグ単位で draft の長さに依存しない**ので、query は 1 回だけ引いて
+ * 掛け算は client の pure 関数（`projectActualMinutes`）で行う。draft の時間を
+ * 動かすたびに query を撃つ必要は無く、debounce も要らない。
+ */
+
+import { useMemo } from 'react';
+
+import { CACHE_5_MINUTES } from '@/lib/date';
+import { api } from '@/lib/trpc';
+
+import { projectActualMinutes } from '../domain/tag-estimation-factor';
+
+interface TagEstimationProjection {
+  /** draft の予定時間に係数を掛けた実時間（分、5 分刻み）。 */
+  minutes: number;
+  /** 中央値の元になった Plan 件数。`n >= 3` が保証されている。 */
+  sampleCount: number;
+}
+
+interface TagEstimationFactors {
+  /** 条件を満たさない場合は null。呼び出し側は null で何も描画しない。 */
+  project: (tagId: string | null, draftMinutes: number) => TagEstimationProjection | null;
+}
+
+export function useTagEstimationFactors(): TagEstimationFactors {
+  // 意図的に isError をハンドリングしない（`.claude/rules/quality.md` の
+  // 「UI を描画する全 useQuery は ErrorState 必須」に対する明示的な例外）。
+  // これは受動的なヒントで、取れなかった事実をユーザーに見せる価値が無く、
+  // ErrorState を出すと ADR-026 の「静かに教える」トーンを壊す。
+  // 失敗時は data が undefined のまま project() が null を返し、何も描画されない。
+  const { data } = api.statistics.getTagEstimationFactors.useQuery(undefined, {
+    staleTime: CACHE_5_MINUTES,
+  });
+
+  const factorsByTagId = useMemo(
+    () => new Map((data ?? []).map((entry) => [entry.tagId, entry])),
+    [data],
+  );
+
+  return useMemo(
+    () => ({
+      project(tagId, draftMinutes) {
+        if (tagId == null || draftMinutes <= 0) return null;
+        const entry = factorsByTagId.get(tagId);
+        if (!entry) return null;
+        return {
+          minutes: projectActualMinutes(entry.factor, draftMinutes),
+          sampleCount: entry.sampleCount,
+        };
+      },
+    }),
+    [factorsByTagId],
+  );
+}

--- a/apps/product/src/features/timeblock/index.ts
+++ b/apps/product/src/features/timeblock/index.ts
@@ -57,6 +57,11 @@ export { getTimeblockMenuItems } from './lib/timeblock-menu-items';
 export { ConfirmDayButton } from './components/editor/TimeblockRecordActions';
 
 // =============================================================================
+// Components (作成時フィードフォワード — calendar のドラッグ作成からも使う)
+// =============================================================================
+export { EstimationFeedforward } from './components/editor/EstimationFeedforward';
+
+// =============================================================================
 // Components (Inspector fields — 他 feature から再利用可能な入力 row)
 // =============================================================================
 export { DateTimeSection } from './components/inspector/fields/DateTimeSection';

--- a/apps/product/src/features/timeblock/server/__tests__/statistics-feedforward-service.test.ts
+++ b/apps/product/src/features/timeblock/server/__tests__/statistics-feedforward-service.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+
+import { createChainableMock, createMockSupabase } from '@/lib/test/trpc-test-helpers';
+
+import {
+  ESTIMATION_WINDOW_DAYS,
+  StatisticsFeedforwardService,
+} from '../statistics-feedforward-service';
+import type { ServiceSupabaseClient } from '../types';
+
+const USER_ID = 'user-feedforward-1';
+const NOW = new Date('2026-08-07T12:00:00.000Z');
+
+function createService(
+  plans: ReadonlyArray<Record<string, unknown>>,
+  records: ReadonlyArray<Record<string, unknown>>,
+) {
+  const plansMock = createChainableMock(plans);
+  const recordsMock = createChainableMock(records);
+  const mockSupabase = createMockSupabase();
+  mockSupabase.from.mockImplementation((table: string) => {
+    if (table === 'plans') return plansMock;
+    if (table === 'records') return recordsMock;
+    throw new Error(`Unexpected table access in test: ${table}`);
+  });
+  return {
+    plansMock,
+    recordsMock,
+    service: new StatisticsFeedforwardService(mockSupabase as unknown as ServiceSupabaseClient),
+  };
+}
+
+/** 予定 60 分 / 実績 90 分 の Plan-Record ペアを n 件作る（比 1.5）。 */
+function buildPair(index: number, actualMinutes = 90) {
+  const day = String(index + 1).padStart(2, '0');
+  return {
+    plan: {
+      id: `plan-${index}`,
+      tag_id: 'tag-a',
+      start_at: `2026-08-${day}T09:00:00.000Z`,
+      end_at: `2026-08-${day}T10:00:00.000Z`,
+      skipped_at: null,
+    },
+    record: {
+      id: `record-${index}`,
+      tag_id: 'tag-a',
+      plan_id: `plan-${index}`,
+      source: 'from_plan',
+      start_at: `2026-08-${day}T09:00:00.000Z`,
+      end_at: new Date(
+        new Date(`2026-08-${day}T09:00:00.000Z`).getTime() + actualMinutes * 60_000,
+      ).toISOString(),
+    },
+  };
+}
+
+describe('StatisticsFeedforwardService', () => {
+  it('4 週窓は plan.start_at に対して切る（record の発生時刻では切らない）', async () => {
+    const { plansMock, service } = createService([], []);
+
+    await service.getTagEstimationFactors(USER_ID, NOW);
+
+    // 過去 Plan への遅延記録があっても、窓は Plan 側の start_at だけで決まる。
+    // record 側で切ると「4 週前の Plan を昨日記録した」比が窓に入り、
+    // 「直近 4 週の見積もり傾向」ではなくなる。
+    const expectedStart = new Date(
+      NOW.getTime() - ESTIMATION_WINDOW_DAYS * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    expect(plansMock.gte).toHaveBeenCalledWith('start_at', expectedStart);
+    expect(plansMock.gte).toHaveBeenCalledTimes(1);
+  });
+
+  it('窓は 28 日（ADR-026 の「直近 4 週」）', () => {
+    expect(ESTIMATION_WINDOW_DAYS).toBe(28);
+  });
+
+  it('Plan が 0 件なら records を引かずに空配列を返す', async () => {
+    const { recordsMock, service } = createService([], []);
+
+    await expect(service.getTagEstimationFactors(USER_ID, NOW)).resolves.toEqual([]);
+    expect(recordsMock.select).not.toHaveBeenCalled();
+  });
+
+  it('start_at / end_at から予定・実績の分数を導いて係数を返す', async () => {
+    const pairs = [buildPair(0), buildPair(1), buildPair(2)];
+    const { service } = createService(
+      pairs.map((pair) => pair.plan),
+      pairs.map((pair) => pair.record),
+    );
+
+    await expect(service.getTagEstimationFactors(USER_ID, NOW)).resolves.toEqual([
+      { tagId: 'tag-a', factor: 1.5, sampleCount: 3 },
+    ]);
+  });
+
+  it('skipped_at を持つ Plan は分母から外れる', async () => {
+    const pairs = [buildPair(0), buildPair(1), buildPair(2)];
+    const plans: Record<string, unknown>[] = pairs.map((pair) => ({ ...pair.plan }));
+    plans[2] = { ...(plans[2] as Record<string, unknown>), skipped_at: '2026-08-03T10:00:00.000Z' };
+    const { service } = createService(
+      plans,
+      pairs.map((pair) => pair.record),
+    );
+
+    // n が 2 に落ちるので沈黙する
+    await expect(service.getTagEstimationFactors(USER_ID, NOW)).resolves.toEqual([]);
+  });
+
+  it('取得した Plan の id だけを使って records を引く', async () => {
+    const pairs = [buildPair(0), buildPair(1), buildPair(2)];
+    const { recordsMock, service } = createService(
+      pairs.map((pair) => pair.plan),
+      pairs.map((pair) => pair.record),
+    );
+
+    await service.getTagEstimationFactors(USER_ID, NOW);
+
+    expect(recordsMock.in).toHaveBeenCalledWith('plan_id', ['plan-0', 'plan-1', 'plan-2']);
+  });
+});

--- a/apps/product/src/features/timeblock/server/statistics-feedforward-service.ts
+++ b/apps/product/src/features/timeblock/server/statistics-feedforward-service.ts
@@ -1,0 +1,56 @@
+import 'server-only';
+
+/**
+ * 統計 service — 作成時フィードフォワード（タグ別見積もり係数）
+ *
+ * ADR-026（`docs/product/log/2026-07-10-analytics-expression-policy.md`）の 1 点目。
+ * 集計の定義は `domain/tag-estimation-factor.ts` が正本で、この層は行取得と分単位への
+ * 変換だけを担う。
+ */
+
+import { MS_PER_DAY } from '@/lib/date/constants';
+
+import { aggregateTagEstimationFactors, type TagEstimationFactor } from '../domain';
+
+import { fetchPlansForEstimation, fetchRecordsByPlanIds } from './statistics-fetchers';
+import { minutesBetween } from './statistics-service-grouping';
+import type { ServiceSupabaseClient } from './types';
+
+/** ADR-026 の「直近 4 週」。`plans.start_at` に対して切る。 */
+export const ESTIMATION_WINDOW_DAYS = 28;
+
+export class StatisticsFeedforwardService {
+  constructor(private readonly supabase: ServiceSupabaseClient) {}
+
+  /**
+   * 直近 4 週のタグ別見積もり係数を返す。`n >= 3` のタグだけが含まれる。
+   *
+   * 期間は UTC の絶対時刻で切る。タイムゾーン境界に依存する「日」の集計ではなく
+   * 「今から 28 日前まで」の窓なので、user timezone を引く必要が無い。
+   */
+  async getTagEstimationFactors(userId: string, now = new Date()): Promise<TagEstimationFactor[]> {
+    const startDate = new Date(now.getTime() - ESTIMATION_WINDOW_DAYS * MS_PER_DAY).toISOString();
+    const plans = await fetchPlansForEstimation(this.supabase, userId, { startDate });
+    if (plans.length === 0) return [];
+
+    const records = await fetchRecordsByPlanIds(
+      this.supabase,
+      userId,
+      plans.map((plan) => plan.id),
+    );
+
+    return aggregateTagEstimationFactors(
+      plans.map((plan) => ({
+        id: plan.id,
+        tag_id: plan.tag_id,
+        planned_minutes: minutesBetween(plan.start_at, plan.end_at),
+        is_skipped: plan.skipped_at != null,
+      })),
+      records.map((record) => ({
+        plan_id: record.plan_id,
+        source: record.source,
+        minutes: minutesBetween(record.start_at, record.end_at),
+      })),
+    );
+  }
+}

--- a/apps/product/src/features/timeblock/server/statistics-fetchers.ts
+++ b/apps/product/src/features/timeblock/server/statistics-fetchers.ts
@@ -27,6 +27,11 @@ export interface StatRecordRow {
   end_at: string;
 }
 
+/** 見積もり係数用の Plan 行。skip 判定に `skipped_at` を要するため専用 shape にする。 */
+interface EstimationPlanRow extends StatPlanRow {
+  skipped_at: string | null;
+}
+
 export interface TagLookupRow {
   id: string;
   name: string;
@@ -100,6 +105,35 @@ export async function fetchPlans(
     throw captureUnexpectedDatabaseError(error, {
       feature: 'statistics',
       operation: 'fetch_plans',
+    });
+  }
+  return data ?? [];
+}
+
+/**
+ * 見積もり係数用の Plan 取得。`fetchPlans` と違い `skipped_at` を含める。
+ *
+ * `fetchPlans` 側に列を足さないのは、既存 consumer（Time P/L / 空白率 / 見積もり精度）が
+ * skip 状態を見ない設計で、そこへ未使用列を流し込むと「使われている」と誤読されるため。
+ */
+export async function fetchPlansForEstimation(
+  supabase: ServiceSupabaseClient,
+  userId: string,
+  range: DateRangeInput = {},
+): Promise<EstimationPlanRow[]> {
+  let query = supabase
+    .from('plans')
+    .select('id, tag_id, start_at, end_at, skipped_at')
+    .eq('user_id', userId)
+    .is('deleted_at', null);
+  if (range.startDate) query = query.gte('start_at', range.startDate);
+  if (range.endDate) query = query.lt('start_at', range.endDate);
+
+  const { data, error } = await query;
+  if (error) {
+    throw captureUnexpectedDatabaseError(error, {
+      feature: 'statistics',
+      operation: 'fetch_plans_for_estimation',
     });
   }
   return data ?? [];

--- a/apps/product/src/features/timeblock/server/statistics-kpi-router.ts
+++ b/apps/product/src/features/timeblock/server/statistics-kpi-router.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { createTRPCRouter, proProcedure } from '@/lib/trpc/procedures';
+import { createTRPCRouter, proProcedure, protectedProcedure } from '@/lib/trpc/procedures';
 
 import { StatisticsService } from './statistics-service';
 import { dateRangeInput, handleStatsError } from './statistics-shared';
@@ -32,6 +32,26 @@ export const statisticsKpiRouter = createTRPCRouter({
         return await new StatisticsService(ctx.supabase).getBlankRate(ctx.userId, input);
       } catch (error) {
         handleStatsError('getBlankRate', error);
+      }
+    }),
+
+  /**
+   * 作成時フィードフォワード: タグ別見積もり係数（直近 4 週の中央値、`n >= 3`）
+   *
+   * `protectedProcedure` を使う。同じ statistics router 内でも Pro 区分は分かれており、
+   * Calendar の常設導線が引くもの（`getTagStats` / `getTimeByTag` / `getStreak` /
+   * `getTimePL`）は protected、Review の分析深度にあたるもの（`getEstimationAccuracy` /
+   * `getStatsPageData` 等）は pro になっている。本 procedure は Plan を作る瞬間の
+   * 中核ループ（ADR-026 の 1 点目）に属するため前者に揃える。
+   * Free / Pro 境界の最終決定は #1336 が持つ。
+   */
+  getTagEstimationFactors: protectedProcedure
+    .meta({ description: '作成時フィードフォワード（タグ別見積もり係数の中央値）' })
+    .query(async ({ ctx }) => {
+      try {
+        return await new StatisticsService(ctx.supabase).getTagEstimationFactors(ctx.userId);
+      } catch (error) {
+        handleStatsError('getTagEstimationFactors', error);
       }
     }),
 });

--- a/apps/product/src/features/timeblock/server/statistics-service.ts
+++ b/apps/product/src/features/timeblock/server/statistics-service.ts
@@ -6,9 +6,10 @@ import 'server-only';
  * Step 0 の Aggregation Source Contract（`docs/projects/time-model-split/step-0-statistics-rpc-policy.md`）
  * に従い、実績系は `records`、予定系は `plans`、予実比較は `plans` LEFT JOIN `records`（`plan_id` 経由）を読む。
  *
- * **dormant**: このクラスは router から未接続。既存 RPC ベースの router
- * (`statistics-general-router.ts` 等) は現状維持のまま、この service は Step 8 の
- * カットオーバーで router 内部の実装として丸ごと差し替えられる前提のシグネチャを持つ。
+ * Step 8 のカットオーバーは完了済みで、**統計 procedure はすべてこのクラス経由**で動く
+ * （`statistics-general-router.ts` / `statistics-kpi-router.ts` / `statistics-summary-router.ts`
+ * の全 procedure が `new StatisticsService(ctx.supabase)` を呼ぶ）。PL/pgSQL の統計 RPC は
+ * 呼ばれていない。
  *
  * 公開 API は facade（このファイル）。実装はドメイン単位の service に分割されている:
  * - General（タグ別統計・時間帯分布・トレンド）: statistics-general-service.ts

--- a/apps/product/src/features/timeblock/server/statistics-service.ts
+++ b/apps/product/src/features/timeblock/server/statistics-service.ts
@@ -18,6 +18,7 @@ import 'server-only';
  * - 行取得: statistics-fetchers.ts / 行組み立て: statistics-row-builders.ts
  */
 
+import { StatisticsFeedforwardService } from './statistics-feedforward-service';
 import type { DateRangeInput } from './statistics-fetchers';
 import { StatisticsGeneralService } from './statistics-general-service';
 import type { BlankRateInput } from './statistics-kpi-service';
@@ -29,12 +30,14 @@ import { StatisticsTagDashboardService } from './statistics-tag-dashboard-servic
 import type { ServiceSupabaseClient } from './types';
 
 export class StatisticsService {
+  private readonly feedforwardService: StatisticsFeedforwardService;
   private readonly generalService: StatisticsGeneralService;
   private readonly kpiService: StatisticsKpiService;
   private readonly summaryService: StatisticsSummaryService;
   private readonly tagDashboardService: StatisticsTagDashboardService;
 
   constructor(supabase: ServiceSupabaseClient) {
+    this.feedforwardService = new StatisticsFeedforwardService(supabase);
     this.generalService = new StatisticsGeneralService(supabase);
     this.kpiService = new StatisticsKpiService(supabase);
     this.summaryService = new StatisticsSummaryService(supabase, this.kpiService);
@@ -90,6 +93,14 @@ export class StatisticsService {
   /** `get_blank_rate` 相当。予定（plans）ベースのスケジュール時間から空白率を算出する。 */
   async getBlankRate(userId: string, input: BlankRateInput) {
     return this.kpiService.getBlankRate(userId, input);
+  }
+
+  /**
+   * 作成時フィードフォワード用のタグ別見積もり係数（直近 4 週の中央値、`n >= 3`）。
+   * 定義は `domain/tag-estimation-factor.ts` を参照。
+   */
+  async getTagEstimationFactors(userId: string) {
+    return this.feedforwardService.getTagEstimationFactors(userId);
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 概要

`status:ready` の独立した 2 件を束ねた PR（`.claude/rules/workflow.md` §PR 粒度）。どちらも 8/3 に Codex へ dispatch されたまま着手ゼロだったもの（[#1864 の sweep](https://github.com/Dayopt/dayopt/pull/1864) で `status:ready` へ差し戻し済み）。

## 1. #1559 作成時フィードフォワード

ADR-026（[2026-07-10-analytics-expression-policy.md](https://github.com/Dayopt/dayopt/blob/main/docs/product/log/2026-07-10-analytics-expression-policy.md)）が定める 3 点のうち **1 点目「タグ別見積もり係数」**。principles.md で「3 点の中で最重要・未実装」と位置づけられていたもの。

Plan を作る・編集する瞬間に「このタグの直近実績は 45m 前後です」を 1 行で静かに出す。警告色・アイコン・感嘆符は使わず、ユーザーの入力は一切書き換えない。

### 数値定義（ADR-026 のまま）

| 項目 | 実装 |
| --- | --- |
| 比の作り方 | Plan 1 件ごとに `Σ(Record duration) ÷ Plan duration` を **1 つ**（1 Plan : N Record は合算） |
| 代表値 | 直近 4 週の**中央値**（平均は 1 回の大事故に引きずられる） |
| タグ帰属 | **Plan 側 `tag_id`**（作成時に draft のタグで引くため、計上キーと参照キーを一致させる） |
| 沈黙閾値 | `n >= 3` 未満は何も出さない |
| 提示形式 | 比ではなく draft に掛けた実時間（5 分丸め、下限 5 分） |

分母から外れるもの: `skipped_at` の Plan / `planned_minutes <= 0` / `tag_id` が null / 紐づく Record が 0 件。
分子から外れるもの: `source = 'auto_migrated'` / `plan_id` を持たない Record。

### 実装の構成

- `domain/tag-estimation-factor.ts` — pure。集計定義の正本
- `server/statistics-feedforward-service.ts` — 窓は **`plans.start_at >= now - 28d`**。Record 側で切ると「4 週前の Plan を昨日記録した」比が窓に入り、「直近 4 週の見積もり傾向」でなくなるため
- `server/statistics-fetchers.ts` — `fetchPlansForEstimation` を追加。既存 `fetchPlans` は**変更していない**（consumer 3 つは skip 状態を見ない設計で、未使用列を流すと「使われている」と誤読される）
- `statistics.getTagEstimationFactors`（`protectedProcedure`。理由は下記）
- `hooks/useTagEstimationFactors.ts` — **係数はタグ単位で duration 非依存**なので query は 1 回だけ引き、掛け算は client の pure 関数。draft の時間を動かすたびに query を撃たず、debounce も不要
- `components/editor/EstimationFeedforward.tsx` — 条件を満たさなければ `return null`

### 接続 2 面

| 面 | 保存先の判定 | 効く環境 |
| --- | --- | --- |
| `TimeblockInspectorForm` | `resolveTimeblockDestination(value.endAt)` | mobile / desktop 両方 |
| `InlineTagPalette`（ドラッグ作成のタグピッカー） | 選択範囲の end | **desktop のみ**（下記） |

保存先は `kind` ではなく **end_at のルール**で判定する。編集で end を過去へ動かした瞬間に消え、未来へ戻せば再び出る。過去 Plan では出ない（時間が凍結されていて見積もりを直す余地が無い）。

`TagQuickSelector`（`features/tags` = Layer 0）には `hint?: React.ReactNode` を足した。tags から上位 feature を import せず、呼び出し側の calendar が組み立てた node を渡すことで依存方向を保つ。

## 2. #1483 Trial 期限表示

`trialing` の Badge は出ていたが、いつまでかが settings のどこにも無かった。

- `BillingOverview` に `trialEndsAt: string | null` を追加し、Stripe subscription の `trial_end`（unix 秒）を ISO へ
- `profiles` に列を足さず **Stripe を正本のまま**にした。列を足すと webhook 同期の整合を持つことになり不可逆度が上がる
- **新しい Stripe 呼び出しは個別に `try/catch` して null へ畳む。** 既存の `Promise.all` は無防備で、ここで throw すると「試用期限という付加情報」のために支払い方法・請求履歴の表示ごと落ちる

## Free / Pro 境界について（#1336 への論点）

`getTagEstimationFactors` は `protectedProcedure` にした。**当初 plan では「統計 procedure は全部 `proProcedure`」と書いていたが、これは誤りだった**（plan-fact-checker の指摘から実測して判明）。実際は用途で分かれている:

| 区分 | procedure |
| --- | --- |
| `protectedProcedure`（Calendar の常設導線） | `getTagStats` / `getTimeByTag` / `getDailyHours` / `getStreak` / `getTimePL` / `getMcpReview` / `getTagDashboard` |
| `proProcedure`（Review の分析深度） | `getEstimationAccuracy` / `getBlankRate` / `getHourlyDistribution` / `getDayOfWeekDistribution` / `getMonthlyTrend` / `getStatsOverview` / `getStatsPageData` |

フィードフォワードは Plan を作る瞬間の中核ループなので前者へ揃えた。1 語で反転できる。**最終決定は #1336 が持つ**ので、そちらの判断材料としてこの区分を記録しておく。

## レビューで直したもの

**この PR の 5 コミットのうち 3 本は、計画どおりではなく検査が落ちた結果**。

### plan-review（`/plan-review`、size m のため必須）

- **plan-fact-checker**: path / symbol / table の誤りゼロ。ただし「`proProcedure` 全部」の主張を「未確認」としてフラグ → 追跡して**上記の誤りを発見**
- **plan-critic**: REVISE。blocker 2 件を採用
  1. barrel export の欠落（calendar から使うのに `features/timeblock/index.ts` へ足す step が無く、`lint:boundaries` に落ちる）
  2. **無防備な `Promise.all` に Stripe 呼び出しを足す設計**（上記の fail-open 対応へ）
  - MAJOR 3 件も採用（4 週窓の起点の明文化 + test 固定 / query 失敗時の挙動仕様化 / `minutesBetween` の再利用明記）

### push 前の敵対的セルフレビュー

- **architecture-guard**: 境界破壊なし（7 主張すべて反証失敗）。副産物として `StatisticsService` の **「dormant: router から未接続」という stale な docblock** を検出。Step 8 のカットオーバーは完了済みで全 procedure がここを通る → `8da2c16` で修正
- **risk-reviewer**（billing）: blocker なし。low finding 2 件を解消
  - fail-open の契約が**コメントの目視確認にしか担保されていない** → `49b62fd` でテスト 5 本追加。`try/catch` を外すと実際に落ちることを確認済み
  - `trial_end` の nullability → `stripe@20.4.1` の `types/Subscriptions.d.ts:232` で `number | null` を一次確認
- **behavior-verifier**: **domain / server / router / hook しか読み切れず、UI と billing を「未確認」と自己申告**。その範囲を Main が直接読み直したところ、**`NaN <= 0` は `false`** なので Invalid Date 由来の draft で「NaN分前後です」が描画されうる穴を発見 → `8745c91` で `Number.isFinite` ガード + 回帰テスト。ガードを外すと `recentActual:NaNm` で落ちることを確認済み

### 外部レビュー（Codex）の状況

**#1850 以降 usage limit で応答が無い期間が続いており、この PR でもレビューは走っていない**（`.claude/rules/workflow.md` §外部レビューが動かない時 に従い事実を記録）。代替として上記の内部反証 3 種を実施し、指摘はすべて本文に記載のとおり解消した。`@codex review` は draft のまま試行する。

## 検証

| コマンド | 結果 |
| --- | --- |
| `pnpm typecheck` | pass（10 packages） |
| `pnpm lint` | pass（9 packages） |
| `pnpm lint:boundaries` | pass（`cross=0 self=0` / Forbidden barrels 0） |
| `pnpm lint:i18n` | pass |
| `pnpm --filter @dayopt/product test:run` | pass（**3,014 tests**） |
| `pnpm quality:deadcode` | **`{"files":[],"issues":[]}`**（#1863 のクリーン baseline を維持） |
| `pnpm --filter @dayopt/storybook build` | pass |
| `pnpm docs:check` | pass（ストック側リンク切れ 0） |

新規テストは domain 18 / service 6 / component 8 / billing 5。中央値・偶数件・n>=3 沈黙・`auto_migrated` 除外・skip 除外・1 Plan : N Record 合算・4 週窓の起点・NaN / 負値ガード・fail-open をそれぞれ固定している。

knip をクリーンに保つため、`MIN_ESTIMATION_SAMPLE_COUNT` / `projectActualMinutes` は domain barrel に出していない（barrel 経由の consumer が実在しないため。`feature-boundaries.md` の判断基準どおり）。

## 未確認事項・既知の限界

1. **視覚確認をしていない。** 本セッションは remote / mobile-only で、共有 browser も `pnpm dev`（1Password 必須）も使えない。Storybook の story は追加し build も通っているが、**実機の画面は誰も見ていない**。merge 前に確認したい
2. **モバイルのドラッグ作成では出ない。** `TagBadgeList` の hover は `onMouseEnter` / `onMouseLeave` なので pointer デバイス限定。モバイルはタップで即作成されるため「タグと長さが両方決まっていて未確定」の瞬間が存在しない。モバイルでは Inspector 側でカバーされる。別 surface が要るなら follow-up issue へ
3. **ローカルの Node は 22 系**（`package.json` は 24.x を要求）。全 test は pass しているが、CI の Node 24 との差は未確認

Closes #1559
Closes #1483

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhDKF9Jj8wiiiBwu2maGe6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhDKF9Jj8wiiiBwu2maGe6)_