### PR TITLE
fix(shell): locale経路と決済バナー表示を安定化する

### DIFF
--- a/apps/product/src/app/[locale]/(app)/_shell/MobileAccountButton.tsx
+++ b/apps/product/src/app/[locale]/(app)/_shell/MobileAccountButton.tsx
@@ -1,31 +1,23 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 
 import { useAuthStore } from '@/features/auth';
 import { getAvatarUrl, getDisplayName, getInitials } from '@/lib/user';
 import { Avatar, AvatarFallback, AvatarImage, cn } from '@dayopt/components';
-
-const LOCALE_PREFIX_PATTERN = /^\/(en|ja)(?=\/|$)/;
-
-function getLocaleFromPathname(pathname: string | null | undefined): 'ja' | 'en' {
-  const segments = pathname?.split('/') ?? [];
-  return segments.length >= 2 && (segments[1] === 'ja' || segments[1] === 'en')
-    ? segments[1]
-    : 'ja';
-}
+import { getPathname, usePathname } from '@dayopt/i18n/navigation';
 
 function buildSettingsReturnPath(
-  pathname: string | null,
+  pathname: string,
   searchParams: { toString: () => string },
 ): string {
-  const pathWithoutLocale = (pathname ?? '').replace(LOCALE_PREFIX_PATTERN, '') || '/day';
+  const returnPathname = pathname || '/day';
   const query = searchParams.toString();
 
-  return query ? `${pathWithoutLocale}?${query}` : pathWithoutLocale;
+  return query ? `${returnPathname}?${query}` : returnPathname;
 }
 
 interface MobileAccountButtonProps {
@@ -68,13 +60,20 @@ export function ConnectedMobileAccountButton({ className }: { className?: string
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const user = useAuthStore((s) => s.user);
-  const locale = getLocaleFromPathname(pathname);
+  const locale = useLocale();
   const displayName = getDisplayName(user, 'User');
   const returnPath = buildSettingsReturnPath(pathname, searchParams);
+  const href = getPathname({
+    locale,
+    href: {
+      pathname: '/settings',
+      query: { returnTo: returnPath },
+    },
+  });
 
   return (
     <MobileAccountButton
-      href={`/${locale}/settings?returnTo=${encodeURIComponent(returnPath)}`}
+      href={href}
       displayName={displayName}
       avatarUrl={getAvatarUrl(user)}
       ariaLabel={t('navigation.navUser.account')}

--- a/apps/product/src/app/[locale]/(app)/_shell/__tests__/MobileAccountButton.test.tsx
+++ b/apps/product/src/app/[locale]/(app)/_shell/__tests__/MobileAccountButton.test.tsx
@@ -1,9 +1,45 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { MobileAccountButton } from '../MobileAccountButton';
+const route = vi.hoisted(() => ({
+  pathname: '/day',
+  query: '',
+  locale: 'en',
+}));
+
+vi.mock('next-intl', () => ({
+  useLocale: () => route.locale,
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn(), back: vi.fn() }),
+  usePathname: () => route.pathname,
+  useParams: () => ({}),
+  useSearchParams: () => new URLSearchParams(route.query),
+  redirect: vi.fn(),
+  permanentRedirect: vi.fn(),
+  notFound: vi.fn(),
+}));
+
+vi.mock('@dayopt/i18n/navigation', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@dayopt/i18n/navigation')>()),
+  usePathname: () => route.pathname,
+}));
+
+vi.mock('@/features/auth', () => ({
+  useAuthStore: (selector: (state: { user: null }) => unknown) => selector({ user: null }),
+}));
+
+import { ConnectedMobileAccountButton, MobileAccountButton } from '../MobileAccountButton';
 
 describe('MobileAccountButton', () => {
+  beforeEach(() => {
+    route.pathname = '/day';
+    route.query = '';
+    route.locale = 'en';
+  });
+
   it('links to settings with an accessible account label', () => {
     render(
       <MobileAccountButton
@@ -17,5 +53,28 @@ describe('MobileAccountButton', () => {
     const link = screen.getByRole('link', { name: 'アカウント' });
     expect(link).toHaveAttribute('href', '/ja/settings');
     expect(screen.getByText('T')).toBeInTheDocument();
+  });
+
+  it('keeps the default locale prefixless and preserves the return query once', () => {
+    route.query = 'date=2026-03-25';
+
+    render(<ConnectedMobileAccountButton />);
+
+    const link = screen.getByRole('link', { name: 'navigation.navUser.account' });
+    expect(link).toHaveAttribute('href', '/settings?returnTo=%2Fday%3Fdate%3D2026-03-25');
+    expect(link.getAttribute('href')).not.toContain('%252F');
+  });
+
+  it('adds the Japanese locale prefix while keeping returnTo locale-free', () => {
+    route.locale = 'ja';
+    route.pathname = '/settings/billing';
+    route.query = 'tab=invoices';
+
+    render(<ConnectedMobileAccountButton />);
+
+    expect(screen.getByRole('link', { name: 'navigation.navUser.account' })).toHaveAttribute(
+      'href',
+      '/ja/settings?returnTo=%2Fsettings%2Fbilling%3Ftab%3Dinvoices',
+    );
   });
 });

--- a/apps/product/src/app/[locale]/(app)/_shell/__tests__/app-shell-layouts.test.tsx
+++ b/apps/product/src/app/[locale]/(app)/_shell/__tests__/app-shell-layouts.test.tsx
@@ -1,0 +1,172 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const pathnameMock = vi.hoisted(() => vi.fn(() => '/projects'));
+const bannerState = vi.hoisted(() => ({
+  current: { visible: true, message: 'Payment required' },
+}));
+
+vi.mock('@dayopt/i18n/navigation', () => ({
+  usePathname: pathnameMock,
+}));
+
+vi.mock('@/features/auth', () => ({
+  useAuthStore: (selector: (state: { user: null }) => unknown) => selector({ user: null }),
+}));
+
+vi.mock('@/features/calendar', () => ({
+  isCalendarViewPath: (pathname: string) => /^\/(?:day|week|[2-7]day)(?:\/|$)/.test(pathname),
+  TagChipRow: () => <div data-testid="tag-chip-row" />,
+}));
+
+vi.mock('@/lib/user', () => ({
+  getAvatarUrl: () => null,
+  getDisplayName: () => 'User',
+}));
+
+vi.mock('@/lib/stores/useShellStore', () => ({
+  useShellStore: {
+    use: {
+      sidebar: () => ({ open: true, width: 256 }),
+      sidebarSuppressed: () => false,
+      toggleSidebar: () => vi.fn(),
+      pageTitle: () => 'Page title',
+    },
+  },
+}));
+
+vi.mock('@/components/shell/AnimatedWidthPanel', () => ({
+  AnimatedWidthPanel: ({ children }: { children: React.ReactNode }) => <aside>{children}</aside>,
+}));
+
+vi.mock('@/components/shell/sidebar', () => ({
+  Sidebar: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../SidebarContent', () => ({
+  SidebarContent: () => <div>Sidebar</div>,
+}));
+
+vi.mock('../MobileAccountButton', () => ({
+  ConnectedMobileAccountButton: () => <button type="button">Account</button>,
+}));
+
+vi.mock('../useAppInlineBanner', () => ({
+  useAppInlineBanner: () => bannerState.current,
+}));
+
+import { DesktopLayout } from '../desktop-layout';
+import { MobileLayout } from '../mobile-layout';
+
+function expectBefore(first: Element, second: Element) {
+  expect(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+}
+
+function expectSingleVisibleBanner(container: HTMLElement) {
+  expect(container.querySelectorAll('[data-slot="inline-banner"]')).toHaveLength(1);
+  const alert = screen.getByRole('alert');
+  expect(alert).toHaveTextContent('Payment required');
+  return alert;
+}
+
+describe('DesktopLayout', () => {
+  beforeEach(() => {
+    pathnameMock.mockReturnValue('/projects');
+    bannerState.current = { visible: true, message: 'Payment required' };
+  });
+
+  it('shows one banner between the shell header and main content on a normal route', () => {
+    const { container } = render(
+      <DesktopLayout>
+        <div>Content</div>
+      </DesktopLayout>,
+    );
+
+    const header = screen.getByRole('banner');
+    const alert = expectSingleVisibleBanner(container);
+    const main = screen.getByRole('main');
+
+    expectBefore(header, alert);
+    expectBefore(alert, main);
+  });
+
+  it('keeps one banner before main content and omits the shell header on prefixless calendar routes', () => {
+    pathnameMock.mockReturnValue('/day');
+
+    const { container } = render(
+      <DesktopLayout>
+        <div>Calendar</div>
+      </DesktopLayout>,
+    );
+
+    expect(screen.queryByRole('banner')).not.toBeInTheDocument();
+    const alert = expectSingleVisibleBanner(container);
+    expectBefore(alert, screen.getByRole('main'));
+  });
+
+  it('keeps a single hidden banner container out of the accessibility tree', () => {
+    bannerState.current = { visible: false, message: '' };
+
+    const { container } = render(
+      <DesktopLayout>
+        <div>Content</div>
+      </DesktopLayout>,
+    );
+
+    expect(container.querySelectorAll('[data-slot="inline-banner"]')).toHaveLength(1);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});
+
+describe('MobileLayout', () => {
+  beforeEach(() => {
+    pathnameMock.mockReturnValue('/projects');
+    bannerState.current = { visible: true, message: 'Payment required' };
+  });
+
+  it('shows one banner between the shell header and main content on a normal route', () => {
+    const { container } = render(
+      <MobileLayout>
+        <div>Content</div>
+      </MobileLayout>,
+    );
+
+    const header = screen.getByRole('banner');
+    const alert = expectSingleVisibleBanner(container);
+    const main = screen.getByRole('main');
+
+    expectBefore(header, alert);
+    expectBefore(alert, main);
+  });
+
+  it.each(['/day', '/settings', '/settings/billing'])(
+    'shows one banner before main content and omits the shell header on %s',
+    (pathname) => {
+      pathnameMock.mockReturnValue(pathname);
+
+      const { container } = render(
+        <MobileLayout>
+          <div>Own header content</div>
+        </MobileLayout>,
+      );
+
+      expect(screen.queryByRole('banner')).not.toBeInTheDocument();
+      const alert = expectSingleVisibleBanner(container);
+      expectBefore(alert, screen.getByRole('main'));
+      expect(screen.queryAllByTestId('tag-chip-row')).toHaveLength(pathname === '/day' ? 1 : 0);
+    },
+  );
+
+  it('keeps a single hidden banner container out of the accessibility tree', () => {
+    bannerState.current = { visible: false, message: '' };
+
+    const { container } = render(
+      <MobileLayout>
+        <div>Content</div>
+      </MobileLayout>,
+    );
+
+    expect(container.querySelectorAll('[data-slot="inline-banner"]')).toHaveLength(1);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});

--- a/apps/product/src/app/[locale]/(app)/_shell/__tests__/useAppInlineBanner.billing-operation.test.tsx
+++ b/apps/product/src/app/[locale]/(app)/_shell/__tests__/useAppInlineBanner.billing-operation.test.tsx
@@ -6,6 +6,14 @@ const beginPortalAttempt = vi.hoisted(() => vi.fn(() => OPERATION_ID));
 const portalMutate = vi.hoisted(() => vi.fn());
 const settlePortalAttempt = vi.hoisted(() => vi.fn(() => true));
 const toastError = vi.hoisted(() => vi.fn());
+const billingOverview = vi.hoisted(
+  () =>
+    ({
+      current: { billingInfo: { subscriptionStatus: 'past_due' } },
+    }) as {
+      current: { billingInfo: { subscriptionStatus: string | null } };
+    },
+);
 const mutationOptions = vi.hoisted(
   () =>
     ({ current: null }) as {
@@ -57,7 +65,7 @@ vi.mock('@/lib/trpc', () => ({
       },
       getOverview: {
         useQuery: () => ({
-          data: { billingInfo: { subscriptionStatus: 'past_due' } },
+          data: billingOverview.current,
         }),
       },
     },
@@ -70,6 +78,7 @@ describe('useAppInlineBanner billing operation', () => {
   beforeEach(() => {
     beginPortalAttempt.mockReturnValue(OPERATION_ID);
     settlePortalAttempt.mockReturnValue(true);
+    billingOverview.current = { billingInfo: { subscriptionStatus: 'past_due' } };
   });
 
   afterEach(() => {
@@ -112,5 +121,16 @@ describe('useAppInlineBanner billing operation', () => {
     });
 
     expect(window.location.hash).toBe('');
+  });
+
+  it.each([
+    ['active subscription', 'active'],
+    ['free account', null],
+  ])('hides the billing banner for %s', (_label, subscriptionStatus) => {
+    billingOverview.current = { billingInfo: { subscriptionStatus } };
+
+    const { result } = renderHook(() => useAppInlineBanner());
+
+    expect(result.current).toEqual({ visible: false, message: '' });
   });
 });

--- a/apps/product/src/app/[locale]/(app)/_shell/base-layout-content.tsx
+++ b/apps/product/src/app/[locale]/(app)/_shell/base-layout-content.tsx
@@ -1,9 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
-
 import { useTranslations } from 'next-intl';
-import { usePathname } from 'next/navigation';
 
 import { CalendarNavigationProvider } from '@/features/calendar';
 import {
@@ -35,15 +32,10 @@ interface BaseLayoutContentProps {
  *   カレンダーの searchParams 読み取りは CalendarNavigationProvider 内部で行う。
  */
 export function BaseLayoutContent({ children }: BaseLayoutContentProps) {
-  const pathname = usePathname() || '/';
   const t = useTranslations();
   const isMobile = useMediaQuery(MEDIA_QUERIES.mobile);
   const trialDialog = useTrialEndedDialog();
   const paymentDialog = usePaymentErrorDialog();
-
-  const localeFromPath = useMemo(() => {
-    return (pathname.split('/')[1] || 'ja') as 'ja' | 'en';
-  }, [pathname]);
 
   return (
     // CalendarNavigationProvider を常にレンダリングしてツリー構造を安定化。
@@ -60,9 +52,9 @@ export function BaseLayoutContent({ children }: BaseLayoutContentProps) {
         </a>
 
         {isMobile ? (
-          <MobileLayout locale={localeFromPath}>{children}</MobileLayout>
+          <MobileLayout>{children}</MobileLayout>
         ) : (
-          <DesktopLayout locale={localeFromPath}>{children}</DesktopLayout>
+          <DesktopLayout>{children}</DesktopLayout>
         )}
         {/* Trial終了ダイアログ（全ページ共通、1度だけ表示） */}
         <TrialEndedDialog open={trialDialog.open} onClose={trialDialog.close} />

--- a/apps/product/src/app/[locale]/(app)/_shell/desktop-layout.tsx
+++ b/apps/product/src/app/[locale]/(app)/_shell/desktop-layout.tsx
@@ -1,8 +1,5 @@
 'use client';
 
-import { usePathname } from 'next/navigation';
-import { useMemo } from 'react';
-
 import { PanelLeft } from 'lucide-react';
 
 import { AnimatedWidthPanel } from '@/components/shell/AnimatedWidthPanel';
@@ -12,6 +9,7 @@ import { useAuthStore } from '@/features/auth';
 import { isCalendarViewPath } from '@/features/calendar';
 import { getAvatarUrl, getDisplayName } from '@/lib/user';
 import { Button, InlineBanner } from '@dayopt/components';
+import { usePathname } from '@dayopt/i18n/navigation';
 
 import { useShellStore } from '@/lib/stores/useShellStore';
 
@@ -21,7 +19,6 @@ import { useAppInlineBanner } from './useAppInlineBanner';
 
 interface DesktopLayoutProps {
   children: React.ReactNode;
-  locale: 'ja' | 'en';
 }
 
 /**
@@ -32,7 +29,7 @@ interface DesktopLayoutProps {
  * - PageHeader + MainContent + Inspector
  *
  */
-export function DesktopLayout({ children, locale }: DesktopLayoutProps) {
+export function DesktopLayout({ children }: DesktopLayoutProps) {
   const pathname = usePathname();
   const sidebar = useShellStore.use.sidebar();
   const sidebarSuppressed = useShellStore.use.sidebarSuppressed();
@@ -47,10 +44,7 @@ export function DesktopLayout({ children, locale }: DesktopLayoutProps) {
   };
 
   // ページ判定: 独自ヘッダーを持つページかどうか（AppHeader表示制御用）
-  const hasOwnHeader = useMemo(() => {
-    const pathWithoutLocale = pathname?.replace(new RegExp(`^/${locale}`), '') ?? '';
-    return isCalendarViewPath(pathWithoutLocale);
-  }, [pathname, locale]);
+  const hasOwnHeader = isCalendarViewPath(pathname);
   const sidebarVisible = sidebar.open && !sidebarSuppressed;
 
   // サイドバーが閉じているときに表示するトグルボタン
@@ -91,8 +85,8 @@ export function DesktopLayout({ children, locale }: DesktopLayoutProps) {
             </AppHeader>
           )}
 
-          {/* インラインバナー（独自ヘッダーを持つページは自前で配置） */}
-          {!hasOwnHeader && <InlineBanner {...banner} />}
+          {/* インラインバナー（自前ヘッダーを持つ画面を含む全ページ共通） */}
+          <InlineBanner {...banner} />
 
           {/* Main Content + Inspector（自動的に残りのスペースを使用） */}
           <div className="min-w-0 flex-1 overflow-hidden">

--- a/apps/product/src/app/[locale]/(app)/_shell/mobile-layout.tsx
+++ b/apps/product/src/app/[locale]/(app)/_shell/mobile-layout.tsx
@@ -1,12 +1,10 @@
 'use client';
 
-import { usePathname } from 'next/navigation';
-import { useMemo } from 'react';
-
 import { AppHeader } from '@/components/shell/AppHeader';
 import { isCalendarViewPath, TagChipRow } from '@/features/calendar';
 import { useShellStore } from '@/lib/stores/useShellStore';
 import { InlineBanner } from '@dayopt/components';
+import { usePathname } from '@dayopt/i18n/navigation';
 
 import { ConnectedMobileAccountButton } from './MobileAccountButton';
 import { useAppInlineBanner } from './useAppInlineBanner';
@@ -15,7 +13,6 @@ import { MainContentWrapper } from './main-content-wrapper';
 
 interface MobileLayoutProps {
   children: React.ReactNode;
-  locale: 'ja' | 'en';
 }
 
 /**
@@ -26,30 +23,17 @@ interface MobileLayoutProps {
  * - MainContent
  * - TagChipRow（Calendar のみ、固定フッター）
  */
-export function MobileLayout({ children, locale: _locale }: MobileLayoutProps) {
+export function MobileLayout({ children }: MobileLayoutProps) {
   const title = useShellStore.use.pageTitle();
   const banner = useAppInlineBanner();
 
   const pathname = usePathname();
 
-  // localePrefix: 'as-needed' により default locale の URL は prefix なし
-  // (例: /day) の場合もあるため、prop の locale ではなく実際の
-  // URL セグメントから /en/ /ja/ のみを剥がす。未知の先頭セグメントは維持する。
-  const pathWithoutLocale = useMemo(
-    () => (pathname ?? '').replace(/^\/(en|ja)(?=\/|$)/, ''),
-    [pathname],
-  );
-
   // ページ判定: 独自ヘッダーを持つページかどうか（AppHeader表示制御用）
-  const hasOwnHeader = useMemo(
-    () =>
-      isCalendarViewPath(pathWithoutLocale) ||
-      pathWithoutLocale === '/settings' ||
-      pathWithoutLocale.startsWith('/settings/'),
-    [pathWithoutLocale],
-  );
+  const hasOwnHeader =
+    isCalendarViewPath(pathname) || pathname === '/settings' || pathname.startsWith('/settings/');
 
-  const isCalendarView = useMemo(() => isCalendarViewPath(pathWithoutLocale), [pathWithoutLocale]);
+  const isCalendarView = isCalendarViewPath(pathname);
 
   return (
     <>
@@ -62,8 +46,8 @@ export function MobileLayout({ children, locale: _locale }: MobileLayoutProps) {
           </AppHeader>
         )}
 
-        {/* インラインバナー（独自ヘッダーを持つページは自前で配置） */}
-        {!hasOwnHeader && <InlineBanner {...banner} />}
+        {/* インラインバナー（自前ヘッダーを持つ画面を含む全ページ共通） */}
+        <InlineBanner {...banner} />
 
         {/* Main Content（calendar view ではタグフッター分の余白を確保） */}
         {isCalendarView ? (

--- a/apps/product/src/lib/test/e2e/deep-link.spec.ts
+++ b/apps/product/src/lib/test/e2e/deep-link.spec.ts
@@ -65,4 +65,20 @@ test.describe('Deep Link: SSR rendering of app routes', () => {
     // Calendar グリッドが deep link 直後から描画される
     await expect(page.locator('[data-calendar-grid]').first()).toBeVisible({ timeout: 10_000 });
   });
+
+  test('prefixless default-locale calendar renders only its own visible header', async ({
+    page,
+  }, testInfo) => {
+    test.skip(testInfo.project.name.includes('Mobile'), 'desktop-only');
+
+    await loginAndNavigate(page);
+
+    await page.goto('/day?date=2026-04-20');
+    await expect(page).toHaveURL(/\/day\?date=2026-04-20/);
+    await expect(page.locator('[data-calendar-grid]').first()).toBeVisible({ timeout: 10_000 });
+
+    // CalendarLayout は responsive header を2つDOMに持つため、実際に表示中のheaderを数える。
+    // shell側のlocale誤判定が再発すると、desktopでvisible headerが2つになる。
+    await expect(page.locator('header:visible')).toHaveCount(1);
+  });
 });

--- a/apps/storybook/.storybook/mocks/next-intl-navigation.tsx
+++ b/apps/storybook/.storybook/mocks/next-intl-navigation.tsx
@@ -1,39 +1,162 @@
-import type { AnchorHTMLAttributes, ReactNode } from 'react';
+import { createContext, useContext, type AnchorHTMLAttributes, type ReactNode } from 'react';
 
-/**
- * Storybook用 next-intl/navigation モック
- *
- * next-intl/navigation は内部で React を暗黙的に参照するため、
- * Storybook のバンドルで ReferenceError: React is not defined が発生する。
- * このモックで createNavigation の返り値を再現する。
- */
+import { usePathname as useNextPathname, useRouter as useNextRouter } from 'next/navigation';
 
-interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
-  href: string;
-  children: ReactNode;
+/** Storybook で再現する next-intl の最小 routing 設定。 */
+interface RoutingConfig {
+  locales?: readonly string[];
+  defaultLocale?: string;
+  localePrefix?: 'always' | 'as-needed' | 'never' | { mode?: 'always' | 'as-needed' | 'never' };
 }
 
-function MockLink({ href, children, ...props }: LinkProps) {
+type QueryValue =
+  boolean | number | string | readonly (boolean | number | string)[] | null | undefined;
+
+interface StructuredHref {
+  pathname: string;
+  query?: Record<string, QueryValue>;
+}
+
+type NavigationHref = string | StructuredHref;
+
+interface LinkProps extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> {
+  href: NavigationHref;
+  children: ReactNode;
+  locale?: string;
+}
+
+interface GetPathnameArgs {
+  href: NavigationHref;
+  locale: string;
+}
+
+const StorybookPathnameContext = createContext<string | null>(null);
+
+/** AllPatterns内で複数routeを同時描画するためのStorybook専用pathname境界。 */
+export function StorybookPathnameProvider({
+  children,
+  pathname,
+}: {
+  children: ReactNode;
+  pathname: string;
+}) {
   return (
-    <a href={href} {...props}>
+    <StorybookPathnameContext.Provider value={pathname}>
       {children}
-    </a>
+    </StorybookPathnameContext.Provider>
   );
 }
 
-export function createNavigation() {
+/** 個別StoryではNext mock、複合Storyでは最寄りのoverrideを使う。 */
+function useStorybookPathname(): string {
+  const override = useContext(StorybookPathnameContext);
+  const pathname = useNextPathname();
+  return override ?? pathname ?? '/';
+}
+
+/** pathname の先頭にある対応 locale だけを取り除く。 */
+function stripLocalePrefix(pathname: string, locales: readonly string[]): string {
+  const [pathWithQuery = '/', hash] = pathname.split('#', 2);
+  const [path = '/', query] = pathWithQuery.split('?', 2);
+  const segments = path.split('/');
+  const firstSegment = segments[1];
+
+  if (firstSegment && locales.includes(firstSegment)) {
+    segments.splice(1, 1);
+  }
+
+  const normalizedPath = segments.join('/') || '/';
+  return `${normalizedPath}${query ? `?${query}` : ''}${hash ? `#${hash}` : ''}`;
+}
+
+/** query 値をURLSearchParamsへ一度だけ渡してURLを組み立てる。 */
+function resolveHref(href: NavigationHref): string {
+  if (typeof href === 'string') return href;
+
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(href.query ?? {})) {
+    if (value == null) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) params.append(key, String(item));
+    } else {
+      params.set(key, String(value));
+    }
+  }
+
+  const query = params.toString();
+  return query ? `${href.pathname}?${query}` : href.pathname;
+}
+
+/** 外部URL・hash・特殊schemeはlocale処理の対象外。 */
+function isExternalHref(href: string): boolean {
+  return href.startsWith('#') || href.startsWith('//') || /^[a-z][a-z\d+.-]*:/i.test(href);
+}
+
+/** routing.localePrefix に従って内部URLをlocalizeする。 */
+function localizeHref(href: NavigationHref, locale: string, routing: RoutingConfig): string {
+  const resolvedHref = resolveHref(href);
+  if (isExternalHref(resolvedHref)) return resolvedHref;
+
+  const locales = routing.locales ?? ['en', 'ja'];
+  const defaultLocale = routing.defaultLocale ?? 'en';
+  const prefixMode =
+    typeof routing.localePrefix === 'object'
+      ? (routing.localePrefix.mode ?? 'always')
+      : (routing.localePrefix ?? 'always');
+  const localeFreeHref = stripLocalePrefix(resolvedHref, locales);
+  const needsPrefix =
+    prefixMode === 'always' || (prefixMode === 'as-needed' && locale !== defaultLocale);
+
+  if (!needsPrefix) return localeFreeHref;
+
+  return localeFreeHref === '/' ? `/${locale}` : `/${locale}${localeFreeHref}`;
+}
+
+/** Storybook用 next-intl/navigation モック。 */
+export function createNavigation(routing: RoutingConfig = {}) {
+  const locales = routing.locales ?? ['en', 'ja'];
+  const defaultLocale = routing.defaultLocale ?? 'en';
+
+  function MockLink({ href, children, locale, ...props }: LinkProps) {
+    const pathname = useStorybookPathname();
+    const currentLocale = locales.find(
+      (candidate) => pathname === `/${candidate}` || pathname.startsWith(`/${candidate}/`),
+    );
+    const localizedHref = localizeHref(href, locale ?? currentLocale ?? defaultLocale, routing);
+
+    return (
+      <a href={localizedHref} {...props}>
+        {children}
+      </a>
+    );
+  }
+
   return {
     Link: MockLink,
     redirect: () => undefined,
-    usePathname: () => '/',
-    useRouter: () => ({
-      push: () => {},
-      replace: () => {},
-      back: () => {},
-      forward: () => {},
-      refresh: () => {},
-      prefetch: () => {},
-    }),
-    getPathname: () => '/',
+    usePathname: () => stripLocalePrefix(useStorybookPathname(), locales),
+    useRouter: () => {
+      const router = useNextRouter();
+      const pathname = useStorybookPathname();
+      const currentLocale =
+        locales.find(
+          (candidate) => pathname === `/${candidate}` || pathname.startsWith(`/${candidate}/`),
+        ) ?? defaultLocale;
+
+      return {
+        ...router,
+        push: (href: NavigationHref, options?: { locale?: string; scroll?: boolean }) =>
+          router.push(localizeHref(href, options?.locale ?? currentLocale, routing), {
+            scroll: options?.scroll,
+          }),
+        replace: (href: NavigationHref, options?: { locale?: string; scroll?: boolean }) =>
+          router.replace(localizeHref(href, options?.locale ?? currentLocale, routing), {
+            scroll: options?.scroll,
+          }),
+        prefetch: (href: NavigationHref, options?: { locale?: string }) =>
+          router.prefetch(localizeHref(href, options?.locale ?? currentLocale, routing)),
+      };
+    },
+    getPathname: ({ href, locale }: GetPathnameArgs) => localizeHref(href, locale, routing),
   };
 }

--- a/apps/storybook/.storybook/mocks/next-intl-navigation.tsx
+++ b/apps/storybook/.storybook/mocks/next-intl-navigation.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, type AnchorHTMLAttributes, type ReactNode } from 'react';
 
+import { useLocale } from 'next-intl';
 import { usePathname as useNextPathname, useRouter as useNextRouter } from 'next/navigation';
 
 /** Storybook で再現する next-intl の最小 routing 設定。 */
@@ -26,6 +27,7 @@ interface LinkProps extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'
 }
 
 interface GetPathnameArgs {
+  forcePrefix?: boolean;
   href: NavigationHref;
   locale: string;
 }
@@ -93,7 +95,12 @@ function isExternalHref(href: string): boolean {
 }
 
 /** routing.localePrefix に従って内部URLをlocalizeする。 */
-function localizeHref(href: NavigationHref, locale: string, routing: RoutingConfig): string {
+function localizeHref(
+  href: NavigationHref,
+  locale: string,
+  routing: RoutingConfig,
+  forcePrefix?: boolean,
+): string {
   const resolvedHref = resolveHref(href);
   if (isExternalHref(resolvedHref)) return resolvedHref;
 
@@ -105,7 +112,8 @@ function localizeHref(href: NavigationHref, locale: string, routing: RoutingConf
       : (routing.localePrefix ?? 'always');
   const localeFreeHref = stripLocalePrefix(resolvedHref, locales);
   const needsPrefix =
-    prefixMode === 'always' || (prefixMode === 'as-needed' && locale !== defaultLocale);
+    forcePrefix ??
+    (prefixMode === 'always' || (prefixMode === 'as-needed' && locale !== defaultLocale));
 
   if (!needsPrefix) return localeFreeHref;
 
@@ -115,14 +123,15 @@ function localizeHref(href: NavigationHref, locale: string, routing: RoutingConf
 /** Storybook用 next-intl/navigation モック。 */
 export function createNavigation(routing: RoutingConfig = {}) {
   const locales = routing.locales ?? ['en', 'ja'];
-  const defaultLocale = routing.defaultLocale ?? 'en';
 
   function MockLink({ href, children, locale, ...props }: LinkProps) {
-    const pathname = useStorybookPathname();
-    const currentLocale = locales.find(
-      (candidate) => pathname === `/${candidate}` || pathname.startsWith(`/${candidate}/`),
+    const currentLocale = useLocale();
+    const localizedHref = localizeHref(
+      href,
+      locale ?? currentLocale,
+      routing,
+      locale != null ? true : undefined,
     );
-    const localizedHref = localizeHref(href, locale ?? currentLocale ?? defaultLocale, routing);
 
     return (
       <a href={localizedHref} {...props}>
@@ -137,26 +146,46 @@ export function createNavigation(routing: RoutingConfig = {}) {
     usePathname: () => stripLocalePrefix(useStorybookPathname(), locales),
     useRouter: () => {
       const router = useNextRouter();
-      const pathname = useStorybookPathname();
-      const currentLocale =
-        locales.find(
-          (candidate) => pathname === `/${candidate}` || pathname.startsWith(`/${candidate}/`),
-        ) ?? defaultLocale;
+      const currentLocale = useLocale();
 
       return {
         ...router,
         push: (href: NavigationHref, options?: { locale?: string; scroll?: boolean }) =>
-          router.push(localizeHref(href, options?.locale ?? currentLocale, routing), {
-            scroll: options?.scroll,
-          }),
+          router.push(
+            localizeHref(
+              href,
+              options?.locale ?? currentLocale,
+              routing,
+              options?.locale != null ? true : undefined,
+            ),
+            {
+              scroll: options?.scroll,
+            },
+          ),
         replace: (href: NavigationHref, options?: { locale?: string; scroll?: boolean }) =>
-          router.replace(localizeHref(href, options?.locale ?? currentLocale, routing), {
-            scroll: options?.scroll,
-          }),
+          router.replace(
+            localizeHref(
+              href,
+              options?.locale ?? currentLocale,
+              routing,
+              options?.locale != null ? true : undefined,
+            ),
+            {
+              scroll: options?.scroll,
+            },
+          ),
         prefetch: (href: NavigationHref, options?: { locale?: string }) =>
-          router.prefetch(localizeHref(href, options?.locale ?? currentLocale, routing)),
+          router.prefetch(
+            localizeHref(
+              href,
+              options?.locale ?? currentLocale,
+              routing,
+              options?.locale != null ? true : undefined,
+            ),
+          ),
       };
     },
-    getPathname: ({ href, locale }: GetPathnameArgs) => localizeHref(href, locale, routing),
+    getPathname: ({ forcePrefix, href, locale }: GetPathnameArgs) =>
+      localizeHref(href, locale, routing, forcePrefix),
   };
 }

--- a/apps/storybook/.storybook/stories/patterns/AppShell.stories.tsx
+++ b/apps/storybook/.storybook/stories/patterns/AppShell.stories.tsx
@@ -1,0 +1,211 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { ArrowLeft } from 'lucide-react';
+
+import { DesktopLayout } from '@/app/[locale]/(app)/_shell/desktop-layout';
+import { MobileLayout } from '@/app/[locale]/(app)/_shell/mobile-layout';
+import { AppHeader } from '@/components/shell/AppHeader';
+import { CalendarNavigationProvider } from '@/features/calendar';
+import { Button } from '@dayopt/components';
+import { StorybookPathnameProvider } from '@dayopt/storybook/mocks/next-intl-navigation';
+
+import { PRESET_AUTH, PRESET_USER_SETTINGS } from '../../mocks/presets';
+
+const PAST_DUE_OVERVIEW = {
+  billingInfo: {
+    subscriptionStatus: 'past_due',
+    stripeCustomerId: 'cus_storybook',
+    subscriptionId: 'sub_storybook',
+  },
+  paymentMethod: null,
+  invoices: [],
+  trialEndsAt: null,
+};
+
+const SHELL_STORE = {
+  sidebar: { open: false, width: 256 },
+  sidebarSuppressed: false,
+  pageTitle: '',
+};
+
+type ShellPattern = 'desktop-calendar' | 'mobile-calendar' | 'mobile-settings';
+
+interface AppShellPreviewProps {
+  pattern: ShellPattern;
+}
+
+function CalendarOwnHeader({ mobile = false }: { mobile?: boolean }) {
+  return (
+    <AppHeader>
+      <h1 className="truncate text-lg font-medium">
+        {mobile ? 'March 25' : 'Wednesday, March 25'}
+      </h1>
+    </AppHeader>
+  );
+}
+
+function SettingsOwnHeader() {
+  return (
+    <AppHeader
+      leftSlot={
+        <Button type="button" variant="ghost" size="sm" icon aria-label="Back">
+          <ArrowLeft className="size-5" />
+        </Button>
+      }
+    >
+      <h1 className="truncate text-lg font-medium">Billing</h1>
+    </AppHeader>
+  );
+}
+
+function CalendarSurface() {
+  return (
+    <div className="bg-background flex min-h-0 flex-1 flex-col">
+      <div className="border-border grid flex-1 grid-cols-4 border-t">
+        {Array.from({ length: 16 }, (_, index) => (
+          <div key={index} className="border-border-subtle border-r border-b" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SettingsSurface() {
+  return (
+    <div className="bg-background flex flex-1 flex-col gap-4 p-4">
+      <div className="bg-surface-container h-12 rounded-lg" />
+      <div className="bg-surface-container h-20 rounded-lg" />
+      <div className="bg-surface-container h-16 rounded-lg" />
+    </div>
+  );
+}
+
+/** 実App Shellと代表的な自前headerを合成するpast_dueプレビュー。 */
+function AppShellPreview({ pattern }: AppShellPreviewProps) {
+  const mobile = pattern !== 'desktop-calendar';
+  const settings = pattern === 'mobile-settings';
+  const content = settings ? (
+    <>
+      <SettingsOwnHeader />
+      <SettingsSurface />
+    </>
+  ) : (
+    <>
+      <CalendarOwnHeader mobile={mobile} />
+      <CalendarSurface />
+    </>
+  );
+
+  return (
+    <CalendarNavigationProvider>
+      <div className="bg-background h-full min-h-0 overflow-hidden">
+        {mobile ? <MobileLayout>{content}</MobileLayout> : <DesktopLayout>{content}</DesktopLayout>}
+      </div>
+    </CalendarNavigationProvider>
+  );
+}
+
+const meta = {
+  title: 'Product/Patterns/AppShell',
+  component: AppShellPreview,
+  parameters: {
+    layout: 'fullscreen',
+    trpcMocks: {
+      'billing.getOverview': PAST_DUE_OVERVIEW,
+      'tags.list': { data: [] },
+      'tags.listArchived': [],
+      'tags.listHierarchy': [],
+      'statistics.getTagStats': { counts: {}, planCounts: {}, lastUsed: {} },
+      'userSettings.get': PRESET_USER_SETTINGS.default,
+    },
+    storeMocks: {
+      useAuthStore: PRESET_AUTH.authenticated,
+      useShellStore: SHELL_STORE,
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof AppShellPreview>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** prefixなし英語calendarでshell headerを重複させずpast_due bannerを表示する。 */
+export const DesktopCalendarPastDue: Story = {
+  args: { pattern: 'desktop-calendar' },
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: '/day',
+        query: { date: '2026-03-25' },
+      },
+    },
+  },
+};
+
+/** mobile calendarの自前header直前にpast_due bannerを表示する。 */
+export const MobileCalendarPastDue: Story = {
+  args: { pattern: 'mobile-calendar' },
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: '/day',
+        query: { date: '2026-03-25' },
+      },
+    },
+  },
+  globals: {
+    viewport: { value: 'mobile1' },
+  },
+};
+
+/** mobile settingsの自前header直前にpast_due bannerを表示する。 */
+export const MobileSettingsPastDue: Story = {
+  args: { pattern: 'mobile-settings' },
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: '/settings/billing',
+        query: { returnTo: '/day?date=2026-03-25' },
+      },
+    },
+  },
+  globals: {
+    viewport: { value: 'mobile1' },
+  },
+};
+
+/** calendarとsettingsのApp Shell配置を一画面で比較する。 */
+export const AllPatterns: Story = {
+  args: { pattern: 'desktop-calendar' },
+  render: () => (
+    <div className="bg-muted grid gap-6 p-6">
+      <StorybookPathnameProvider pathname="/day">
+        <div className="border-border bg-background h-96 overflow-hidden rounded-lg border">
+          <AppShellPreview pattern="desktop-calendar" />
+        </div>
+      </StorybookPathnameProvider>
+      <div className="flex flex-wrap gap-6">
+        <StorybookPathnameProvider pathname="/day">
+          <div
+            className="border-border bg-background h-96 w-80 overflow-hidden rounded-lg border"
+            aria-hidden="true"
+            inert
+          >
+            <AppShellPreview pattern="mobile-calendar" />
+          </div>
+        </StorybookPathnameProvider>
+        <StorybookPathnameProvider pathname="/settings/billing">
+          <div
+            className="border-border bg-background h-96 w-80 overflow-hidden rounded-lg border"
+            aria-hidden="true"
+            inert
+          >
+            <AppShellPreview pattern="mobile-settings" />
+          </div>
+        </StorybookPathnameProvider>
+      </div>
+    </div>
+  ),
+};

--- a/docs/engineering/infra.md
+++ b/docs/engineering/infra.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_verified: 2026-07-30
+last_verified: 2026-08-09
 ---
 
 # インフラ・環境・API/Routing 総覧
@@ -301,9 +301,12 @@ main ruleset の required status checks は `ci.yml` の 4 job（`🔍 Static Ch
 
 | context                   | 発行元            | 目的                                                       |
 | ------------------------- | ----------------- | ---------------------------------------------------------- |
+| `🛡️ docs & secrets guard` | GitHub Actions    | docs lifecycle と secret 漏えい防止の検査が成功すること    |
 | `Production Config Audit` | GitHub Actions    | live な Vercel env metadata が Production 契約を満たすこと |
 | `Vercel – product`        | Vercel GitHub App | Product の Preview build が成功すること                    |
 | `Vercel – web`            | Vercel GitHub App | Web の Preview build が成功すること                        |
+
+`🛡️ docs & secrets guard` は #1868 で main ruleset の required check へ追加した。
 
 - `Vercel – product` / `Vercel – web` の区切り文字は en dash（U+2013）で、hyphen ではない
 - **`branch:finish` はこの 2 context を無条件には要求しない（2026-08-04、#1813）。**

--- a/docs/projects/app-shell-reliability/overview.md
+++ b/docs/projects/app-shell-reliability/overview.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: done
 last_verified: 2026-08-09
 code: apps/product/src/app/[locale]/(app)/_shell
 ---

--- a/docs/projects/app-shell-reliability/overview.md
+++ b/docs/projects/app-shell-reliability/overview.md
@@ -1,0 +1,53 @@
+---
+status: active
+last_verified: 2026-08-09
+code: apps/product/src/app/[locale]/(app)/_shell
+---
+
+# app-shell-reliability — locale と常設バナーの経路を揃える
+
+GitHub issue #1838 / #1874 の実装設計。default locale の prefix なし URL と自前ヘッダ画面を app shell の通常経路として扱い、ヘッダ・設定導線・決済失敗バナーの欠落を防ぐ。
+
+## Goal
+
+- 英語の `/day` でも Calendar 固有ヘッダだけを表示する
+- mobile の設定導線で現在 locale、pathname、query を保持する
+- `past_due` の常設バナーを Calendar と mobile settings を含む全 app 画面で一度だけ表示する
+
+## Minimum Viable Approach
+
+1. shell の route 判定は `@dayopt/i18n/navigation` の locale-free `usePathname` に統一し、pathname 先頭 segment の手動 locale 判定を削除する。
+2. mobile の設定 URL は `useLocale` と `getPathname` で生成し、locale-free pathname と query を既存の `returnTo` へ一度だけ encode する。
+3. `InlineBanner` は shell が常に所有し、通常画面では AppHeader の後、自前ヘッダ画面では main の前に置く。`hasOwnHeader` は AppHeader の重複防止だけに使う。
+
+## Acceptance Criteria
+
+- `/day` と `/ja/day` で shell AppHeader が重複しない
+- EN / JA の設定 URL が現在 locale と query を保ち、`returnTo` を二重 encode しない
+- desktop / mobile の Calendar、mobile settings、通常画面で `past_due` バナーが一度だけ表示される
+- `past_due` でない場合はアクセシブルな alert が表示されない
+- shell unit test、認証済み Calendar E2E、Storybook の desktop / mobile fixture、repository quality gate が通る
+
+## Reversibility Table
+
+| 変更                | 可逆性      | 根拠                                        |
+| ------------------- | ----------- | ------------------------------------------- |
+| route / locale 判定 | `[minutes]` | client shell 内部の配線だけで revert できる |
+| banner 配置         | `[minutes]` | billing 判定や feature API を変えない       |
+| test / Story / docs | `[minutes]` | repo 内の検証資産だけ                       |
+
+DB、公開 API、schema、翻訳キー、canonical URL の変更はない。
+
+## Existing Code to Reuse
+
+- `@dayopt/i18n/navigation` の `usePathname` / `getPathname`
+- `next-intl` の `useLocale`
+- `isCalendarViewPath`、`useAppInlineBanner`、`InlineBanner`
+- `MobileAccountButton` の既存 presentation API と settings の `returnTo` 契約
+
+## What I'm Not Doing
+
+- app 全体の locale / return URL 処理の包括的 refactor
+- `CalendarLayout` や settings feature への banner prop / context 配線
+- billing / Stripe 状態判定、`useAppInlineBanner` の返り値、UI 文言の変更
+- 未参照の `common.inlineBanner` 翻訳キー整理

--- a/docs/projects/app-shell-reliability/summary.md
+++ b/docs/projects/app-shell-reliability/summary.md
@@ -1,0 +1,29 @@
+---
+status: current
+last_verified: 2026-08-09
+code: apps/product/src/app/[locale]/(app)/_shell
+---
+
+# app-shell-reliability 完了サマリー
+
+default locale の prefix なし URL と自前ヘッダ画面を shell の通常経路へ揃え、英語 Calendar のヘッダ重複、mobile 設定導線の locale 変更、`past_due` 常設バナーの欠落を解消した。
+
+## 完了した契約
+
+- shell の route 判定は `@dayopt/i18n/navigation` の locale-free pathname を使い、URL segment を locale として手動解釈しない
+- mobile 設定 URL は現在 locale を保ち、locale-free pathname と query を `returnTo` に一度だけ encode する
+- `InlineBanner` は shell が所有して全 app 画面で一度だけ描画し、`hasOwnHeader` は AppHeader の重複防止だけに使う
+- `MobileAccountButton` の presentation API、billing 状態判定、公開 URL、server / client 境界は変更しない
+
+## 検証
+
+- shell layout と mobile account URL の unit test
+- prefix なし英語 Calendar の認証済み E2E
+- past_due の desktop Calendar、mobile Calendar、mobile settings Story
+- `pnpm check`
+- `pnpm lint:boundaries`
+- `pnpm build`
+- `pnpm build-storybook`
+- Storybook 実画面（desktop Calendar / mobile Calendar / mobile settings）で banner 1件、header 1件、console error 0件、横 overflow 0件
+
+詳細な設計と対象外は [overview](./overview.md) を参照する。


### PR DESCRIPTION
## Summary

- app shell の route 判定を `@dayopt/i18n/navigation` の locale-free pathname に統一
- default locale の `/day` で shell header が重複する回帰を修正
- mobile settings 導線で現在 locale・pathname・query を維持し、`returnTo` を一度だけ encode
- `past_due` の常設 banner を Calendar / mobile settings を含む全 app 画面で shell が一度だけ描画
- desktop / mobile の Storybook fixture、unit / E2E 回帰テスト、完了 docs を追加
- main ruleset の required checks 正本を docs に同期

## Root cause

- prefix なし URL の先頭 segment を locale とみなす手動判定により、`/day` 自体が locale として除去され、Calendar 固有 header の存在判定が外れていた
- mobile account 導線が prefix のない locale を日本語と推測していた
- `InlineBanner` が `hasOwnHeader` と同じ条件で除外される一方、自前 header 側には banner の所有者がいなかった

## Validation

- `pnpm check`（Product 310 files / 3,030 tests、Web 39 files / 272 tests、scripts 24 files / 395 tests など）
- `pnpm lint:boundaries`
- `pnpm docs:check`
- `pnpm build`
- `pnpm build-storybook`
- AppShell browser Story: 4 / 4
- Storybook 実画面: desktop Calendar / mobile Calendar / mobile settings で banner 1件、header 1件、console error 0件、横 overflow 0件
- behavior / architecture / risk の独立レビュー。検出した Storybook locale 契約の P2 は修正後に再レビュー済み
- 認証済み prefixless Calendar E2E を追加（required CI で実行）

## Merge gate

- [x] ruleset `6790553` に `🛡️ docs & secrets guard`（integration_id `15368`）を重複なしで追加
- [x] 再 GET とこの PR の required checks で上記 context を確認
- [x] required CI と review thread をすべて解消

Closes #1838
Closes #1874
Closes #1868


