### PR TITLE
fix(timeblock): 見積もり係数を直近4週に限定する

### DIFF
--- a/apps/product/src/features/timeblock/server/__tests__/statistics-feedforward-service.test.ts
+++ b/apps/product/src/features/timeblock/server/__tests__/statistics-feedforward-service.test.ts
@@ -55,7 +55,7 @@ function buildPair(index: number, actualMinutes = 90) {
 }
 
 describe('StatisticsFeedforwardService', () => {
-  it('4 週窓は plan.start_at に対して切る（record の発生時刻では切らない）', async () => {
+  it('4 週窓は plan.start_at の [28 日前, now) で切る（record の発生時刻では切らない）', async () => {
     const { plansMock, service } = createService([], []);
 
     await service.getTagEstimationFactors(USER_ID, NOW);
@@ -67,7 +67,9 @@ describe('StatisticsFeedforwardService', () => {
       NOW.getTime() - ESTIMATION_WINDOW_DAYS * 24 * 60 * 60 * 1000,
     ).toISOString();
     expect(plansMock.gte).toHaveBeenCalledWith('start_at', expectedStart);
+    expect(plansMock.lt).toHaveBeenCalledWith('start_at', NOW.toISOString());
     expect(plansMock.gte).toHaveBeenCalledTimes(1);
+    expect(plansMock.lt).toHaveBeenCalledTimes(1);
   });
 
   it('窓は 28 日（ADR-026 の「直近 4 週」）', () => {

--- a/apps/product/src/features/timeblock/server/statistics-feedforward-service.ts
+++ b/apps/product/src/features/timeblock/server/statistics-feedforward-service.ts
@@ -16,7 +16,7 @@ import { fetchPlansForEstimation, fetchRecordsByPlanIds } from './statistics-fet
 import { minutesBetween } from './statistics-service-grouping';
 import type { ServiceSupabaseClient } from './types';
 
-/** ADR-026 の「直近 4 週」。`plans.start_at` に対して切る。 */
+/** ADR-026 の「直近 4 週」。`plans.start_at` の [now - 28 日, now) で切る。 */
 export const ESTIMATION_WINDOW_DAYS = 28;
 
 export class StatisticsFeedforwardService {
@@ -30,7 +30,8 @@ export class StatisticsFeedforwardService {
    */
   async getTagEstimationFactors(userId: string, now = new Date()): Promise<TagEstimationFactor[]> {
     const startDate = new Date(now.getTime() - ESTIMATION_WINDOW_DAYS * MS_PER_DAY).toISOString();
-    const plans = await fetchPlansForEstimation(this.supabase, userId, { startDate });
+    const endDate = now.toISOString();
+    const plans = await fetchPlansForEstimation(this.supabase, userId, { startDate, endDate });
     if (plans.length === 0) return [];
 
     const records = await fetchRecordsByPlanIds(


### PR DESCRIPTION
## 概要

直近48時間のPRレビューで見つかった PR #1865 の期間上限漏れを修正します。

- タグ別見積もり係数の Plan 取得範囲を `[now - 28日, now)` に限定
- 同一の注入済み `now` から開始・終了時刻を生成
- 将来 Plan を除外する回帰テストを追加

## 背景

これまでは `plans.start_at >= now - 28日` の下限だけを渡していたため、将来の Plan も「直近4週」の母集団に含まれていました。将来 Plan には実績 Record を紐付けられないため、不要な Plan ID の取得と Record 検索を増やし、件数上限に達した場合は係数を欠落・歪曲させる可能性がありました。

## 検証

- 修正前: 回帰テストで `lt('start_at', now)` が0回となることを再現
- 対象テスト: 6 tests passed
- `pnpm check`（Node 24.19.0）: success
  - Product 308 files / 3014 tests
  - Web 39 files / 272 tests
  - Scripts 24 files / 395 tests
- 時刻境界の反証レビュー: P1/P2なし
