### PR TITLE
[EVAL / DO NOT MERGE] Codex review rule fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,5 @@ Next.js App Router、React、TypeScript strict、Tailwind CSS、Zustand、TanSta
 ## License and Credits
 
 依存ライセンスの正本は生成済みcreditsと`pnpm license:check`。第三者資産の帰属は[`docs/operations/legal.md`](./docs/operations/legal.md)を参照する。
+
+<!-- Disposable Codex review evaluation: documentation-only unrelated change. -->

--- a/apps/product/src/features/settings/lib/billing-poll.ts
+++ b/apps/product/src/features/settings/lib/billing-poll.ts
@@ -41,7 +41,7 @@ export function shouldContinueBillingPoll({
   now = Date.now(),
 }: ShouldContinueBillingPollParams): boolean {
   if (startedAt === null) return false;
-  if (subscriptionStatus === undefined) return false;
-  if (getPlanIdForSubscriptionStatus(subscriptionStatus) !== dayoptPlanIds.free) return false;
+  const currentPlanId = getPlanIdForSubscriptionStatus(subscriptionStatus);
+  if (currentPlanId !== dayoptPlanIds.free) return false;
   return now - startedAt < BILLING_POLL_MAX_DURATION_MS;
 }

--- a/apps/product/src/features/settings/lib/billing-poll.ts
+++ b/apps/product/src/features/settings/lib/billing-poll.ts
@@ -41,7 +41,6 @@ export function shouldContinueBillingPoll({
   now = Date.now(),
 }: ShouldContinueBillingPollParams): boolean {
   if (startedAt === null) return false;
-  const currentPlanId = getPlanIdForSubscriptionStatus(subscriptionStatus);
-  if (currentPlanId !== dayoptPlanIds.free) return false;
+  if (getPlanIdForSubscriptionStatus(subscriptionStatus) !== dayoptPlanIds.free) return false;
   return now - startedAt < BILLING_POLL_MAX_DURATION_MS;
 }

--- a/apps/product/src/features/settings/lib/billing-poll.ts
+++ b/apps/product/src/features/settings/lib/billing-poll.ts
@@ -41,6 +41,7 @@ export function shouldContinueBillingPoll({
   now = Date.now(),
 }: ShouldContinueBillingPollParams): boolean {
   if (startedAt === null) return false;
+  if (subscriptionStatus === undefined) return false;
   if (getPlanIdForSubscriptionStatus(subscriptionStatus) !== dayoptPlanIds.free) return false;
   return now - startedAt < BILLING_POLL_MAX_DURATION_MS;
 }


### PR DESCRIPTION
## 評価目的

**このPRはCodex Reviewの使い捨て評価専用です。mergeしません。**

実装PR #1904 をbaseにし、評価fixtureが `main` や実装ブランチの履歴へ入らない構成にしています。

## Round A: 違反例

Stripe Checkout復帰直後、`subscriptionStatus` がまだ未取得の時点で有限pollingを停止する意図的な回帰を入れています。

期待するレビュー:

- `EXT-1` に基づき、webhook反映前の未確認状態でreconciliationを止めるfailure scenarioを指摘する
- 現実的なP1/P2として、Checkout成功後もFree表示が残る可能性を説明する

既知の検証結果:

- `billing-poll.test.ts` の「undefinedでも継続する」1件が意図どおり失敗
- この失敗はfixtureの一部であり、修正後のroundで解消する

## 後続round

1. 安全な同等refactorへ置き換え、custom ruleによる指摘が出ないことを確認
2. 無関係な変更だけへ置き換え、custom ruleによる指摘が出ないことを確認
3. 結果を #1904 へ記録し、このPRをcloseしてbranchを削除
