### PR TITLE
fix(deps): 新規公開された間接依存脆弱性を修正する

### DIFF
--- a/docs/operations/security.md
+++ b/docs/operations/security.md
@@ -187,10 +187,17 @@ OWASP準拠のセキュリティ監視の全体像と、定期検査の cadence 
 定期検査の正本は `/gardening` §5.7（月次セキュリティ sweep）とする。実施内容:
 
 1. Supabase security advisors の確認（`mcp__supabase__get_advisors`、read-only）
-2. `pnpm security:check`（= `pnpm audit --audit-level=moderate`）
+2. `pnpm security:check`（= `pnpm audit --audit-level=moderate`。後述のローカルパッチ済み advisory は `auditConfig` で除く）
 3. `/claude-security` の全体スキャン実行をユーザーへ提案
 
 2 は **CI では実行しない**。依存脆弱性の継続検知は Dependabot alerts が担当し（security update は schedule と無関係に即時 PR が出る）、CI に `pnpm audit` を足すと新しい advisory が公開された瞬間に無関係な PR まで落ちる。Actions 課金が PR 本数に比例する構造（`.claude/rules/workflow.md` §PR 粒度）でもあるため、月次の手動実行に留める。
+
+`image-size@2.0.2` の
+`GHSA-w3rx-r6r6-pgpr` と `GHSA-5p2g-fcmc-qvqq` は修正版が未リリースのため、
+`pnpm-workspace.yaml` の `patchedDependencies` で上流修正を固定している。
+`security:check` は `pnpm-workspace.yaml` の `auditConfig.ignoreGhsas` で
+この 2 件だけを除外し、局所パッチの回帰は
+`scripts/__tests__/image-size-security-patch.test.ts` で検査する。
 
 secret 検出はこれとは別で、**全 PR で自動実行される**。`docs-guard.yml`（job 名 `docs & secrets guard`、path filter なし）が gitleaks で base ref からの差分を、`pnpm secrets:check` で tracked tree 全体を見る。加えて `ci.yml` がビルド後の client bundle への混入を grep する。ローカルでは `pnpm check` に `secrets:check` が含まれる（CI 側は docs-guard の 1 回のみで、二重実行はしない）。
 

--- a/patches/image-size@2.0.2.patch
+++ b/patches/image-size@2.0.2.patch
@@ -1,0 +1,388 @@
+diff --git a/dist/detector.cjs b/dist/detector.cjs
+index 0898608dbeca36722dfd795341b1c3c1448f58aa..aced8ae668fdf5db0a4e495168215746bfb64a67 100644
+--- a/dist/detector.cjs
++++ b/dist/detector.cjs
+@@ -171,7 +171,7 @@ var HEIF = {
+         width = rawWidth - cropRight;
+       }
+       images.push({ height, width });
+-      currentOffset = ispeBox.offset + ispeBox.size;
++      currentOffset = ispeBox.offset + (ispeBox.size > 0 ? ispeBox.size : 8);
+     }
+     if (images.length === 0) {
+       throw new TypeError("Invalid HEIF, no sizes found");
+@@ -253,7 +253,7 @@ var ICNS = {
+       const imageHeader = readImageHeader(input, imageOffset);
+       const imageSize = getImageSize2(imageHeader[0]);
+       images.push(imageSize);
+-      imageOffset += imageHeader[1];
++      imageOffset += imageHeader[1] > 0 ? imageHeader[1] : 8;
+     }
+     if (images.length === 0) {
+       throw new TypeError("Invalid ICNS, no sizes found");
+@@ -488,7 +488,7 @@ function extractPartialStreams(input) {
+     partialStreams.push(
+       input.slice(jxlpBox.offset + 12, jxlpBox.offset + jxlpBox.size)
+     );
+-    offset = jxlpBox.offset + jxlpBox.size;
++    offset = jxlpBox.offset + (jxlpBox.size > 0 ? jxlpBox.size : 8);
+   }
+   return partialStreams;
+ }
+diff --git a/dist/detector.mjs b/dist/detector.mjs
+index 67afcab02d627f95e98c938499e07a934b832a26..0d4d52fecb0fa30664e03526079126a7a5408d6a 100644
+--- a/dist/detector.mjs
++++ b/dist/detector.mjs
+@@ -169,7 +169,7 @@ var HEIF = {
+         width = rawWidth - cropRight;
+       }
+       images.push({ height, width });
+-      currentOffset = ispeBox.offset + ispeBox.size;
++      currentOffset = ispeBox.offset + (ispeBox.size > 0 ? ispeBox.size : 8);
+     }
+     if (images.length === 0) {
+       throw new TypeError("Invalid HEIF, no sizes found");
+@@ -251,7 +251,7 @@ var ICNS = {
+       const imageHeader = readImageHeader(input, imageOffset);
+       const imageSize = getImageSize2(imageHeader[0]);
+       images.push(imageSize);
+-      imageOffset += imageHeader[1];
++      imageOffset += imageHeader[1] > 0 ? imageHeader[1] : 8;
+     }
+     if (images.length === 0) {
+       throw new TypeError("Invalid ICNS, no sizes found");
+@@ -486,7 +486,7 @@ function extractPartialStreams(input) {
+     partialStreams.push(
+       input.slice(jxlpBox.offset + 12, jxlpBox.offset + jxlpBox.size)
+     );
+-    offset = jxlpBox.offset + jxlpBox.size;
++    offset = jxlpBox.offset + (jxlpBox.size > 0 ? jxlpBox.size : 8);
+   }
+   return partialStreams;
+ }
+diff --git a/dist/fromFile.cjs b/dist/fromFile.cjs
+index c226d3dac07f235db456c774b26cca88f655e1af..861e0beaa3c372ad72a50c78f0fea2a03d7a6fbc 100644
+--- a/dist/fromFile.cjs
++++ b/dist/fromFile.cjs
+@@ -197,7 +197,7 @@ var HEIF = {
+         width = rawWidth - cropRight;
+       }
+       images.push({ height, width });
+-      currentOffset = ispeBox.offset + ispeBox.size;
++      currentOffset = ispeBox.offset + (ispeBox.size > 0 ? ispeBox.size : 8);
+     }
+     if (images.length === 0) {
+       throw new TypeError("Invalid HEIF, no sizes found");
+@@ -279,7 +279,7 @@ var ICNS = {
+       const imageHeader = readImageHeader(input, imageOffset);
+       const imageSize2 = getImageSize2(imageHeader[0]);
+       images.push(imageSize2);
+-      imageOffset += imageHeader[1];
++      imageOffset += imageHeader[1] > 0 ? imageHeader[1] : 8;
+     }
+     if (images.length === 0) {
+       throw new TypeError("Invalid ICNS, no sizes found");
+@@ -514,7 +514,7 @@ function extractPartialStreams(input) {
+     partialStreams.push(
+       input.slice(jxlpBox.offset + 12, jxlpBox.offset + jxlpBox.size)
+     );
+-    offset = jxlpBox.offset + jxlpBox.size;
++    offset = jxlpBox.offset + (jxlpBox.size > 0 ? jxlpBox.size : 8);
+   }
+   return partialStreams;
+ }
+diff --git a/dist/fromFile.mjs b/dist/fromFile.mjs
+index 4a3c44432982397204f7a9d04fc66ef65a8e7ba4..38cd262d99978ee711826405a13c9946e609418e 100644
+--- a/dist/fromFile.mjs
++++ b/dist/fromFile.mjs
+@@ -174,7 +174,7 @@ var HEIF = {
+         width = rawWidth - cropRight;
+       }
+       images.push({ height, width });
+-      currentOffset = ispeBox.offset + ispeBox.size;
++      currentOffset = ispeBox.offset + (ispeBox.size > 0 ? ispeBox.size : 8);
+     }
+     if (images.length === 0) {
+       throw new TypeError("Invalid HEIF, no sizes found");
+@@ -256,7 +256,7 @@ var ICNS = {
+       const imageHeader = readImageHeader(input, imageOffset);
+       const imageSize2 = getImageSize2(imageHeader[0]);
+       images.push(imageSize2);
+-      imageOffset += imageHeader[1];
++      imageOffset += imageHeader[1] > 0 ? imageHeader[1] : 8;
+     }
+     if (images.length === 0) {
+       throw new TypeError("Invalid ICNS, no sizes found");
+@@ -491,7 +491,7 @@ function extractPartialStreams(input) {
+     partialStreams.push(
+       input.slice(jxlpBox.offset + 12, jxlpBox.offset + jxlpBox.size)
+     );
+-    offset = jxlpBox.offset + jxlpBox.size;
++    offset = jxlpBox.offset + (jxlpBox.size > 0 ? jxlpBox.size : 8);
+   }
+   return partialStreams;
+ }
+diff --git a/dist/index.cjs b/dist/index.cjs
+index bde0210eb131db06ccca30a5c466c7252a03af50..a850884225a1a4ecf359b0a27d3c1dee5c7bce06 100644
+--- a/dist/index.cjs
++++ b/dist/index.cjs
+@@ -173,7 +173,7 @@ var HEIF = {
+         width = rawWidth - cropRight;
+       }
+       images.push({ height, width });
+-      currentOffset = ispeBox.offset + ispeBox.size;
++      currentOffset = ispeBox.offset + (ispeBox.size > 0 ? ispeBox.size : 8);
+     }
+     if (images.length === 0) {
+       throw new TypeError("Invalid HEIF, no sizes found");
+@@ -255,7 +255,7 @@ var ICNS = {
+       const imageHeader = readImageHeader(input, imageOffset);
+       const imageSize2 = getImageSize2(imageHeader[0]);
+       images.push(imageSize2);
+-      imageOffset += imageHeader[1];
++      imageOffset += imageHeader[1] > 0 ? imageHeader[1] : 8;
+     }
+     if (images.length === 0) {
+       throw new TypeError("Invalid ICNS, no sizes found");
+@@ -490,7 +490,7 @@ function extractPartialStreams(input) {
+     partialStreams.push(
+       input.slice(jxlpBox.offset + 12, jxlpBox.offset + jxlpBox.size)
+     );
+-    offset = jxlpBox.offset + jxlpBox.size;
++    offset = jxlpBox.offset + (jxlpBox.size > 0 ? jxlpBox.size : 8);
+   }
+   return partialStreams;
+ }
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 22c17afad4e406eba013fff7858366cb5f8e3ba4..485e761dff1c5050e1c0571d505a98833026fc26 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -169,7 +169,7 @@ var HEIF = {
+         width = rawWidth - cropRight;
+       }
+       images.push({ height, width });
+-      currentOffset = ispeBox.offset + ispeBox.size;
++      currentOffset = ispeBox.offset + (ispeBox.size > 0 ? ispeBox.size : 8);
+     }
+     if (images.length === 0) {
+       throw new TypeError("Invalid HEIF, no sizes found");
+@@ -251,7 +251,7 @@ var ICNS = {
+       const imageHeader = readImageHeader(input, imageOffset);
+       const imageSize2 = getImageSize2(imageHeader[0]);
+       images.push(imageSize2);
+-      imageOffset += imageHeader[1];
++      imageOffset += imageHeader[1] > 0 ? imageHeader[1] : 8;
+     }
+     if (images.length === 0) {
+       throw new TypeError("Invalid ICNS, no sizes found");
+@@ -486,7 +486,7 @@ function extractPartialStreams(input) {
+     partialStreams.push(
+       input.slice(jxlpBox.offset + 12, jxlpBox.offset + jxlpBox.size)
+     );
+-    offset = jxlpBox.offset + jxlpBox.size;
++    offset = jxlpBox.offset + (jxlpBox.size > 0 ? jxlpBox.size : 8);
+   }
+   return partialStreams;
+ }
+diff --git a/dist/lookup.cjs b/dist/lookup.cjs
+index 9731ad8bb0949f8fdf9297851bdb312e91282f01..815a73048829588dfbaf612494496c5ee0f926a4 100644
+--- a/dist/lookup.cjs
++++ b/dist/lookup.cjs
+@@ -171,7 +171,7 @@ var HEIF = {
+         width = rawWidth - cropRight;
+       }
+       images.push({ height, width });
+-      currentOffset = ispeBox.offset + ispeBox.size;
++      currentOffset = ispeBox.offset + (ispeBox.size > 0 ? ispeBox.size : 8);
+     }
+     if (images.length === 0) {
+       throw new TypeError("Invalid HEIF, no sizes found");
+@@ -253,7 +253,7 @@ var ICNS = {
+       const imageHeader = readImageHeader(input, imageOffset);
+       const imageSize2 = getImageSize2(imageHeader[0]);
+       images.push(imageSize2);
+-      imageOffset += imageHeader[1];
++      imageOffset += imageHeader[1] > 0 ? imageHeader[1] : 8;
+     }
+     if (images.length === 0) {
+       throw new TypeError("Invalid ICNS, no sizes found");
+@@ -488,7 +488,7 @@ function extractPartialStreams(input) {
+     partialStreams.push(
+       input.slice(jxlpBox.offset + 12, jxlpBox.offset + jxlpBox.size)
+     );
+-    offset = jxlpBox.offset + jxlpBox.size;
++    offset = jxlpBox.offset + (jxlpBox.size > 0 ? jxlpBox.size : 8);
+   }
+   return partialStreams;
+ }
+diff --git a/dist/lookup.mjs b/dist/lookup.mjs
+index f787d1c8408d7b681fec8617595d058f66959869..f580ed250206423b387ebcae3feac8676eb7e695 100644
+--- a/dist/lookup.mjs
++++ b/dist/lookup.mjs
+@@ -169,7 +169,7 @@ var HEIF = {
+         width = rawWidth - cropRight;
+       }
+       images.push({ height, width });
+-      currentOffset = ispeBox.offset + ispeBox.size;
++      currentOffset = ispeBox.offset + (ispeBox.size > 0 ? ispeBox.size : 8);
+     }
+     if (images.length === 0) {
+       throw new TypeError("Invalid HEIF, no sizes found");
+@@ -251,7 +251,7 @@ var ICNS = {
+       const imageHeader = readImageHeader(input, imageOffset);
+       const imageSize2 = getImageSize2(imageHeader[0]);
+       images.push(imageSize2);
+-      imageOffset += imageHeader[1];
++      imageOffset += imageHeader[1] > 0 ? imageHeader[1] : 8;
+     }
+     if (images.length === 0) {
+       throw new TypeError("Invalid ICNS, no sizes found");
+@@ -486,7 +486,7 @@ function extractPartialStreams(input) {
+     partialStreams.push(
+       input.slice(jxlpBox.offset + 12, jxlpBox.offset + jxlpBox.size)
+     );
+-    offset = jxlpBox.offset + jxlpBox.size;
++    offset = jxlpBox.offset + (jxlpBox.size > 0 ? jxlpBox.size : 8);
+   }
+   return partialStreams;
+ }
+diff --git a/dist/types/heif.cjs b/dist/types/heif.cjs
+index 1f490788ea654ea9896060a5c0253d81e348af92..cb49c5648afe835964978e3cf53b98c5883ef6ed 100644
+--- a/dist/types/heif.cjs
++++ b/dist/types/heif.cjs
+@@ -69,7 +69,7 @@ var HEIF = {
+         width = rawWidth - cropRight;
+       }
+       images.push({ height, width });
+-      currentOffset = ispeBox.offset + ispeBox.size;
++      currentOffset = ispeBox.offset + (ispeBox.size > 0 ? ispeBox.size : 8);
+     }
+     if (images.length === 0) {
+       throw new TypeError("Invalid HEIF, no sizes found");
+diff --git a/dist/types/heif.mjs b/dist/types/heif.mjs
+index 01330919e01b3c034a96a7b4b1dbf5a7f658bb2d..57f4d1faf7c2365757c833f7fde3cd5729efde48 100644
+--- a/dist/types/heif.mjs
++++ b/dist/types/heif.mjs
+@@ -67,7 +67,7 @@ var HEIF = {
+         width = rawWidth - cropRight;
+       }
+       images.push({ height, width });
+-      currentOffset = ispeBox.offset + ispeBox.size;
++      currentOffset = ispeBox.offset + (ispeBox.size > 0 ? ispeBox.size : 8);
+     }
+     if (images.length === 0) {
+       throw new TypeError("Invalid HEIF, no sizes found");
+diff --git a/dist/types/icns.cjs b/dist/types/icns.cjs
+index 32c8d370dcf80a10f14a6deebfdbe04d3c70585c..1c0690e0982327a56b4401a0de05509c89deb778 100644
+--- a/dist/types/icns.cjs
++++ b/dist/types/icns.cjs
+@@ -74,7 +74,7 @@ var ICNS = {
+       const imageHeader = readImageHeader(input, imageOffset);
+       const imageSize = getImageSize(imageHeader[0]);
+       images.push(imageSize);
+-      imageOffset += imageHeader[1];
++      imageOffset += imageHeader[1] > 0 ? imageHeader[1] : 8;
+     }
+     if (images.length === 0) {
+       throw new TypeError("Invalid ICNS, no sizes found");
+diff --git a/dist/types/icns.mjs b/dist/types/icns.mjs
+index 8710027bc5890a79d05a7fdb87de3018e556729e..f3becc784b73b40fa5c4eebf78444572e7969b47 100644
+--- a/dist/types/icns.mjs
++++ b/dist/types/icns.mjs
+@@ -72,7 +72,7 @@ var ICNS = {
+       const imageHeader = readImageHeader(input, imageOffset);
+       const imageSize = getImageSize(imageHeader[0]);
+       images.push(imageSize);
+-      imageOffset += imageHeader[1];
++      imageOffset += imageHeader[1] > 0 ? imageHeader[1] : 8;
+     }
+     if (images.length === 0) {
+       throw new TypeError("Invalid ICNS, no sizes found");
+diff --git a/dist/types/index.cjs b/dist/types/index.cjs
+index 6949cd134db7ab59dae7b804b36c7bacb4e387cf..3fe762c6393f448a1179332c0b0c1f90a083dd67 100644
+--- a/dist/types/index.cjs
++++ b/dist/types/index.cjs
+@@ -171,7 +171,7 @@ var HEIF = {
+         width = rawWidth - cropRight;
+       }
+       images.push({ height, width });
+-      currentOffset = ispeBox.offset + ispeBox.size;
++      currentOffset = ispeBox.offset + (ispeBox.size > 0 ? ispeBox.size : 8);
+     }
+     if (images.length === 0) {
+       throw new TypeError("Invalid HEIF, no sizes found");
+@@ -253,7 +253,7 @@ var ICNS = {
+       const imageHeader = readImageHeader(input, imageOffset);
+       const imageSize = getImageSize2(imageHeader[0]);
+       images.push(imageSize);
+-      imageOffset += imageHeader[1];
++      imageOffset += imageHeader[1] > 0 ? imageHeader[1] : 8;
+     }
+     if (images.length === 0) {
+       throw new TypeError("Invalid ICNS, no sizes found");
+@@ -488,7 +488,7 @@ function extractPartialStreams(input) {
+     partialStreams.push(
+       input.slice(jxlpBox.offset + 12, jxlpBox.offset + jxlpBox.size)
+     );
+-    offset = jxlpBox.offset + jxlpBox.size;
++    offset = jxlpBox.offset + (jxlpBox.size > 0 ? jxlpBox.size : 8);
+   }
+   return partialStreams;
+ }
+diff --git a/dist/types/index.mjs b/dist/types/index.mjs
+index b026dda4aa16c6077a76e4b3cfe3f54fe1d6d1d0..d93db0b06eb3adf61659234b6f90361279e3bad6 100644
+--- a/dist/types/index.mjs
++++ b/dist/types/index.mjs
+@@ -169,7 +169,7 @@ var HEIF = {
+         width = rawWidth - cropRight;
+       }
+       images.push({ height, width });
+-      currentOffset = ispeBox.offset + ispeBox.size;
++      currentOffset = ispeBox.offset + (ispeBox.size > 0 ? ispeBox.size : 8);
+     }
+     if (images.length === 0) {
+       throw new TypeError("Invalid HEIF, no sizes found");
+@@ -251,7 +251,7 @@ var ICNS = {
+       const imageHeader = readImageHeader(input, imageOffset);
+       const imageSize = getImageSize2(imageHeader[0]);
+       images.push(imageSize);
+-      imageOffset += imageHeader[1];
++      imageOffset += imageHeader[1] > 0 ? imageHeader[1] : 8;
+     }
+     if (images.length === 0) {
+       throw new TypeError("Invalid ICNS, no sizes found");
+@@ -486,7 +486,7 @@ function extractPartialStreams(input) {
+     partialStreams.push(
+       input.slice(jxlpBox.offset + 12, jxlpBox.offset + jxlpBox.size)
+     );
+-    offset = jxlpBox.offset + jxlpBox.size;
++    offset = jxlpBox.offset + (jxlpBox.size > 0 ? jxlpBox.size : 8);
+   }
+   return partialStreams;
+ }
+diff --git a/dist/types/jxl.cjs b/dist/types/jxl.cjs
+index a12095be85c7a8fd25763895a47c46b4292ebd9c..93d5f01aa4362808248d5492789a2fc3b3ca60a4 100644
+--- a/dist/types/jxl.cjs
++++ b/dist/types/jxl.cjs
+@@ -119,7 +119,7 @@ function extractPartialStreams(input) {
+     partialStreams.push(
+       input.slice(jxlpBox.offset + 12, jxlpBox.offset + jxlpBox.size)
+     );
+-    offset = jxlpBox.offset + jxlpBox.size;
++    offset = jxlpBox.offset + (jxlpBox.size > 0 ? jxlpBox.size : 8);
+   }
+   return partialStreams;
+ }
+diff --git a/dist/types/jxl.mjs b/dist/types/jxl.mjs
+index 49b0c4cac6abb366378e5feed745f16981b441c0..24daee333740e2b80149165869a5033b99da8592 100644
+--- a/dist/types/jxl.mjs
++++ b/dist/types/jxl.mjs
+@@ -117,7 +117,7 @@ function extractPartialStreams(input) {
+     partialStreams.push(
+       input.slice(jxlpBox.offset + 12, jxlpBox.offset + jxlpBox.size)
+     );
+-    offset = jxlpBox.offset + jxlpBox.size;
++    offset = jxlpBox.offset + (jxlpBox.size > 0 ? jxlpBox.size : 8);
+   }
+   return partialStreams;
+ }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   '@types/react': 19.2.17
   '@types/react-dom': 19.2.3
   hono: ^4.12.25
-  dompurify: ^3.4.11
+  dompurify: ^3.4.13
   esbuild: ^0.28.1
   js-yaml@4.1.1: ^4.2.0
   postcss@8.4.31: ^8.5.16
@@ -19,6 +19,10 @@ overrides:
   valibot@1.2.0: ^1.4.2
   js-yaml@3.14.2: 3.15.1
   uuid@8.3.2: 11.1.1
+  nanoid@5.1.5: ^5.1.16
+
+patchedDependencies:
+  image-size@2.0.2: 77c12533e3a635c4066c55da8952f4912e8210416539dc1249550fa639271595
 
 importers:
 
@@ -5681,8 +5685,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -7500,8 +7504,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.1.5:
-    resolution: {integrity: sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==}
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -14411,7 +14415,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -15003,7 +15007,7 @@ snapshots:
       '@sitespeed.io/tracium': 0.3.3
       commander: 12.0.0
       find-chrome-bin: 2.0.4
-      nanoid: 5.1.5
+      nanoid: 5.1.16
       puppeteer-core: 24.22.0
     transitivePeerDependencies:
       - bare-abort-controller
@@ -15656,7 +15660,7 @@ snapshots:
 
   ignore@7.0.6: {}
 
-  image-size@2.0.2: {}
+  image-size@2.0.2(patch_hash=77c12533e3a635c4066c55da8952f4912e8210416539dc1249550fa639271595): {}
 
   image-ssim@0.2.0: {}
 
@@ -16529,7 +16533,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.21
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       es-toolkit: 1.49.0
       katex: 0.16.47
       khroma: 2.1.0
@@ -16886,7 +16890,7 @@ snapshots:
 
   nanoid@3.3.17: {}
 
-  nanoid@5.1.5: {}
+  nanoid@5.1.16: {}
 
   nanospinner@1.2.2:
     dependencies:
@@ -19124,7 +19128,7 @@ snapshots:
   vite-plugin-storybook-nextjs@3.3.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(storybook@10.5.2(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.7))(typescript@5.9.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@next/env': 16.0.0
-      image-size: 2.0.2
+      image-size: 2.0.2(patch_hash=77c12533e3a635c4066c55da8952f4912e8210416539dc1249550fa639271595)
       magic-string: 0.30.21
       module-alias: 2.3.4
       next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -19139,7 +19143,7 @@ snapshots:
   vite-plugin-storybook-nextjs@3.3.0(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(storybook@10.5.2(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.7))(typescript@5.9.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@next/env': 16.0.0
-      image-size: 2.0.2
+      image-size: 2.0.2(patch_hash=77c12533e3a635c4066c55da8952f4912e8210416539dc1249550fa639271595)
       magic-string: 0.30.21
       module-alias: 2.3.4
       next: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -19154,7 +19158,7 @@ snapshots:
   vite-plugin-storybook-nextjs@3.3.0(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(storybook@10.5.6(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.7))(typescript@5.9.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@next/env': 16.0.0
-      image-size: 2.0.2
+      image-size: 2.0.2(patch_hash=77c12533e3a635c4066c55da8952f4912e8210416539dc1249550fa639271595)
       magic-string: 0.30.21
       module-alias: 2.3.4
       next: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,11 @@ allowBuilds:
   sharp: true
   supabase: true
   unrs-resolver: true
+auditConfig:
+  # image-size 2.0.2 に未リリースの上流修正を適用済みの advisory だけを除外する
+  ignoreGhsas:
+    - GHSA-w3rx-r6r6-pgpr
+    - GHSA-5p2g-fcmc-qvqq
 overrides:
   tar: '^7.5.4'
   tmp: '^0.2.4'
@@ -17,7 +22,7 @@ overrides:
   # security: Dependabot alerts解消 (#1569)
   # 同一 major に閉じる `^` で上限を付け、意図せぬメジャー更新を防ぐ
   hono: '^4.12.25'
-  dompurify: '^3.4.11'
+  dompurify: '^3.4.13'
   esbuild: '^0.28.1'
   'js-yaml@4.1.1': '^4.2.0'
   'postcss@8.4.31': '^8.5.16'
@@ -27,3 +32,9 @@ overrides:
   'valibot@1.2.0': '^1.4.2'
   'js-yaml@3.14.2': '3.15.1'
   'uuid@8.3.2': '11.1.1'
+  # estimo が 5.1.5 を exact pin しているため、脆弱な v5 だけを置換する
+  'nanoid@5.1.5': '^5.1.16'
+# image-size 2.0.2 の未リリース上流修正を固定する。
+# GHSA-w3rx-r6r6-pgpr / GHSA-5p2g-fcmc-qvqq は patchedDependencies で緩和済み。
+patchedDependencies:
+  image-size@2.0.2: patches/image-size@2.0.2.patch

--- a/scripts/__tests__/image-size-security-patch.test.ts
+++ b/scripts/__tests__/image-size-security-patch.test.ts
@@ -1,0 +1,198 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const rootRequire = createRequire(resolve(process.cwd(), 'package.json'));
+const storybookRequire = createRequire(rootRequire.resolve('@storybook/nextjs-vite/package.json'));
+const imageSizeEntry = storybookRequire.resolve('image-size');
+const imageSizeDistDirectory = dirname(imageSizeEntry);
+const fixtureDirectory = mkdtempSync(join(tmpdir(), 'dayopt-image-size-security-'));
+
+const terminationProbe = String.raw`
+  const { pathToFileURL } = require('node:url');
+
+  (async () => {
+    const [entrypoint, moduleMode, operation, exportName, inputArgument] =
+      process.argv.slice(1);
+    let loadedModule;
+    try {
+      loadedModule =
+        moduleMode === 'import'
+          ? await import(pathToFileURL(entrypoint).href)
+          : require(entrypoint);
+    } catch (error) {
+      console.error(error);
+      process.exitCode = 2;
+      return;
+    }
+
+    try {
+      if (operation === 'buffer') {
+        loadedModule.imageSize(Buffer.from(inputArgument, 'base64'));
+      } else if (operation === 'file') {
+        await loadedModule.imageSizeFromFile(inputArgument);
+      } else {
+        loadedModule[exportName].calculate(Buffer.from(inputArgument, 'base64'));
+      }
+    } catch {
+      // Malformed files may be rejected; the security contract is prompt termination.
+    }
+    process.stdout.write('terminated');
+  })();
+`;
+
+function makeIcnsWithZeroLengthEntry(): Buffer {
+  const input = Buffer.alloc(16);
+  input.write('icns', 0, 'ascii');
+  input.writeUInt32BE(input.length, 4);
+  input.write('ic07', 8, 'ascii');
+  input.writeUInt32BE(0, 12);
+  return input;
+}
+
+function makeJxlWithZeroLengthPartialStream(): Buffer {
+  const input = Buffer.alloc(32);
+  input.writeUInt32BE(12, 0);
+  input.write('JXL ', 4, 'ascii');
+  input.writeUInt32BE(12, 12);
+  input.write('ftyp', 16, 'ascii');
+  input.write('jxl ', 20, 'ascii');
+  input.writeUInt32BE(0, 24);
+  input.write('jxlp', 28, 'ascii');
+  return input;
+}
+
+function makeHeifWithZeroLengthImageProperty(): Buffer {
+  const input = Buffer.alloc(64);
+  input.writeUInt32BE(16, 0);
+  input.write('ftyp', 4, 'ascii');
+  input.write('heic', 8, 'ascii');
+  input.writeUInt32BE(48, 16);
+  input.write('meta', 20, 'ascii');
+  input.writeUInt32BE(36, 28);
+  input.write('iprp', 32, 'ascii');
+  input.writeUInt32BE(28, 36);
+  input.write('ipco', 40, 'ascii');
+  input.writeUInt32BE(0, 44);
+  input.write('ispe', 48, 'ascii');
+  input.writeUInt32BE(1, 56);
+  input.writeUInt32BE(1, 60);
+  return input;
+}
+
+const maliciousCases = [
+  {
+    format: 'ICNS',
+    input: makeIcnsWithZeroLengthEntry(),
+    typeExport: 'ICNS',
+    typeFile: 'icns',
+  },
+  {
+    format: 'JXL',
+    input: makeJxlWithZeroLengthPartialStream(),
+    typeExport: 'JXL',
+    typeFile: 'jxl',
+  },
+  {
+    format: 'HEIF',
+    input: makeHeifWithZeroLengthImageProperty(),
+    typeExport: 'HEIF',
+    typeFile: 'heif',
+  },
+] as const;
+
+const moduleVariants = [
+  { extension: 'cjs', label: 'CommonJS', mode: 'require' },
+  { extension: 'mjs', label: 'ESM', mode: 'import' },
+] as const;
+
+type ProbeTarget = {
+  entrypoint: string;
+  exportName?: string;
+  inputArgument: string;
+  moduleMode: 'import' | 'require';
+  operation: 'buffer' | 'file' | 'type';
+};
+
+function expectPromptTermination({
+  entrypoint,
+  exportName = '',
+  inputArgument,
+  moduleMode,
+  operation,
+}: ProbeTarget): void {
+  const result = spawnSync(
+    process.execPath,
+    ['-e', terminationProbe, entrypoint, moduleMode, operation, exportName, inputArgument],
+    {
+      encoding: 'utf8',
+      timeout: 2000,
+    },
+  );
+
+  expect(result.error?.message ?? '').not.toContain('ETIMEDOUT');
+  expect(result.signal).toBeNull();
+  expect(result.status).toBe(0);
+  expect(result.stderr).toBe('');
+  expect(result.stdout).toBe('terminated');
+}
+
+afterAll(() => {
+  rmSync(fixtureDirectory, { force: true, recursive: true });
+});
+
+describe('image-size security patch', () => {
+  for (const variant of moduleVariants) {
+    describe(variant.label, () => {
+      it.each(maliciousCases)('terminates via root entry for $format', ({ input }) => {
+        expectPromptTermination({
+          entrypoint: join(imageSizeDistDirectory, `index.${variant.extension}`),
+          inputArgument: input.toString('base64'),
+          moduleMode: variant.mode,
+          operation: 'buffer',
+        });
+      });
+
+      it.each(maliciousCases)('terminates via fromFile entry for $format', ({ format, input }) => {
+        const fixturePath = join(fixtureDirectory, `${format.toLowerCase()}-zero-length.bin`);
+        writeFileSync(fixturePath, input);
+
+        expectPromptTermination({
+          entrypoint: join(imageSizeDistDirectory, `fromFile.${variant.extension}`),
+          inputArgument: fixturePath,
+          moduleMode: variant.mode,
+          operation: 'file',
+        });
+      });
+
+      it.each(maliciousCases)(
+        'terminates via type entry for $format',
+        ({ input, typeExport, typeFile }) => {
+          expectPromptTermination({
+            entrypoint: join(imageSizeDistDirectory, 'types', `${typeFile}.${variant.extension}`),
+            exportName: typeExport,
+            inputArgument: input.toString('base64'),
+            moduleMode: variant.mode,
+            operation: 'type',
+          });
+        },
+      );
+    });
+  }
+
+  it('preserves valid image detection', () => {
+    const validPng = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+      'base64',
+    );
+    const { imageSize } = storybookRequire(imageSizeEntry) as {
+      imageSize: (input: Uint8Array) => { height: number; type: string; width: number };
+    };
+
+    expect(imageSize(validPng)).toMatchObject({ height: 1, type: 'png', width: 1 });
+  });
+});


### PR DESCRIPTION
## 概要

直近48時間のPRレビューで再検出した、間接依存の新規advisoryを解消します。

- DOMPurifyを3.4.13へ更新
- estimoが固定するnanoid 5.1.5だけを5.1.16へ置換
- 修正版未リリースのimage-size 2.0.2へ上流のゼロ長box修正を局所適用
- 局所修正済みの2 GHSAだけを監査除外し、理由を運用文書に固定

## 背景

PR #1855 の時点では依存監査は0件でしたが、その後advisory DBが更新されました。image-sizeは公開済み修正版がないため、単なる監査除外ではなく、ICNS/JXL/HEIFのゼロ長boxでparserが前進しない箇所へ上流修正を適用しています。

対象:

- GHSA-55q2-fjhq-7xh7
- GHSA-28wg-ghj8-5hjv
- GHSA-2v37-7h3g-55p8
- GHSA-w3rx-r6r6-pgpr
- GHSA-5p2g-fcmc-qvqq

## 検証

- 修正前: ICNS/JXL/HEIFの悪性入力3種が750msでtimeoutすることを再現
- `pnpm check`（Node 24.19.0）: success
  - Product 308 files / 3014 tests
  - Web 39 files / 272 tests
  - Scripts 24 files / 395 tests
- image-size回帰: root / fromFile / type entryをCJS・ESMで検証、19 tests passed
- `pnpm security:check`: exit 0（局所修正済み2件のみignored）
- `pnpm security:check:production`: 既知脆弱性0件
- `pnpm install --frozen-lockfile`: success
- `pnpm build-storybook`: success
- risk-reviewer反証レビュー: P1/P2なし
