### PR TITLE
fix(auth): production パスワードリセットの3層バグを修理する

### DIFF
--- a/apps/product/messages/en/auth.json
+++ b/apps/product/messages/en/auth.json
@@ -28,7 +28,9 @@
       "ipBlocked": "Too many attempts from this IP address. Please try again in {minutes} minutes.",
       "ipBlockedTitle": "IP address blocked",
       "oauthCallbackError": "We couldn't finish signing you in. Please try again.",
-      "oauthCallbackMissingCode": "We couldn't verify your sign-in. Please try again."
+      "oauthCallbackMissingCode": "We couldn't verify your sign-in. Please try again.",
+      "recoveryMfaBlocked": "Two-factor authentication is enabled, so this link can't change your password. Log in and change it from settings, or contact support@dayopt.app.",
+      "recoverySessionInvalid": "Your session has expired. Request a new password reset email."
     },
     "confirmed": {
       "email_change_confirmed": {

--- a/apps/product/messages/en/auth.json
+++ b/apps/product/messages/en/auth.json
@@ -29,8 +29,8 @@
       "ipBlockedTitle": "IP address blocked",
       "oauthCallbackError": "We couldn't finish signing you in. Please try again.",
       "oauthCallbackMissingCode": "We couldn't verify your sign-in. Please try again.",
-      "recoveryMfaBlocked": "Two-factor authentication is enabled, so this link can't change your password. Log in and change it from settings, or contact support@dayopt.app.",
-      "recoverySessionInvalid": "Your session has expired. Request a new password reset email."
+      "recoveryMfaBlocked": "Two-factor authentication is enabled, so this link can't change your password. If you remember your password, log in and change it from settings. If you can't log in, contact support@dayopt.app.",
+      "recoverySessionInvalid": "We couldn't complete this. Request a new password reset email."
     },
     "confirmed": {
       "email_change_confirmed": {

--- a/apps/product/messages/ja/auth.json
+++ b/apps/product/messages/ja/auth.json
@@ -29,8 +29,8 @@
       "ipBlockedTitle": "IPアドレスがブロックされています",
       "oauthCallbackError": "ログインを完了できませんでした。もう一度お試しください",
       "oauthCallbackMissingCode": "認証情報が確認できませんでした。もう一度ログインをお試しください",
-      "recoveryMfaBlocked": "二段階認証が有効なため、このリンクからはパスワードを変更できません。ログインしてから設定画面で変更するか、support@dayopt.app までご連絡ください",
-      "recoverySessionInvalid": "セッションの有効期限が切れました。もう一度パスワードリセットのメールをリクエストしてください"
+      "recoveryMfaBlocked": "二段階認証が有効なため、このリンクからは変更できません。パスワードを覚えている場合はログインしてから設定画面で変更してください。ログインできない場合は support@dayopt.app までご連絡ください",
+      "recoverySessionInvalid": "この操作を完了できませんでした。もう一度パスワードリセットのメールをリクエストしてください"
     },
     "confirmed": {
       "email_change_confirmed": {

--- a/apps/product/messages/ja/auth.json
+++ b/apps/product/messages/ja/auth.json
@@ -28,7 +28,9 @@
       "ipBlocked": "このIPアドレスからの試行が制限されています。{minutes}分後に再試行してください",
       "ipBlockedTitle": "IPアドレスがブロックされています",
       "oauthCallbackError": "ログインを完了できませんでした。もう一度お試しください",
-      "oauthCallbackMissingCode": "認証情報が確認できませんでした。もう一度ログインをお試しください"
+      "oauthCallbackMissingCode": "認証情報が確認できませんでした。もう一度ログインをお試しください",
+      "recoveryMfaBlocked": "二段階認証が有効なため、このリンクからはパスワードを変更できません。ログインしてから設定画面で変更するか、support@dayopt.app までご連絡ください",
+      "recoverySessionInvalid": "セッションの有効期限が切れました。もう一度パスワードリセットのメールをリクエストしてください"
     },
     "confirmed": {
       "email_change_confirmed": {

--- a/apps/product/src/app/[locale]/(auth)/auth/confirm/__tests__/route.test.ts
+++ b/apps/product/src/app/[locale]/(auth)/auth/confirm/__tests__/route.test.ts
@@ -82,14 +82,35 @@ describe('auth confirm route', () => {
     },
   );
 
-  // signup / recovery は confirm route を共用する。session が立つ通常経路で
+  // signup は confirm route を共用する。session が立つ通常経路で
   // next へ行く挙動が変わっていないことを固定する（regression 対象）。
-  it.each(['signup', 'recovery'])('%s は session が立てば従来どおり next へ送る', async (type) => {
+  it('signup は session が立てば従来どおり next へ送る', async () => {
     verifyOtp.mockResolvedValue({ data: { session: SESSION }, error: null });
 
-    const response = await GET(request(`token_hash=hash&type=${type}&next=%2Fcalendar`));
+    const response = await GET(request('token_hash=hash&type=signup&next=%2Fcalendar'));
 
     expect(locationOf(response).pathname).toBe('/calendar');
+  });
+
+  // #1928: recovery は next を無視して固定で /auth/reset-password へ送る。メール送信経路
+  // （Edge Function の redirect_to 構築、または Redirect URLs allowlist）の欠落で next が
+  // 付かないと fallback の /week へ落ち、パスワード設定フォームに到達できない事故があった。
+  it('recovery は session が立てば next を無視して /auth/reset-password へ送る', async () => {
+    verifyOtp.mockResolvedValue({ data: { session: SESSION }, error: null });
+
+    const response = await GET(request('token_hash=hash&type=recovery&next=%2Fcalendar'));
+
+    expect(locationOf(response).pathname).toBe('/auth/reset-password');
+  });
+
+  // recovery で next が無い（当初の #1928 症状: next 自体が付与されなかった）場合も
+  // 固定 path へ送る。next の値に依存しない設計であることを確認する。
+  it('recovery は next が無くても /auth/reset-password へ送る', async () => {
+    verifyOtp.mockResolvedValue({ data: { session: SESSION }, error: null });
+
+    const response = await GET(request('token_hash=hash&type=recovery'));
+
+    expect(locationOf(response).pathname).toBe('/auth/reset-password');
   });
 
   // 失敗も同じ結果ページへ送る。login へ送ると、認証済み browser では proxy が /week へ

--- a/apps/product/src/app/[locale]/(auth)/auth/confirm/route.ts
+++ b/apps/product/src/app/[locale]/(auth)/auth/confirm/route.ts
@@ -78,7 +78,13 @@ export async function GET(request: NextRequest) {
       // token を伴わない session オブジェクトでは cookie が書かれない。truthy 判定だと
       // その場合に保護ページへ送ってしまい、直したはずの無言バウンスが再現する。
       if (data.session?.access_token) {
-        return NextResponse.redirect(new URL(next, request.url));
+        // recovery だけ next を無視して固定 path へ送る（#1928）。`next` はメール送信経路
+        // （Edge Function の redirect_to 構築、または Supabase 側の Redirect URLs allowlist）
+        // の欠落で付かないことがあり、その場合 fallback の `/week` へ落ちてパスワード設定
+        // フォームに到達できない。recovery の着地先は固定で問題なく、`next` の生成経路に
+        // 依存しない形にする方が壊れにくい。
+        const target = type === 'recovery' ? '/auth/reset-password' : next;
+        return NextResponse.redirect(new URL(target, request.url));
       }
 
       return NextResponse.redirect(confirmedUrl(statusForType(type), request));

--- a/apps/product/src/app/[locale]/(auth)/auth/confirm/route.ts
+++ b/apps/product/src/app/[locale]/(auth)/auth/confirm/route.ts
@@ -78,11 +78,11 @@ export async function GET(request: NextRequest) {
       // token を伴わない session オブジェクトでは cookie が書かれない。truthy 判定だと
       // その場合に保護ページへ送ってしまい、直したはずの無言バウンスが再現する。
       if (data.session?.access_token) {
-        // recovery だけ next を無視して固定 path へ送る（#1928）。`next` はメール送信経路
-        // （Edge Function の redirect_to 構築、または Supabase 側の Redirect URLs allowlist）
-        // の欠落で付かないことがあり、その場合 fallback の `/week` へ落ちてパスワード設定
-        // フォームに到達できない。recovery の着地先は固定で問題なく、`next` の生成経路に
-        // 依存しない形にする方が壊れにくい。
+        // recovery だけ next を無視して固定 path へ送る（#1928）。実際の発生原因は
+        // production の Redirect URLs allowlist に `/auth/reset-password` が未登録で、
+        // GoTrue が `redirect_to` を拒否して `next` が付かないまま fallback の `/week` へ
+        // 落ちていたこと（allowlist は User が追加済み）。recovery の着地先は固定で問題
+        // ないため、allowlist が再びドリフトしても壊れない形にしておく（防御層）。
         const target = type === 'recovery' ? '/auth/reset-password' : next;
         return NextResponse.redirect(new URL(target, request.url));
       }

--- a/apps/product/src/features/auth/components/AuthLayout.stories.tsx
+++ b/apps/product/src/features/auth/components/AuthLayout.stories.tsx
@@ -102,6 +102,37 @@ export const LoginPathSkipped: Story = {
   ),
 };
 
+/**
+ * パスワード設定ページ相当のパス — ラップをスキップ（#2009 の回帰確認）。
+ *
+ * `/auth/reset-password` は自前で全画面センタリング wrapper（`max-w-sm`）を持つため、
+ * allowlist から漏れていると AuthLayout 自身の `max-w-sm` カードに二重ネストされ、
+ * カード幅が極端に狭くなる（1 行 7〜8 文字で縦折り返し）。allowlist 追加後は
+ * LoginPathSkipped と同じく children がそのまま返る。
+ */
+export const ResetPasswordPathSkipped: Story = {
+  parameters: {
+    nextjs: {
+      navigation: {
+        pathname: '/ja/auth/reset-password',
+      },
+    },
+  },
+  render: () => (
+    <div className="bg-surface-container flex min-h-svh flex-col items-center justify-center p-4 md:p-8">
+      <div className="w-full max-w-sm">
+        <AuthLayout>
+          <div className="bg-card rounded-lg border p-6">
+            <p className="text-muted-foreground text-sm">
+              パスワード設定フォーム相当（ページ自前の wrapper のみ、二重ネストなし）
+            </p>
+          </div>
+        </AuthLayout>
+      </div>
+    </div>
+  ),
+};
+
 /** 全パターン一覧。 */
 export const AllPatterns: Story = {
   render: () => (
@@ -115,6 +146,7 @@ export const AllPatterns: Story = {
           <li>Default — メール確認完了ページ</li>
           <li>ErrorPage — リンク期限切れページ</li>
           <li>LoginPathSkipped — /auth/login パスではラップなし</li>
+          <li>ResetPasswordPathSkipped — /auth/reset-password パスではラップなし（#2009）</li>
         </ul>
       </section>
     </div>

--- a/apps/product/src/features/auth/components/AuthLayout.tsx
+++ b/apps/product/src/features/auth/components/AuthLayout.tsx
@@ -13,6 +13,7 @@ export function AuthLayout({ children }: { children: React.ReactNode }) {
     pathname?.includes('/auth/login') ||
     pathname?.includes('/auth/signup') ||
     pathname?.includes('/auth/password') ||
+    pathname?.includes('/auth/reset-password') ||
     pathname?.includes('/auth/mfa-verify')
   ) {
     return <>{children}</>;

--- a/apps/product/src/features/auth/components/ResetPasswordForm.tsx
+++ b/apps/product/src/features/auth/components/ResetPasswordForm.tsx
@@ -31,8 +31,13 @@ import { useAuthStore } from '../stores/useAuthStore';
  *
  * - `insufficient_aal`: アカウントに MFA(TOTP) が有効。recovery session は aal1 止まりで、
  *   GoTrue が config に関わらず更新を拒否する（step-up 検証の実装は #2013 で別途追う）
- * - `current_password_required` / `current_password_mismatch`: recovery session でない
- *   セッション（通常ログイン中の直接アクセス等）でこの画面に来た
+ * - `current_password_required` / `current_password_invalid`: recovery session でない
+ *   セッション（通常ログイン中の直接アクセス等）でこの画面に来た。GoTrue ソース
+ *   （`apierrors.ErrorCodeCurrentPasswordRequired` / `ErrorCodeCurrentPasswordMismatch`）で
+ *   実際の文字列値を確認済み（後者は定数名に反し `current_password_invalid` を返す）
+ * - `invalid_credentials`: `PasswordChangeDialog.tsx` の `isCurrentPasswordError` が同じ
+ *   GoTrue 経路で観測している code。上と重複する可能性があるが、どちらが実際に返るかを
+ *   確定できていないため両方を検知対象にする
  * - `reauthentication_needed`: production では現状発生しないが、設定 drift への保険
  *
  * 汎用の「時間をおいて再試行」に畳むと、再試行しても直らない状況で誤った案内になる。
@@ -41,7 +46,8 @@ import { useAuthStore } from '../stores/useAuthStore';
  */
 const RECOVERY_UPDATE_BLOCKED_CODES = new Set([
   'current_password_required',
-  'current_password_mismatch',
+  'current_password_invalid',
+  'invalid_credentials',
   'reauthentication_needed',
 ]);
 

--- a/apps/product/src/features/auth/components/ResetPasswordForm.tsx
+++ b/apps/product/src/features/auth/components/ResetPasswordForm.tsx
@@ -27,6 +27,40 @@ import { passwordSchema } from '../schemas/auth.schema';
 import { useAuthStore } from '../stores/useAuthStore';
 
 /**
+ * GoTrue が「本人確認が recovery session だけでは足りない」を示しているか。
+ *
+ * - `insufficient_aal`: アカウントに MFA(TOTP) が有効。recovery session は aal1 止まりで、
+ *   GoTrue が config に関わらず更新を拒否する（step-up 検証の実装は #2013 で別途追う）
+ * - `current_password_required` / `current_password_mismatch`: recovery session でない
+ *   セッション（通常ログイン中の直接アクセス等）でこの画面に来た
+ * - `reauthentication_needed`: production では現状発生しないが、設定 drift への保険
+ *
+ * 汎用の「時間をおいて再試行」に畳むと、再試行しても直らない状況で誤った案内になる。
+ * 構造化 code を優先し、message の substring 判定は使わない（`PasswordChangeDialog.tsx`
+ * の `isCurrentPasswordError` と同じ設計）。
+ */
+const RECOVERY_UPDATE_BLOCKED_CODES = new Set([
+  'current_password_required',
+  'current_password_mismatch',
+  'reauthentication_needed',
+]);
+
+function errorCode(error: unknown): string | undefined {
+  return error !== null && typeof error === 'object' && 'code' in error
+    ? ((error as { code?: unknown }).code as string | undefined)
+    : undefined;
+}
+
+function isMfaBlocked(error: unknown): boolean {
+  return errorCode(error) === 'insufficient_aal';
+}
+
+function isRecoverySessionInvalid(error: unknown): boolean {
+  const code = errorCode(error);
+  return typeof code === 'string' && RECOVERY_UPDATE_BLOCKED_CODES.has(code);
+}
+
+/**
  * 新しいパスワード設定フォーム。
  * recovery リンクは /auth/confirm の verifyOtp でセッション確立済みで着地する前提
  * （セッション無しの直接アクセスは page.tsx がサーバー側で弾く）
@@ -70,7 +104,11 @@ export function ResetPasswordForm({ className, ...props }: React.ComponentProps<
         const { error } = await updatePassword(password);
 
         if (error) {
-          const errorKey = getAuthErrorKey(error.message, 'updatePassword');
+          const errorKey = isMfaBlocked(error)
+            ? 'auth.errors.recoveryMfaBlocked'
+            : isRecoverySessionInvalid(error)
+              ? 'auth.errors.recoverySessionInvalid'
+              : getAuthErrorKey(error.message, 'updatePassword');
           setError(t(errorKey));
         } else {
           setSuccess(true);

--- a/apps/product/src/features/auth/components/__tests__/ResetPasswordForm.test.tsx
+++ b/apps/product/src/features/auth/components/__tests__/ResetPasswordForm.test.tsx
@@ -81,21 +81,23 @@ describe('ResetPasswordForm', () => {
 
   // ブロック側: recovery session でないセッション（直接アクセス等）で current_password_required
   // が返った場合は、セッション再取得を促すメッセージを出す。
-  it.each(['current_password_required', 'current_password_mismatch', 'reauthentication_needed'])(
-    '%s はセッション再取得を促すメッセージを表示する',
-    async (code) => {
-      mockUpdatePassword.mockResolvedValue({
-        data: { user: null },
-        error: Object.assign(new Error('rejected'), { code }),
-      });
+  it.each([
+    'current_password_required',
+    'current_password_invalid',
+    'invalid_credentials',
+    'reauthentication_needed',
+  ])('%s はセッション再取得を促すメッセージを表示する', async (code) => {
+    mockUpdatePassword.mockResolvedValue({
+      data: { user: null },
+      error: Object.assign(new Error('rejected'), { code }),
+    });
 
-      await submitValidPassword();
+    await submitValidPassword();
 
-      await waitFor(() => {
-        expect(screen.getByRole('alert')).toHaveTextContent('auth.errors.recoverySessionInvalid');
-      });
-    },
-  );
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('auth.errors.recoverySessionInvalid');
+    });
+  });
 
   // 既存挙動の固定: 構造化 code を持たない・未知の code のエラーは従来どおり
   // getAuthErrorKey の汎用判定（message の weak/short 判定）にフォールバックする。

--- a/apps/product/src/features/auth/components/__tests__/ResetPasswordForm.test.tsx
+++ b/apps/product/src/features/auth/components/__tests__/ResetPasswordForm.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ResetPasswordForm } from '../ResetPasswordForm';
+
+const mockUpdatePassword = vi.fn();
+const mockPush = vi.fn();
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ locale: 'ja' }),
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock('@dayopt/i18n/navigation', async () => {
+  const React = await import('react');
+  return {
+    Link: ({ children, href, ...props }: { children: React.ReactNode; href: string }) =>
+      React.createElement('a', { href, ...props }, children),
+  };
+});
+
+vi.mock('../../stores/useAuthStore', () => ({
+  useAuthStore: (selector: (state: { updatePassword: typeof mockUpdatePassword }) => unknown) =>
+    selector({ updatePassword: mockUpdatePassword }),
+}));
+
+function renderForm() {
+  return render(<ResetPasswordForm />);
+}
+
+async function submitValidPassword() {
+  const user = userEvent.setup();
+  renderForm();
+
+  await user.type(screen.getByLabelText('auth.resetPasswordForm.newPassword'), 'NewPassw0rd!23');
+  await user.type(
+    screen.getByLabelText('auth.resetPasswordForm.confirmPassword'),
+    'NewPassw0rd!23',
+  );
+  await user.click(screen.getByRole('button', { name: 'auth.resetPasswordForm.updateButton' }));
+}
+
+describe('ResetPasswordForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // #1928: 通過側。recovery session からの正常な更新は従来どおり成功画面へ遷移する。
+  it('通常の recovery session からの更新は成功画面へ遷移する', async () => {
+    mockUpdatePassword.mockResolvedValue({ data: { user: null }, error: null });
+
+    await submitValidPassword();
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+        'auth.resetPasswordForm.successTitle',
+      );
+    });
+  });
+
+  // #1928 A1: ブロック側。MFA(TOTP) 有効アカウントの recovery session は GoTrue が
+  // config に関わらず insufficient_aal で拒否する。汎用「時間をおいて再試行」は
+  // 再試行しても直らないため、MFA 専用の actionable message を出す。
+  it('insufficient_aal は MFA 専用メッセージを表示する', async () => {
+    mockUpdatePassword.mockResolvedValue({
+      data: { user: null },
+      error: Object.assign(new Error('AAL2 session is required'), { code: 'insufficient_aal' }),
+    });
+
+    await submitValidPassword();
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('auth.errors.recoveryMfaBlocked');
+    });
+  });
+
+  // ブロック側: recovery session でないセッション（直接アクセス等）で current_password_required
+  // が返った場合は、セッション再取得を促すメッセージを出す。
+  it.each(['current_password_required', 'current_password_mismatch', 'reauthentication_needed'])(
+    '%s はセッション再取得を促すメッセージを表示する',
+    async (code) => {
+      mockUpdatePassword.mockResolvedValue({
+        data: { user: null },
+        error: Object.assign(new Error('rejected'), { code }),
+      });
+
+      await submitValidPassword();
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent('auth.errors.recoverySessionInvalid');
+      });
+    },
+  );
+
+  // 既存挙動の固定: 構造化 code を持たない・未知の code のエラーは従来どおり
+  // getAuthErrorKey の汎用判定（message の weak/short 判定）にフォールバックする。
+  it('未知の code は従来どおり汎用エラー判定にフォールバックする', async () => {
+    mockUpdatePassword.mockResolvedValue({
+      data: { user: null },
+      error: new Error('some unexpected failure'),
+    });
+
+    await submitValidPassword();
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('auth.errors.unexpectedError');
+    });
+  });
+});

--- a/apps/product/src/features/auth/stores/__tests__/useAuthStore.updatePassword.test.ts
+++ b/apps/product/src/features/auth/stores/__tests__/useAuthStore.updatePassword.test.ts
@@ -49,13 +49,50 @@ describe('useAuthStore.updatePassword', () => {
   // risk-reviewer 指摘: observeAuthOperation は catch した例外を re-throw する契約
   // （lib/sentry/integration.ts）。signOut の失敗を握り潰さないと、外側の try/catch に
   // 落ちて「パスワード更新は成功しているのに失敗として返る」誤報告になる。
-  it('signOut が失敗しても更新成功の結果は失敗に変わらない', async () => {
+  it('signOut が throw しても更新成功の結果は失敗に変わらない', async () => {
     const updateResult = { data: { user: { id: 'user-1' } }, error: null };
     mockUpdateUser.mockResolvedValue(updateResult);
     mockSignOut.mockRejectedValue(new Error('network error'));
 
     const result = await useAuthStore.getState().updatePassword('NewPassw0rd!23');
 
+    expect(result).toEqual(updateResult);
+    expect(useAuthStore.getState().error).toBeNull();
+  });
+
+  // Codex round1 P1: auth-js の signOut は throw せず `{ error }` の resolve でも
+  // 失敗を返す（本番で実際に起こりうる経路）。throw だけを見るテストではこれを
+  // 検出できないため、resolve 経路を別途固定する。
+  it('signOut が resolved error を返しても更新成功の結果は失敗に変わらない', async () => {
+    const updateResult = { data: { user: { id: 'user-1' } }, error: null };
+    mockUpdateUser.mockResolvedValue(updateResult);
+    mockSignOut.mockResolvedValue({ error: new Error('sign out failed') });
+
+    const result = await useAuthStore.getState().updatePassword('NewPassw0rd!23');
+
+    expect(result).toEqual(updateResult);
+    expect(useAuthStore.getState().error).toBeNull();
+  });
+
+  it('resolved error の場合は 1 回だけ再試行し、再試行が成功すればそこで止める', async () => {
+    mockUpdateUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    mockSignOut
+      .mockResolvedValueOnce({ error: new Error('sign out failed') })
+      .mockResolvedValueOnce({ error: null });
+
+    await useAuthStore.getState().updatePassword('NewPassw0rd!23');
+
+    expect(mockSignOut).toHaveBeenCalledTimes(2);
+  });
+
+  it('再試行後も失敗する場合は 2 回で諦め、更新成功の結果は失敗に変わらない', async () => {
+    const updateResult = { data: { user: { id: 'user-1' } }, error: null };
+    mockUpdateUser.mockResolvedValue(updateResult);
+    mockSignOut.mockResolvedValue({ error: new Error('sign out failed') });
+
+    const result = await useAuthStore.getState().updatePassword('NewPassw0rd!23');
+
+    expect(mockSignOut).toHaveBeenCalledTimes(2);
     expect(result).toEqual(updateResult);
     expect(useAuthStore.getState().error).toBeNull();
   });

--- a/apps/product/src/features/auth/stores/__tests__/useAuthStore.updatePassword.test.ts
+++ b/apps/product/src/features/auth/stores/__tests__/useAuthStore.updatePassword.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUpdateUser = vi.fn();
+const mockSignOut = vi.fn();
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    auth: {
+      updateUser: mockUpdateUser,
+      signOut: mockSignOut,
+    },
+  }),
+}));
+
+vi.mock('@/lib/sentry', () => ({
+  captureUnexpectedAuthError: vi.fn(),
+  observeAuthOperation: (_name: string, operation: () => unknown) => operation(),
+}));
+
+import { useAuthStore } from '../useAuthStore';
+
+describe('useAuthStore.updatePassword', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSignOut.mockResolvedValue({ error: null });
+  });
+
+  // #1928 Fix4: recovery でパスワードを変更した後、他端末の session を失効させる。
+  // アカウント乗っ取り被害者が復旧しても攻撃者の refresh token が生き残る欠陥への対処。
+  it('更新成功時は他端末の session を signOut する', async () => {
+    mockUpdateUser.mockResolvedValue({ data: { user: {} }, error: null });
+
+    await useAuthStore.getState().updatePassword('NewPassw0rd!23');
+
+    expect(mockSignOut).toHaveBeenCalledWith({ scope: 'others' });
+  });
+
+  it('更新失敗時は signOut を呼ばない', async () => {
+    mockUpdateUser.mockResolvedValue({
+      data: { user: null },
+      error: Object.assign(new Error('rejected'), { code: 'insufficient_aal' }),
+    });
+
+    await useAuthStore.getState().updatePassword('NewPassw0rd!23');
+
+    expect(mockSignOut).not.toHaveBeenCalled();
+  });
+});

--- a/apps/product/src/features/auth/stores/__tests__/useAuthStore.updatePassword.test.ts
+++ b/apps/product/src/features/auth/stores/__tests__/useAuthStore.updatePassword.test.ts
@@ -45,4 +45,18 @@ describe('useAuthStore.updatePassword', () => {
 
     expect(mockSignOut).not.toHaveBeenCalled();
   });
+
+  // risk-reviewer 指摘: observeAuthOperation は catch した例外を re-throw する契約
+  // （lib/sentry/integration.ts）。signOut の失敗を握り潰さないと、外側の try/catch に
+  // 落ちて「パスワード更新は成功しているのに失敗として返る」誤報告になる。
+  it('signOut が失敗しても更新成功の結果は失敗に変わらない', async () => {
+    const updateResult = { data: { user: { id: 'user-1' } }, error: null };
+    mockUpdateUser.mockResolvedValue(updateResult);
+    mockSignOut.mockRejectedValue(new Error('network error'));
+
+    const result = await useAuthStore.getState().updatePassword('NewPassw0rd!23');
+
+    expect(result).toEqual(updateResult);
+    expect(useAuthStore.getState().error).toBeNull();
+  });
 });

--- a/apps/product/src/features/auth/stores/useAuthStore.ts
+++ b/apps/product/src/features/auth/stores/useAuthStore.ts
@@ -337,14 +337,25 @@ export const useAuthStore = create<AuthState>()(
             // アカウント乗っ取り被害者が最も自然に取る回復操作（パスワードリセット）で
             // 攻撃者の refresh token を道連れにする。失敗してもパスワード更新自体は
             // 成功しているため、結果は分岐させない（PasswordChangeDialog と同じ扱い）。
-            // `observeAuthOperation` は catch した例外を re-throw する契約なので、ここで
-            // 握り潰さないと外側の catch に落ち、成功した更新が失敗として返ってしまう。
-            try {
-              await observeAuthOperation('sign_out_other_sessions', () =>
-                supabase.auth.signOut({ scope: 'others' }),
-              );
-            } catch {
-              // 上記コメントの通り、他端末の失効に失敗しても更新自体の成功は変えない。
+            //
+            // 失敗は throw だけでなく `{ error }` の resolve でも起こる（auth-js の
+            // `signOut` はネットワーク/HTTP 失敗を返り値エラーとして返す設計）ため両方
+            // 見る。一時的な失敗を想定して 1 回だけ再試行する。store は component 跨ぎの
+            // i18n 文言を持てずユーザー通知ができないため、再試行後も失敗したら諦める
+            // （`observeAuthOperation` 内の `captureUnexpectedAuthError` で Sentry には残る）。
+            let signOutSucceeded = false;
+            for (let attempt = 0; attempt < 2 && !signOutSucceeded; attempt++) {
+              try {
+                const { error: signOutError } = await observeAuthOperation(
+                  'sign_out_other_sessions',
+                  () => supabase.auth.signOut({ scope: 'others' }),
+                );
+                signOutSucceeded = !signOutError;
+              } catch {
+                // `observeAuthOperation` は catch した例外を re-throw する契約なので、
+                // ここで握り潰さないと外側の catch に落ち、成功した更新が失敗として
+                // 返ってしまう。次の attempt へ（最終 attempt なら諦める）。
+              }
             }
             set({ loading: false });
           }

--- a/apps/product/src/features/auth/stores/useAuthStore.ts
+++ b/apps/product/src/features/auth/stores/useAuthStore.ts
@@ -337,9 +337,15 @@ export const useAuthStore = create<AuthState>()(
             // アカウント乗っ取り被害者が最も自然に取る回復操作（パスワードリセット）で
             // 攻撃者の refresh token を道連れにする。失敗してもパスワード更新自体は
             // 成功しているため、結果は分岐させない（PasswordChangeDialog と同じ扱い）。
-            await observeAuthOperation('sign_out_other_sessions', () =>
-              supabase.auth.signOut({ scope: 'others' }),
-            );
+            // `observeAuthOperation` は catch した例外を re-throw する契約なので、ここで
+            // 握り潰さないと外側の catch に落ち、成功した更新が失敗として返ってしまう。
+            try {
+              await observeAuthOperation('sign_out_other_sessions', () =>
+                supabase.auth.signOut({ scope: 'others' }),
+              );
+            } catch {
+              // 上記コメントの通り、他端末の失効に失敗しても更新自体の成功は変えない。
+            }
             set({ loading: false });
           }
 

--- a/apps/product/src/features/auth/stores/useAuthStore.ts
+++ b/apps/product/src/features/auth/stores/useAuthStore.ts
@@ -333,6 +333,13 @@ export const useAuthStore = create<AuthState>()(
             const safeError = getAuthErrorKey(result.error.message, 'updatePassword');
             set({ error: safeError, loading: false });
           } else {
+            // recovery でパスワードを変更した後は他端末の session を失効させる。
+            // アカウント乗っ取り被害者が最も自然に取る回復操作（パスワードリセット）で
+            // 攻撃者の refresh token を道連れにする。失敗してもパスワード更新自体は
+            // 成功しているため、結果は分岐させない（PasswordChangeDialog と同じ扱い）。
+            await observeAuthOperation('sign_out_other_sessions', () =>
+              supabase.auth.signOut({ scope: 'others' }),
+            );
             set({ loading: false });
           }
 


### PR DESCRIPTION
## Summary

production でパスワードリセットが機能しない3層の独立バグ（#1928）と、そのフォームの UI 崩れ（#2009）を修理する。

1. **redirect 未到達**: recovery メールのリンクが `/auth/confirm` に `next=/auth/reset-password` 無しで届き、fallback の `/week` へ流れてフォームに到達できなかった。実測で確認した真因は **production の Supabase Auth Redirect URLs allowlist に `/auth/reset-password` が未登録**だったこと（User が Dashboard で確認・追加済み）。本 PR の `confirm/route.ts` の修正は、`type=recovery` を特例化して `next` の生成経路（テンプレート/allowlist のいずれか）に依存せず固定 redirect する**再発時の防御層**という位置づけ。allowlist 自体の正しさは Dashboard 側の運用に依存し、コードでは検証できないため #2014 で監視強化を別途検討する
2. **フォーム到達後の updateUser 失敗**: ローカル Supabase (Docker) で TOTP factor を enroll・verify したテストユーザーを作成し、recovery link → verifyOtp（aal1 session）→ `updateUser({password})` を実行したところ `{"code":401,"error_code":"insufficient_aal"}` を確定的に再現した（テストユーザーは検証後に削除、production 未接触）。GoTrue は `user.HasMFAEnabled() && !session.IsAAL2()` を他の全 Auth 設定より先にチェックし、config に関わらず拒否する仕様（ソースで確認済み）。**MFA(TOTP) が有効なアカウントは、パスワードを忘れて復旧しようとしても現状 GoTrue の仕様上 recovery session だけでは絶対に通らず、自己復旧の経路がゼロになる**（#2013 で TOTP step-up 検証の実装を追う。それまではサポート連絡が唯一の回復手段）。本 PR では `current_password_required` / `current_password_invalid` / `invalid_credentials` / `insufficient_aal` / `reauthentication_needed` を検出し、汎用の「時間をおいて再試行」ではなく actionable なメッセージ（ログインできる場合の導線、できない場合のサポート連絡先）を表示するところまでを scope とする
3. **UI 崩れ（#2009）**: `AuthLayout.tsx` の pathname allowlist に `/auth/reset-password` が抜けており、login/signup/password と同型の自前 wrapper を持つのに二重ネストされてカード幅が極端に狭くなっていた（1行修正）

あわせて、recovery でパスワードを変更した後に他端末の session を `signOut({scope:'others'})` で失効させる（`PasswordChangeDialog.tsx` との非対称を解消。アカウント乗っ取り被害者が復旧しても攻撃者の refresh token が残る実欠陥への対処）。

## push 前反証で見つけた実装バグ（2件、修正済み）

- `current_password_mismatch` は実在しない error code だった。GoTrue ソース（`apierrors.go`）を直接確認し、実際の値 `current_password_invalid` に修正
- `signOut({scope:'others'})` が例外を投げると、`observeAuthOperation` の re-throw 契約により成功した更新が失敗として返っていた。ローカル try/catch で修正

## Closes / Refs

Closes #1928
Closes #2009
Refs #2013
Refs #2014

## Test plan

- [x] `pnpm check`（static checks 全 green、既知の Node26 環境 issue による無関係な test 失敗のみ残存）
- [x] `apps/product/src/app/[locale]/(auth)/auth/confirm/__tests__/route.test.ts`: recovery 固定 redirect の回帰テスト追加
- [x] `ResetPasswordForm.test.tsx`（新規）: 各エラー code のブロック側・通過側
- [x] `useAuthStore.updatePassword.test.ts`（新規）: signOut 成功/失敗時の挙動
- [x] Storybook 視覚確認: `AuthLayout.stories.tsx` の `ResetPasswordPathSkipped` story で二重ネスト解消を確認
- [ ] production での実地確認（recovery メール → フォーム到達 → 更新成功、User 操作枠）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
