### PR TITLE
fix(calendar): 検索結果遷移と現行ナビゲーションを安定化する

### DIFF
--- a/apps/product/src/app/[locale]/(app)/_overlays/GlobalOverlays.tsx
+++ b/apps/product/src/app/[locale]/(app)/_overlays/GlobalOverlays.tsx
@@ -10,20 +10,18 @@ import { ShortcutCheatSheetDialog } from '@/components/ui/overlays/shortcut-chea
 import {
   CalendarViewType,
   buildCalendarReviewPanelPath,
-  buildTimeblockSearchResultPath,
   isCalendarViewPath,
-  resolveTimeblockSearchResultDate,
   useCalendarNavigation,
   useShortcutRegistry,
   useTimeblockClipboardStore,
   useTimeblockSearchShortcut,
-  type TimeblockSearchResult,
 } from '@/features/calendar';
 import { useTimeblockInspectorStore, type ClipboardTimeblock } from '@/features/timeblock';
 import { useUserPreferences } from '@/lib/hooks/useUserPreferences';
 import { useShellStore } from '@/lib/stores/useShellStore';
 import { toast } from '@/lib/toast';
 import { APP_SHORTCUT_CATALOG } from './app-shortcut-catalog';
+import { useTimeblockSearchResultNavigation } from './useTimeblockSearchResultNavigation';
 
 const ContactDialog = dynamic(
   () =>
@@ -153,23 +151,13 @@ export function GlobalOverlays() {
     [closeTimeblockSearch, openTimeblockSearch],
   );
 
-  const handleOpenSearchResult = useCallback(
-    (result: TimeblockSearchResult) => {
-      calendarNavigation?.navigateToDate(
-        resolveTimeblockSearchResultDate(result.startAt, timezone),
-      );
-      router.push(
-        buildTimeblockSearchResultPath({
-          locale,
-          startAt: result.startAt,
-          timezone,
-          timeblockId: result.id,
-          kind: result.kind,
-        }),
-      );
-    },
-    [calendarNavigation, locale, router, timezone],
-  );
+  const handleOpenSearchResult = useTimeblockSearchResultNavigation({
+    calendarNavigation,
+    locale,
+    timezone,
+    timeblockSearchOpen,
+    isInspectorOpen,
+  });
 
   return (
     <>

--- a/apps/product/src/app/[locale]/(app)/_overlays/__tests__/useTimeblockSearchResultNavigation.test.ts
+++ b/apps/product/src/app/[locale]/(app)/_overlays/__tests__/useTimeblockSearchResultNavigation.test.ts
@@ -1,0 +1,118 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { TimeblockSearchResult } from '@/features/calendar';
+
+const routerPush = vi.hoisted(() => vi.fn());
+
+vi.mock('next/navigation', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('next/navigation')>()),
+  useRouter: () => ({ push: routerPush }),
+}));
+
+import { useTimeblockSearchResultNavigation } from '../useTimeblockSearchResultNavigation';
+
+const RESULT: TimeblockSearchResult = {
+  kind: 'record',
+  id: 'record-1',
+  note: 'Search result',
+  tagId: 'tag-1',
+  startAt: '2026-07-14T01:30:00.000Z',
+  endAt: '2026-07-14T02:30:00.000Z',
+  isSkipped: false,
+};
+
+describe('useTimeblockSearchResultNavigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.history.replaceState(null, '', '/ja/day?date=2026-08-09');
+  });
+
+  it('対象日の描画とoverlay終了後にだけ検索結果URLを1回公開する', async () => {
+    const navigateToDate = vi.fn();
+    const pushState = vi.spyOn(window.history, 'pushState');
+    const initialDate = new Date(2026, 7, 9, 12);
+
+    const { result, rerender } = renderHook(
+      ({ currentDate, searchOpen, inspectorOpen }) =>
+        useTimeblockSearchResultNavigation({
+          calendarNavigation: { currentDate, navigateToDate },
+          locale: 'ja',
+          timezone: 'Asia/Tokyo',
+          timeblockSearchOpen: searchOpen,
+          isInspectorOpen: inspectorOpen,
+        }),
+      {
+        initialProps: {
+          currentDate: initialDate,
+          searchOpen: true,
+          inspectorOpen: false,
+        },
+      },
+    );
+
+    act(() => result.current(RESULT));
+
+    expect(navigateToDate).toHaveBeenCalledOnce();
+    expect(pushState).not.toHaveBeenCalled();
+    const targetDate = navigateToDate.mock.calls[0]![0] as Date;
+
+    rerender({ currentDate: initialDate, searchOpen: false, inspectorOpen: false });
+    expect(pushState).not.toHaveBeenCalled();
+
+    rerender({ currentDate: targetDate, searchOpen: false, inspectorOpen: true });
+    expect(pushState).not.toHaveBeenCalled();
+
+    rerender({ currentDate: targetDate, searchOpen: false, inspectorOpen: false });
+    await waitFor(() => expect(pushState).toHaveBeenCalledOnce());
+    expect(window.location.pathname + window.location.search).toBe(
+      '/ja/day?date=2026-07-14&timeblock=record%3Arecord-1',
+    );
+
+    rerender({ currentDate: targetDate, searchOpen: false, inspectorOpen: false });
+    expect(pushState).toHaveBeenCalledOnce();
+  });
+
+  it('CalendarNavigationProvider外ではrouter navigationへfallbackする', () => {
+    const { result } = renderHook(() =>
+      useTimeblockSearchResultNavigation({
+        calendarNavigation: null,
+        locale: 'ja',
+        timezone: 'Asia/Tokyo',
+        timeblockSearchOpen: false,
+        isInspectorOpen: false,
+      }),
+    );
+
+    act(() => result.current(RESULT));
+
+    expect(routerPush).toHaveBeenCalledWith('/ja/day?date=2026-07-14&timeblock=record%3Arecord-1');
+  });
+
+  it('対象日を既に表示中なら不要な日付更新をせず同じ結果を開き直す', async () => {
+    const navigateToDate = vi.fn();
+    const currentDate = new Date(2026, 6, 14, 12);
+
+    const { result, rerender } = renderHook(
+      ({ searchOpen }) =>
+        useTimeblockSearchResultNavigation({
+          calendarNavigation: { currentDate, navigateToDate },
+          locale: 'ja',
+          timezone: 'Asia/Tokyo',
+          timeblockSearchOpen: searchOpen,
+          isInspectorOpen: false,
+        }),
+      { initialProps: { searchOpen: true } },
+    );
+
+    act(() => result.current(RESULT));
+    expect(navigateToDate).not.toHaveBeenCalled();
+
+    rerender({ searchOpen: false });
+    await waitFor(() =>
+      expect(window.location.pathname + window.location.search).toBe(
+        '/ja/day?date=2026-07-14&timeblock=record%3Arecord-1',
+      ),
+    );
+  });
+});

--- a/apps/product/src/app/[locale]/(app)/_overlays/useTimeblockSearchResultNavigation.ts
+++ b/apps/product/src/app/[locale]/(app)/_overlays/useTimeblockSearchResultNavigation.ts
@@ -1,0 +1,85 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useRef } from 'react';
+
+import {
+  buildTimeblockSearchResultPath,
+  resolveTimeblockSearchResultDate,
+  type TimeblockSearchResult,
+} from '@/features/calendar';
+
+interface CalendarSearchNavigation {
+  currentDate: Date;
+  navigateToDate: (date: Date) => void;
+}
+
+interface PendingSearchNavigation {
+  targetDate: Date;
+  targetPath: string;
+}
+
+interface UseTimeblockSearchResultNavigationOptions {
+  calendarNavigation: CalendarSearchNavigation | null;
+  locale: string;
+  timezone: string;
+  timeblockSearchOpen: boolean;
+  isInspectorOpen: boolean;
+}
+
+/** Calendar の描画日を確定してから検索結果の URL と Inspector を公開する。 */
+export function useTimeblockSearchResultNavigation({
+  calendarNavigation,
+  locale,
+  timezone,
+  timeblockSearchOpen,
+  isInspectorOpen,
+}: UseTimeblockSearchResultNavigationOptions) {
+  const router = useRouter();
+  const pendingNavigationRef = useRef<PendingSearchNavigation | null>(null);
+
+  useEffect(() => {
+    const pendingNavigation = pendingNavigationRef.current;
+    if (
+      !pendingNavigation ||
+      !calendarNavigation ||
+      timeblockSearchOpen ||
+      isInspectorOpen ||
+      calendarNavigation.currentDate.getTime() !== pendingNavigation.targetDate.getTime()
+    ) {
+      return;
+    }
+
+    // ref を先に消費し、Next の履歴同期が再レンダーしても履歴を複数回追加しない。
+    pendingNavigationRef.current = null;
+    const currentPath = `${window.location.pathname}${window.location.search}`;
+    if (currentPath !== pendingNavigation.targetPath) {
+      window.history.pushState(null, '', pendingNavigation.targetPath);
+    }
+  }, [calendarNavigation, isInspectorOpen, timeblockSearchOpen]);
+
+  return useCallback(
+    (result: TimeblockSearchResult) => {
+      const targetDate = resolveTimeblockSearchResultDate(result.startAt, timezone);
+      const targetPath = buildTimeblockSearchResultPath({
+        locale,
+        startAt: result.startAt,
+        timezone,
+        timeblockId: result.id,
+        kind: result.kind,
+      });
+
+      // GlobalOverlays は CalendarNavigationProvider 配下だが、型上の null fallback は維持する。
+      if (!calendarNavigation) {
+        router.push(targetPath);
+        return;
+      }
+
+      pendingNavigationRef.current = { targetDate, targetPath };
+      if (calendarNavigation.currentDate.getTime() !== targetDate.getTime()) {
+        calendarNavigation.navigateToDate(targetDate);
+      }
+    },
+    [calendarNavigation, locale, router, timezone],
+  );
+}

--- a/apps/product/src/features/calendar/components/search/TimeblockSearchDialog.tsx
+++ b/apps/product/src/features/calendar/components/search/TimeblockSearchDialog.tsx
@@ -338,8 +338,8 @@ export function TimeblockSearchDialog({
 
   const handleOpenResult = useCallback(
     (result: TimeblockSearchResult) => {
-      onOpenResult(result);
       resetAndClose();
+      onOpenResult(result);
     },
     [onOpenResult, resetAndClose],
   );

--- a/apps/product/src/features/calendar/components/search/__tests__/TimeblockSearchDialog.test.tsx
+++ b/apps/product/src/features/calendar/components/search/__tests__/TimeblockSearchDialog.test.tsx
@@ -173,7 +173,9 @@ describe('TimeblockSearchDialog', () => {
   });
 
   it('結果を選ぶとopen callbackを呼び、検索語をリセットして閉じる', async () => {
-    const props = renderDialog();
+    const onOpenChange = vi.fn();
+    const onOpenResult = vi.fn();
+    renderDialog({ onOpenChange, onOpenResult });
     fireEvent.change(screen.getByRole('combobox'), { target: { value: 'work' } });
 
     await act(async () => {
@@ -182,10 +184,13 @@ describe('TimeblockSearchDialog', () => {
     expect(screen.queryByText('Legacy deep work title')).not.toBeInTheDocument();
     fireEvent.click(screen.getByText('Work'));
 
-    expect(props.onOpenResult).toHaveBeenCalledWith(
+    expect(onOpenResult).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'plan-1', kind: 'plan' }),
     );
-    expect(props.onOpenChange).toHaveBeenCalledWith(false);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onOpenChange.mock.invocationCallOrder[0]).toBeLessThan(
+      onOpenResult.mock.invocationCallOrder[0]!,
+    );
     expect(screen.getByRole('combobox')).toHaveValue('');
   });
 

--- a/apps/product/src/features/timeblock/hooks/__tests__/useInspectorURLSync.test.tsx
+++ b/apps/product/src/features/timeblock/hooks/__tests__/useInspectorURLSync.test.tsx
@@ -4,11 +4,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useTimeblockInspectorStore } from '../../stores/useTimeblockInspectorStore';
 
 const push = vi.hoisted(() => vi.fn());
-const replace = vi.hoisted(() => vi.fn());
 
 vi.mock('next/navigation', () => ({
   usePathname: () => '/ja/day',
-  useRouter: () => ({ push, replace }),
+  useRouter: () => ({ push }),
   useSearchParams: () => new URLSearchParams(window.location.search),
 }));
 
@@ -74,8 +73,25 @@ describe('useInspectorURLSync', () => {
 
     act(() => useTimeblockInspectorStore.getState().closeInspector());
 
-    expect(replace).toHaveBeenLastCalledWith('/ja/day', { scroll: false });
+    expect(window.location.pathname + window.location.search).toBe('/ja/day');
     expect(useTimeblockInspectorStore.getState().isOpen).toBe(false);
+  });
+
+  it('閉じたInspectorと同じURLパラメータを再指定すると開き直す', () => {
+    window.history.replaceState({}, '', '/ja/day?timeblock=record%3Arecord-id');
+    const { rerender } = renderHook(() => useInspectorURLSync());
+
+    act(() => useTimeblockInspectorStore.getState().closeInspector());
+    expect(window.location.pathname + window.location.search).toBe('/ja/day');
+
+    window.history.replaceState({}, '', '/ja/day?timeblock=record%3Arecord-id');
+    rerender();
+
+    expect(useTimeblockInspectorStore.getState()).toMatchObject({
+      timeblockId: 'record-id',
+      timeblockKind: 'record',
+      isOpen: true,
+    });
   });
 
   it('旧log URLは受理しない', () => {

--- a/apps/product/src/features/timeblock/hooks/useInspectorURLSync.ts
+++ b/apps/product/src/features/timeblock/hooks/useInspectorURLSync.ts
@@ -92,7 +92,10 @@ export function useInspectorURLSync() {
         const newUrl = currentParams.toString()
           ? `${currentPathname}?${currentParams.toString()}`
           : currentPathname;
-        router.replace(newUrl, { scroll: false });
+        // 検索overlayから同じblockを即座に選び直しても、古い非同期replaceが
+        // 後着して新しいInspector URLを消さないよう同期的に反映する。
+        previousURLParamRef.current = null;
+        window.history.replaceState(null, '', newUrl);
       }
     }
   }, [isOpen, timeblockId, timeblockKind, pathname, searchParams, router]);

--- a/apps/product/src/lib/test/e2e/block-search.spec.ts
+++ b/apps/product/src/lib/test/e2e/block-search.spec.ts
@@ -173,10 +173,28 @@ describeWithEnv('Block search', () => {
       .poll(() => new URL(page.url()).searchParams.get('timeblock'))
       .toBe(`record:${recordId}`);
     expect(new URL(page.url()).searchParams.get('date')).toBe(recordDate);
+    await expect(
+      page
+        .locator('[data-calendar-grid][data-calendar-day-index="0"] [data-record-lane-card]', {
+          hasText: TAG_NAME,
+        })
+        .first(),
+    ).toBeVisible({ timeout: 10_000 });
     await expect(page.getByRole('dialog', { name: TAG_NAME })).toBeVisible();
 
-    // Inspector は modal dialog なので、開いたまま背後の検索ボタンは押せない。
-    // 実際の導線どおり一度閉じてから次の検索を開く。
+    // Inspectorを閉じた直後に同じblockを検索し直しても、close時のURL cleanupが
+    // 後着して再オープンを打ち消さない。
+    await page.keyboard.press('Escape');
+    await expect(page.getByRole('dialog', { name: TAG_NAME })).toHaveCount(0);
+    await page.getByRole('button', { name: 'ブロックを検索' }).first().click();
+    await page.getByRole('combobox', { name: '予定と記録を検索' }).fill(RECORD_NOTE);
+    await page.getByText(RECORD_NOTE).click();
+    await expect
+      .poll(() => new URL(page.url()).searchParams.get('timeblock'))
+      .toBe(`record:${recordId}`);
+    await expect(page.getByRole('dialog', { name: TAG_NAME })).toBeVisible();
+
+    // Inspector は modal dialog なので、実際の導線どおり一度閉じてから次の検索を開く。
     await page.keyboard.press('Escape');
     await expect(page.getByRole('dialog', { name: TAG_NAME })).toHaveCount(0);
 
@@ -190,6 +208,13 @@ describeWithEnv('Block search', () => {
       .poll(() => new URL(page.url()).searchParams.get('timeblock'))
       .toBe(`plan:${planId}`);
     expect(new URL(page.url()).searchParams.get('date')).toBe(planDate);
+    await expect(
+      page
+        .locator('[data-calendar-grid][data-calendar-day-index="0"] [data-plan-lane-card]', {
+          hasText: TAG_NAME,
+        })
+        .first(),
+    ).toBeVisible({ timeout: 10_000 });
     await expect(page.getByRole('dialog', { name: TAG_NAME })).toBeVisible();
   });
 

--- a/apps/product/src/lib/test/e2e/calendar-navigation.spec.ts
+++ b/apps/product/src/lib/test/e2e/calendar-navigation.spec.ts
@@ -1,0 +1,159 @@
+import { expect, type Page, test } from '@playwright/test';
+import { createClient } from '@supabase/supabase-js';
+
+import type { Database } from '@/lib/database';
+
+import { resolveServiceRoleTarget } from './service-role-target-guard';
+import { suppressConsentBanner } from './suppress-consent-banner';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const SERVICE_ROLE_TARGET = resolveServiceRoleTarget(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+const describeWithEnv = SERVICE_ROLE_TARGET.safe ? test.describe : test.describe.skip;
+
+const TIMEZONE = 'Asia/Tokyo';
+const TEST_DATE = '2026-04-20';
+const TEST_RUN_ID = crypto.randomUUID();
+const TEST_USER_ID = crypto.randomUUID();
+const TEST_EMAIL = `calendar-navigation-${TEST_RUN_ID}@example.com`;
+const TEST_PASSWORD = 'test-password-123';
+
+type SupabaseClient = ReturnType<typeof createClient<Database>>;
+
+async function expectCalendarUrl(
+  page: Page,
+  expected: { pathname: string; date: string; panel?: string | null },
+) {
+  await expect
+    .poll(() => {
+      const url = new URL(page.url());
+      return {
+        pathname: url.pathname,
+        date: url.searchParams.get('date'),
+        panel: url.searchParams.get('panel'),
+      };
+    })
+    .toEqual({
+      pathname: expected.pathname,
+      date: expected.date,
+      panel: expected.panel ?? null,
+    });
+}
+
+async function login(page: Page) {
+  await suppressConsentBanner(page);
+  await page.goto('/ja/auth/login');
+  await page.locator('input[type="email"], input[name="email"]').first().fill(TEST_EMAIL);
+  await page.locator('input[type="password"]').first().fill(TEST_PASSWORD);
+  await page.locator('button[type="submit"]').first().click();
+  await page.waitForURL(/\/ja\/(day|week)/i, { timeout: 15_000 });
+  await expect(page.locator('[data-calendar-grid]').first()).toBeVisible({ timeout: 10_000 });
+}
+
+describeWithEnv('Calendar navigation', () => {
+  test.describe.configure({ mode: 'serial' });
+  test.use({ timezoneId: TIMEZONE });
+
+  let adminSupabase: SupabaseClient;
+
+  test.beforeAll(async () => {
+    adminSupabase = createClient<Database>(SUPABASE_URL!, SUPABASE_SERVICE_KEY!, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    const { error: authError } = await adminSupabase.auth.admin.createUser({
+      id: TEST_USER_ID,
+      email: TEST_EMAIL,
+      password: TEST_PASSWORD,
+      email_confirm: true,
+      user_metadata: { full_name: 'calendar navigation e2e' },
+    });
+    if (authError && !authError.message.includes('already exists')) {
+      throw new Error(authError.message);
+    }
+
+    await adminSupabase.from('profiles').upsert({
+      id: TEST_USER_ID,
+      email: TEST_EMAIL,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+    await adminSupabase.from('user_settings').upsert({
+      user_id: TEST_USER_ID,
+      timezone: TIMEZONE,
+      preferred_locale: 'ja',
+      default_view: 'day',
+      default_duration: 60,
+      time_format: '24h',
+      week_starts_on: 1,
+    });
+  });
+
+  test.afterAll(async () => {
+    if (!adminSupabase) return;
+    await adminSupabase.from('user_settings').delete().eq('user_id', TEST_USER_ID);
+    await adminSupabase.from('profiles').delete().eq('id', TEST_USER_ID);
+    await adminSupabase.auth.admin.deleteUser(TEST_USER_ID);
+  });
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name.includes('Mobile'), 'desktop-only');
+    await login(page);
+    await page.goto(`/ja/day?date=${TEST_DATE}`);
+    await expect(page.locator('[data-calendar-grid]').first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('Review panelとviewを実UI操作・reload・browser backで復元する', async ({ page }) => {
+    const reviewToggle = page.getByRole('button', { name: '振り返りパネルを切り替え' });
+    const reviewPanel = page.getByRole('region', { name: '振り返り' });
+
+    await reviewToggle.click();
+    await expectCalendarUrl(page, { pathname: '/ja/day', date: TEST_DATE, panel: 'review' });
+    await expect(reviewToggle).toHaveAttribute('aria-pressed', 'true');
+    await expect(reviewPanel).toBeVisible();
+
+    await page.reload();
+    await expect(page.locator('[data-calendar-grid]').first()).toBeVisible({ timeout: 10_000 });
+    await expectCalendarUrl(page, { pathname: '/ja/day', date: TEST_DATE, panel: 'review' });
+    await expect(reviewToggle).toHaveAttribute('aria-pressed', 'true');
+    await expect(reviewPanel).toBeVisible();
+
+    await reviewPanel.getByRole('button', { name: '閉じる' }).click();
+    await expectCalendarUrl(page, { pathname: '/ja/day', date: TEST_DATE });
+    await expect(reviewPanel).toHaveCount(0);
+
+    await page.getByRole('button', { name: '日', exact: true }).click();
+    await page.getByRole('menuitem', { name: /^3日\s*3$/ }).click();
+    await expectCalendarUrl(page, { pathname: '/ja/3day', date: TEST_DATE });
+    await expect(page.locator('[data-calendar-grid]')).toHaveCount(3);
+
+    await page.goBack();
+    await expectCalendarUrl(page, { pathname: '/ja/day', date: TEST_DATE });
+    await expect(page.locator('[data-calendar-grid]')).toHaveCount(1);
+    await expect(page.getByRole('button', { name: '日', exact: true })).toBeVisible();
+  });
+
+  test('sidebarのclose/open状態をreload後も復元する', async ({ page }) => {
+    await expect(page.getByRole('complementary').first()).toBeVisible();
+
+    await page.getByRole('button', { name: 'サイドバーを閉じる' }).click();
+    await expect(page.getByRole('complementary')).toHaveCount(0);
+    const openSidebar = page.getByRole('button', {
+      name: /^(Open sidebar|サイドバーを開く)$/,
+    });
+    await expect(openSidebar).toBeVisible();
+
+    await page.reload();
+    await expect(page.locator('[data-calendar-grid]').first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole('complementary')).toHaveCount(0);
+    await expect(openSidebar).toBeVisible();
+    await openSidebar.click();
+    await expect(page.getByRole('complementary').first()).toBeVisible();
+    await expect(page.getByRole('button', { name: 'サイドバーを閉じる' })).toBeVisible();
+
+    await page.reload();
+    await expect(page.locator('[data-calendar-grid]').first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole('complementary').first()).toBeVisible();
+    await expect(page.getByRole('button', { name: 'サイドバーを閉じる' })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## 概要

- 検索結果を選んだとき、検索overlayを先に閉じ、対象日の描画と既存Inspectorのcleanup完了後に結果URLを公開するよう変更
- 同一日の同一blockを再検索した場合も、不要な日付更新と遅延URL cleanupでInspectorが閉じないよう修正
- 現行CalendarのReview panel・3日表示・browser back・sidebar永続化を実UIで検証するE2Eを追加

## 原因

検索結果選択時に日付変更とInspector URL公開を同時に行っていたため、既存の日付変更cleanupが新しいInspectorを後から閉じ、URLとCalendar描画日がずれるraceがありました。同一日でも新しいDate objectを設定すると同じcleanupが走り、同じblockの再選択を打ち消す境界もありました。

## 検証

- `pnpm check`（Node 24）: success
  - Product: 309 files / 3018 tests
  - Web: 39 files / 272 tests
  - scripts: 24 files / 395 tests
- Product production build: success
- Chromium E2E（対象2 specs、`--repeat-each=5`）: 15 passed / 5 expected skips
- behavior-verifier / architecture-guard: final SHA `751acce57`、P1/P2なし
- migration / RLS / billing / public API変更: なし

Closes #1845
Closes #1842