### PR TITLE
fix(billing)/test: 決済復帰の表示ラグ修正と test 品質 3 件の束ね対応

### DIFF
--- a/apps/product/messages/en/settings.json
+++ b/apps/product/messages/en/settings.json
@@ -630,7 +630,8 @@
           }
         }
       },
-      "trialEndsAt": "Your trial runs through {date}"
+      "trialEndsAt": "Your trial runs through {date}",
+      "syncingPlan": "Confirming your update… your Pro plan will show up shortly"
     }
   }
 }

--- a/apps/product/messages/ja/settings.json
+++ b/apps/product/messages/ja/settings.json
@@ -630,7 +630,8 @@
           }
         }
       },
-      "trialEndsAt": "試用期間は {date} までです"
+      "trialEndsAt": "試用期間は {date} までです",
+      "syncingPlan": "反映を確認しています…しばらくすると Pro プランが表示されます"
     }
   }
 }

--- a/apps/product/src/app/[locale]/(app)/_shell/__tests__/useAppInlineBanner.billing-operation.test.tsx
+++ b/apps/product/src/app/[locale]/(app)/_shell/__tests__/useAppInlineBanner.billing-operation.test.tsx
@@ -33,6 +33,10 @@ vi.mock('@/lib/toast', () => ({
 }));
 
 vi.mock('@/features/settings', () => ({
+  // 課金 checkout 復帰の有限ポーリング（issue #1887）。この test では復帰を
+  // 起こさないため startedAt は常に null（= ポーリング非アクティブ）。
+  BILLING_POLL_INTERVAL_MS: 2500,
+  BILLING_POLL_MAX_DURATION_MS: 30_000,
   getBillingOperationErrorDisposition: (error: unknown) => {
     const serviceCode =
       typeof error === 'object' &&
@@ -46,6 +50,13 @@ vi.mock('@/features/settings', () => ({
     if (serviceCode === 'BILLING_ACCOUNT_CLOSING') return 'account_closing';
     if (serviceCode === 'BILLING_RESPONSE_EXPIRED') return 'terminal';
     return 'retryable';
+  },
+  shouldContinueBillingPoll: () => false,
+  useBillingPollStore: {
+    use: {
+      startedAt: () => null,
+      stop: () => vi.fn(),
+    },
   },
   useStableBillingOperation: () => ({
     begin: beginPortalAttempt,

--- a/apps/product/src/app/[locale]/(app)/_shell/useAppInlineBanner.ts
+++ b/apps/product/src/app/[locale]/(app)/_shell/useAppInlineBanner.ts
@@ -9,6 +9,7 @@ import { api } from '@/lib/trpc';
 
 import {
   BILLING_POLL_INTERVAL_MS,
+  BILLING_POLL_MAX_DURATION_MS,
   getBillingOperationErrorDisposition,
   shouldContinueBillingPoll,
   useBillingPollStore,

--- a/apps/product/src/app/[locale]/(app)/_shell/useAppInlineBanner.ts
+++ b/apps/product/src/app/[locale]/(app)/_shell/useAppInlineBanner.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { useTranslations } from 'next-intl';
 
@@ -8,7 +8,10 @@ import { toast } from '@/lib/toast';
 import { api } from '@/lib/trpc';
 
 import {
+  BILLING_POLL_INTERVAL_MS,
   getBillingOperationErrorDisposition,
+  shouldContinueBillingPoll,
+  useBillingPollStore,
   useStableBillingOperation,
 } from '@/features/settings';
 
@@ -37,9 +40,38 @@ export function useAppInlineBanner(): InlineBannerState {
     settle: settlePortalAttempt,
   } = useStableBillingOperation();
 
+  // Checkout 成功復帰直後（settings/[category]/page.tsx が useBillingPollStore を
+  // start する）だけ短い間隔で再取得する。webhook 経由の subscription_status 反映が
+  // invalidate に追いつかないケースの救済（issue #1887）。この hook は app shell に
+  // 常駐するため、settings modal の開閉に関係なくポーリングを継続できる。
+  const pollStartedAt = useBillingPollStore.use.startedAt();
+  const stopBillingPoll = useBillingPollStore.use.stop();
+
   const billingQuery = api.billing.getOverview.useQuery(undefined, {
     retry: false,
+    refetchInterval: (query) => {
+      if (pollStartedAt === null) return false;
+      const status = query.state.data?.billingInfo.subscriptionStatus;
+      return shouldContinueBillingPoll({ startedAt: pollStartedAt, subscriptionStatus: status })
+        ? BILLING_POLL_INTERVAL_MS
+        : false;
+    },
   });
+
+  useEffect(() => {
+    if (pollStartedAt === null) return;
+    const status = billingQuery.data?.billingInfo.subscriptionStatus;
+    if (!shouldContinueBillingPoll({ startedAt: pollStartedAt, subscriptionStatus: status })) {
+      stopBillingPoll();
+      return;
+    }
+    // webhook 未達のまま data が変化しないと、この effect は再実行されず
+    // startedAt が残って「反映中」表示が消えない。refetchInterval の自然停止とは
+    // 別に、打ち切り時刻（+ 最終 refetch の着地猶予 1 interval）で必ず stop する
+    const remainingMs = BILLING_POLL_MAX_DURATION_MS - (Date.now() - pollStartedAt);
+    const timer = setTimeout(stopBillingPoll, Math.max(remainingMs, 0) + BILLING_POLL_INTERVAL_MS);
+    return () => clearTimeout(timer);
+  }, [billingQuery.data, pollStartedAt, stopBillingPoll]);
   const createPortal = api.billing.createPortalSession.useMutation({
     onSuccess(data, variables) {
       if (!variables) return;

--- a/apps/product/src/app/[locale]/(app)/settings/[category]/page.tsx
+++ b/apps/product/src/app/[locale]/(app)/settings/[category]/page.tsx
@@ -12,7 +12,12 @@ import {
   removeCalendarCallbackParams,
   type CalendarCallbackError,
 } from '@/features/external-calendar';
-import { isValidCategory, SETTINGS_CATEGORIES, SettingsContent } from '@/features/settings';
+import {
+  isValidCategory,
+  SETTINGS_CATEGORIES,
+  SettingsContent,
+  useBillingPollStore,
+} from '@/features/settings';
 import { MEDIA_QUERIES } from '@/lib/breakpoints';
 import { useHasMounted } from '@/lib/hooks/useHasMounted';
 import { useMediaQuery } from '@/lib/hooks/useMediaQuery';
@@ -113,6 +118,14 @@ export default function SettingsCategoryPage() {
       // 永続化され staleTime 5 分は fresh 扱いのため、invalidate しないと外部遷移前の
       // 値がそのまま復元されて解約やプラン変更が反映されない
       void utils.billing.getOverview.invalidate();
+
+      // Checkout 成功直後は subscription_status の webhook 反映が invalidate に
+      // 追いつかず、再取得しても古い free が返りうる（issue #1887）。この場合だけ
+      // 有限ポーリングを開始する（useAppInlineBanner 側の billing.getOverview query
+      // が startedAt を見て refetchInterval を有効化する）。
+      if (billingReturn === 'checkout_success') {
+        useBillingPollStore.getState().start();
+      }
 
       if (!isMobile) {
         openSettings(category);

--- a/apps/product/src/features/settings/components/BillingSettings.tsx
+++ b/apps/product/src/features/settings/components/BillingSettings.tsx
@@ -36,6 +36,7 @@ import {
 
 import { useStableBillingOperation } from '../hooks/useStableBillingOperation';
 import { getBillingOperationErrorDisposition } from '../lib/billing-operation';
+import { useBillingPollStore } from '../stores/useBillingPollStore';
 
 interface Plan {
   id: DayoptPlanId;
@@ -98,10 +99,14 @@ export function BillingSettings() {
   // openSettings + router.replace('/') で query が消えるため、ここで searchParams を
   // 読んでも間に合わない。
 
-  // 統合エンドポイントで一括取得（N+1 解消）
+  // 統合エンドポイントで一括取得（N+1 解消）。refetchInterval は useAppInlineBanner
+  // 側で有効化される（app shell に常駐し、settings modal の開閉に依存しないため）。
   const overview = api.billing.getOverview.useQuery(undefined, {
     retry: false,
   });
+  // Checkout 成功復帰直後のポーリング中は、まだ Free のまま見えていても
+  // 「反映中」であることをユーザーに伝える（issue #1887）。
+  const isPollingAfterCheckout = useBillingPollStore.use.startedAt() !== null;
 
   const subscriptionStatus = overview.data?.billingInfo.subscriptionStatus;
   const trialEndsAt = overview.data?.trialEndsAt ?? null;
@@ -269,6 +274,12 @@ export function BillingSettings() {
                   ? t('settings.subscription.proPlanDescription')
                   : t('settings.subscription.freePlanDescription')}
             </p>
+            {/* Checkout 成功直後、webhook 反映待ちでまだ Free に見えている間の一時表示 */}
+            {isPollingAfterCheckout && !canAccessPro && (
+              <p className="text-muted-foreground text-base md:text-sm">
+                {t('settings.subscription.syncingPlan')}
+              </p>
+            )}
             {/* Stripe から期限を取れなかった場合は表示しない（Badge と説明文は従来どおり出る） */}
             {subscriptionStatus === 'trialing' && trialEndsAt && (
               <p className="text-muted-foreground text-base md:text-sm">

--- a/apps/product/src/features/settings/index.ts
+++ b/apps/product/src/features/settings/index.ts
@@ -47,6 +47,16 @@ export { TrialEndedDialog } from './components/TrialEndedDialog';
 // Utils
 // =============================================================================
 export { getBillingOperationErrorDisposition } from './lib/billing-operation';
+export {
+  BILLING_POLL_INTERVAL_MS,
+  BILLING_POLL_MAX_DURATION_MS,
+  shouldContinueBillingPoll,
+} from './lib/billing-poll';
+
+// =============================================================================
+// Stores (Composition Layer 向け)
+// =============================================================================
+export { useBillingPollStore } from './stores/useBillingPollStore';
 
 // タイムゾーン等のserver stateはuseUserPreferences経由でquery cacheから取得する。
 

--- a/apps/product/src/features/settings/lib/__tests__/billing-poll.test.ts
+++ b/apps/product/src/features/settings/lib/__tests__/billing-poll.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { BILLING_POLL_MAX_DURATION_MS, shouldContinueBillingPoll } from '../billing-poll';
+
+describe('shouldContinueBillingPoll', () => {
+  it('startedAt が null なら（未開始）ポーリングしない', () => {
+    expect(shouldContinueBillingPoll({ startedAt: null, subscriptionStatus: 'free', now: 0 })).toBe(
+      false,
+    );
+  });
+
+  it('subscriptionStatus が未取得（undefined）でも、経過時間内なら継続する', () => {
+    expect(
+      shouldContinueBillingPoll({ startedAt: 0, subscriptionStatus: undefined, now: 1000 }),
+    ).toBe(true);
+  });
+
+  it('subscriptionStatus が free のまま、経過時間内なら継続する', () => {
+    expect(shouldContinueBillingPoll({ startedAt: 0, subscriptionStatus: 'free', now: 1000 })).toBe(
+      true,
+    );
+  });
+
+  it.each(['active', 'trialing', 'past_due'] as const)(
+    'subscriptionStatus が %s（Pro 相当）になったら停止する',
+    (status) => {
+      expect(
+        shouldContinueBillingPoll({ startedAt: 0, subscriptionStatus: status, now: 1000 }),
+      ).toBe(false);
+    },
+  );
+
+  it('最大経過時間ちょうどで停止する（未満のみ継続）', () => {
+    expect(
+      shouldContinueBillingPoll({
+        startedAt: 0,
+        subscriptionStatus: 'free',
+        now: BILLING_POLL_MAX_DURATION_MS,
+      }),
+    ).toBe(false);
+  });
+
+  it('最大経過時間の直前までは継続する', () => {
+    expect(
+      shouldContinueBillingPoll({
+        startedAt: 0,
+        subscriptionStatus: 'free',
+        now: BILLING_POLL_MAX_DURATION_MS - 1,
+      }),
+    ).toBe(true);
+  });
+
+  it('最大経過時間を超えたら停止する', () => {
+    expect(
+      shouldContinueBillingPoll({
+        startedAt: 0,
+        subscriptionStatus: 'free',
+        now: BILLING_POLL_MAX_DURATION_MS + 1,
+      }),
+    ).toBe(false);
+  });
+
+  it('now を省略すると Date.now() を使う（未開始なら影響しない）', () => {
+    expect(shouldContinueBillingPoll({ startedAt: null, subscriptionStatus: 'free' })).toBe(false);
+  });
+});

--- a/apps/product/src/features/settings/lib/billing-poll.ts
+++ b/apps/product/src/features/settings/lib/billing-poll.ts
@@ -1,0 +1,46 @@
+import {
+  dayoptPlanIds,
+  getPlanIdForSubscriptionStatus,
+  type SubscriptionStatus,
+} from '@dayopt/billing';
+
+/**
+ * Stripe Checkout 成功復帰直後の有限ポーリング。
+ *
+ * `subscription_status` の更新は webhook 経由の非同期処理のため、Checkout 成功で
+ * 復帰した直後は `billing.getOverview` を invalidate しても webhook 未到達で
+ * 古い `free` が返りうる（issue #1887）。復帰直後だけ短い間隔で再取得し、
+ * webhook 到達を待つ。
+ */
+
+/** ポーリング間隔（ミリ秒） */
+export const BILLING_POLL_INTERVAL_MS = 2500;
+
+/** ポーリングを打ち切るまでの最大経過時間（ミリ秒） */
+export const BILLING_POLL_MAX_DURATION_MS = 30_000;
+
+interface ShouldContinueBillingPollParams {
+  /** ポーリング開始時刻（epoch ms）。null は非アクティブ（開始されていない） */
+  startedAt: number | null;
+  /** 直近取得した `subscription_status`（未取得時は undefined） */
+  subscriptionStatus: SubscriptionStatus | null | undefined;
+  /** テスト用に注入できる現在時刻（epoch ms）。省略時は `Date.now()` */
+  now?: number;
+}
+
+/**
+ * ポーリングを続けるべきか判定する。
+ *
+ * 打ち切り条件は 2 つ（いずれか一方で停止）:
+ * (a) `subscription_status` が Free 相当から抜けた（webhook 反映済み）
+ * (b) 開始から {@link BILLING_POLL_MAX_DURATION_MS} を超えた（webhook 未達のまま打ち切り）
+ */
+export function shouldContinueBillingPoll({
+  startedAt,
+  subscriptionStatus,
+  now = Date.now(),
+}: ShouldContinueBillingPollParams): boolean {
+  if (startedAt === null) return false;
+  if (getPlanIdForSubscriptionStatus(subscriptionStatus) !== dayoptPlanIds.free) return false;
+  return now - startedAt < BILLING_POLL_MAX_DURATION_MS;
+}

--- a/apps/product/src/features/settings/stores/useBillingPollStore.ts
+++ b/apps/product/src/features/settings/stores/useBillingPollStore.ts
@@ -1,0 +1,41 @@
+'use client';
+
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+
+import { createSelectors } from '@/lib/zustand/createSelectors';
+
+/**
+ * Stripe Checkout 成功復帰直後の有限ポーリング状態。
+ *
+ * `settings/[category]/page.tsx` が checkout success 復帰を検出した時に `start()` を
+ * 呼ぶ。`useAppInlineBanner` 側の `billing.getOverview` query がこの `startedAt` を見て
+ * refetchInterval を有効化し、`shouldContinueBillingPoll`（`../lib/billing-poll`）が
+ * false を返した時点で `stop()` する。
+ *
+ * PC 復帰は `openSettings` + `router.replace` で query が消えるが、これは SPA 内の
+ * client navigation でフルリロードは起きないため、この store の状態は
+ * 遷移をまたいで保持される。永続化はしない（タブを跨いで古い開始時刻を
+ * 引き継ぐ意味がなく、むしろ誤ってポーリングが再開する害の方が大きい）。
+ */
+interface BillingPollState {
+  /** ポーリング開始時刻（epoch ms）。null は非アクティブ */
+  startedAt: number | null;
+  /** checkout success 復帰を検出した時に呼ぶ */
+  start: () => void;
+  /** Pro 反映確認 or タイムアウトで呼ぶ */
+  stop: () => void;
+}
+
+const useBillingPollStoreBase = create<BillingPollState>()(
+  devtools(
+    (set) => ({
+      startedAt: null,
+      start: () => set({ startedAt: Date.now() }, false, 'start'),
+      stop: () => set({ startedAt: null }, false, 'stop'),
+    }),
+    { name: 'billing-poll-store', enabled: process.env.NODE_ENV !== 'production' },
+  ),
+);
+
+export const useBillingPollStore = createSelectors(useBillingPollStoreBase);

--- a/apps/product/src/lib/test/e2e/auth.spec.ts
+++ b/apps/product/src/lib/test/e2e/auth.spec.ts
@@ -10,6 +10,15 @@ import { expect, test } from '@playwright/test';
  * - features/auth/components/__tests__/PasswordResetForm.test.tsx
  * 未認証リダイレクトとログイン導線の重複は smoke.spec.ts が正。
  *
+ * MFA（TOTP）/ リカバリーコードのログイン経路は E2E では持たない（#1873 の判断）:
+ * - AAL2 昇格の分岐・redirect は LoginForm.test.tsx / proxy の unit test がモックで検証済み、
+ *   recovery code の crypto / DB 層は unit + integration（rls-access.integration.test.ts）が正
+ * - Supabase Admin API に MFA enroll のショートカットが無く事前 seed 不可、TOTP 生成の
+ *   新規依存と 30 秒ウィンドウの clock skew が恒常的 flaky 要因になり、E2E 化のコストが
+ *   検証価値（残 gap は実 Cookie 経由の AAL2 受け渡しのみ）に見合わない
+ * - 手薄なのは client UI 層の component test（useMFA / MFAVerifyForm / MFASection）で、
+ *   これは本コメント冒頭の原則どおり component test の領域（別 issue で追跡）
+ *
  * @see Storybook → Features/Auth/* でUI詳細を確認
  */
 

--- a/apps/product/src/lib/test/e2e/auth.spec.ts
+++ b/apps/product/src/lib/test/e2e/auth.spec.ts
@@ -81,7 +81,7 @@ test.describe('Auth: 認証フロー', () => {
   });
 
   test('誤った認証情報でエラー表示', async ({ page }) => {
-    await page.goto('/auth/login');
+    await page.goto('/ja/auth/login');
 
     await page
       .locator('input[type="email"], input[name="email"]')
@@ -90,9 +90,21 @@ test.describe('Auth: 認証フロー', () => {
     await page.locator('input[type="password"]').first().fill('WrongPassword123');
     await page.locator('button[type="submit"]').first().click();
 
-    // エラーメッセージが表示される（ユーザー列挙を防ぐ汎用メッセージ）
-    await expect(
-      page.locator('[role="alert"], [data-field-error], .text-destructive').first(),
-    ).toBeVisible({ timeout: 10000 });
+    // エラーメッセージが表示される（ユーザー列挙を防ぐ汎用メッセージ）。
+    //
+    // 待つ対象はサーバーエラーの FieldError と invalidCredentials の文言に限定する。
+    // `.text-destructive` を含む複合 locator では、必須ラベルの「＊」マーカー
+    // （field.tsx が required に付ける）が送信前から可視なため即座に一致してしまい、
+    // 認証エラーが実際には出ていない regression でもテストが green になる
+    // （account-deletion.spec.ts の再ログイン検証と同型の偽陽性、#1883）。
+    // role="alert" が付くのは announceImmediately の FieldError（= サーバーエラー）
+    // だけだが、Next.js の route announcer も role="alert" を持つため
+    // data-slot でさらに絞る。
+    await expect(page.locator('[role="alert"][data-slot="field-error"]')).toContainText(
+      'メールアドレスまたはパスワードが正しくありません',
+      { timeout: 10000 },
+    );
+    // 認証が通っていないこと自体も確認する（成功していれば /day 等へ抜ける）
+    await expect(page).toHaveURL(/\/auth\/login/);
   });
 });

--- a/apps/product/src/lib/test/integration/calendar-ciphertext-expiry-lock.integration.test.ts
+++ b/apps/product/src/lib/test/integration/calendar-ciphertext-expiry-lock.integration.test.ts
@@ -380,13 +380,15 @@ WHERE operation.operation_id IN (
   :'second_operation_id'::UUID
 );
 
+-- outbox の expires_at は未来に保つ（#1866）。この列を読むのは pg_cron の
+-- ハード期限切れ掃除（expire-calendar-revoke-outbox、毎分、FOR UPDATE SKIP LOCKED、
+-- operation の state / lock を見ない）だけで、テスト対象の
+-- expire_calendar_revoke_authority_v3 経路は operations 側の expires_at のみ参照する。
+-- ここを過去に倒すと、setup〜assertion の間に cron tick が挟まった時だけ
+-- deferred 行の outbox まで消えて '0|1' 期待が '0|0' になる（CI flake の原因）。
 UPDATE private.calendar_revoke_outbox AS queued
 SET created_at = pg_catalog.clock_timestamp() - INTERVAL '2 hours',
-    expires_at = CASE
-      WHEN queued.id = :'first_operation_id'::UUID
-        THEN pg_catalog.clock_timestamp() - INTERVAL '2 minutes'
-      ELSE pg_catalog.clock_timestamp() - INTERVAL '1 minute'
-    END
+    expires_at = pg_catalog.clock_timestamp() + INTERVAL '1 hour'
 WHERE queued.id IN (
   :'first_operation_id'::UUID,
   :'second_operation_id'::UUID


### PR DESCRIPTION
## 概要

`status:ready` の issue 4 件を 1 branch に束ねて対応（`.claude/rules/workflow.md` §PR 粒度）。

### #1887 — 決済成功復帰直後に Free 表示が残りうる
checkout success 復帰時だけ 2.5 秒間隔・最大 30 秒の有限ポーリングを app shell 常駐の `billing.getOverview` query で行う。Pro 反映 / タイムアウトの二重条件（refetchInterval 判定 + setTimeout）で必ず停止し、`?canceled=true` ではポーリングしない。ポーリング中は課金設定に「反映を確認しています」を表示。打ち切りロジックは純粋関数 `billing-poll.ts` に切り出し unit test 10 件で固定。

### #1883 — auth.spec.ts の誤認証エラー検証が偽陽性
必須ラベルの「＊」（`.text-destructive`）に送信前から一致していた複合 locator を `[role="alert"][data-slot="field-error"]` + `invalidCredentials` 文言検証に修正（account-deletion.spec.ts / PR #1882 と同型）。locale を `/ja/auth/login` に固定（default locale は en のため必須）。

### #1866 — calendar-ciphertext-expiry-lock の CI flake
原因は実装バグではなくテストの isolation 欠落。outbox の `expires_at` を過去に倒す setup が、毎分走る pg_cron のハード期限切れ掃除（operation の lock を見ず SKIP LOCKED で消す既存仕様）の削除対象を作っていた。outbox 側 `expires_at` を未来に保ち cron の対象から構造的に除外。テスト対象経路は operations 側の `expires_at` しか読まないため検証対象は不変。**当該 spec をローカルで 5 回連続 green を確認**。

### #1873 — MFA E2E の設計判断（Step 0）
「E2E では持たない」と判断し、根拠を `auth.spec.ts` の境界コメントに記録（詳細は issue コメント）。実際の gap（MFA client UI 層の component test ゼロ）は #1889 に起票。

## 検証

- `pnpm check`: typecheck / lint / lint:boundaries / knip / docs 通過。unit test の失敗 85 件はすべて localStorage/persist 系の既知 node26 環境依存で、**main checkout でも同一に失敗することを確認済み**（CI の node24 では pass する既知パターン）
- `pnpm test:integration`（当該 spec）: 5 回連続 green
- billing-poll / useAppInlineBanner の unit test: 15/15 pass
- auth E2E のローカル実行は `TEST_USER_*` 未設定のため未実施（ready 化後の重量層 CI で検証）

## 内部レビュー（read-only subagent クロスレビュー）

- `risk-reviewer`（billing）: 開始条件・3 重の停止・auth 境界・param 改ざん耐性の反証すべて不成立。import 欠落 1 件を検出 → 修正済み
- `behavior-verifier`: 3 変更とも既存挙動維持を一次情報で確認、反証不成立。warning 1 件（`syncingPlan` 表示の component test 欠如、任意 follow-up）
- `architecture-guard`: barrel 経路・store 配置・依存方向すべて規約と既存 precedent に一致、違反なし

## 備考

- #1866 調査の副産物: `expire_calendar_revoke_outbox_legacy_unbound_internal_v1` が未配線（詳細は #1866 のコメント。external-calendar epic の文脈で要ユーザー判断）

Closes #1887
Closes #1883
Closes #1866
Closes #1873
Refs #1889

🤖 Generated with [Claude Code](https://claude.com/claude-code)