### PR TITLE
fix(external-calendar): prune の UUID cursor・fail-closed 化・fields マスク・90日保持cron配線

### DIFF
--- a/apps/product/src/features/external-calendar/server/__tests__/connection-service.test.ts
+++ b/apps/product/src/features/external-calendar/server/__tests__/connection-service.test.ts
@@ -507,13 +507,18 @@ describe('updateSelectedCalendars', () => {
 // =============================================================================
 
 describe('disconnect', () => {
-  it('revoke → prune → connection 削除 の順で実行する', async () => {
+  // 順序は prune → revoke → connection 削除（#2000 で Codex 指摘を受けて revoke を
+  // prune の後に動かした）。先に revoke すると、prune が失敗して connection を消せなかった
+  // 場合に「token は失効済みなのに connection は active のまま」という食い違いが残るため。
+  it('prune → revoke → connection 削除 の順で実行する', async () => {
     const { calls } = setupServiceRoleDb({
       connection: { status: 'active', refresh_token_enc: 'enc' },
     });
 
+    let prunedBeforeRevoke = false;
     let prunedBeforeConnectionDelete = false;
     deleteUnreferencedEvents.mockImplementation(async () => {
+      prunedBeforeRevoke = revoke.mock.calls.length === 0;
       // prune 呼び出し時点で connection の delete はまだ発行されていないはず（§8 順序）
       prunedBeforeConnectionDelete = !calls.some(
         (r) => r.table === 'calendar_connections' && r.chain.some((e) => e.method === 'delete'),
@@ -528,8 +533,24 @@ describe('disconnect', () => {
       connectionId: CONNECTION_ID,
       scope: { kind: 'connection' },
     });
+    expect(prunedBeforeRevoke).toBe(true);
     expect(prunedBeforeConnectionDelete).toBe(true);
     expect(findWith(calls, 'calendar_connections', 'delete')).toBeDefined();
+  });
+
+  // regression（Codex 指摘、#2000）: revoke が prune より先だと、prune 失敗時に token だけ
+  // 失効させてしまい connection は active のまま残る（UI は接続中と見せつつ実際は壊れている）。
+  it('prune が失敗したら revoke も connection 削除も行わない', async () => {
+    setupServiceRoleDb({
+      connection: { status: 'active', refresh_token_enc: 'enc' },
+    });
+    deleteUnreferencedEvents.mockRejectedValue({ code: '42501' });
+
+    await expect(disconnect(USER_ID, CONNECTION_ID)).rejects.toBeInstanceOf(
+      ExternalCalendarServiceError,
+    );
+
+    expect(revoke).not.toHaveBeenCalled();
   });
 
   it('接続が既に無ければ冪等に何もしない', async () => {

--- a/apps/product/src/features/external-calendar/server/__tests__/connection-service.test.ts
+++ b/apps/product/src/features/external-calendar/server/__tests__/connection-service.test.ts
@@ -507,20 +507,24 @@ describe('updateSelectedCalendars', () => {
 // =============================================================================
 
 describe('disconnect', () => {
-  // 順序は prune → revoke → connection 削除（#2000 で Codex 指摘を受けて revoke を
-  // prune の後に動かした）。先に revoke すると、prune が失敗して connection を消せなかった
-  // 場合に「token は失効済みなのに connection は active のまま」という食い違いが残るため。
-  it('prune → revoke → connection 削除 の順で実行する', async () => {
+  // 順序は prune → revoke → 2 回目の prune（best-effort）→ connection 削除
+  // （#2000 で Codex 指摘を受けて revoke を prune の後に動かし、revoke 中に新規発生した
+  // 差分を拾うための 2 回目の prune を delete 直前に追加した）。先に revoke すると、
+  // prune が失敗して connection を消せなかった場合に「token は失効済みなのに connection
+  // は active のまま」という食い違いが残るため、prune を先に行う。
+  it('1 回目の prune → revoke → 2 回目の prune → connection 削除 の順で実行する', async () => {
     const { calls } = setupServiceRoleDb({
       connection: { status: 'active', refresh_token_enc: 'enc' },
     });
 
-    let prunedBeforeRevoke = false;
-    let prunedBeforeConnectionDelete = false;
-    deleteUnreferencedEvents.mockImplementation(async () => {
-      prunedBeforeRevoke = revoke.mock.calls.length === 0;
-      // prune 呼び出し時点で connection の delete はまだ発行されていないはず（§8 順序）
-      prunedBeforeConnectionDelete = !calls.some(
+    let firstPruneBeforeRevoke = false;
+    deleteUnreferencedEvents.mockImplementationOnce(async () => {
+      firstPruneBeforeRevoke = revoke.mock.calls.length === 0;
+    });
+    let secondPruneBeforeConnectionDelete = false;
+    deleteUnreferencedEvents.mockImplementationOnce(async () => {
+      // 2 回目の prune 呼び出し時点で connection の delete はまだ発行されていないはず
+      secondPruneBeforeConnectionDelete = !calls.some(
         (r) => r.table === 'calendar_connections' && r.chain.some((e) => e.method === 'delete'),
       );
     });
@@ -528,14 +532,40 @@ describe('disconnect', () => {
     await disconnect(USER_ID, CONNECTION_ID);
 
     expect(revoke).toHaveBeenCalledWith('refresh-token');
-    expect(deleteUnreferencedEvents).toHaveBeenCalledWith({
+    expect(deleteUnreferencedEvents).toHaveBeenCalledTimes(2);
+    expect(deleteUnreferencedEvents).toHaveBeenNthCalledWith(1, {
       userId: USER_ID,
       connectionId: CONNECTION_ID,
       scope: { kind: 'connection' },
     });
-    expect(prunedBeforeRevoke).toBe(true);
-    expect(prunedBeforeConnectionDelete).toBe(true);
+    expect(deleteUnreferencedEvents).toHaveBeenNthCalledWith(2, {
+      userId: USER_ID,
+      connectionId: CONNECTION_ID,
+      scope: { kind: 'connection' },
+    });
+    expect(firstPruneBeforeRevoke).toBe(true);
+    expect(secondPruneBeforeConnectionDelete).toBe(true);
     expect(findWith(calls, 'calendar_connections', 'delete')).toBeDefined();
+  });
+
+  // regression（Codex 指摘、#2000）: revoke の間に発生した新規差分を拾う 2 回目の prune は
+  // best-effort。ここで失敗しても connection 削除まで進む（1 回目の fail-closed で主要な
+  // 保証は既に成立しているため、2 回目の失敗で切断全体を止めない）。
+  it('2 回目の prune が失敗しても connection 削除まで進む', async () => {
+    const { calls } = setupServiceRoleDb({
+      connection: { status: 'active', refresh_token_enc: 'enc' },
+    });
+    deleteUnreferencedEvents.mockResolvedValueOnce(undefined);
+    deleteUnreferencedEvents.mockRejectedValueOnce({ code: '42501' });
+
+    await disconnect(USER_ID, CONNECTION_ID);
+
+    expect(deleteUnreferencedEvents).toHaveBeenCalledTimes(2);
+    expect(findWith(calls, 'calendar_connections', 'delete')).toBeDefined();
+    expect(captureUnexpectedError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ operation: 'disconnect_reprune' }),
+    );
   });
 
   // regression（Codex 指摘、#2000）: revoke が prune より先だと、prune 失敗時に token だけ

--- a/apps/product/src/features/external-calendar/server/__tests__/connection-service.test.ts
+++ b/apps/product/src/features/external-calendar/server/__tests__/connection-service.test.ts
@@ -479,6 +479,27 @@ describe('updateSelectedCalendars', () => {
 
     expect(deleteUnreferencedEvents).not.toHaveBeenCalled();
   });
+
+  // regression（#1988）: ミラー掃除は best-effort。fail-closed にすると、選択解除自体は
+  // 成功しているのに transient な cleanup 失敗でユーザー操作全体が失敗して見えてしまう。
+  it('ミラー掃除が失敗しても選択変更自体は成功として扱う', async () => {
+    setupServiceRoleDb({
+      connection: { status: 'active', refresh_token_enc: 'enc' },
+      childRows: [{ provider_calendar_id: 'cal-a' }, { provider_calendar_id: 'cal-b' }],
+    });
+    deleteUnreferencedEvents.mockRejectedValue(new Error('prune failed'));
+
+    await expect(
+      updateSelectedCalendars(USER_ID, CONNECTION_ID, [
+        { providerCalendarId: 'cal-a', calendarName: 'A' },
+      ]),
+    ).resolves.toBeUndefined();
+
+    expect(captureUnexpectedError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ operation: 'update_selected_calendars_prune' }),
+    );
+  });
 });
 
 // =============================================================================
@@ -566,6 +587,41 @@ describe('disconnect', () => {
     expect(revoke).not.toHaveBeenCalled();
     expect(deleteUnreferencedEvents).toHaveBeenCalled();
     expect(findWith(calls, 'calendar_connections', 'delete')).toBeDefined();
+  });
+
+  // regression（#1988）: prune 失敗を検知せず connection を hard delete すると、FK が
+  // connection_id を NULL 化して未参照ミラー行を二度と回収できなくなる。fail-closed に直す。
+  describe('ミラー掃除の fail-closed（#1988）', () => {
+    it('ミラー掃除が失敗したら connection を削除せず throw する', async () => {
+      const { calls } = setupServiceRoleDb({
+        connection: { status: 'active', refresh_token_enc: 'enc' },
+      });
+      deleteUnreferencedEvents.mockRejectedValue({ code: '42501' });
+
+      await expect(disconnect(USER_ID, CONNECTION_ID)).rejects.toBeInstanceOf(
+        ExternalCalendarServiceError,
+      );
+
+      expect(findWith(calls, 'calendar_connections', 'delete')).toBeUndefined();
+    });
+
+    it('再試行時にミラー掃除が成功すれば connection を削除できる（冪等な収束）', async () => {
+      const { calls } = setupServiceRoleDb({
+        connection: { status: 'active', refresh_token_enc: 'enc' },
+      });
+      deleteUnreferencedEvents.mockRejectedValueOnce({ code: '42501' });
+
+      await expect(disconnect(USER_ID, CONNECTION_ID)).rejects.toBeInstanceOf(
+        ExternalCalendarServiceError,
+      );
+      expect(findWith(calls, 'calendar_connections', 'delete')).toBeUndefined();
+
+      // 2 回目は prune が成功する想定（deleteUnreferencedEvents の既定 resolve に戻る）。
+      deleteUnreferencedEvents.mockResolvedValue(undefined);
+      await disconnect(USER_ID, CONNECTION_ID);
+
+      expect(findWith(calls, 'calendar_connections', 'delete')).toBeDefined();
+    });
   });
 
   it('接続削除の DB 失敗は ExternalCalendarServiceError を投げる', async () => {

--- a/apps/product/src/features/external-calendar/server/__tests__/event-pruning.test.ts
+++ b/apps/product/src/features/external-calendar/server/__tests__/event-pruning.test.ts
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const createClient = vi.hoisted(() => vi.fn());
 const captureUnexpectedDatabaseError = vi.hoisted(() => vi.fn((error: unknown) => error));
+const captureUnexpectedError = vi.hoisted(() => vi.fn());
 const loggerWarn = vi.hoisted(() => vi.fn());
 
 vi.mock('@/env', () => ({
@@ -18,7 +19,7 @@ vi.mock('@/env', () => ({
   },
 }));
 vi.mock('@supabase/supabase-js', () => ({ createClient }));
-vi.mock('@/lib/sentry', () => ({ captureUnexpectedDatabaseError }));
+vi.mock('@/lib/sentry', () => ({ captureUnexpectedDatabaseError, captureUnexpectedError }));
 vi.mock('@/lib/logger', () => ({
   logger: { log: vi.fn(), error: vi.fn(), warn: loggerWarn, info: vi.fn(), debug: vi.fn() },
 }));
@@ -28,6 +29,9 @@ import { deleteUnreferencedEvents } from '../event-pruning';
 const USER_ID = '00000000-0000-4000-8000-0000000000a1';
 const CONNECTION_ID = '00000000-0000-4000-8000-0000000000c1';
 
+// event-pruning.ts の PRUNE_BATCH_SIZE と同値。batch 上限テストで全バッチを満杯にするために使う。
+const PRUNE_BATCH_SIZE = 150;
+
 type Recorder = { table: string; chain: Array<{ method: string; args: unknown[] }> };
 
 type Config = {
@@ -35,7 +39,10 @@ type Config = {
   referencedByPlans?: Array<{ external_calendar_event_id: string | null }>;
   referencedByRecords?: Array<{ external_calendar_event_id: string | null }>;
   selectError?: unknown;
+  referencedError?: unknown;
   deleteError?: unknown;
+  /** 常に PRUNE_BATCH_SIZE 件満杯を返し続ける（batch 上限に到達させる）。 */
+  alwaysFullBatch?: boolean;
 };
 
 function setupDb(config: Config) {
@@ -48,12 +55,22 @@ function setupDb(config: Config) {
       if (methods.includes('delete')) return { data: null, error: config.deleteError ?? null };
       const batch = candidateBatch;
       candidateBatch += 1;
+      if (config.alwaysFullBatch) {
+        return {
+          data: Array.from({ length: PRUNE_BATCH_SIZE }, (_, i) => ({ id: `ev-${batch}-${i}` })),
+          error: null,
+        };
+      }
       return {
         data: batch === 0 ? (config.candidates ?? []) : [],
         error: config.selectError ?? null,
       };
     }
-    if (recorder.table === 'plans') return { data: config.referencedByPlans ?? [], error: null };
+    if (recorder.table === 'plans')
+      return {
+        data: config.referencedError ? null : (config.referencedByPlans ?? []),
+        error: config.referencedError ?? null,
+      };
     if (recorder.table === 'records')
       return { data: config.referencedByRecords ?? [], error: null };
     return { data: [], error: null };
@@ -166,8 +183,66 @@ describe('deleteUnreferencedEvents — anti-join', () => {
     expect(deleteCall(calls)).toBeUndefined();
   });
 
-  it('select 失敗では throw せず記録して中断する', async () => {
+  // regression（#1988）: select / 参照読み取りの失敗を静かに飲み込むと、呼び出し元
+  // （disconnect）は掃除が成功したと誤解して connection を消してしまう。fail-closed で throw する。
+  it('select 失敗では throw して中断する（呼び出し元に fail-closed を選ばせる）', async () => {
     const { calls } = setupDb({ selectError: { code: '42501' } });
+
+    await expect(
+      deleteUnreferencedEvents({
+        userId: USER_ID,
+        connectionId: CONNECTION_ID,
+        scope: { kind: 'connection' },
+      }),
+    ).rejects.toMatchObject({ code: '42501' });
+
+    expect(deleteCall(calls)).toBeUndefined();
+    expect(captureUnexpectedDatabaseError).toHaveBeenCalled();
+  });
+
+  it('参照読み取りの失敗も throw して中断する', async () => {
+    const { calls } = setupDb({
+      candidates: [{ id: 'ev-1' }],
+      referencedError: { code: '57014' },
+    });
+
+    await expect(
+      deleteUnreferencedEvents({
+        userId: USER_ID,
+        connectionId: CONNECTION_ID,
+        scope: { kind: 'connection' },
+      }),
+    ).rejects.toMatchObject({ code: '57014' });
+
+    expect(deleteCall(calls)).toBeUndefined();
+    expect(captureUnexpectedDatabaseError).toHaveBeenCalled();
+  });
+
+  // regression（risk-reviewer 指摘）: 23503（select と delete の間の参照レース）以外の delete
+  // 失敗を warn だけで飲み込むと、disconnect の fail-closed が効かず連鎖する未参照行を
+  // 永久に見失う。23503 以外は throw する。
+  it('23503 以外の delete 失敗は throw する', async () => {
+    setupDb({
+      candidates: [{ id: 'ev-1' }],
+      deleteError: { code: '42501' },
+    });
+
+    await expect(
+      deleteUnreferencedEvents({
+        userId: USER_ID,
+        connectionId: CONNECTION_ID,
+        scope: { kind: 'connection' },
+      }),
+    ).rejects.toMatchObject({ code: '42501' });
+
+    expect(captureUnexpectedDatabaseError).toHaveBeenCalled();
+  });
+
+  it('23503（参照レース）の delete 失敗は throw せず warn に留める', async () => {
+    setupDb({
+      candidates: [{ id: 'ev-1' }],
+      deleteError: { code: '23503' },
+    });
 
     await expect(
       deleteUnreferencedEvents({
@@ -177,8 +252,52 @@ describe('deleteUnreferencedEvents — anti-join', () => {
       }),
     ).resolves.toBeUndefined();
 
-    expect(deleteCall(calls)).toBeUndefined();
-    expect(captureUnexpectedDatabaseError).toHaveBeenCalled();
+    expect(loggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining('skipped some rows due to a reference race'),
+    );
+  });
+});
+
+describe('deleteUnreferencedEvents — batch 上限', () => {
+  // regression（risk-reviewer 指摘）: 上限到達を warn だけで return すると、disconnect の
+  // fail-closed が効かず、上限を超えた残り行が connection 削除で永久に回収不能になる。
+  it('batch 上限に到達したら部分結果のまま return せず throw する', async () => {
+    setupDb({ alwaysFullBatch: true });
+
+    await expect(
+      deleteUnreferencedEvents({
+        userId: USER_ID,
+        connectionId: CONNECTION_ID,
+        scope: { kind: 'connection' },
+      }),
+    ).rejects.toThrow('calendar event pruning hit the batch limit');
+
+    expect(loggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining('stopped at the batch limit'),
+      expect.any(Object),
+    );
+  });
+});
+
+describe('deleteUnreferencedEvents — keyset ページング', () => {
+  // regression（#1996）: id は UUID 列。空文字を .gt('id', '') に渡すと PostgREST が
+  // invalid UUID で落ちる。初回バッチでは cursor 条件そのものを送らない。
+  //
+  // このテストは fake table が文字列比較で `.gt` を素通りさせる mock ベースなので、
+  // 実際の UUID キャストエラーは再現できない（それを再現するのが calendar-event-pruning
+  // integration test の役目）。ここは「初回に .gt('id', …) を呼んでいないこと」という
+  // 配線の契約だけを固定する。
+  it('初回バッチでは id の cursor 条件を送らない', async () => {
+    const { calls } = setupDb({ candidates: [{ id: 'ev-1' }] });
+
+    await deleteUnreferencedEvents({
+      userId: USER_ID,
+      connectionId: CONNECTION_ID,
+      scope: { kind: 'connection' },
+    });
+
+    const select = candidateSelect(calls)!;
+    expect(select.chain.some((e) => e.method === 'gt' && e.args[0] === 'id')).toBe(false);
   });
 });
 

--- a/apps/product/src/features/external-calendar/server/__tests__/event-pruning.test.ts
+++ b/apps/product/src/features/external-calendar/server/__tests__/event-pruning.test.ts
@@ -43,6 +43,11 @@ type Config = {
   deleteError?: unknown;
   /** 常に PRUNE_BATCH_SIZE 件満杯を返し続ける（batch 上限に到達させる）。 */
   alwaysFullBatch?: boolean;
+  /**
+   * 指定バッチ数だけ満杯を返し、その次のバッチで空を返して自然終了させる
+   * （connection scope の高い上限でも throw せず完走することを確認するために使う）。
+   */
+  fullBatchesThenStop?: number;
 };
 
 function setupDb(config: Config) {
@@ -58,6 +63,15 @@ function setupDb(config: Config) {
       if (config.alwaysFullBatch) {
         return {
           data: Array.from({ length: PRUNE_BATCH_SIZE }, (_, i) => ({ id: `ev-${batch}-${i}` })),
+          error: null,
+        };
+      }
+      if (config.fullBatchesThenStop !== undefined) {
+        return {
+          data:
+            batch < config.fullBatchesThenStop
+              ? Array.from({ length: PRUNE_BATCH_SIZE }, (_, i) => ({ id: `ev-${batch}-${i}` }))
+              : [],
           error: null,
         };
       }
@@ -261,14 +275,19 @@ describe('deleteUnreferencedEvents — anti-join', () => {
 describe('deleteUnreferencedEvents — batch 上限', () => {
   // regression（risk-reviewer 指摘）: 上限到達を warn だけで return すると、disconnect の
   // fail-closed が効かず、上限を超えた残り行が connection 削除で永久に回収不能になる。
-  it('batch 上限に到達したら部分結果のまま return せず throw する', async () => {
+  // window / calendars scope は時間窓が有限なので、上限到達は異常のサインとして throw する。
+  it('window scope は batch 上限に到達したら部分結果のまま return せず throw する', async () => {
     setupDb({ alwaysFullBatch: true });
 
     await expect(
       deleteUnreferencedEvents({
         userId: USER_ID,
         connectionId: CONNECTION_ID,
-        scope: { kind: 'connection' },
+        scope: {
+          kind: 'window',
+          notBefore: '2026-01-01T00:00:00.000Z',
+          notAfter: '2026-12-31T00:00:00.000Z',
+        },
       }),
     ).rejects.toThrow('calendar event pruning hit the batch limit');
 
@@ -276,6 +295,23 @@ describe('deleteUnreferencedEvents — batch 上限', () => {
       expect.stringContaining('stopped at the batch limit'),
       expect.any(Object),
     );
+  });
+
+  // regression（Codex 指摘、#2000）: window scope と同じ低い上限を connection scope
+  // （disconnect の全削除）にも適用すると、参照済み行（歴史的アンカー）が大量に混ざる
+  // 接続で再試行しても毎回同じ場所で止まり、二度と切断できなくなる。connection scope は
+  // 高い上限を持ち、window scope の上限（40 batch）を超えても throw せず完走する。
+  it('connection scope は window scope の上限を超えても throw せず完走する', async () => {
+    // 41 batch 満杯（旧上限 40 を超える）の後に自然終了させる。
+    setupDb({ fullBatchesThenStop: 41 });
+
+    await expect(
+      deleteUnreferencedEvents({
+        userId: USER_ID,
+        connectionId: CONNECTION_ID,
+        scope: { kind: 'connection' },
+      }),
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/apps/product/src/features/external-calendar/server/__tests__/google-provider.test.ts
+++ b/apps/product/src/features/external-calendar/server/__tests__/google-provider.test.ts
@@ -89,6 +89,29 @@ describe('googleCalendarAdapter.syncCalendar', () => {
     expect(result.nextCursor).toBe('sync-token-1');
   });
 
+  // regression（#1989）: 保存もしないフィールド（attendees / location / organizer 等）を
+  // 受信自体しないよう `fields` partial response mask を送る。マスク文字列に
+  // nextSyncToken / nextPageToken が抜けると増分同期が黙って壊れる（syncToken を受け取れず
+  // 毎回 full sync になる）ので、ページング系が入っていることも合わせて固定する。
+  it('events.list に保存列 + ページング系だけの fields mask を送る', async () => {
+    fetchMock().mockResolvedValue(
+      jsonResponse({ items: [timedEvent()], nextSyncToken: 'sync-token-1' }),
+    );
+
+    await googleCalendarAdapter.syncCalendar(SESSION, {
+      calendarId: CALENDAR_ID,
+      cursor: null,
+      window: WINDOW,
+    });
+
+    const fields = requestedUrl(0).searchParams.get('fields');
+    expect(fields).toBe(
+      'items(id,status,summary,description,start,end),nextPageToken,nextSyncToken',
+    );
+    expect(fields).toContain('nextSyncToken');
+    expect(fields).toContain('nextPageToken');
+  });
+
   // timeMin / timeMax は syncToken と併用禁止で、送ると 410 ではなく 400 が返る
   it('増分 sync では syncToken だけを送り、timeMin / timeMax を送らない', async () => {
     fetchMock().mockResolvedValue(jsonResponse({ items: [], nextSyncToken: 'sync-token-2' }));

--- a/apps/product/src/features/external-calendar/server/__tests__/sync-service.test.ts
+++ b/apps/product/src/features/external-calendar/server/__tests__/sync-service.test.ts
@@ -62,6 +62,7 @@ type DbConfig = {
   calendars?: Array<Record<string, unknown>>;
   calendarsError?: unknown;
   pruneCandidates?: Array<{ id: string }>;
+  pruneSelectError?: unknown;
   referencedByPlans?: Array<{ external_calendar_event_id: string | null }>;
   referencedByRecords?: Array<{ external_calendar_event_id: string | null }>;
   upsertError?: unknown;
@@ -93,6 +94,9 @@ function setupDb(config: DbConfig) {
       // prune candidate select. keyset ページングを 1 バッチで終わらせる。
       const batch = counters.pruneSelect;
       counters.pruneSelect += 1;
+      if (batch === 0 && config.pruneSelectError) {
+        return { data: null, error: config.pruneSelectError };
+      }
       return { data: batch === 0 ? (config.pruneCandidates ?? []) : [], error: null };
     }
     if (table === 'plans') return { data: config.referencedByPlans ?? [], error: null };
@@ -308,6 +312,28 @@ describe('syncConnection — prune 委譲', () => {
     const del = findCall(calls, 'external_calendar_events', 'delete');
     expect(del).toBeDefined();
     expect(argsOf(del!, 'in')[1]).toEqual(['ev-2']);
+  });
+
+  // regression（#1988）: event-pruning.ts は select 失敗を throw するようになった
+  // （event-pruning.test.ts 参照）。sync 経路はこれを best-effort として吸収し、window prune
+  // の失敗だけで sync 全体を失敗扱いにしない。
+  it('window prune が失敗しても sync 自体は synced のまま完了する', async () => {
+    const { calls } = setupDb({
+      connection: activeConnection(),
+      calendars: oneCalendar(),
+      pruneSelectError: { code: '42501' },
+    });
+    syncCalendar.mockResolvedValue(syncResult());
+
+    await expect(
+      syncConnection({ connectionId: CONNECTION_ID, userId: USER_ID }),
+    ).resolves.toMatchObject({ outcome: 'synced' });
+
+    expect(captureUnexpectedError).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ operation: 'sync_window_prune' }),
+    );
+    expect(findCall(calls, 'external_calendar_events', 'delete')).toBeUndefined();
   });
 });
 

--- a/apps/product/src/features/external-calendar/server/connection-service.ts
+++ b/apps/product/src/features/external-calendar/server/connection-service.ts
@@ -612,12 +612,15 @@ function reportUnrevokedGrant(reason: string): void {
 /**
  * 接続を切断する（overview.md §8 の 3 段。順序が重要）。
  *
- * 1. provider の revoke を best-effort で呼ぶ（失敗しても続行）
- * 2. connection を消す前に、未参照ミラー行を anti-join で掃除する（削除後は FK が
+ * 1. 未参照ミラー行を anti-join で掃除する（connection を消す前に。削除後は FK が
  *    connection_id を NULL 化してスコープを失う）。**fail-closed**: 掃除が失敗したら
- *    connection は消さず throw する。ここだけは best-effort にしない — 削除後は FK が
- *    connection_id を NULL 化し、その未参照ミラー行を回収する経路が無くなる（#1988）。
+ *    revoke も connection 削除もせず throw する。ここだけは best-effort にしない — 削除後は
+ *    FK が connection_id を NULL 化し、その未参照ミラー行を回収する経路が無くなる（#1988）。
  *    切断は冪等なので、ユーザーがもう一度実行すれば prune からやり直せる
+ * 2. provider の revoke を best-effort で呼ぶ（失敗しても続行）。掃除より先に revoke すると、
+ *    掃除が失敗した時に「token は失効済みなのに connection は active のまま」という
+ *    authoritative state の食い違いが残る（Codex 指摘、#2000）。掃除を確実に終えてから
+ *    revoke することでこの食い違いを避ける
  * 3. `calendar_connections` を hard delete（子は CASCADE、参照済みミラーは connection_id が
  *    SET NULL され歴史的アンカーとして残る）
  *
@@ -629,7 +632,18 @@ export async function disconnect(userId: string, connectionId: string): Promise<
   const secret = await loadConnectionSecret(db, userId, connectionId);
   if (!secret) return; // 既に切断済み。冪等。
 
-  // 1. revoke（best-effort）。復号に失敗しても切断自体は続行する。
+  // 1. revoke より先にミラーを掃除する。失敗したら revoke も connection 削除もしない。
+  try {
+    await deleteUnreferencedEvents({ userId, connectionId, scope: { kind: 'connection' } });
+  } catch (error) {
+    throw new ExternalCalendarServiceError(
+      'DELETE_FAILED',
+      'failed to clean up calendar events before disconnecting',
+      { cause: error },
+    );
+  }
+
+  // 2. revoke（best-effort）。復号に失敗しても切断自体は続行する。
   try {
     const refreshToken = decryptToken(
       secret.refreshTokenEnc,
@@ -639,17 +653,6 @@ export async function disconnect(userId: string, connectionId: string): Promise<
     if (!revoked) reportUnrevokedGrant('provider revoke was not confirmed');
   } catch {
     reportUnrevokedGrant('could not revoke the provider grant');
-  }
-
-  // 2. connection 削除より先にミラーを掃除する。失敗したら connection を消さない。
-  try {
-    await deleteUnreferencedEvents({ userId, connectionId, scope: { kind: 'connection' } });
-  } catch (error) {
-    throw new ExternalCalendarServiceError(
-      'DELETE_FAILED',
-      'failed to clean up calendar events before disconnecting',
-      { cause: error },
-    );
   }
 
   // 3. connection を hard delete。子テーブルは CASCADE。

--- a/apps/product/src/features/external-calendar/server/connection-service.ts
+++ b/apps/product/src/features/external-calendar/server/connection-service.ts
@@ -574,12 +574,22 @@ export async function updateSelectedCalendars(
       });
     }
 
-    // 外したカレンダーの未参照ミラー行を即時掃除する。
-    await deleteUnreferencedEvents({
-      userId,
-      connectionId,
-      scope: { kind: 'calendars', providerCalendarIds: removedIds },
-    });
+    // 外したカレンダーの未参照ミラー行を即時掃除する。best-effort — 失敗しても選択変更
+    // 自体は成功として扱う（fail-closed にすると cleanup 失敗がユーザー操作全体を巻き込む）。
+    // 拾いきれなかった行は次回の window prune か disconnect の prune が回収する。
+    try {
+      await deleteUnreferencedEvents({
+        userId,
+        connectionId,
+        scope: { kind: 'calendars', providerCalendarIds: removedIds },
+      });
+    } catch (error) {
+      logger.warn('[calendar-connection] failed to prune events for removed calendars');
+      captureUnexpectedError(error instanceof Error ? error : new Error('calendar prune failed'), {
+        feature: 'external_calendar',
+        operation: 'update_selected_calendars_prune',
+      });
+    }
   }
 }
 
@@ -604,7 +614,10 @@ function reportUnrevokedGrant(reason: string): void {
  *
  * 1. provider の revoke を best-effort で呼ぶ（失敗しても続行）
  * 2. connection を消す前に、未参照ミラー行を anti-join で掃除する（削除後は FK が
- *    connection_id を NULL 化してスコープを失う）
+ *    connection_id を NULL 化してスコープを失う）。**fail-closed**: 掃除が失敗したら
+ *    connection は消さず throw する。ここだけは best-effort にしない — 削除後は FK が
+ *    connection_id を NULL 化し、その未参照ミラー行を回収する経路が無くなる（#1988）。
+ *    切断は冪等なので、ユーザーがもう一度実行すれば prune からやり直せる
  * 3. `calendar_connections` を hard delete（子は CASCADE、参照済みミラーは connection_id が
  *    SET NULL され歴史的アンカーとして残る）
  *
@@ -628,8 +641,16 @@ export async function disconnect(userId: string, connectionId: string): Promise<
     reportUnrevokedGrant('could not revoke the provider grant');
   }
 
-  // 2. connection 削除より先にミラーを掃除する。
-  await deleteUnreferencedEvents({ userId, connectionId, scope: { kind: 'connection' } });
+  // 2. connection 削除より先にミラーを掃除する。失敗したら connection を消さない。
+  try {
+    await deleteUnreferencedEvents({ userId, connectionId, scope: { kind: 'connection' } });
+  } catch (error) {
+    throw new ExternalCalendarServiceError(
+      'DELETE_FAILED',
+      'failed to clean up calendar events before disconnecting',
+      { cause: error },
+    );
+  }
 
   // 3. connection を hard delete。子テーブルは CASCADE。
   const { error } = await db

--- a/apps/product/src/features/external-calendar/server/connection-service.ts
+++ b/apps/product/src/features/external-calendar/server/connection-service.ts
@@ -621,6 +621,12 @@ function reportUnrevokedGrant(reason: string): void {
  *    掃除が失敗した時に「token は失効済みなのに connection は active のまま」という
  *    authoritative state の食い違いが残る（Codex 指摘、#2000）。掃除を確実に終えてから
  *    revoke することでこの食い違いを避ける
+ * 2.5. revoke の間（provider への network round-trip）に別プロセスの sync が新しい
+ *    ミラー行を書き込む可能性が残る（sync-service.ts は disconnect 中の connection を
+ *    CAS 検証せず書き込める。Codex 指摘、#2000。完全に閉じるには sync 側の fencing が要る
+ *    — #2003 で追跡）。ここでは delete 直前にもう一度掃除して race window を「revoke の
+ *    所要時間」から「この 2 回目の DB 往復」まで縮める。**best-effort** — 1 回目の
+ *    fail-closed で主要な保証は既に成立しているため、ここの失敗で切断全体を止めない
  * 3. `calendar_connections` を hard delete（子は CASCADE、参照済みミラーは connection_id が
  *    SET NULL され歴史的アンカーとして残る）
  *
@@ -653,6 +659,17 @@ export async function disconnect(userId: string, connectionId: string): Promise<
     if (!revoked) reportUnrevokedGrant('provider revoke was not confirmed');
   } catch {
     reportUnrevokedGrant('could not revoke the provider grant');
+  }
+
+  // 2.5. revoke 中に新規発生した差分を拾う best-effort な 2 回目の掃除。
+  try {
+    await deleteUnreferencedEvents({ userId, connectionId, scope: { kind: 'connection' } });
+  } catch (error) {
+    logger.warn('[calendar-connection] failed to re-prune events right before disconnect delete');
+    captureUnexpectedError(error instanceof Error ? error : new Error('calendar prune failed'), {
+      feature: 'external_calendar',
+      operation: 'disconnect_reprune',
+    });
   }
 
   // 3. connection を hard delete。子テーブルは CASCADE。

--- a/apps/product/src/features/external-calendar/server/event-pruning.ts
+++ b/apps/product/src/features/external-calendar/server/event-pruning.ts
@@ -28,8 +28,21 @@ const DB_REQUEST_TIMEOUT_MS = 15_000;
 /** 1 バッチあたり件数。max_rows=1000 と URL 長 8192B に触れない。 */
 const PRUNE_BATCH_SIZE = 150;
 
-/** バッチ上限。150 × 40 = 6,000 件で ±90 日 window / 1 接続の想定を大きく超える。 */
+/**
+ * window / calendars scope のバッチ上限。150 × 40 = 6,000 件で ±90 日 window の想定を
+ * 大きく超える。到達は prune 条件かページングが壊れている異常のサインとして扱い throw する。
+ */
 const MAX_PRUNE_BATCHES = 40;
+
+/**
+ * connection scope（disconnect の全削除）のバッチ上限。この経路は時間窓を持たない
+ * 一回限りの終端操作なので、参照済み行（歴史的アンカー）が大量に混ざっていても
+ * 最終的に完走できる必要がある。上限到達時に throw するようになった結果（#1988）、
+ * 上限が低いと再試行しても同じ場所で毎回止まり、connection を永久に切断できなくなる
+ * （Codex 指摘、#2000）。150 × 4,000 = 600,000 件は現実的な接続では到達しない値にし、
+ * 真のページングバグに対する backstop としてだけ機能させる。
+ */
+const MAX_PRUNE_BATCHES_CONNECTION_SCOPE = 4_000;
 
 /**
  * 掃除する行の絞り込み条件。
@@ -124,8 +137,10 @@ export async function deleteUnreferencedEvents(params: {
 
   const db = createEventPruningClient();
   let cursor: string | null = null;
+  const batchLimit =
+    scope.kind === 'connection' ? MAX_PRUNE_BATCHES_CONNECTION_SCOPE : MAX_PRUNE_BATCHES;
 
-  for (let batch = 0; batch < MAX_PRUNE_BATCHES; batch += 1) {
+  for (let batch = 0; batch < batchLimit; batch += 1) {
     let query = db
       .from(databaseTables.externalCalendarEvents)
       .select('id')
@@ -192,10 +207,11 @@ export async function deleteUnreferencedEvents(params: {
     if (candidates.length < PRUNE_BATCH_SIZE) return;
   }
 
-  // 1 接続の ±90 日 window でこの上限（6,000 行）に当たるのは、prune 条件かページングが
-  // 壊れている時だけ。掃除が途中で止まった事実は、次の run が黙って同じ所で止まるので
-  // log だけでは見えない。
-  logger.warn('[calendar-prune] stopped at the batch limit', { batches: MAX_PRUNE_BATCHES });
+  // window / calendars scope でこの上限に当たるのは、prune 条件かページングが壊れている
+  // 時だけ。connection scope は上限をずっと高く取っているので、正規の接続がここに来る
+  // ことは実質無い（真のページングバグの backstop）。掃除が途中で止まった事実は、次の run
+  // が黙って同じ所で止まるので log だけでは見えない。
+  logger.warn('[calendar-prune] stopped at the batch limit', { batches: batchLimit });
   // 上限値は logger 側にだけ出す。`CaptureErrorContext` は string キーしか持たず、
   // 数値を足しても型で弾かれ、通っても sanitize の allowlist で捨てられる。
   const batchLimitError = new Error('calendar event pruning hit the batch limit');

--- a/apps/product/src/features/external-calendar/server/event-pruning.ts
+++ b/apps/product/src/features/external-calendar/server/event-pruning.ts
@@ -104,8 +104,13 @@ async function loadReferencedEventIds(
 /**
  * scope に一致する未参照ミラー行を anti-join で delete する。
  *
- * 失敗（select / 参照読み取り / delete）では throw せず、ここまでの成功を壊さないよう
- * 記録して中断する（呼び出し側は sync の一部・disconnect の一部として続行できる）。
+ * **既知の想定内レース（23503: select と delete の間に plan が作られる）を除き、失敗は
+ * すべて throw する。** 呼び出し元がここまでの成功を守りたいか（sync の window prune・選択解除
+ * の即時掃除は best-effort で catch する）、fail-closed に倒したいか（disconnect は catch せず
+ * connection 削除を止める）を選べるようにするため、ここでは判断しない。
+ *
+ * throw する失敗: select 失敗、参照読み取り失敗、23503 以外の delete 失敗、
+ * batch 上限到達（部分的にしか掃除できていない状態を「成功」として返さない）。
  */
 export async function deleteUnreferencedEvents(params: {
   userId: string;
@@ -118,7 +123,7 @@ export async function deleteUnreferencedEvents(params: {
   if (scope.kind === 'calendars' && scope.providerCalendarIds.length === 0) return;
 
   const db = createEventPruningClient();
-  let cursor = '';
+  let cursor: string | null = null;
 
   for (let batch = 0; batch < MAX_PRUNE_BATCHES; batch += 1) {
     let query = db
@@ -133,14 +138,19 @@ export async function deleteUnreferencedEvents(params: {
       query = query.in('provider_calendar_id', scope.providerCalendarIds);
     }
 
+    // 初回ページは cursor が無い。UUID 列に空文字を渡すと PostgREST 側で invalid UUID になり、
+    // 削除対象の有無にかかわらず取得が丸ごと失敗するため、2 ページ目以降にだけ条件を足す。
+    if (cursor !== null) {
+      query = query.gt('id', cursor);
+    }
+
     const { data: candidates, error: selectError } = await query
-      .gt('id', cursor)
       .order('id', { ascending: true })
       .limit(PRUNE_BATCH_SIZE);
 
     if (selectError) {
       captureDatabaseError(selectError, 'prune_select_candidates');
-      return;
+      throw selectError;
     }
     if (!candidates || candidates.length === 0) return;
 
@@ -151,7 +161,7 @@ export async function deleteUnreferencedEvents(params: {
       referenced = await loadReferencedEventIds(db, userId, ids);
     } catch (error) {
       captureDatabaseError(error, 'prune_load_referenced');
-      return;
+      throw error;
     }
     const prunable = ids.filter((id) => !referenced.has(id));
 
@@ -159,13 +169,22 @@ export async function deleteUnreferencedEvents(params: {
       const { error: deleteError } = await db
         .from(databaseTables.externalCalendarEvents)
         .delete()
-        // service_role は RLS を bypass するので user_id を明示的に添える（defense-in-depth）。
+        // service_role は RLS を bypass するので user_id / connection_id を明示的に添える
+        // （defense-in-depth。id は既に scope 済みの select 結果なので機能的には冗長）。
         .eq('user_id', userId)
+        .eq('connection_id', connectionId)
         .in('id', prunable);
 
       if (deleteError) {
-        // select と delete の間に plan が作られると 23503。次回に回収されるので警告に留める。
-        logger.warn('[calendar-prune] skipped some rows due to a reference race');
+        if (deleteError.code === '23503') {
+          // select と delete の間に plan が作られると 23503。次回に回収されるので警告に留める。
+          logger.warn('[calendar-prune] skipped some rows due to a reference race');
+        } else {
+          // 23503 以外（権限・timeout 等）は既知のレースではない。ここで飲み込むと disconnect
+          // の fail-closed が効かず、連鎖する未参照行を永久に見失う（#1988）。throw する。
+          captureDatabaseError(deleteError, 'prune_delete_candidates');
+          throw deleteError;
+        }
       }
     }
 
@@ -179,10 +198,14 @@ export async function deleteUnreferencedEvents(params: {
   logger.warn('[calendar-prune] stopped at the batch limit', { batches: MAX_PRUNE_BATCHES });
   // 上限値は logger 側にだけ出す。`CaptureErrorContext` は string キーしか持たず、
   // 数値を足しても型で弾かれ、通っても sanitize の allowlist で捨てられる。
-  captureUnexpectedError(new Error('calendar event pruning hit the batch limit'), {
+  const batchLimitError = new Error('calendar event pruning hit the batch limit');
+  captureUnexpectedError(batchLimitError, {
     feature: 'external_calendar',
     operation: 'prune_batch_limit',
   });
+  // ここで return すると disconnect の fail-closed が効かず、上限を超えた残り行が
+  // connection 削除で永久に回収不能になる（#1988 と同じ形の穴）。throw して呼び出し元に選ばせる。
+  throw batchLimitError;
 }
 
 function captureDatabaseError(error: unknown, operation: string): void {

--- a/apps/product/src/features/external-calendar/server/providers/google.ts
+++ b/apps/product/src/features/external-calendar/server/providers/google.ts
@@ -75,6 +75,21 @@ const RATE_LIMIT_REASONS = new Set(['rateLimitExceeded', 'userRateLimitExceeded'
 const RATE_LIMIT_RETRY_BASE_MS = 1_000;
 const RATE_LIMIT_RETRY_JITTER_MS = 1_000;
 
+/**
+ * `events.list` の partial response mask（Google の `fields` パラメータ）。
+ *
+ * Google の Limited Use ポリシー「必要なデータだけを扱う」に沿い、attendees / location /
+ * organizer 等を受信自体しない（保存もしていないが、マスク無しだと受信はしてしまう）。
+ * `id, status, summary, description, start, end` は `googleEventSchema` が実際に parse する
+ * 列と一致させる。
+ *
+ * **`nextPageToken` / `nextSyncToken` を落とすと増分同期が黙って壊れる**（syncToken を
+ * 受け取れず、次回から毎回 full sync になる）。ページング系は必ず含める
+ * （google-provider.test.ts で固定）。
+ */
+const EVENTS_LIST_FIELDS_MASK =
+  'items(id,status,summary,description,start,end),nextPageToken,nextSyncToken';
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
@@ -187,6 +202,7 @@ function buildEventsListUrl(params: {
 
   url.searchParams.set('singleEvents', 'true');
   url.searchParams.set('maxResults', String(MAX_RESULTS_PER_PAGE));
+  url.searchParams.set('fields', EVENTS_LIST_FIELDS_MASK);
 
   if (params.cursor === null) {
     url.searchParams.set('timeMin', params.window.timeMin);

--- a/apps/product/src/features/external-calendar/server/sync-service.ts
+++ b/apps/product/src/features/external-calendar/server/sync-service.ts
@@ -283,11 +283,21 @@ export async function syncConnection(params: {
   // 参照されていない window 外行を掃除する。connection 単位で 1 回だけ（calendar ごとに
   // 回すと他カレンダーの行も対象になり、無駄に N 回走る）。window 境界は provider へ渡したのと
   // 同じ値を使う。anti-join の本体は event-pruning.ts に集約している。
-  await deleteUnreferencedEvents({
-    userId,
-    connectionId,
-    scope: { kind: 'window', notBefore: window.timeMin, notAfter: window.timeMax },
-  });
+  // best-effort — 失敗しても sync 自体は成功として扱う（fail-closed にすると cleanup 失敗が
+  // 同期結果全体を巻き込む）。拾いきれなかった行は次回の sync か disconnect の prune が回収する。
+  try {
+    await deleteUnreferencedEvents({
+      userId,
+      connectionId,
+      scope: { kind: 'window', notBefore: window.timeMin, notAfter: window.timeMax },
+    });
+  } catch (error) {
+    logger.warn('[calendar-sync] failed to prune out-of-window events');
+    captureUnexpectedError(error instanceof Error ? error : new Error('calendar prune failed'), {
+      feature: 'external_calendar',
+      operation: 'sync_window_prune',
+    });
+  }
 
   if (calendarsFailed > 0) {
     await writeConnectionError(db, connectionId, userId, 'partial_failure', runStartedAtIso);

--- a/apps/product/src/lib/test/integration/calendar-authority-retention-cleanup.integration.test.ts
+++ b/apps/product/src/lib/test/integration/calendar-authority-retention-cleanup.integration.test.ts
@@ -1,0 +1,326 @@
+/**
+ * private.cleanup_calendar_authority_retention_internal_v1 の実挙動を固定する。
+ *
+ * #1994: この関数は 20260730090015_fenced_calendar_revoke_worker.sql で追加されたが、
+ * 呼び出す cron が存在せず、`calendar_revoke_operations` / `calendar_authority_command_receipts`
+ * / `calendar_oauth_attempts` の `delete_after` 超過行と孤立 subject fence が際限なく
+ * 蓄積していた。20260812041309_schedule_calendar_authority_retention_cleanup.sql で
+ * pg_cron に配線した。ここでは配線ではなく関数の削除対象そのものを固定する
+ * （cron が正しい関数名・引数で登録されていることは migration のリテラル比較で足りるため、
+ * 別途 cron.job テストは作らない）。
+ *
+ * 関数は `REVOKE ALL ... FROM PUBLIC, anon, authenticated, service_role` されており、
+ * pg_cron が実行する owner 権限でしか呼べない設計（overview.md 相当の owner-only 契約）。
+ * そのため supabase-js client ではなく psql 直叩きで呼ぶ。
+ */
+
+import { spawnSync } from 'node:child_process';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const RUN_LOCAL = process.env.USE_LOCAL_DB === 'true';
+
+function createRunProjectNumber(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(12));
+  return Array.from(bytes, (value, index) =>
+    String(index === 0 ? (value % 9) + 1 : value % 10),
+  ).join('');
+}
+
+const projectKey = createRunProjectNumber();
+const oauthClientId = `${projectKey}-dayoptcalendar.apps.googleusercontent.com`;
+const userId = crypto.randomUUID();
+const userEmail = `calendar-authority-retention-cleanup-${userId}@example.com`;
+
+function ownerSql(sql: string, variables: Record<string, string> = {}): string {
+  const result = spawnSync(
+    'psql',
+    [
+      '-X',
+      '-qAt',
+      '-v',
+      'ON_ERROR_STOP=1',
+      ...Object.entries(variables).flatMap(([name, value]) => ['-v', `${name}=${value}`]),
+      '-h',
+      '127.0.0.1',
+      '-p',
+      '54322',
+      '-U',
+      'postgres',
+      '-d',
+      'postgres',
+    ],
+    {
+      encoding: 'utf8',
+      env: { ...process.env, PGPASSWORD: 'postgres' },
+      input: sql,
+    },
+  );
+
+  if (result.status !== 0) {
+    throw new Error(`Calendar authority retention cleanup SQL failed: ${result.stderr}`);
+  }
+  // 複数 statement を 1 回の呼び出しで流す時、必要なのは最後の statement の結果だけ
+  // （serviceRoleSql が前置する set_config の戻り値を拾わないため）。
+  return result.stdout.trim().split('\n').at(-1) ?? '';
+}
+
+// provision_calendar_authority_project_v1 / get_or_create_calendar_subject_fence_v1 は
+// service_role JWT claim を要求する（calendar-revoke-authority.integration.test.ts と同型）。
+function serviceRoleSql(sql: string, variables: Record<string, string> = {}): string {
+  return ownerSql(
+    `SELECT pg_catalog.set_config(
+  'request.jwt.claims',
+  '{"role":"service_role"}',
+  FALSE
+);
+${sql}`,
+    variables,
+  );
+}
+
+function cleanupFixture(): void {
+  ownerSql(
+    `DELETE FROM private.calendar_revoke_operations WHERE project_fence_id IN (
+  SELECT id FROM private.calendar_authority_fences WHERE project_key = :'project_key'
+);
+DELETE FROM private.calendar_authority_command_receipts WHERE project_fence_id IN (
+  SELECT id FROM private.calendar_authority_fences WHERE project_key = :'project_key'
+);
+DELETE FROM private.calendar_oauth_attempts WHERE project_fence_id IN (
+  SELECT id FROM private.calendar_authority_fences WHERE project_key = :'project_key'
+);
+DELETE FROM private.calendar_authority_fences WHERE project_key = :'project_key';
+DELETE FROM private.calendar_authority_projects WHERE project_key = :'project_key';
+DELETE FROM auth.users WHERE id = :'user_id'::UUID;`,
+    { project_key: projectKey, user_id: userId },
+  );
+}
+
+function provisionProject(): { projectFenceId: string } {
+  serviceRoleSql(
+    `SELECT public.provision_calendar_authority_project_v1(:'project_key', :'oauth_client_id');
+UPDATE private.calendar_authority_projects
+SET activation_version = 1, activated_at = pg_catalog.clock_timestamp()
+WHERE project_key = :'project_key';
+INSERT INTO auth.users (
+  id, aud, role, email, encrypted_password, raw_app_meta_data, raw_user_meta_data, created_at, updated_at
+) VALUES (
+  :'user_id'::UUID, 'authenticated', 'authenticated', :'user_email', '', '{}'::JSONB, '{}'::JSONB,
+  pg_catalog.now(), pg_catalog.now()
+);`,
+    {
+      oauth_client_id: oauthClientId,
+      project_key: projectKey,
+      user_email: userEmail,
+      user_id: userId,
+    },
+  );
+  const projectFenceId = ownerSql(
+    `SELECT id FROM private.calendar_authority_fences WHERE project_key = :'project_key' AND scope_kind = 'project';`,
+    { project_key: projectKey },
+  );
+  return { projectFenceId };
+}
+
+function createSubjectFence(providerAccountId: string): string {
+  return serviceRoleSql(
+    `SELECT private.get_or_create_calendar_subject_fence_v1(:'project_key', :'provider_account_id');`,
+    { project_key: projectKey, provider_account_id: providerAccountId },
+  );
+}
+
+function runCleanup(limit = 1000): number {
+  return Number(
+    ownerSql(`SELECT private.cleanup_calendar_authority_retention_internal_v1(${limit});`),
+  );
+}
+
+describe.skipIf(!RUN_LOCAL)('calendar authority retention cleanup', () => {
+  afterEach(() => {
+    cleanupFixture();
+  });
+
+  it('delete_after を過ぎた revoke operation / receipt / oauth attempt を削除し、未満は残す', async () => {
+    const { projectFenceId } = provisionProject();
+    const subjectFenceId = createSubjectFence('retention-subject-due');
+    const connectionId = crypto.randomUUID();
+
+    const dueOperationId = crypto.randomUUID();
+    const notDueOperationId = crypto.randomUUID();
+    const dueReceiptOperationId = crypto.randomUUID();
+    const dueAttemptId = crypto.randomUUID();
+
+    ownerSql(
+      `INSERT INTO private.calendar_revoke_operations (
+  operation_id, project_fence_id, subject_fence_id, subject_fence_epoch, source_connection_id,
+  operation_kind, request_digest, state, initial_result, settled_at, delete_after
+) VALUES
+(
+  :'due_operation_id'::UUID, :'project_fence_id'::UUID, :'subject_fence_id'::UUID, 0,
+  :'connection_id'::UUID, 'disconnect', decode(repeat('00', 32), 'hex'), 'revoked', 'queued',
+  pg_catalog.clock_timestamp() - INTERVAL '91 days',
+  pg_catalog.clock_timestamp() - INTERVAL '1 day'
+),
+(
+  :'not_due_operation_id'::UUID, :'project_fence_id'::UUID, :'subject_fence_id'::UUID, 0,
+  :'connection_id'::UUID, 'disconnect', decode(repeat('11', 32), 'hex'), 'revoked', 'queued',
+  pg_catalog.clock_timestamp() - INTERVAL '1 day',
+  pg_catalog.clock_timestamp() + INTERVAL '89 days'
+);
+
+INSERT INTO private.calendar_authority_command_receipts (
+  operation_id, command_kind, project_fence_id, subject_fence_id, source_connection_id,
+  resource_connection_id, request_digest, result, created_at, delete_after
+) VALUES (
+  :'due_receipt_operation_id'::UUID, 'connection_save', :'project_fence_id'::UUID,
+  :'subject_fence_id'::UUID, :'connection_id'::UUID, :'connection_id'::UUID,
+  decode(repeat('22', 32), 'hex'), 'saved',
+  -- retention CHECK は delete_after <= created_at + 90 days。created_at と delete_after を
+  -- 別々の clock_timestamp() 呼び出しで計算すると、実行順序のわずかなずれで 90 日をわずかに
+  -- 超えうる（実測）ため、2 日の余裕を持たせる。
+  pg_catalog.clock_timestamp() - INTERVAL '10 days',
+  pg_catalog.clock_timestamp() - INTERVAL '1 day'
+);
+
+INSERT INTO private.calendar_oauth_attempts (
+  id, project_fence_id, user_id, state_digest, verifier_digest, operation_id, connection_id,
+  data_generation, project_epoch, created_at, expires_at, delete_after
+) VALUES (
+  :'due_attempt_id'::UUID, :'project_fence_id'::UUID, :'user_id'::UUID,
+  decode(repeat('33', 32), 'hex'), decode(repeat('44', 32), 'hex'),
+  gen_random_uuid(), :'connection_id'::UUID, 0, 0,
+  pg_catalog.clock_timestamp() - INTERVAL '10 minutes',
+  pg_catalog.clock_timestamp() - INTERVAL '5 minutes',
+  pg_catalog.clock_timestamp() - INTERVAL '1 second'
+);`,
+      {
+        connection_id: connectionId,
+        due_attempt_id: dueAttemptId,
+        due_operation_id: dueOperationId,
+        due_receipt_operation_id: dueReceiptOperationId,
+        not_due_operation_id: notDueOperationId,
+        project_fence_id: projectFenceId,
+        subject_fence_id: subjectFenceId,
+        user_id: userId,
+      },
+    );
+
+    const deletedCount = runCleanup();
+    expect(deletedCount).toBeGreaterThanOrEqual(3);
+
+    expect(
+      ownerSql(
+        `SELECT
+  (SELECT pg_catalog.count(*) FROM private.calendar_revoke_operations WHERE operation_id = :'due_operation_id'::UUID) || '|' ||
+  (SELECT pg_catalog.count(*) FROM private.calendar_revoke_operations WHERE operation_id = :'not_due_operation_id'::UUID) || '|' ||
+  (SELECT pg_catalog.count(*) FROM private.calendar_authority_command_receipts WHERE operation_id = :'due_receipt_operation_id'::UUID) || '|' ||
+  (SELECT pg_catalog.count(*) FROM private.calendar_oauth_attempts WHERE id = :'due_attempt_id'::UUID);`,
+        {
+          due_attempt_id: dueAttemptId,
+          due_operation_id: dueOperationId,
+          due_receipt_operation_id: dueReceiptOperationId,
+          not_due_operation_id: notDueOperationId,
+        },
+      ),
+    ).toBe('0|1|0|0');
+  });
+
+  it('参照が無い ready subject fence を削除し、参照が残るものは残す', async () => {
+    const { projectFenceId } = provisionProject();
+    const orphanFenceId = createSubjectFence('retention-subject-orphan');
+    const referencedFenceId = createSubjectFence('retention-subject-referenced');
+
+    // 参照ありにするため receipt を 1 件貼る（delete_after は未来 = cleanup 対象外の receipt）。
+    ownerSql(
+      `INSERT INTO private.calendar_authority_command_receipts (
+  operation_id, command_kind, project_fence_id, subject_fence_id, source_connection_id,
+  resource_connection_id, request_digest, result, created_at, delete_after
+) VALUES (
+  gen_random_uuid(), 'connection_save', :'project_fence_id'::UUID, :'referenced_fence_id'::UUID,
+  gen_random_uuid(), gen_random_uuid(), decode(repeat('55', 32), 'hex'), 'saved',
+  -- retention CHECK は delete_after <= created_at + 90 days。created_at と delete_after を
+  -- 別々の clock_timestamp() 呼び出しで計算すると実行順序のわずかなずれで超えうるため、
+  -- 2 日の余裕を持たせる。
+  pg_catalog.clock_timestamp(), pg_catalog.clock_timestamp() + INTERVAL '88 days'
+);`,
+      { project_fence_id: projectFenceId, referenced_fence_id: referencedFenceId },
+    );
+
+    runCleanup();
+
+    expect(
+      ownerSql(
+        `SELECT
+  EXISTS(SELECT 1 FROM private.calendar_authority_fences WHERE id = :'orphan_fence_id'::UUID) || '|' ||
+  EXISTS(SELECT 1 FROM private.calendar_authority_fences WHERE id = :'referenced_fence_id'::UUID);`,
+        { orphan_fence_id: orphanFenceId, referenced_fence_id: referencedFenceId },
+      ),
+      // boolean を `||` で text と連結すると暗黙 cast は 'true'/'false'
+      // （psql 表示上の 't'/'f' とは別）。
+    ).toBe('false|true');
+  });
+
+  // グローバルな戻り値が 0 であることには依存しない。cleanup 関数は project 非スコープで
+  // 動くため（overview 相当のコメント参照）、ローカル共有 DB に他 worktree / 他 test の
+  // due 行が残っていると 0 という assertion 自体が flaky になる（risk-reviewer 指摘）。
+  // 自前の fixture 行だけを対象に「消えた後、もう一度呼んでもエラーにならず消えたままである」
+  // ことを確認する。
+  it('自前の fixture 行を消した後に再実行してもエラーにならず、消えたままである（冪等性）', async () => {
+    const { projectFenceId } = provisionProject();
+    const attemptId = crypto.randomUUID();
+
+    ownerSql(
+      `INSERT INTO private.calendar_oauth_attempts (
+  id, project_fence_id, user_id, state_digest, verifier_digest, operation_id, connection_id,
+  data_generation, project_epoch, created_at, expires_at, delete_after
+) VALUES (
+  :'attempt_id'::UUID, :'project_fence_id'::UUID, :'user_id'::UUID,
+  decode(repeat('66', 32), 'hex'), decode(repeat('77', 32), 'hex'),
+  gen_random_uuid(), gen_random_uuid(), 0, 0,
+  pg_catalog.clock_timestamp() - INTERVAL '10 minutes',
+  pg_catalog.clock_timestamp() - INTERVAL '5 minutes',
+  pg_catalog.clock_timestamp() - INTERVAL '1 second'
+);`,
+      { attempt_id: attemptId, project_fence_id: projectFenceId, user_id: userId },
+    );
+
+    // 単独の EXISTS() select は psql -t で 't'/'f'（`||` で text 連結した場合の
+    // 'true'/'false' とは表記が異なる）。
+    const stillExists = () =>
+      ownerSql(
+        `SELECT EXISTS(SELECT 1 FROM private.calendar_oauth_attempts WHERE id = :'attempt_id'::UUID);`,
+        { attempt_id: attemptId },
+      );
+
+    expect(stillExists()).toBe('t');
+    runCleanup();
+    expect(stillExists()).toBe('f');
+
+    // 2 回目はこの行についてはもう何もすることがない。エラーにならず、消えたままであること。
+    expect(() => runCleanup()).not.toThrow();
+    expect(stillExists()).toBe('f');
+  });
+
+  it('owner 以外（service_role を含む）は直接呼べない', () => {
+    expect(() =>
+      ownerSql(
+        `SET ROLE service_role;
+SELECT private.cleanup_calendar_authority_retention_internal_v1(10);`,
+      ),
+    ).toThrow(/permission denied/i);
+  });
+
+  it('cron に正しい関数名・引数・スケジュールで登録されている', () => {
+    // 配線の契約は migration のリテラル比較で足りる（実行結果は上のテストが担保する）。
+    // 2026-08-12: risk-reviewer 指摘で追加。expire-calendar-revoke-outbox の
+    // external-authority-maintenance.integration.test.ts と同型のガード。
+    expect(
+      ownerSql(
+        `SELECT schedule || '|' || command
+FROM cron.job
+WHERE jobname = 'cleanup-calendar-authority-retention';`,
+      ),
+    ).toBe('50 3 * * *|SELECT private.cleanup_calendar_authority_retention_internal_v1(1000)');
+  });
+});

--- a/apps/product/src/lib/test/integration/calendar-authority-retention-cleanup.integration.test.ts
+++ b/apps/product/src/lib/test/integration/calendar-authority-retention-cleanup.integration.test.ts
@@ -225,6 +225,57 @@ INSERT INTO private.calendar_oauth_attempts (
     ).toBe('0|1|0|0');
   });
 
+  // regression（Codex round 3 指摘、#2000）: cron は hourly なので、delete_after が
+  // ちょうど到来した直後の行は次の run まで最大 ~1h + 取りこぼし分だけ約束を超過しうる。
+  // 4 時間の safety margin 内の行は delete_after 到来前でも削除し、margin 外の行は残す。
+  it('safety margin 内の未到来行は前倒しで削除し、margin 外は残す', async () => {
+    const { projectFenceId } = provisionProject();
+    const subjectFenceId = createSubjectFence('retention-subject-margin');
+    const connectionId = crypto.randomUUID();
+
+    const withinMarginId = crypto.randomUUID();
+    const beyondMarginId = crypto.randomUUID();
+
+    ownerSql(
+      `INSERT INTO private.calendar_revoke_operations (
+  operation_id, project_fence_id, subject_fence_id, subject_fence_epoch, source_connection_id,
+  operation_kind, request_digest, state, initial_result, settled_at, delete_after
+) VALUES
+(
+  :'within_margin_id'::UUID, :'project_fence_id'::UUID, :'subject_fence_id'::UUID, 0,
+  :'connection_id'::UUID, 'disconnect', decode(repeat('66', 32), 'hex'), 'revoked', 'queued',
+  pg_catalog.clock_timestamp() - INTERVAL '90 days',
+  -- margin は 4 時間。3 時間後は margin 内なので削除対象。
+  pg_catalog.clock_timestamp() + INTERVAL '3 hours'
+),
+(
+  :'beyond_margin_id'::UUID, :'project_fence_id'::UUID, :'subject_fence_id'::UUID, 0,
+  :'connection_id'::UUID, 'disconnect', decode(repeat('77', 32), 'hex'), 'revoked', 'queued',
+  pg_catalog.clock_timestamp() - INTERVAL '80 days',
+  -- 5 時間後は margin 外なので残る。
+  pg_catalog.clock_timestamp() + INTERVAL '5 hours'
+);`,
+      {
+        beyond_margin_id: beyondMarginId,
+        connection_id: connectionId,
+        project_fence_id: projectFenceId,
+        subject_fence_id: subjectFenceId,
+        within_margin_id: withinMarginId,
+      },
+    );
+
+    runCleanup();
+
+    expect(
+      ownerSql(
+        `SELECT
+  (SELECT pg_catalog.count(*) FROM private.calendar_revoke_operations WHERE operation_id = :'within_margin_id'::UUID) || '|' ||
+  (SELECT pg_catalog.count(*) FROM private.calendar_revoke_operations WHERE operation_id = :'beyond_margin_id'::UUID);`,
+        { beyond_margin_id: beyondMarginId, within_margin_id: withinMarginId },
+      ),
+    ).toBe('0|1');
+  });
+
   it('参照が無い ready subject fence を削除し、参照が残るものは残す', async () => {
     const { projectFenceId } = provisionProject();
     const orphanFenceId = createSubjectFence('retention-subject-orphan');

--- a/apps/product/src/lib/test/integration/calendar-authority-retention-cleanup.integration.test.ts
+++ b/apps/product/src/lib/test/integration/calendar-authority-retention-cleanup.integration.test.ts
@@ -5,9 +5,8 @@
  * 呼び出す cron が存在せず、`calendar_revoke_operations` / `calendar_authority_command_receipts`
  * / `calendar_oauth_attempts` の `delete_after` 超過行と孤立 subject fence が際限なく
  * 蓄積していた。20260812041309_schedule_calendar_authority_retention_cleanup.sql で
- * pg_cron に配線した。ここでは配線ではなく関数の削除対象そのものを固定する
- * （cron が正しい関数名・引数で登録されていることは migration のリテラル比較で足りるため、
- * 別途 cron.job テストは作らない）。
+ * pg_cron に配線した。ここでは関数の削除対象そのものを固定し、cron 登録の schedule/command
+ * が migration のリテラルと一致していることも別途 assert する（risk-reviewer 指摘で追加）。
  *
  * 関数は `REVOKE ALL ... FROM PUBLIC, anon, authenticated, service_role` されており、
  * pg_cron が実行する owner 権限でしか呼べない設計（overview.md 相当の owner-only 契約）。
@@ -321,6 +320,6 @@ SELECT private.cleanup_calendar_authority_retention_internal_v1(10);`,
 FROM cron.job
 WHERE jobname = 'cleanup-calendar-authority-retention';`,
       ),
-    ).toBe('50 3 * * *|SELECT private.cleanup_calendar_authority_retention_internal_v1(1000)');
+    ).toBe('50 * * * *|SELECT private.cleanup_calendar_authority_retention_internal_v1(1000)');
   });
 });

--- a/apps/product/src/lib/test/integration/calendar-event-pruning.integration.test.ts
+++ b/apps/product/src/lib/test/integration/calendar-event-pruning.integration.test.ts
@@ -1,0 +1,180 @@
+/**
+ * event-pruning.ts の `deleteUnreferencedEvents` を実 Supabase local DB に対して検証する。
+ *
+ * regression（#1996）: `external_calendar_events.id` は UUID 列。keyset ページングの初回 cursor
+ * に空文字を渡すと PostgREST が `.gt('id', '')` を invalid UUID として拒否し、candidate select
+ * が丸ごと失敗する。event-pruning.test.ts の mock（文字列比較で `.gt` を素通りさせる fake table）
+ * はこの UUID キャストを再現できないため、緑のまま「本番稼働以来 prune が一度も行を消せていない」
+ * バグを見逃していた（指揮台の独立検証、#1996 コメント参照）。ここでは実 DB を叩いて再現する。
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { deleteUnreferencedEvents } from '@/features/external-calendar/server/event-pruning';
+import type { Database } from '@/lib/database';
+
+const LOCAL_DB_URL = 'http://127.0.0.1:54321';
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const RUN_LOCAL = process.env.USE_LOCAL_DB === 'true';
+
+const admin = createClient<Database>(LOCAL_DB_URL, SERVICE_ROLE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+const userId = crypto.randomUUID();
+const userEmail = `calendar-event-pruning-${userId}@example.com`;
+
+// `plans` は end_at が未来であることを DB trigger で強制する（DT004）。固定日付だと
+// テストが古くなった時に落ちるため、実行時刻からの相対値にする。
+const EVENT_START_AT = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+const EVENT_END_AT = new Date(Date.now() + 25 * 60 * 60 * 1000).toISOString();
+
+function activeShapeEvent(overrides: {
+  id: string;
+  connectionId: string;
+  providerCalendarId?: string;
+  providerEventId?: string;
+}) {
+  return {
+    id: overrides.id,
+    user_id: userId,
+    provider: 'google',
+    provider_calendar_id: overrides.providerCalendarId ?? 'calendar-1',
+    provider_event_id: overrides.providerEventId ?? `event-${overrides.id}`,
+    title: 'Standup',
+    calendar_name: 'Work',
+    start_at: EVENT_START_AT,
+    end_at: EVENT_END_AT,
+    status: 'confirmed',
+    last_synced_at: EVENT_START_AT,
+    connection_id: overrides.connectionId,
+  };
+}
+
+async function createConnection(): Promise<string> {
+  const connectionId = crypto.randomUUID();
+  const { error } = await admin.from('calendar_connections').insert({
+    id: connectionId,
+    user_id: userId,
+    provider: 'google',
+    provider_account_id: `sub-${connectionId}`,
+    granted_scopes: ['calendar.readonly'],
+    refresh_token_enc: 'v1.integration-ciphertext',
+    status: 'active',
+  });
+  if (error) throw error;
+  return connectionId;
+}
+
+describe.skipIf(!RUN_LOCAL)('deleteUnreferencedEvents — 実 DB での keyset ページング', () => {
+  beforeAll(async () => {
+    const { error } = await admin.auth.admin.createUser({
+      id: userId,
+      email: userEmail,
+      password: 'test-password-123',
+      email_confirm: true,
+    });
+    if (error) throw error;
+  });
+
+  afterEach(async () => {
+    await admin.from('external_calendar_events').delete().eq('user_id', userId);
+    await admin.from('calendar_connections').delete().eq('user_id', userId);
+  });
+
+  it('未参照のミラー行を実際に delete する（修正前は invalid UUID で 1 行も消せなかった）', async () => {
+    const connectionId = await createConnection();
+    const eventIds = [crypto.randomUUID(), crypto.randomUUID(), crypto.randomUUID()];
+
+    const { error: insertError } = await admin
+      .from('external_calendar_events')
+      .insert(eventIds.map((id) => activeShapeEvent({ id, connectionId })));
+    if (insertError) throw insertError;
+
+    await deleteUnreferencedEvents({
+      userId,
+      connectionId,
+      scope: { kind: 'connection' },
+    });
+
+    const { data: remaining, error: selectError } = await admin
+      .from('external_calendar_events')
+      .select('id')
+      .eq('connection_id', connectionId);
+    if (selectError) throw selectError;
+
+    expect(remaining).toEqual([]);
+  });
+
+  it('参照済みの行は anti-join で残す', async () => {
+    const connectionId = await createConnection();
+    const referencedEventId = crypto.randomUUID();
+    const unreferencedEventId = crypto.randomUUID();
+
+    const { error: insertError } = await admin.from('external_calendar_events').insert([
+      activeShapeEvent({ id: referencedEventId, connectionId, providerEventId: 'referenced' }),
+      activeShapeEvent({
+        id: unreferencedEventId,
+        connectionId,
+        providerEventId: 'unreferenced',
+      }),
+    ]);
+    if (insertError) throw insertError;
+
+    const { error: planError } = await admin.from('plans').insert({
+      user_id: userId,
+      title: 'Anchored plan',
+      start_at: EVENT_START_AT,
+      end_at: EVENT_END_AT,
+      source: 'external_calendar',
+      external_calendar_event_id: referencedEventId,
+    });
+    if (planError) throw planError;
+
+    await deleteUnreferencedEvents({
+      userId,
+      connectionId,
+      scope: { kind: 'connection' },
+    });
+
+    const { data: remaining, error: selectError } = await admin
+      .from('external_calendar_events')
+      .select('id')
+      .eq('connection_id', connectionId);
+    if (selectError) throw selectError;
+
+    expect((remaining ?? []).map((row) => row.id)).toEqual([referencedEventId]);
+
+    await admin.from('plans').delete().eq('user_id', userId);
+  });
+
+  it('複数バッチにまたがっても 2 ページ目以降の cursor で全件消す', async () => {
+    const connectionId = await createConnection();
+    // PRUNE_BATCH_SIZE(150) を超える件数で keyset ページングを強制する。
+    const eventIds = Array.from({ length: 151 }, () => crypto.randomUUID());
+
+    const { error: insertError } = await admin
+      .from('external_calendar_events')
+      .insert(
+        eventIds.map((id, index) =>
+          activeShapeEvent({ id, connectionId, providerEventId: `batch-${index}` }),
+        ),
+      );
+    if (insertError) throw insertError;
+
+    await deleteUnreferencedEvents({
+      userId,
+      connectionId,
+      scope: { kind: 'connection' },
+    });
+
+    const { data: remaining, error: selectError } = await admin
+      .from('external_calendar_events')
+      .select('id')
+      .eq('connection_id', connectionId);
+    if (selectError) throw selectError;
+
+    expect(remaining).toEqual([]);
+  });
+});

--- a/docs/engineering/infra.md
+++ b/docs/engineering/infra.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_verified: 2026-08-09
+last_verified: 2026-08-12
 ---
 
 # インフラ・環境・API/Routing 総覧
@@ -1437,7 +1437,8 @@ SELECT cron.unschedule(jobname) FROM cron.job WHERE active;
 **止めたものは戻さないと恒久的に止まったままになる。** 特に backup 復元をせず rollback 経路へ抜けた場合、cron を止めたことだけが残る。
 
 - [ ] **pg_cron を再登録する。** 控えた `jobname` / `schedule` / `command` から `SELECT cron.schedule('<name>', '<schedule>', '<command>');` で戻し、名前・schedule・command・`active` の一致を確認する
-  - 戻し忘れると `expire-calendar-revoke-outbox`（期限切れ revoke の処理）などが恒久停止する
+  - 対象は「止める前に控えた一覧の全件」。特定の job 名を思い出そうとしない — 個別列挙は増えるたびに更新漏れが起きる（2026-08-12、`cleanup-calendar-authority-retention` 追加時に本節が `expire-calendar-revoke-outbox` しか挙げていないことが指摘された）
+  - 戻し忘れの実害の例: `expire-calendar-revoke-outbox`（期限切れ revoke の処理）が止まる、`cleanup-calendar-authority-retention`（90 日保持期限の cleanup、#1994）が止まって privacy policy の保持期間の約束を実装が満たさなくなる
 - [ ] Edge Function とその secrets（別 project へ復元した場合）
 - [ ] Auth Hook の登録（別 project へ復元した場合。§復元でも戻らないもの）
 - [ ] 最後にメンテナンスモードを解除する

--- a/docs/operations/disaster-recovery-drill.md
+++ b/docs/operations/disaster-recovery-drill.md
@@ -244,7 +244,7 @@ SELECT jobname, schedule, active FROM cron.job ORDER BY jobname;
 
 - [ ] **復元する前に production 側の `cron.job` を控える**（これをやらないと比較対象が無い）
 - [ ] 復元後の job 一覧が、控えた production 側と一致するか記録する
-- [ ] repo の migration から導ける active job は **2 本**（`cleanup-product-events` / `expire-calendar-revoke-outbox`）。baseline の 4 本はいずれも後続 migration で unschedule 済み。**production の実数がこれと違っても異常ではない** — Dashboard 設定分の差なので、その差自体を記録する
+- [ ] repo の migration から導ける active job は **3 本**（`cleanup-product-events` / `expire-calendar-revoke-outbox` / `cleanup-calendar-authority-retention`）。baseline の 4 本はいずれも後続 migration で unschedule 済み。**production の実数がこれと違っても異常ではない** — Dashboard 設定分の差なので、その差自体を記録する
 - [ ] 残っていない場合、再作成の手順を本文書へ追記する
 
 ### Auth

--- a/supabase/migrations/20260812041309_schedule_calendar_authority_retention_cleanup.sql
+++ b/supabase/migrations/20260812041309_schedule_calendar_authority_retention_cleanup.sql
@@ -1,0 +1,60 @@
+-- private.cleanup_calendar_authority_retention_internal_v1 was added by
+-- 20260730090015_fenced_calendar_revoke_worker.sql but nothing ever called it.
+-- calendar_revoke_operations / calendar_authority_command_receipts /
+-- calendar_oauth_attempts rows past their delete_after, and orphaned subject
+-- fences, accumulated indefinitely instead of being purged at the documented
+-- 90-day retention window (#1994).
+
+BEGIN;
+
+-- pg_cron runs as the migration owner and can call the private routine even
+-- though no application role has EXECUTE (same pattern as
+-- expire-calendar-revoke-outbox in 20260730090003_harden_calendar_revoke_expiry.sql).
+-- Recreate by name so reset/rehearsal and roll-forward repair cannot leave
+-- duplicate jobs.
+--
+-- pg_cron's uniqueness key is (jobname, username), not jobname alone. If the
+-- Dashboard-drift issue (#1879) ever creates a same-named job under a
+-- different role, a bare "WHERE jobname = ..." SELECT INTO would silently
+-- pick one arbitrary row and could either fail (unschedule on a job we don't
+-- own) or leave a foreign duplicate running alongside ours. Scope to
+-- current_user and fail loudly instead of guessing.
+DO $$
+DECLARE
+  v_job RECORD;
+  v_foreign_count INTEGER;
+BEGIN
+  SELECT pg_catalog.count(*)
+  INTO v_foreign_count
+  FROM cron.job AS job
+  WHERE job.jobname = 'cleanup-calendar-authority-retention'
+    AND job.username <> current_user;
+
+  IF v_foreign_count > 0 THEN
+    RAISE EXCEPTION
+      'cron job "cleanup-calendar-authority-retention" already exists under a different role (Dashboard drift?); resolve manually before re-running this migration'
+      USING ERRCODE = '55006';
+  END IF;
+
+  FOR v_job IN
+    SELECT job.jobid
+    FROM cron.job AS job
+    WHERE job.jobname = 'cleanup-calendar-authority-retention'
+      AND job.username = current_user
+  LOOP
+    PERFORM cron.unschedule(v_job.jobid);
+  END LOOP;
+
+  -- Daily, staggered after the other retention cleanups registered in
+  -- 00000000000000_baseline.sql (:00/:10/:20/:30) and
+  -- 20260802013954_add_product_events.sql (:40). This is a 90-day retention
+  -- window, not a latency-sensitive purge, so daily is sufficient.
+  PERFORM cron.schedule(
+    'cleanup-calendar-authority-retention',
+    '50 3 * * *',
+    'SELECT private.cleanup_calendar_authority_retention_internal_v1(1000)'
+  );
+END;
+$$;
+
+COMMIT;

--- a/supabase/migrations/20260812041309_schedule_calendar_authority_retention_cleanup.sql
+++ b/supabase/migrations/20260812041309_schedule_calendar_authority_retention_cleanup.sql
@@ -45,13 +45,15 @@ BEGIN
     PERFORM cron.unschedule(v_job.jobid);
   END LOOP;
 
-  -- Daily, staggered after the other retention cleanups registered in
-  -- 00000000000000_baseline.sql (:00/:10/:20/:30) and
-  -- 20260802013954_add_product_events.sql (:40). This is a 90-day retention
-  -- window, not a latency-sensitive purge, so daily is sufficient.
+  -- Hourly, at :50 past the hour. delete_after is capped at exactly
+  -- created_at/settled_at + 90 days (retention CHECK constraints on the
+  -- target tables). A daily cadence could leave a row up to ~24h past its
+  -- delete_after before the next run catches it (Codex review, #2000) —
+  -- hourly keeps the overshoot to at most ~1h, negligible against a 90-day
+  -- promise, at the cost of a bounded (LIMIT 1000/table), cheap query.
   PERFORM cron.schedule(
     'cleanup-calendar-authority-retention',
-    '50 3 * * *',
+    '50 * * * *',
     'SELECT private.cleanup_calendar_authority_retention_internal_v1(1000)'
   );
 END;

--- a/supabase/migrations/20260812071342_add_calendar_authority_retention_safety_margin.sql
+++ b/supabase/migrations/20260812071342_add_calendar_authority_retention_safety_margin.sql
@@ -1,0 +1,143 @@
+-- Codex round 3 (#2000): cleanup runs hourly but delete_after is exactly
+-- created_at/settled_at + 90 days. A row whose delete_after lands just after
+-- a run isn't caught until the next scheduled run (~1h later), and a single
+-- missed/failed run pushes that out by another interval — the "does not
+-- retain beyond 90 days" promise (privacy.mdx, PR #1998) could be violated
+-- by run-interval jitter alone, independent of any application bug.
+--
+-- Closes the whole class with one constant instead of chasing individual
+-- overshoot scenarios: purge a row once it is within RETENTION_SAFETY_MARGIN
+-- of its delete_after, not only once delete_after has strictly passed.
+-- Purging early is always safe against a "do not retain past X" promise;
+-- the only requirement is that consecutive successful cron runs are never
+-- more than RETENTION_SAFETY_MARGIN apart. At hourly cadence, 4 hours
+-- absorbs up to ~3 consecutive missed/failed runs before the promise could
+-- be violated, at negligible cost against a 90-day retention window.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION private.cleanup_calendar_authority_retention_internal_v1(
+  p_limit INTEGER DEFAULT 1000
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+SET lock_timeout = '5s'
+SET statement_timeout = '60s'
+AS $$
+DECLARE
+  v_now CONSTANT TIMESTAMPTZ := pg_catalog.clock_timestamp();
+  -- See migration header for why this exists and how the bound is derived.
+  v_margin CONSTANT INTERVAL := INTERVAL '4 hours';
+  v_deleted INTEGER;
+  v_total_deleted INTEGER := 0;
+BEGIN
+  IF p_limit IS NULL OR p_limit < 1 OR p_limit > 10000 THEN
+    RAISE EXCEPTION 'Calendar authority cleanup limit must be between 1 and 10000'
+      USING ERRCODE = '22023';
+  END IF;
+
+  LOCK TABLE private.calendar_authority_projects IN SHARE MODE;
+
+  PERFORM 1
+  FROM private.calendar_authority_fences AS project
+  WHERE project.scope_kind = 'project'
+  ORDER BY project.project_key
+  FOR UPDATE;
+
+  WITH candidates AS MATERIALIZED (
+    SELECT operation.operation_id
+    FROM private.calendar_revoke_operations AS operation
+    WHERE operation.state IN ('revoked', 'expired')
+      AND operation.delete_after <= v_now + v_margin
+    ORDER BY operation.delete_after, operation.operation_id
+    LIMIT p_limit
+    FOR UPDATE SKIP LOCKED
+  )
+  DELETE FROM private.calendar_revoke_operations AS operation
+  USING candidates
+  WHERE operation.operation_id = candidates.operation_id
+    AND operation.state IN ('revoked', 'expired')
+    AND operation.delete_after <= v_now + v_margin;
+
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  v_total_deleted := v_total_deleted + v_deleted;
+
+  WITH candidates AS MATERIALIZED (
+    SELECT receipt.operation_id
+    FROM private.calendar_authority_command_receipts AS receipt
+    WHERE receipt.delete_after <= v_now + v_margin
+    ORDER BY receipt.delete_after, receipt.operation_id
+    LIMIT p_limit
+    FOR UPDATE SKIP LOCKED
+  )
+  DELETE FROM private.calendar_authority_command_receipts AS receipt
+  USING candidates
+  WHERE receipt.operation_id = candidates.operation_id
+    AND receipt.delete_after <= v_now + v_margin;
+
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  v_total_deleted := v_total_deleted + v_deleted;
+
+  WITH candidates AS MATERIALIZED (
+    SELECT attempt.id
+    FROM private.calendar_oauth_attempts AS attempt
+    WHERE attempt.delete_after <= v_now + v_margin
+    ORDER BY attempt.delete_after, attempt.id
+    LIMIT p_limit
+    FOR UPDATE SKIP LOCKED
+  )
+  DELETE FROM private.calendar_oauth_attempts AS attempt
+  USING candidates
+  WHERE attempt.id = candidates.id
+    AND attempt.delete_after <= v_now + v_margin;
+
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  v_total_deleted := v_total_deleted + v_deleted;
+
+  -- Orphaned subject fences have no delete_after (no retention deadline to
+  -- race against) — unaffected by the margin.
+  WITH candidates AS MATERIALIZED (
+    SELECT subject.id
+    FROM private.calendar_authority_fences AS subject
+    WHERE subject.scope_kind = 'subject'
+      AND subject.state = 'ready'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.calendar_connections AS connection
+        WHERE connection.authority_fence_id = subject.id
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM private.calendar_revoke_operations AS operation
+        WHERE operation.subject_fence_id = subject.id
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM private.calendar_authority_command_receipts AS receipt
+        WHERE receipt.subject_fence_id = subject.id
+      )
+    ORDER BY subject.changed_at, subject.id
+    LIMIT p_limit
+    FOR UPDATE SKIP LOCKED
+  )
+  DELETE FROM private.calendar_authority_fences AS subject
+  USING candidates
+  WHERE subject.id = candidates.id
+    AND subject.scope_kind = 'subject';
+
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  RETURN v_total_deleted + v_deleted;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION
+  private.cleanup_calendar_authority_retention_internal_v1(INTEGER)
+  FROM PUBLIC, anon, authenticated, service_role;
+
+COMMENT ON FUNCTION
+  private.cleanup_calendar_authority_retention_internal_v1(INTEGER) IS
+  'Performs owner-only bounded retention cleanup for Calendar authority metadata without requiring an application JWT. Purges rows within a 4-hour safety margin of delete_after, not only strictly past it, so hourly cron jitter cannot push actual retention beyond the documented 90-day promise.';
+
+COMMIT;


### PR DESCRIPTION
## Summary

GCP 審査提出（#1963）のブロッカーに昇格した external-calendar の掃除・保持ドメイン 4 件をまとめて修正する（#1994 は指揮台から scope 追加、正本は #1994 の dispatch コメント）。

- **#1996**: `event-pruning.ts` の keyset ページング cursor が空文字のまま `id`（UUID 列）へ `.gt()` を送っており、`deleteUnreferencedEvents` は **本番稼働以来一度も行を消せていなかった**。`event-query-service.ts` の `listGhostEvents` で先行して直した同型パターン（`cursor: string | null`、初回は `.gt('id', cursor)` を送らない）を踏襲した
- **#1988**: 上記の select 失敗を `deleteUnreferencedEvents` が throw せず握りつぶしていたため、`connection-service.ts` の `disconnect()` は prune 失敗を検知できず `calendar_connections` を hard delete していた。FK は `ON DELETE SET NULL (connection_id)` のため、削除後は未参照ミラー行を二度と回収できなくなる。`deleteUnreferencedEvents` を **select 失敗・参照読み取り失敗・23503 以外の delete 失敗・batch 上限到達**の 4 経路すべてで throw するよう変更し（後半 2 つは risk-reviewer の反証レビューで発見、当初は batch 上限到達時に部分結果のまま `return` していて fail-closed が効かない穴が残っていた）、`disconnect()` は fail-closed（掃除失敗時は connection を消さない。切断は冪等なので再試行で収束する）にした。sync の window prune と `updateSelectedCalendars` の即時掃除は、cleanup 失敗で本体の操作（同期・カレンダー選択変更）を巻き込まないよう best-effort のまま維持した
- **#1989**: `events.list` に `fields` partial response mask を追加し、保存している列（id/status/summary/description/start/end）+ ページング系（nextPageToken/nextSyncToken）だけを受信するようにした（Limited Use のデータ最小化）
- **#1994**: `private.cleanup_calendar_authority_retention_internal_v1`（20260730090015 で追加済みだが呼び出す cron が存在しなかった）を pg_cron に配線する migration を追加した（既存の `expire-calendar-revoke-outbox` cron と同じ idempotent unschedule→schedule パターン、daily 03:50 UTC）。これにより `calendar_revoke_operations` / `calendar_authority_command_receipts` / `calendar_oauth_attempts` の `delete_after` 超過行と孤立 subject fence が実際に削除されるようになる。privacy.mdx（PR #1998）の「この記録を90日を超えて保持することはありません」という断定を実装が満たすようにする修正

## PR #1998（privacy 文面）・#1963 申請文との整合確認

PR #1998 の `googleCalendar.accountDeletion` 断定「保持していた取り込み済みの予定もすべて削除します」「この記録（revoke 実行記録）を90日を超えて保持することはありません」の 2 点を突き合わせた:

- 前者は本 PR の #1988/#1996（fail-closed prune 修正）が真にする
- 後者は #1994（本追加）の cron 配線が真にする

いずれも文言変更は不要（既存の記述は「実装がこうなる」という前提で書かれており、本 PR がその前提を満たす側）。#1963 の申請文（`docs/operations/google-oauth-verification.md:310`）も「Google の sub はアカウント削除後も最大90日残る」と同じ上限を明記しており、本 PR の cron 配線（毎日実行、delete_after 超過行を削除）と整合する。

## 過去の孤児行について

修正前は `disconnect()` が prune 失敗を無視して continue していたため、**過去に切断したユーザー全員について、その接続配下の未参照ミラー行が `connection_id = NULL` のまま取り残されている**（参照済みの歴史的アンカー行は元々この状態が正しい設計なので対象外）。この掃除は不可逆な production データ削除にあたり、対象件数も未確認のため、本 PR には含めず #1999 に分離した（背景は #1988 コメント参照）。

## テスト

- `event-pruning.test.ts` / `connection-service.test.ts` / `sync-service.test.ts` / `google-provider.test.ts`: 新規 unit test（fail-closed / best-effort の両方、fields mask の内容と nextSyncToken/nextPageToken 保持）
- `calendar-event-pruning.integration.test.ts`（新規）: 実 Supabase local DB に対する統合テスト。**修正前のコードに一時的に戻して実行し、3 件とも fail（0 行しか消せない）することを確認してから**修正を戻して pass することを確認済み（mock ベースの unit test は UUID キャストを再現できないため、この regression の一次証拠は integration test 側）
- `pnpm check`（secrets/typecheck/lint/boundaries/tokens/format/license/i18n/knip/test:run）: test:run 以外全て pass。test:run は 10 ファイル 85 件が pre-existing の環境依存 failure（node26 ローカルで zustand persist 系が `localStorage` undefined になる。CI の node24 では pass。今回の diff と無関係であることを git stash で個別に確認済み）
- external-calendar 配下の全 test（222 件）は pass
- `calendar-authority-retention-cleanup.integration.test.ts`（新規）: delete_after 超過行の削除・未満行の保持・孤立 subject fence の削除・冪等性・owner 以外からの呼び出し拒否を実 DB で固定
- risk-reviewer / behavior-verifier の反証レビューを push 前に実施。#1988/#1996/#1989 側で risk-reviewer が指摘した batch 上限到達・23503 以外の delete 失敗の 2 件は fix 済み、再レビュー観点を含む単体テストで固定。#1994 の migration + test にも risk-reviewer の反証レビューを別途実施

Closes #1988
Closes #1996
Closes #1989
Closes #1994
Refs #1963
