### PR TITLE
docs(operations): production DB 復元演習の手順書と災害復旧手順を用意する

### DIFF
--- a/.claude/skills/supabase/SKILL.md
+++ b/.claude/skills/supabase/SKILL.md
@@ -381,13 +381,15 @@ export function useEntityRealtime(onUpdate: () => void) {
 
 ### 構成
 
-| Function          | 用途                                 | Preview | Staging | Production |
-| ----------------- | ------------------------------------ | ------- | ------- | ---------- |
-| `send-auth-email` | Supabase Auth メール送信(Resend経由) | ✅      | ✅      | ✅         |
-| `check-reminders` | リマインダー通知(cron)               | ❌      | ✅      | ✅         |
-| `daily-insights`  | 日次AI洞察(cron)                     | ❌      | ✅      | ✅         |
+**正本は `supabase/functions/` の実体と `supabase/config.toml` の `[functions.*]` 宣言。** この表ではなく、そちらを確認する。
 
-**方針**: preview branch には「PR検証に必要な function のみ」デプロイする。cron は preview で動いても意味がなく、Anthropic API 等のコスト要因になるため除外。
+| Function          | 用途                                 | Preview | Production |
+| ----------------- | ------------------------------------ | ------- | ---------- |
+| `send-auth-email` | Supabase Auth メール送信(Resend経由) | ✅      | ✅         |
+
+**方針**: preview branch には「PR検証に必要な function のみ」デプロイする。cron は preview で動いても意味がなく、コスト要因になるため除外。
+
+かつて `check-reminders` / `daily-insights` を運用していたが、実体・宣言とも既に無く、DB 側の cron 登録も `20260425000000_unschedule_removed_edge_function_cron_jobs.sql` で解除済み。
 
 ### Auth Hook を Edge Function で受ける時の verify_jwt
 
@@ -409,15 +411,8 @@ export function useEntityRealtime(onUpdate: () => void) {
 # preview branch
 npx supabase functions deploy send-auth-email --use-api --project-ref=<PREVIEW_REF>
 
-# staging
-for fn in send-auth-email check-reminders daily-insights; do
-  npx supabase functions deploy $fn --use-api --project-ref=<STAGING_REF>
-done
-
 # production
-for fn in send-auth-email check-reminders daily-insights; do
-  npx supabase functions deploy $fn --use-api --project-ref=<PROD_REF>
-done
+npx supabase functions deploy send-auth-email --use-api --project-ref=<PROD_REF>
 ```
 
 通常は GitHub Actions で自動実行される。手動デプロイは緊急時のみ。

--- a/.claude/skills/supabase/SKILL.md
+++ b/.claude/skills/supabase/SKILL.md
@@ -464,7 +464,7 @@ npx supabase secrets set --env-file .env.edge.<env> --project-ref=<REF>
 - デプロイは必ず `--use-api` フラグ付きで実行
 - production の secrets を preview / staging にコピーしない
 - `RESEND_API_KEY` の live key は production のみ
-- cron function(`check-reminders` / `daily-insights`)は preview にデプロイしない
+- cron function は preview にデプロイしない（現状そのような function は無い）
 
 ### Secrets
 

--- a/docs/engineering/infra.md
+++ b/docs/engineering/infra.md
@@ -1311,10 +1311,15 @@ ORDER BY schemaname, tablename;
 **メンテナンスモード（`NEXT_PUBLIC_MAINTENANCE_MODE`）は Next.js app 層しか止めない。** pg_cron の job は Postgres 内部で独立に走り続けるため、「書き込みを止めた」つもりで復元しても cron 起因の書き込みは続く。
 
 ```sql
--- 対象 job を確認してから止める
-SELECT jobid, jobname, active FROM cron.job;
+-- ① 先に控える。production の cron は Dashboard 設定が正本で、
+--    migration から再生成できない。控えずに止めると復旧手段が消える
+SELECT jobid, jobname, schedule, command, active FROM cron.job ORDER BY jobname;
+
+-- ② 控えた内容を保存してから止める
 SELECT cron.unschedule(jobname) FROM cron.job WHERE active;
 ```
+
+**①を飛ばさない。** 止めた job は復旧後に手で戻すことになり、控えが無いとスケジュールも command も分からなくなる。
 
 §DB Migration Rollback 手順書 の緊急対応フローチャートには pg_cron 停止ステップがあるが、災害復旧でも同じことが要る。
 

--- a/docs/engineering/infra.md
+++ b/docs/engineering/infra.md
@@ -5,7 +5,7 @@ last_verified: 2026-08-09
 
 # インフラ・環境・API/Routing 総覧
 
-環境構成（Local / PR Preview / Production）、CI品質ゲートのロードマップ、Bot 対策（Turnstile）、API endpoints 総覧、Supabase 型自動生成、App Router routing 総覧、パフォーマンス監視の原則、開発コマンド一覧、マイグレーション/リリースチェックリスト、DB Migration Rollback 手順書、出口コスト台帳。「環境・デプロイ・シークレットは?」の正。
+環境構成（Local / PR Preview / Production）、CI品質ゲートのロードマップ、Bot 対策（Turnstile）、API endpoints 総覧、Supabase 型自動生成、App Router routing 総覧、パフォーマンス監視の原則、開発コマンド一覧、マイグレーション/リリースチェックリスト、災害復旧手順、DB Migration Rollback 手順書、出口コスト台帳。「環境・デプロイ・シークレットは?」の正。
 
 ---
 
@@ -1283,9 +1283,53 @@ ORDER BY schemaname, tablename;
 
 ---
 
+## 災害復旧手順
+
+策定日: 2026-08-12（[#1879](https://github.com/Dayopt/dayopt/issues/1879)）
+
+**次節の §DB Migration Rollback 手順書 が「判断の巻き戻し」（自分が適用した migration を戻す）なのに対し、本節は「事故からの復旧」（データ消失・オペミス・DB 破損）を扱う。** 原因が自分の変更なら次節、失われたデータを取り戻すなら本節。
+
+> **⚠ 本節の RTO / RPO はまだ実測されていない。** 復元演習は未実施で、手順は [復元演習手順書](../operations/disaster-recovery-drill.md) に用意済み。**演習を通していない経路を障害中にぶっつけで走らせることになる**前提で判断する。演習後にここへ実測値を書く。
+
+### 復元でも戻らないもの
+
+障害対応中に最初に知るべきはこれ。**DB backup をどう復元しても、以下は戻らない。**
+
+| 対象                        | なぜ                                             | 戻し方                                                     |
+| --------------------------- | ------------------------------------------------ | ---------------------------------------------------------- |
+| **Storage オブジェクト**    | どの DB backup にも含まれない（Supabase の仕様） | S3 互換エンドポイント経由で別途搬出・復元。versioning 無し |
+| **Edge Functions**          | 復元対象外                                       | `supabase functions deploy <slug> --use-api` で再デプロイ  |
+| **custom role の password** | backup に含まれない                              | 再設定                                                     |
+| **Realtime publication**    | 別 project へ復元した場合は再有効化が必要        | 現状 publication は空なので影響なし                        |
+
+**production の pg_cron job は `supabase/migrations/` が正本ではない**（baseline に「本番は Dashboard で設定」とある）。復元の前後で `SELECT jobname, schedule, active FROM cron.job;` を控えて突き合わせる。
+
+### 復旧経路の選択
+
+| 状況                       | 経路                                                                                                    |
+| -------------------------- | ------------------------------------------------------------------------------------------------------- |
+| 自分の migration が原因    | §DB Migration Rollback 手順書（逆 SQL を新 migration として適用）                                       |
+| データ消失・破損・オペミス | backup / PITR から復元。**production への in-place restore は破壊的で、実行中はプロジェクトが停止する** |
+| schema だけ壊れた          | forward restoration migration（削除済みデータは戻らない）                                               |
+
+**backup の保持期間と PITR の有効・無効は Dashboard でしか確認できない**（Management API の project endpoint は backup 情報を返さない。2026-08-12 実測）。障害中に「backup があるはず」で動かず、まず Dashboard で存在を確認する。
+
+### 実測値
+
+| 指標                             | 値                                                            |
+| -------------------------------- | ------------------------------------------------------------- |
+| RTO（復元開始 → 主要フロー通過） | **未実測**                                                    |
+| RPO（失う最大時間幅）            | **未実測**（daily backup なら最大 24 時間、PITR なら約 2 分） |
+
+手順の詳細・確認観点・中止条件は [復元演習手順書](../operations/disaster-recovery-drill.md) が正本。本節は結論と「戻らないもの」だけを持つ。
+
+---
+
 ## DB Migration Rollback 手順書
 
 本番デプロイ事故時の逆マイグレーションSQL集。Supabaseはネイティブのrollback機構を持たないため、**逆SQLを新しいマイグレーションとして適用する**方式で対応する。
+
+**データ消失・オペミスからの復旧は本節の対象外。** その場合は §災害復旧手順 を読む。
 
 > **対象**: `supabase/migrations/` 配下の全17マイグレーション（baseline除く）
 

--- a/docs/engineering/infra.md
+++ b/docs/engineering/infra.md
@@ -1308,7 +1308,31 @@ ORDER BY schemaname, tablename;
 
 ### 復元前に止めるもの
 
-**メンテナンスモード（`NEXT_PUBLIC_MAINTENANCE_MODE`）は Next.js app 層しか止めない。** pg_cron の job は Postgres 内部で独立に走り続けるため、「書き込みを止めた」つもりで復元しても cron 起因の書き込みは続く。
+**復元より前に書き込みを止める。** 止まっていないと、backup 時刻以降の書き込みが復元で丸ごと消える。ところが**現状 Dayopt に「書き込みを止める」手段は無い**。
+
+#### メンテナンスモードは書き込みを止めない（2026-08-12 実測）
+
+`NEXT_PUBLIC_MAINTENANCE_MODE=true` が止めるのは**画面遷移だけ**。
+
+- `apps/product/src/proxy.ts` はメンテナンス判定（`isMaintenanceMode`）より**前に** `pathname.startsWith('/api')` で早期 return する
+- さらに `config.matcher` が `api` を除外しているので、`/api/trpc` と `/api/webhooks/*` は proxy を通らない
+
+結果として、**既に画面を開いているユーザーの mutation と Stripe / Resend の webhook は、メンテナンスモード中も DB を更新し続ける**。「メンテナンスモードにしたから止まった」と判断すると、その間の書き込みを失う。
+
+#### いま実際に止められるもの
+
+| 対象                   | 手段                                                         | 影響                                       |
+| ---------------------- | ------------------------------------------------------------ | ------------------------------------------ |
+| 画面からの操作         | `NEXT_PUBLIC_MAINTENANCE_MODE=true`                          | 小                                         |
+| API / webhook 書き込み | **専用の手段が無い。** deployment を止めるしかない           | 大（サービス全停止。webhook は再送に頼る） |
+| MCP 経由の書き込み     | 既存の write gate（`writes_enabled` / `enabled_client_ids`） | MCP 利用者のみ                             |
+| pg_cron                | 下記 SQL                                                     | cron 処理の停止                            |
+
+**恒久対応（API 層の write fence）は [#1972](https://github.com/Dayopt/dayopt/issues/1972) で追う。** それまでは「メンテナンスモード + deployment 停止」でしか write を止められない前提で判断する。
+
+#### pg_cron を止める
+
+pg_cron の job は Postgres 内部で独立に走るため、app 側を何をしても止まらない。
 
 ```sql
 -- ① 先に控える。production の cron は Dashboard 設定が正本で、
@@ -1320,6 +1344,16 @@ SELECT cron.unschedule(jobname) FROM cron.job WHERE active;
 ```
 
 **①を飛ばさない。** 止めた job は復旧後に手で戻すことになり、控えが無いとスケジュールも command も分からなくなる。
+
+### 復旧後に戻すもの（サービス再開前に確認する）
+
+**止めたものは戻さないと恒久的に止まったままになる。** 特に backup 復元をせず rollback 経路へ抜けた場合、cron を止めたことだけが残る。
+
+- [ ] **pg_cron を再登録する。** 控えた `jobname` / `schedule` / `command` から `SELECT cron.schedule('<name>', '<schedule>', '<command>');` で戻し、名前・schedule・command・`active` の一致を確認する
+  - 戻し忘れると `expire-calendar-revoke-outbox`（期限切れ revoke の処理）などが恒久停止する
+- [ ] Edge Function とその secrets（別 project へ復元した場合）
+- [ ] Auth Hook の登録（別 project へ復元した場合。§復元でも戻らないもの）
+- [ ] 最後にメンテナンスモードを解除する
 
 §DB Migration Rollback 手順書 の緊急対応フローチャートには pg_cron 停止ステップがあるが、災害復旧でも同じことが要る。
 

--- a/docs/engineering/infra.md
+++ b/docs/engineering/infra.md
@@ -1295,14 +1295,28 @@ ORDER BY schemaname, tablename;
 
 障害対応中に最初に知るべきはこれ。**DB backup をどう復元しても、以下は戻らない。**
 
-| 対象                        | なぜ                                             | 戻し方                                                     |
-| --------------------------- | ------------------------------------------------ | ---------------------------------------------------------- |
-| **Storage オブジェクト**    | どの DB backup にも含まれない（Supabase の仕様） | S3 互換エンドポイント経由で別途搬出・復元。versioning 無し |
-| **Edge Functions**          | 復元対象外                                       | `supabase functions deploy <slug> --use-api` で再デプロイ  |
-| **custom role の password** | backup に含まれない                              | 再設定                                                     |
-| **Realtime publication**    | 別 project へ復元した場合は再有効化が必要        | 現状 publication は空なので影響なし                        |
+| 対象                                              | なぜ                                                           | 戻し方                                                                                                                                          |
+| ------------------------------------------------- | -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Storage オブジェクト**                          | どの DB backup にも含まれない（Supabase の仕様）               | S3 互換エンドポイント経由で別途搬出・復元。versioning 無し                                                                                      |
+| **Edge Functions とその secrets**                 | 復元対象外                                                     | `supabase functions deploy <slug> --use-api` で再デプロイ + **secrets を再投入**（`supabase secrets set`）。コードを戻しても secrets は戻らない |
+| **Vault の secrets（別 project へ復元した場合）** | 暗号鍵は project 単位。別 project では復号できない可能性が高い | 1Password から再投入する（`vault.secrets` に 9 件。`stripe_secret_key` / `resend_api_key` / `service_role_key` / `recovery_code_pepper` 等）    |
+| **Realtime publication**                          | 別 project へ復元した場合は再有効化が必要                      | 現状 publication は空なので影響なし                                                                                                             |
 
 **production の pg_cron job は `supabase/migrations/` が正本ではない**（baseline に「本番は Dashboard で設定」とある）。復元の前後で `SELECT jobname, schedule, active FROM cron.job;` を控えて突き合わせる。
+
+> custom role の password も backup に含まれないが、**現状 Dayopt に custom role は無い**（migration に `CREATE ROLE` / `CREATE USER` が 0 件）。追加したらこの表に足す。
+
+### 復元前に止めるもの
+
+**メンテナンスモード（`NEXT_PUBLIC_MAINTENANCE_MODE`）は Next.js app 層しか止めない。** pg_cron の job は Postgres 内部で独立に走り続けるため、「書き込みを止めた」つもりで復元しても cron 起因の書き込みは続く。
+
+```sql
+-- 対象 job を確認してから止める
+SELECT jobid, jobname, active FROM cron.job;
+SELECT cron.unschedule(jobname) FROM cron.job WHERE active;
+```
+
+§DB Migration Rollback 手順書 の緊急対応フローチャートには pg_cron 停止ステップがあるが、災害復旧でも同じことが要る。
 
 ### 復旧経路の選択
 

--- a/docs/operations/disaster-recovery-drill.md
+++ b/docs/operations/disaster-recovery-drill.md
@@ -114,7 +114,7 @@ supabase branches create --help
 **γ を synthetic データで先に通し（= dry run）、その後 β を本番経路の証明として 1 回実行する。**
 
 - α は前提が 2 つとも壊れている（`--with-data` 未確認 + branch が migration に失敗する既知不具合）ので**初回演習では採らない**。#1461 が解決したら再評価する
-- γ を**実データで**回すのは既定で採らない。schema + roles だけを実データから取り、データ本体は `pnpm db:fresh` の seed で代用する。実データ複製が要ると判断した場合は User の明示判断とし、演習後に dump ファイルを削除するところまで手順に含める
+- γ を**実データで**回すのは既定で採らない。production から取るのは schema と roles だけで、データ本体は復元先で seed から作る（Step 1-1 / 1-2）。実データ複製が要ると判断した場合は User の明示判断とし、演習後に dump ファイルと復元先 DB を削除するところまで手順に含める
 - β は「本当に戻せるか」を答える唯一の案なので、**最終的に 1 回は通す**
 
 ---
@@ -123,24 +123,54 @@ supabase branches create --help
 
 目的は**手順を枯らすこと**。ここで詰まった箇所は Step 2 でも詰まる。
 
-### 1-1. 論理 dump を取る
+### 1-1. 論理 dump を取る（**既定では production のデータを取らない**）
 
-`supabase db dump` は既定で **schema のみ**、かつ `auth` / `storage` / extension 由来 schema を**除外**する。完全な論理バックアップは 3 本に分かれる。
+`supabase db dump` は既定で **schema のみ**、かつ `auth` / `storage` / extension 由来 schema を**除外**する。完全な論理バックアップは 3 本に分かれるが、**dry run で production から取るのは roles と schema の 2 本だけ**にする。
 
 ```bash
-supabase db dump --db-url "$DB_URL" --role-only -f roles.sql
-supabase db dump --db-url "$DB_URL" -f schema.sql
-supabase db dump --db-url "$DB_URL" --data-only --use-copy -f data.sql
+# production から取ってよいのはこの 2 本だけ（データを含まない）
+supabase db dump --db-url "$PROD_DB_URL" --role-only -f roles.sql
+supabase db dump --db-url "$PROD_DB_URL" -f schema.sql
 ```
+
+データ本体は **local の seed から作る**（後述 1-2）。production の `--data-only` は `plans` / `records` / `profiles` を平文の SQL としてローカルへ落とすため、**実行した時点で顧客 PII のローカル複製が成立する**。
+
+<details>
+<summary><strong>実データで回す必要が出た場合（User の明示判断が要る）</strong></summary>
+
+RTO はデータ量にほぼ比例するため、synthetic では所要時間が実態とずれる。実測が要ると判断した場合だけ、次を**セットで**満たす。
+
+```bash
+supabase db dump --db-url "$PROD_DB_URL" --data-only --use-copy -f data.sql
+```
+
+- [ ] User の明示判断を得た（「PII をローカルへ複製してよい」）
+- [ ] 保存先を決めた（暗号化されたディスク上。共有ディレクトリ・クラウド同期フォルダに置かない）
+- [ ] 演習終了後に `data.sql` と復元先 DB を**削除した**ことを確認した
+- [ ] 実測記録へ「実データを使った」と残した
+
+これを満たせないなら synthetic で回し、RTO は「データ量に比例して伸びる」と注記して残す。
+
+</details>
 
 > **credential を標準出力へ出さない。** 接続文字列は環境変数へ直接読み込み、値を echo しない。Management API / CLI の出力を見る時は [secrets.md §API 経由の設定読戻し](./secrets.md) の **allowlist 射影**に従う。denylist（危なそうな名前を隠す）方式は 2026-08-11 に実際に破綻している（判定語が `password` で実キー名が `db_pass` だった）。`supabase branches get` は credential を JSON で返す command なので、状態確認には `branches list` を使う。
 
-### 1-2. local へ復元して確認する
+### 1-2. 復元先を用意する（**`pnpm db:reset` は使わない**）
+
+`pnpm db:reset` は `supabase db reset --local` で、`config.toml` の `[db.migrations] enabled = true` と `[db.seed] enabled = true` により **migration と seed を適用した状態**を作る。ここへ `schema.sql` を流すと既存 object の再作成で失敗し、`data.sql` を入れれば seed と主キーが衝突する。**復元先は空でなければならない。**
 
 ```bash
-pnpm db:reset          # 空の local DB
-# roles.sql → schema.sql → data.sql の順に適用
+# local Supabase は起動しておく（Postgres だけ使う）
+createdb -h 127.0.0.1 -p 54322 -U postgres restore_drill
+
+DRILL_URL="postgresql://postgres:postgres@127.0.0.1:54322/restore_drill"
+psql -v ON_ERROR_STOP=1 -d "$DRILL_URL" -f roles.sql     # role は cluster 共有。既存なら skip されうる
+psql -v ON_ERROR_STOP=1 -d "$DRILL_URL" -f schema.sql
 ```
+
+`ON_ERROR_STOP=1` を必ず付ける。付けないと途中のエラーを無視して進み、**壊れた復元を「成功」と誤認する**。
+
+synthetic データは、この復元先に対して `supabase/seed.sql` と手動作成のテストユーザーで作る。**演習後に `dropdb` する。**
 
 ### 1-3. 観測ポイント（Step 2 でも同じものを見る）
 
@@ -167,16 +197,23 @@ pnpm db:reset          # 空の local DB
 
 ### データ
 
-- [ ] `plans` / `records` / `tags` / `profiles` の行数が復元元と一致する
-- [ ] 最新行の `created_at` を見て、**実際に失われた時間幅（RPO）** を算出する
+- [ ] `plans` / `records` / `tags` / `profiles` の行数が Step 0 で控えた値と一致する
 - [ ] `mcp_mutation_receipts` / `oauth_connections` など MCP 系テーブルが揃っている
+
+**RPO は最新 `created_at` では測れない。** backup 以降に「更新・削除しかなかった」場合、最新 `created_at` は一致するのに変更は失われている。逆に新規作成が長期間なければ、損失ゼロでも大きな RPO を算出してしまう。**sentinel を使う。**
+
+- [ ] backup 取得時刻の**前後に** sentinel 行（既知の内容の Plan など）を作っておき、復元先にどちらが存在するかで境界を挟む
+- [ ] あわせて `updated_at` を持つ既知の更新系列と、backup の recovery timestamp を突き合わせる
+- [ ] 算出した RPO と、その根拠（どの sentinel が残り／消えたか）を記録する
 
 ### 権限（機械判定できる）
 
 ```bash
-pnpm rls:snapshot        # 復元先に対して再生成
-pnpm rls:snapshot:check  # drift ゼロが合格
+# 復元先を指して check だけを走らせる。exit 0 が合格
+DATABASE_URL="$DRILL_URL" pnpm rls:snapshot:check
 ```
+
+> **`pnpm rls:snapshot`（`--check` なし）を先に実行しない。** `scripts/generate-rls-snapshot.ts` は checked-in の `rls-snapshot.md` を**上書きする**ため、その直後の `:check` は自分が今書いた内容と比較して必ず一致する。backup から policy や GRANT が欠落していても合格になり、**演習の権限検証がまるごと無意味になる**。比較対象は常に main の golden snapshot に保つ。
 
 期待値は [rls-snapshot.md](../engineering/data/db/rls-snapshot.md) の現行値（policy 43 / RLS 有効テーブル 20 / GRANT 215 / storage policy 8 / Realtime publication 0）。**演習日に本番側の数値を取り直してから比較する**（この数値は 2026-08-12 時点）。
 
@@ -214,7 +251,15 @@ SELECT jobname, schedule, active FROM cron.job ORDER BY jobname;
 
 - [ ] `auth.users` の件数が一致する（**経路依存**: 物理復元は cluster 単位なので入るはず、論理 dump は既定で除外）
 - [ ] ログインが実際に通る
-- [ ] `send-auth-email` の Auth Hook 設定（`verify_jwt = false`）が保たれている
+
+#### Auth Hook（**別 project へ復元すると失われる。project 単位の GoTrue 設定**）
+
+DB 内の hook function が戻っても、**GoTrue 側の hook 登録は引き継がれない**。`config.toml` は 2 つの hook を定義している。
+
+- [ ] `[auth.hook.send_email]` を再登録する（URI + 署名 secret）。落ちていると**認証メールが 1 通も送れない**
+- [ ] `[auth.hook.custom_access_token]`（`pg-functions://postgres/public/custom_access_token_hook`）を再登録する。落ちていると **JWT に `subscription_status` が乗らず有料機能が壊れる**
+- [ ] `send-auth-email` の `verify_jwt = false` が保たれている（`true` だと入口で弾かれる）
+- [ ] **実際にサインアップ／パスワード再設定のメールが届くところまで確認する**（設定の見た目だけで判定しない）
 
 ### Edge Functions（**復元対象外。手動で戻す**）
 
@@ -228,7 +273,12 @@ SELECT jobname, schedule, active FROM cron.job ORDER BY jobname;
 
 - [ ] `avatars` / `attachments` バケットが存在する（バケット定義は migration に入っているので schema と一緒に戻る）
 - [ ] **オブジェクト本体は空**であることを確認する。これは異常ではなく仕様
-- [ ] オブジェクトの搬出・復元は S3 互換エンドポイント経由（`rclone copy` 等）。**Storage には versioning が無く、削除は復元不可**
+
+> **⚠ 現状、Storage には復元元が存在しない。** オブジェクトは DB backup に含まれず、Supabase の S3 互換 endpoint には versioning も無い（削除は恒久）。**定期搬出の仕組みが無いため、`avatars` / `attachments` が削除・破損した事故では復旧手段が無い。** 障害後に live の bucket から `rclone copy` しても、失われたファイルはそこにもう無い。
+>
+> これは手順で埋まる穴ではなく**未実装の機能**なので、[#1971](https://github.com/Dayopt/dayopt/issues/1971) で追う。**paid billing のゲート条件に含めるかは User 判断**（現状 avatar と添付が恒久消失しうる状態で課金を開始してよいか）。
+>
+> 演習では「オブジェクトが空で戻る」ことの確認までを行い、versioned backup からの restore は [#1971](https://github.com/Dayopt/dayopt/issues/1971) の実装後に演習項目へ足す。
 
 ### Vault / 秘密情報（**案β で最も壊れやすい箇所**）
 

--- a/docs/operations/disaster-recovery-drill.md
+++ b/docs/operations/disaster-recovery-drill.md
@@ -1,0 +1,313 @@
+---
+status: current
+last_verified: 2026-08-12
+code:
+  - supabase/config.toml
+  - supabase/migrations
+  - scripts/generate-rls-snapshot.ts
+  - docs/engineering/infra.md
+---
+
+# 復元演習（restore drill）手順書
+
+**この文書は「演習のやり方」を持つ。事故が起きた時に読む復旧手順は [infra.md §災害復旧手順](../engineering/infra.md#災害復旧手順) が正本。**
+
+3 つの文書の役割が紛らわしいので先に区別する。
+
+| 文書                                                              | 何のため                                   | いつ読む             |
+| ----------------------------------------------------------------- | ------------------------------------------ | -------------------- |
+| [infra.md §DB Migration Rollback 手順書](../engineering/infra.md) | **判断の巻き戻し**（migration を戻す）     | 自分の変更が原因の時 |
+| [infra.md §災害復旧手順](../engineering/infra.md)                 | **事故からの復旧**（データ消失・オペミス） | 障害対応中           |
+| 本文書                                                            | **平時の演習**（復旧経路が本当に動くか）   | 演習日               |
+
+テストしていないバックアップは「あるつもり」でしかない。この演習の目的は、復元が**できること**の確認ではなく、**どれだけ失われ、どれだけ時間がかかり、何が復元されないか**を数値と一覧で確定させることにある。
+
+> **演習の完了は paid billing 有効化の前提条件**（epic [#1669](https://github.com/Dayopt/dayopt/issues/1669) のゲート）。課金を始めると、失うデータに他人のお金が乗る。
+
+---
+
+## 演習前に確定していないこと
+
+**この手順書は演習前に書かれている。以下は未確認のまま残っており、Step 0 で確定させる。** 確認するまで、後続 Step の所要時間・可否は見積りでしかない。
+
+| 未確認事項                                                       | なぜ未確認か                                                                                 | 確定させる場所    |
+| ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | ----------------- |
+| 現行プランと backup 種別（daily / PITR）、保持期間、直近成功時刻 | Management API の project endpoint は backup 情報を返さない（2026-08-12 実測）               | Dashboard（User） |
+| daily backup が **logical / physical** のどちらか                | 方式によって復元経路が変わる。project 作成が 2025-12-23 と新しいため physical の可能性が高い | Dashboard（User） |
+| `supabase branches create --with-data` が実在するか              | CLI reference には記載があるが Branching guide は「data-less」と書いており、公式内で矛盾     | `--help` の実出力 |
+| pg_cron の `cron.job` が復元を跨いで残るか                       | 公式ドキュメントに記載が無い                                                                 | 演習中の実測      |
+| production の cron job の実数                                    | baseline に「本番は Dashboard で設定」とあり、repo が正本でない                              | Step 0 で控える   |
+| `auth` schema が復元対象に入るか（経路により異なる）             | 物理復元は cluster 単位なので入るはず。論理 dump は既定で除外                                | 演習中の実測      |
+| production DB の実サイズ                                         | RTO はサイズにほぼ比例する                                                                   | Step 0 で計測     |
+
+**空欄のまま infra.md へ数値を書かない。** 測っていない RTO / RPO を復旧手順書に書くのは、無いより危険（障害中にその数値を信じて判断される）。
+
+---
+
+## Step 0: 事前確認（User 操作。演習日の前に済ませる）
+
+Main は Dashboard と課金設定に触れない。ここは User の一次情報。
+
+### 0-1. Supabase Dashboard で確認する
+
+Dashboard → Project `dayopt` → Settings / Database → Backups
+
+- [ ] 現在のプラン（Free / Pro / Team）
+- [ ] daily backup の**有無・保持日数・直近の成功時刻**
+- [ ] backup 方式が **logical / physical** のどちらか（画面に "Restore" ボタンがあるか、CLI 手順へ誘導されるか）
+- [ ] PITR が有効か無効か
+- [ ] DB サイズ（Reports → Database、または `SELECT pg_size_pretty(pg_database_size(current_database()));`）
+- [ ] **復元前の production の状態を控える**（復元後の比較対象がこれしかない）
+  - `SELECT jobname, schedule, active FROM cron.job ORDER BY jobname;`
+  - `plans` / `records` / `tags` / `profiles` の行数と、各テーブルの最新 `created_at`
+
+**Free プランなら backup は存在しない。** その場合この演習は「backup を作るところ」から始まる（`db dump` の定期実行 + 保管先の決定）。
+
+### 0-2. PITR の費用と復旧可能範囲（判断は User）
+
+| 項目             | daily backup     | PITR                                           |
+| ---------------- | ---------------- | ---------------------------------------------- |
+| 失う最大時間幅   | **最大 24 時間** | **約 2 分**（WAL の archive 間隔）             |
+| 月額             | プランに含まれる | **$100（7 日）/ $200（14 日）/ $400（28 日）** |
+| 併用             | —                | **有効化すると daily backup は停止する**       |
+| spend cap の対象 | —                | **対象外**（上限で止まらない）                 |
+
+出典は Supabase 公式の [Manage PITR usage](https://supabase.com/docs/guides/platform/manage-your-usage/point-in-time-recovery)。**価格は変動するので演習日に再確認する。**
+
+判断材料は「24 時間分の予定・記録を失って許されるか」。課金開始前の現在は許容できる可能性があるが、**課金後は他人のお金が絡むため基準が変わる**。有効化するかは User の判断。
+
+### 0-3. CLI の実挙動を確認する（Main が実行可）
+
+```bash
+supabase branches create --help
+```
+
+`--with-data` が存在するかを**実出力で**確認する。ドキュメントは信用しない（公式内で矛盾している）。
+
+### 0-4. 必要な権限・準備物
+
+| 要るもの                            | 誰が持つか | 用途                                   |
+| ----------------------------------- | ---------- | -------------------------------------- |
+| Supabase Dashboard のログイン       | User       | backup 状態確認、restore 実行          |
+| Supabase 組織の課金設定へのアクセス | User       | PITR 有効化の判断・実行                |
+| production の DB 接続情報           | User       | 案γ で dump を取る時だけ               |
+| 1Password `Dayopt-Production`       | User       | 上記 credential の取り出し             |
+| `supabase` CLI（ログイン済み）      | 共通       | dump / branches / functions            |
+| `rclone` または S3 クライアント     | 共通       | Storage オブジェクトの搬出（案による） |
+| Stripe Dashboard（**test mode**）   | User       | 復元後の billing 確認                  |
+
+---
+
+## 演習対象の選択
+
+**production を復元対象にしない。** 復元先は必ず branch / 新規 project / local のいずれか。
+
+| 案                             | 復元先         | 費用 | 何を証明するか                                       | 未解決リスク                                                                                                                                                         |
+| ------------------------------ | -------------- | ---- | ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **α** branch へ複製            | preview branch | 低   | branch 経路                                          | `--with-data` の実在が未確認。加えて 2026-08-11 に作った branch は 2 本とも `MIGRATIONS_FAILED`（[#1461](https://github.com/Dayopt/dayopt/issues/1461)、原因未特定） |
+| **β** backup を新規 project へ | 新規 project   | 中   | **実際の DR 経路**。データが Supabase 境界内に留まる | project 作成が要る。physical backup だと Dashboard restore が使えない可能性                                                                                          |
+| **γ** 論理 dump を local へ    | local Postgres | ゼロ | 論理復元の手順が通ること                             | 実データを落とすと**顧客 PII のローカル複製**が発生する                                                                                                              |
+
+### 推奨
+
+**γ を synthetic データで先に通し（= dry run）、その後 β を本番経路の証明として 1 回実行する。**
+
+- α は前提が 2 つとも壊れている（`--with-data` 未確認 + branch が migration に失敗する既知不具合）ので**初回演習では採らない**。#1461 が解決したら再評価する
+- γ を**実データで**回すのは既定で採らない。schema + roles だけを実データから取り、データ本体は `pnpm db:fresh` の seed で代用する。実データ複製が要ると判断した場合は User の明示判断とし、演習後に dump ファイルを削除するところまで手順に含める
+- β は「本当に戻せるか」を答える唯一の案なので、**最終的に 1 回は通す**
+
+---
+
+## Step 1: dry run（案γ / synthetic データ / ゼロコスト）
+
+目的は**手順を枯らすこと**。ここで詰まった箇所は Step 2 でも詰まる。
+
+### 1-1. 論理 dump を取る
+
+`supabase db dump` は既定で **schema のみ**、かつ `auth` / `storage` / extension 由来 schema を**除外**する。完全な論理バックアップは 3 本に分かれる。
+
+```bash
+supabase db dump --db-url "$DB_URL" --role-only -f roles.sql
+supabase db dump --db-url "$DB_URL" -f schema.sql
+supabase db dump --db-url "$DB_URL" --data-only --use-copy -f data.sql
+```
+
+> **credential を標準出力へ出さない。** 接続文字列は環境変数へ直接読み込み、値を echo しない。Management API / CLI の出力を見る時は [secrets.md §API 経由の設定読戻し](./secrets.md) の **allowlist 射影**に従う。denylist（危なそうな名前を隠す）方式は 2026-08-11 に実際に破綻している（判定語が `password` で実キー名が `db_pass` だった）。`supabase branches get` は credential を JSON で返す command なので、状態確認には `branches list` を使う。
+
+### 1-2. local へ復元して確認する
+
+```bash
+pnpm db:reset          # 空の local DB
+# roles.sql → schema.sql → data.sql の順に適用
+```
+
+### 1-3. 観測ポイント（Step 2 でも同じものを見る）
+
+各項目の**所要時間も測る**。合計が RTO の下限になる。
+
+---
+
+## Step 2: 本番経路の演習（案β）
+
+1. Step 0 で確認した backup（daily / PITR）から**新規 project へ** restore する
+2. 復元完了時刻を記録する
+3. 下記チェックリストを上から実行する
+4. 確認が終わったら**新規 project を削除する**（費用を止める）
+
+**production の restore ボタンは押さない。** in-place restore は破壊的で、実行中プロジェクトは停止する。
+
+---
+
+## 復元後チェックリスト
+
+復元先で上から実行する。1 つでも落ちたら、その時点の状態を記録してから次へ進む（止めない — 何が落ちるかの一覧を作るのが目的）。
+
+### データ
+
+- [ ] `plans` / `records` / `tags` / `profiles` の行数が復元元と一致する
+- [ ] 最新行の `created_at` を見て、**実際に失われた時間幅（RPO）** を算出する
+- [ ] `mcp_mutation_receipts` / `oauth_connections` など MCP 系テーブルが揃っている
+
+### 権限（機械判定できる）
+
+```bash
+pnpm rls:snapshot        # 復元先に対して再生成
+pnpm rls:snapshot:check  # drift ゼロが合格
+```
+
+期待値は [rls-snapshot.md](../engineering/data/db/rls-snapshot.md) の現行値（policy 43 / RLS 有効テーブル 20 / GRANT 215 / storage policy 8 / Realtime publication 0）。**演習日に本番側の数値を取り直してから比較する**（この数値は 2026-08-12 時点）。
+
+- [ ] `authenticated` に余分な権限が復活していない
+- [ ] custom role の password は**復元されない**（仕様）。必要なら再設定する
+
+### RPC
+
+- [ ] `confirm_day_plans_to_records`
+- [ ] `soft_delete_record` / `restore_record`
+- [ ] `revoke_oauth_connection`
+- [ ] `SECURITY DEFINER` と `search_path` の設定が保たれている
+
+### Realtime
+
+```sql
+SELECT schemaname, tablename FROM pg_publication_tables WHERE pubname = 'supabase_realtime';
+```
+
+- [ ] **0 行が期待値**（Dayopt は Realtime を使っていない）。行が増えていたら復元先の設定ミス
+
+### pg_cron（**未確認事項。ここで答えを出す**）
+
+```sql
+SELECT jobname, schedule, active FROM cron.job ORDER BY jobname;
+```
+
+**repo は production の cron job の正本ではない。** baseline migration に「本番は Dashboard で設定」と明記されており（`supabase/migrations/00000000000000_baseline.sql:1298`）、migration に現れない手動 schedule が production に存在しうる。
+
+- [ ] **復元する前に production 側の `cron.job` を控える**（これをやらないと比較対象が無い）
+- [ ] 復元後の job 一覧が、控えた production 側と一致するか記録する
+- [ ] repo の migration から導ける active job は **2 本**（`cleanup-product-events` / `expire-calendar-revoke-outbox`）。baseline の 4 本はいずれも後続 migration で unschedule 済み。**production の実数がこれと違っても異常ではない** — Dashboard 設定分の差なので、その差自体を記録する
+- [ ] 残っていない場合、再作成の手順を本文書へ追記する
+
+### Auth
+
+- [ ] `auth.users` の件数が一致する（**経路依存**: 物理復元は cluster 単位なので入るはず、論理 dump は既定で除外）
+- [ ] ログインが実際に通る
+- [ ] `send-auth-email` の Auth Hook 設定（`verify_jwt = false`）が保たれている
+
+### Edge Functions（**復元対象外。手動で戻す**）
+
+- [ ] `send-auth-email` を再デプロイする（`--use-api` 必須）
+
+**正本は `supabase/functions/` と `supabase/config.toml` の `[functions.*]` 宣言。** 現在の実体は `send-auth-email` の 1 本だけ。
+
+### Storage（**どの backup にも入らない**）
+
+- [ ] `avatars` / `attachments` バケットが存在する（バケット定義は migration に入っているので schema と一緒に戻る）
+- [ ] **オブジェクト本体は空**であることを確認する。これは異常ではなく仕様
+- [ ] オブジェクトの搬出・復元は S3 互換エンドポイント経由（`rclone copy` 等）。**Storage には versioning が無く、削除は復元不可**
+
+### Vault / 秘密情報
+
+- [ ] `vault.secrets` の値が読めるか確認する。同一 project 内の復元は暗号鍵が同じなので読めるはず。別 project へ復元した場合は要確認
+- [ ] `PLACEHOLDER_REPLACE_ME` のままの行が無いか確認する（migration の seed 値）
+
+### 課金（Stripe / **test mode で行う**）
+
+- [ ] `profiles.stripe_customer_id` / `subscription_status` / `subscription_id` が保たれている
+- [ ] `stripe_webhook_events` の履歴が残っている
+- [ ] Stripe test mode で checkout 相当のデータを作り、復元後の DB に対して **webhook resend** が通る
+- [ ] **test / production mode を取り違えない**
+
+### アプリ主要フロー
+
+復元先を向いたアプリを起動して実行する。
+
+- [ ] `/api/health` が 200 を返す
+- [ ] ログイン → 予定作成 → 記録確定
+- [ ] Calendar / Review / Account / Billing の各画面が表示される
+
+---
+
+## 復元されないもの（確定リスト）
+
+演習で覆るまで、**以下は「戻らない」前提で運用する**。
+
+| 対象                        | 状態                                      | 戻し方                      |
+| --------------------------- | ----------------------------------------- | --------------------------- |
+| **Storage オブジェクト**    | どの DB backup にも入らない               | S3 互換経由で別途搬出・復元 |
+| **Edge Functions**          | 復元対象外                                | `--use-api` で再デプロイ    |
+| **custom role の password** | 復元されない（仕様）                      | 再設定                      |
+| **Realtime publication**    | 別 project へ復元した場合は再有効化が必要 | 現状は空なので影響なし      |
+| **extension の有効化**      | 別 project へ復元した場合は再有効化が必要 | 演習で実測する              |
+
+---
+
+## 実測記録（演習日に埋める）
+
+**空欄のまま infra.md へ転記しない。**
+
+```yaml
+drill_date: 'YYYY-MM-DD'
+target: 'α branch | β new project | γ local'
+source_backup: 'daily YYYY-MM-DDTHH:MM:SSZ | PITR <timestamp>'
+backup_kind: 'logical | physical'
+db_size: '<GB>'
+rto_measured: '<復元開始から主要フロー通過までの実時間>'
+rpo_measured: '<失われた最大時間幅>'
+storage_objects_restored: false
+edge_functions_redeployed: ['send-auth-email']
+cron_jobs_before: '<復元前に控えた production の job 数と名前>'
+cron_jobs_after: '<復元後の job 数と名前>'
+auth_users_restored: '<yes|no>'
+vault_secrets_readable: '<yes|no>'
+failures: []
+operator: '<name>'
+```
+
+---
+
+## 中止条件
+
+次のいずれかで演習を止め、状態を記録する。
+
+- 復元先が production project になっている（**即座に中止**）
+- credential が標準出力・ログ・Issue・PR のいずれかへ出た（[secrets.md](./secrets.md) の対応へ）
+- 案γ で実データの dump ファイルが意図せず作られた（削除まで実施）
+- Stripe を production mode で操作していた
+- 復元先の DB が production を向いた状態でアプリを起動した
+
+---
+
+## 演習後にやること
+
+1. **実測値を [infra.md §災害復旧手順](../engineering/infra.md#災害復旧手順) へ反映する**（RTO / RPO / 復元されないもの）
+2. 記録を `docs/operations/log/YYYY-MM-DD-restore-drill.md` に残す
+3. 本文書の「演習前に確定していないこと」の表を、**確定した事実で置き換える**
+4. 新規 project / branch / dump ファイルを削除する
+5. [#1879](https://github.com/Dayopt/dayopt/issues/1879) を閉じ、epic [#1669](https://github.com/Dayopt/dayopt/issues/1669) のゲート充足を報告する
+
+## 演習の頻度
+
+Supabase 公式に DR 演習のガイダンスは無い。自前で決める。
+
+**初回は課金開始前に 1 回。以後は年 1 回、および DB schema の大規模変更後。** 頻度を上げるより、1 回を実測付きで通す方が価値がある。

--- a/docs/operations/disaster-recovery-drill.md
+++ b/docs/operations/disaster-recovery-drill.md
@@ -39,6 +39,7 @@ code:
 | production の cron job の実数                                    | baseline に「本番は Dashboard で設定」とあり、repo が正本でない                              | Step 0 で控える   |
 | `auth` schema が復元対象に入るか（経路により異なる）             | 物理復元は cluster 単位なので入るはず。論理 dump は既定で除外                                | 演習中の実測      |
 | production DB の実サイズ                                         | RTO はサイズにほぼ比例する                                                                   | Step 0 で計測     |
+| **別 project へ復元した時に Vault の secrets が復号できるか**    | 暗号鍵は project 単位。復号できないと 9 件を手で再投入することになる                         | 演習中の実測      |
 
 **空欄のまま infra.md へ数値を書かない。** 測っていない RTO / RPO を復旧手順書に書くのは、無いより危険（障害中にその数値を信じて判断される）。
 
@@ -156,6 +157,8 @@ pnpm db:reset          # 空の local DB
 
 **production の restore ボタンは押さない。** in-place restore は破壊的で、実行中プロジェクトは停止する。
 
+**production の pg_cron は止めない。** [infra.md §復元前に止めるもの](../engineering/infra.md#復元前に止めるもの) は**実際の障害時**に production を復元する場合の手順で、演習では production に触れない。演習中に止めてよいのは復元先だけ。
+
 ---
 
 ## 復元後チェックリスト
@@ -178,7 +181,6 @@ pnpm rls:snapshot:check  # drift ゼロが合格
 期待値は [rls-snapshot.md](../engineering/data/db/rls-snapshot.md) の現行値（policy 43 / RLS 有効テーブル 20 / GRANT 215 / storage policy 8 / Realtime publication 0）。**演習日に本番側の数値を取り直してから比較する**（この数値は 2026-08-12 時点）。
 
 - [ ] `authenticated` に余分な権限が復活していない
-- [ ] custom role の password は**復元されない**（仕様）。必要なら再設定する
 
 ### RPC
 
@@ -217,6 +219,8 @@ SELECT jobname, schedule, active FROM cron.job ORDER BY jobname;
 ### Edge Functions（**復元対象外。手動で戻す**）
 
 - [ ] `send-auth-email` を再デプロイする（`--use-api` 必須）
+- [ ] **secrets を再投入する。** コードの再デプロイでは戻らない（`RESEND_API_KEY` / `SEND_EMAIL_HOOK_SECRET` 等）。新規 project へ復元した場合は確実に空
+- [ ] 再デプロイ後に**実際に認証メールが 1 通届く**ことを確認する（secrets 未投入だと、デプロイは成功するのにメールだけが送れない）
 
 **正本は `supabase/functions/` と `supabase/config.toml` の `[functions.*]` 宣言。** 現在の実体は `send-auth-email` の 1 本だけ。
 
@@ -226,10 +230,14 @@ SELECT jobname, schedule, active FROM cron.job ORDER BY jobname;
 - [ ] **オブジェクト本体は空**であることを確認する。これは異常ではなく仕様
 - [ ] オブジェクトの搬出・復元は S3 互換エンドポイント経由（`rclone copy` 等）。**Storage には versioning が無く、削除は復元不可**
 
-### Vault / 秘密情報
+### Vault / 秘密情報（**案β で最も壊れやすい箇所**）
 
-- [ ] `vault.secrets` の値が読めるか確認する。同一 project 内の復元は暗号鍵が同じなので読めるはず。別 project へ復元した場合は要確認
+`vault.secrets` には production の要である 9 件が入っている（`stripe_secret_key` / `stripe_webhook_secret` / `resend_api_key` / `resend_webhook_secret` / `service_role_key` / `cron_secret` / `recovery_code_pepper` / `anthropic_api_key` / `supabase_url`）。**暗号鍵は project 単位で管理されるため、案β（別 project への復元）では復号できない可能性が高い。**
+
+- [ ] `vault.secrets` の**値が実際に復号できるか**確認する（行の存在確認だけでは不十分）
 - [ ] `PLACEHOLDER_REPLACE_ME` のままの行が無いか確認する（migration の seed 値）
+- [ ] **復号できなかった場合**: 1Password から再投入する。手順は `20260319000002_vault_seed_secrets.sql` の冒頭コメント（Dashboard の SQL Editor で `UPDATE vault.secrets SET secret = '<値>' WHERE name = '<名前>'`）。**値を標準出力・セッションへ表示しない**
+- [ ] 復号可否と、再投入が要ったかどうかを実測記録へ残す（この結果次第で「復元されないもの」の表が変わる）
 
 ### 課金（Stripe / **test mode で行う**）
 
@@ -252,13 +260,15 @@ SELECT jobname, schedule, active FROM cron.job ORDER BY jobname;
 
 演習で覆るまで、**以下は「戻らない」前提で運用する**。
 
-| 対象                        | 状態                                      | 戻し方                      |
-| --------------------------- | ----------------------------------------- | --------------------------- |
-| **Storage オブジェクト**    | どの DB backup にも入らない               | S3 互換経由で別途搬出・復元 |
-| **Edge Functions**          | 復元対象外                                | `--use-api` で再デプロイ    |
-| **custom role の password** | 復元されない（仕様）                      | 再設定                      |
-| **Realtime publication**    | 別 project へ復元した場合は再有効化が必要 | 現状は空なので影響なし      |
-| **extension の有効化**      | 別 project へ復元した場合は再有効化が必要 | 演習で実測する              |
+| 対象                              | 状態                                                          | 戻し方                                    |
+| --------------------------------- | ------------------------------------------------------------- | ----------------------------------------- |
+| **Storage オブジェクト**          | どの DB backup にも入らない                                   | S3 互換経由で別途搬出・復元               |
+| **Edge Functions とその secrets** | 復元対象外。コードを戻しても secrets は戻らない               | `--use-api` で再デプロイ + secrets 再投入 |
+| **Vault の secrets**              | 別 project へ復元すると復号できない可能性が高い（演習で確定） | 1Password から再投入                      |
+| **Realtime publication**          | 別 project へ復元した場合は再有効化が必要                     | 現状は空なので影響なし                    |
+| **extension の有効化**            | 別 project へ復元した場合は再有効化が必要                     | 演習で実測する                            |
+
+custom role の password も backup に含まれないが、**現状 Dayopt に custom role は無い**（migration に `CREATE ROLE` / `CREATE USER` が 0 件）。追加したらこの表に足す。
 
 ---
 
@@ -279,7 +289,9 @@ edge_functions_redeployed: ['send-auth-email']
 cron_jobs_before: '<復元前に控えた production の job 数と名前>'
 cron_jobs_after: '<復元後の job 数と名前>'
 auth_users_restored: '<yes|no>'
-vault_secrets_readable: '<yes|no>'
+vault_secrets_decryptable: '<yes|no>'
+vault_secrets_reinjected: '<yes|no>'
+edge_function_secrets_reinjected: '<yes|no>'
 failures: []
 operator: '<name>'
 ```

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -108,6 +108,13 @@ supabase functions deploy --use-api
 **ケース A〜C はサービスが止まっているだけでデータは無事。データそのものが失われた場合はここへ来る。**
 
 - [ ] **まず書き込みを止める**（メンテナンスモード有効化）。復元しても、その後の書き込みは失われる
+- [ ] **pg_cron も止める。メンテナンスモードは app 層しか止めない**（cron は Postgres 内部で走り続ける）
+
+```sql
+SELECT jobid, jobname, active FROM cron.job;
+SELECT cron.unschedule(jobname) FROM cron.job WHERE active;
+```
+
 - [ ] 原因が自分の migration なら [infra.md §DB Migration Rollback 手順書](../engineering/infra.md#db-migration-rollback-手順書) へ
 - [ ] データ消失・オペミスなら [infra.md §災害復旧手順](../engineering/infra.md#災害復旧手順) へ
 - [ ] Supabase Dashboard → Database → Backups で **backup の存在と時刻を確認する**（「あるはず」で進めない）

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -107,8 +107,10 @@ supabase functions deploy --use-api
 
 **ケース A〜C はサービスが止まっているだけでデータは無事。データそのものが失われた場合はここへ来る。**
 
-- [ ] **まず書き込みを止める**（メンテナンスモード有効化）。復元しても、その後の書き込みは失われる
-- [ ] **pg_cron も止める。メンテナンスモードは app 層しか止めない**（cron は Postgres 内部で走り続ける）
+- [ ] **書き込みを止める。ただしメンテナンスモードでは止まらない**（[infra.md §復元前に止めるもの](../engineering/infra.md#復元前に止めるもの)）
+  - `NEXT_PUBLIC_MAINTENANCE_MODE` が止めるのは**画面遷移だけ**。`/api/trpc` の mutation と Stripe / Resend webhook は proxy を通らず**書き込み続ける**
+  - API まで止めるには deployment を止めるしかない（[#1972](https://github.com/Dayopt/dayopt/issues/1972) で恒久対応）。**止めた／止めていないを自覚したうえで復元する**
+- [ ] **pg_cron も止める**（Postgres 内部で走るので app 側の操作では止まらない）
 
 ```sql
 -- ① 先に控えて保存する（Dashboard 設定が正本で migration から戻せない）
@@ -120,7 +122,8 @@ SELECT cron.unschedule(jobname) FROM cron.job WHERE active;
 - [ ] 原因が自分の migration なら [infra.md §DB Migration Rollback 手順書](../engineering/infra.md#db-migration-rollback-手順書) へ
 - [ ] データ消失・オペミスなら [infra.md §災害復旧手順](../engineering/infra.md#災害復旧手順) へ
 - [ ] Supabase Dashboard → Database → Backups で **backup の存在と時刻を確認する**（「あるはず」で進めない）
-- [ ] 復元しても **Storage オブジェクト・Edge Functions・custom role の password は戻らない**（§災害復旧手順 の一覧）
+- [ ] 復元しても **Storage オブジェクト・Edge Functions とその secrets・Vault の secrets・Auth Hook 登録は戻らない**（[infra.md §復元でも戻らないもの](../engineering/infra.md#復元でも戻らないもの)）
+- [ ] **サービス再開前に、止めた pg_cron を再登録する**（[infra.md §復旧後に戻すもの](../engineering/infra.md#復旧後に戻すもの)）。戻し忘れると期限切れ revoke の処理などが恒久停止する
 
 > **RTO / RPO は未実測**（復元演習が未実施）。復旧時間を約束できる状態にない。手順と確認観点は [復元演習手順書](./disaster-recovery-drill.md)。
 

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -103,6 +103,18 @@ supabase functions deploy --use-api
 
 - [ ] デプロイ後: Edge Functionsのログで正常動作を確認
 
+#### ケースD: データ消失・DB破損（backup からの復元が要る）
+
+**ケース A〜C はサービスが止まっているだけでデータは無事。データそのものが失われた場合はここへ来る。**
+
+- [ ] **まず書き込みを止める**（メンテナンスモード有効化）。復元しても、その後の書き込みは失われる
+- [ ] 原因が自分の migration なら [infra.md §DB Migration Rollback 手順書](../engineering/infra.md#db-migration-rollback-手順書) へ
+- [ ] データ消失・オペミスなら [infra.md §災害復旧手順](../engineering/infra.md#災害復旧手順) へ
+- [ ] Supabase Dashboard → Database → Backups で **backup の存在と時刻を確認する**（「あるはず」で進めない）
+- [ ] 復元しても **Storage オブジェクト・Edge Functions・custom role の password は戻らない**（§災害復旧手順 の一覧）
+
+> **RTO / RPO は未実測**（復元演習が未実施）。復旧時間を約束できる状態にない。手順と確認観点は [復元演習手順書](./disaster-recovery-drill.md)。
+
 ### 振り返り
 
 - [ ] 根本原因を記録

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -111,7 +111,9 @@ supabase functions deploy --use-api
 - [ ] **pg_cron も止める。メンテナンスモードは app 層しか止めない**（cron は Postgres 内部で走り続ける）
 
 ```sql
-SELECT jobid, jobname, active FROM cron.job;
+-- ① 先に控えて保存する（Dashboard 設定が正本で migration から戻せない）
+SELECT jobid, jobname, schedule, command, active FROM cron.job ORDER BY jobname;
+-- ② 控えてから止める
 SELECT cron.unschedule(jobname) FROM cron.job WHERE active;
 ```
 


### PR DESCRIPTION
#1879 の**準備パートのみ**。演習の実行・production への操作・Supabase cloud への書き込みは含まない（EXPLICIT AUTHORITY のため User 同席で別途実施）。成果物は docs だけ。

> **この PR は #1879 の 5 項目のうち 3 項目（手順書 / dry-run 計画 / User 操作一覧）しか満たさない。** 実測 RTO・RPO と出口コスト台帳の更新は演習実行後にしか埋まらない。**この PR の merge を epic #1669（paid billing 有効化）のゲート充足と読まないこと。**

## 変更

### `docs/operations/disaster-recovery-drill.md`（新規）

演習当日に上から読んで実行できる手順書。

- **Step 0（User 操作）** — Dashboard で確認する項目、PITR の費用と復旧可能範囲の比較表、必要な権限・準備物の一覧
- **演習対象 3 案の比較と推奨** — α branch / β 新規 project / γ local
- **復元後チェックリスト** — データ / 権限 / RPC / Realtime / pg_cron / Auth / Edge Functions / Storage / Vault / 課金 / アプリ主要フロー
- **復元されないもの**の確定リスト、中止条件、実測記録の YAML テンプレート

### `docs/engineering/infra.md` — §災害復旧手順（新規）

既存の §DB Migration Rollback 手順書 が**判断の巻き戻し**（自分の migration を戻す）なのに対し、こちらは**事故からの復旧**（データ消失・オペミス）。両節の冒頭で相互に振り分ける。

正本は分けた。infra.md は「結論と戻らないもの」だけを持ち、逐次コマンドは drill doc に一元化する（`docs/README.md` の「同じ説明を複数面に置かない」）。

### `docs/operations/runbook.md` — Playbook 1 に「ケースD」

既存の 3 ケース（外部障害 / env ミス / Edge Function 障害）は**いずれもデータが無事な障害**で、backup 復元への入口が無かった。障害対応中に runbook から入った人が新設セクションへ辿り着けるようにする。

### `.claude/skills/supabase/SKILL.md`

Edge Function 一覧から `check-reminders` / `daily-insights` を削除。実体（`supabase/functions/`）・宣言（`config.toml`）・DB の cron 登録（`20260425000000_unschedule_removed_edge_function_cron_jobs.sql` で解除済み）のすべてで不在。手動デプロイ手順が存在しない function を 3 本ループで叩く形だったため、復元後の再デプロイ手順としてそのまま踏むと失敗する。

## 判断

**測っていない RTO / RPO を書かなかった。** 「未実測」と明示している。障害対応中に読まれる文書なので、根拠のない復旧時間を信じられる方が危険という判断。演習後に埋める。

**§出口コスト台帳 は触っていない。** issue やること 5 が求める「dump / 移行手段の**実行可能性**の反映」は演習後にしか分からない。台帳自身が「移行手順を 1 段細かくする記述」を対象外と明文化している（PR #1880 で固定）ため、手順の細分化は drill doc 側に置いた。

## 実測で分かったこと（plan の誤りを含む）

- **production の pg_cron は repo が正本ではない。** baseline に「本番は Dashboard で設定」とあり、`20260425000000` の経緯コメントにも Dashboard 手動 schedule の実例が残っている。演習は復元前に `cron.job` を控えることを必須手順にした
- plan 段階で「稼働 cron job 6 本」と書いていたが**誤り**。baseline の 4 本は後続 migration で unschedule 済みで、repo から導けるのは 2 本（`cleanup-product-events` / `expire-calendar-revoke-outbox`）。plan-fact-checker が検出し、migration を直接確認して訂正した
- **backup の状態は Management API の project endpoint から取れない**（2026-08-12 実測: 返るのは id / region / status / postgres version のみ）。Dashboard 確認を User 操作として明記した
- `supabase branches create --with-data` は**公式ドキュメント内で矛盾**（CLI reference にはあるが Branching guide は「data-less」）。演習前に `--help` の実出力で確認する手順にした
- Supabase 公式に DR 演習のガイダンス・RTO 目標は**存在しない**。頻度は自前で定義した

## 検証

- `pnpm docs:check` — pass（ストック側リンク切れ 0 / metadata 0 / 命名 0 / log 凍結ガード違反なし）
- anchor は既存の日本語見出しリンク（`infra.md#merge-gate-の-required-checks` 等）と同じ規約
- コード変更ゼロのため typecheck / lint / boundaries の対象外

## レビュー

- `/plan-review`（plan-fact-checker + plan-critic 並列）を実施。critic は REVISE 判定で、指摘を反映した:
  - 未確認事項を冒頭で明示し、Step 0 で確定させる構成へ変更
  - runbook.md への導線を追加（新設文書に辿り着けない問題）
  - credential 取り扱いに `secrets.md` の allowlist 射影を明示引用
  - 正本を一本化（infra.md は結論のみ、コマンドは drill doc）
  - stale だった SKILL.md をこの PR で修正
  - 凍結コメント・PR 本文に「5 項目中 3 項目のみ」を明記
- fact-checker が pg_cron の件数誤りを検出（上記）
- push 前に `risk-reviewer` の反証レビューを実施

## risk-reviewer の指摘と対応（追記）

判定は REVISE。5 件のうち 4 件を反映した。

1. **メンテナンスモードは pg_cron を止めない** — `NEXT_PUBLIC_MAINTENANCE_MODE` は Next.js app 層のみ。cron は Postgres 内部で走り続けるため「書き込みを止めた」が誤りになる。migration rollback 側のフローチャートには元から cron 停止があり、災害復旧側だけ非対称だった → 両方へ追加
2. **Vault の secrets が「戻らないもの」から欠落** — 暗号鍵は project 単位なので案β（別 project）では復号できない可能性が高い。production の要が 9 件入っている → 表へ追加 + 復号可否を観測項目化 + 再投入手順を明記
3. **Edge Function の secrets はコード再デプロイでは戻らない** — デプロイは成功するのに認証メールだけ送れない状態になる → 「実際にメールが 1 通届く」まで確認項目にした
4. **SKILL.md の絶対ルールに削除済み function 名が 1 行残存** → 削除
5. custom role の password — migration に `CREATE ROLE` / `CREATE USER` が **0 件**で現状該当なしを確認。表から本文の注記へ降格

さらに push 前の自己確認で、**1 の修正自体が新しい穴を開けていた**ことを検出して直した。production の cron は Dashboard 設定が正本で migration から再生成できないのに、控えを取らずに全 active job を unschedule する手順になっていた（控える → 止める の順序を明示）。

Refs #1879
Refs #1669

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 外部レビュー（Codex）1 ラウンド目の対応 — 8 件全対応・全 thread resolve 済み

**P1 4 件・P2 4 件。すべて実装（= 手順）側の誤りで、指摘は全部当たっていた。** 一次情報で裏を取ったうえで反映した。

| 指摘                                | 何が間違っていたか                                                                                                     | 対応                                                             |
| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| **P1** メンテナンスモードで write が止まらない | `proxy.ts:195-202` が `isMaintenanceMode` より**前に** `/api` を早期 return し、`config.matcher` も `api` を除外。tRPC mutation と webhook は止まらない | 「止める」記述を削除し、止まらないことを実測根拠つきで明記。恒久対応を **#1972** で起票 |
| **P1** synthetic 演習で PII が漏れる  | 推奨は synthetic なのに Step 1-1 のコマンド列に production の `--data-only` が無条件で入っていた                        | 既定から除去。実データは承認・保管先・削除・記録をセットにした分岐へ |
| **P1** Auth Hook が復元されない       | `[auth.hook.send_email]` に加え `[auth.hook.custom_access_token]` も project 単位の GoTrue 設定で別 project へ引き継がれない | 専用節を追加。両 hook の再登録と実メール着信までを検証項目に      |
| **P1** Storage に復元元が無い         | DB backup 対象外 + versioning 無し + 定期搬出の仕組み無し。事故後に live から copy しても戻らない                      | 未実装の機能として **#1971** で起票。ゲート条件に含めるかは User 判断 |
| **P2** `db:reset` は空 DB ではない    | `[db.migrations]` / `[db.seed]` がどちらも `enabled = true`。schema.sql が衝突して案γを完走できない                    | `createdb` + `psql -v ON_ERROR_STOP=1` へ置換                    |
| **P2** golden snapshot を上書きしていた | `generate-rls-snapshot.ts:933` が checked-in の snapshot を上書きするため、生成 → check は**必ず通る**。権限検証が無意味だった | `DATABASE_URL` を指して `:check` のみ実行                        |
| **P2** RPO を最新 `created_at` で測っていた | 更新・削除のみの期間は損失を検出できず、新規作成の無い期間は損失ゼロでも大きく出る                                     | backup 前後の sentinel で挟む方式へ                              |
| **P2** 止めた cron を戻す工程が無い   | rollback 経路へ抜けると cron が消えたまま再開し、期限切れ revoke 処理などが恒久停止                                    | infra.md に §復旧後に戻すもの を新設                             |

**この PR で最も価値があったのは 1 件目**（メンテナンスモードでは write が止まらない）。復旧手順の前提そのものが誤っており、実際の障害で「止めたつもり」で復元して差分を失う経路だった。

派生 issue: **#1971**（Storage の復元元）/ **#1972**（write fence）
