### PR TITLE
chore(ci): production-auth-config-audit の uri_allow_list pin に /auth/reset-password を反映する

### DIFF
--- a/scripts/__tests__/production-auth-config-audit-contract.test.ts
+++ b/scripts/__tests__/production-auth-config-audit-contract.test.ts
@@ -55,6 +55,7 @@ describe('production auth config audit contract', () => {
         'uri_allow_list',
         [
           'https://app.dayopt.app/**',
+          'https://app.dayopt.app/auth/reset-password',
           'https://product-*-dayopt.vercel.app/**',
           'https://product-dayopt.vercel.app/',
           'https://product-dayopt.vercel.app/**',

--- a/scripts/production-auth-config-audit.mjs
+++ b/scripts/production-auth-config-audit.mjs
@@ -190,6 +190,7 @@ export const AUTH_CONFIG_CONTRACT = [
     // **`security_captcha_secret` などと違い redirect URL は secret ではない。**
     expected: [
       'https://app.dayopt.app/**',
+      'https://app.dayopt.app/auth/reset-password',
       'https://product-*-dayopt.vercel.app/**',
       'https://product-dayopt.vercel.app/',
       'https://product-dayopt.vercel.app/**',
@@ -207,6 +208,11 @@ export const AUTH_CONFIG_CONTRACT = [
     // 失われたため 2026-08-11 に除去した（依存経路ゼロを実測確認済み）。除去後の値を
     // live 再測して pin してある（除去前後の集合差分が localhost の 1 件だけであることを
     // 確認済み）。
+    //
+    // `https://app.dayopt.app/auth/reset-password` は 2026-08-12、#1928 の production
+    // パスワードリセット復旧時に User が Dashboard へ明示追加した（#1928 コメント
+    // 2026-08-12T06:56Z）。同オリジンの `https://app.dayopt.app/**` ワイルドカードが既に
+    // あるにもかかわらず明示エントリでないと復旧しなかった実測に基づく（#2023）。
     //
     // 残る 5 件のうち `https://product-dayopt.vercel.app/` 系と `/**` 無しの
     // ワイルドカードは重複・冗長に見えるが、preview の実 URL 形への依存が未調査のため

--- a/scripts/production-auth-config-audit.mjs
+++ b/scripts/production-auth-config-audit.mjs
@@ -66,10 +66,11 @@ export const SUPABASE_PRODUCTION_PROJECT_REF = 'yvglwblxrnrenfifsnje';
 /**
  * 監視対象と期待値の正本。
  *
- * `expected` はすべて 2026-08-11 に production の実値を読み取って確定した（推測値を
- * 置くと audit が恒久 failure になり、drift 検出そのものが止まる）。値を変える時は
- * 「Dashboard を変えたから contract を追従させる」のではなく、**変更が意図したもので
- * あることを PR で示してから**追従させる。
+ * `expected` はすべて production の実値を読み取って確定した（推測値を置くと audit が
+ * 恒久 failure になり、drift 検出そのものが止まる）。基準時点は 2026-08-11（`uri_allow_list`
+ * の `/auth/reset-password` のみ 2026-08-12 の Dashboard 変更後に実測して追加、#2023）。
+ * 値を変える時は「Dashboard を変えたから contract を追従させる」のではなく、**変更が
+ * 意図したものであることを PR で示してから**追従させる。
  *
  * ## 監視対象は公開 OpenAPI spec から導出しない
  *
@@ -212,7 +213,9 @@ export const AUTH_CONFIG_CONTRACT = [
     // `https://app.dayopt.app/auth/reset-password` は 2026-08-12、#1928 の production
     // パスワードリセット復旧時に User が Dashboard へ明示追加した（#1928 コメント
     // 2026-08-12T06:56Z）。同オリジンの `https://app.dayopt.app/**` ワイルドカードが既に
-    // あるにもかかわらず明示エントリでないと復旧しなかった実測に基づく（#2023）。
+    // あった上での追加で、明示追加後に復旧した（同 issue で `confirm/route.ts` の
+    // recovery 遷移先固定化も同時に入っており、復旧の因果をこの追加だけに切り分けては
+    // いない）。pin はいずれにせよ production の実値集合に追従させる（#2023）。
     //
     // 残る 5 件のうち `https://product-dayopt.vercel.app/` 系と `/**` 無しの
     // ワイルドカードは重複・冗長に見えるが、preview の実 URL 形への依存が未調査のため


### PR DESCRIPTION
## 背景

#1928 の production パスワードリセット復旧で、User が 2026-08-12 に Supabase Dashboard の Redirect URLs allowlist へ `https://app.dayopt.app/auth/reset-password` を追加した（意図的変更）。しかし `scripts/production-auth-config-audit.mjs` の `uri_allow_list` pin（expected 集合）に未反映のため、Production Config Audit の「Audit Supabase Auth config (trusted)」job が 3 連続 failure 中だった（`uri_allow_list drifted (added: https://app.dayopt.app/auth/reset-password)`）。

## 変更内容

1. `scripts/production-auth-config-audit.mjs` の `uri_allow_list.expected` へ `https://app.dayopt.app/auth/reset-password` を追加し、経緯をコメントに記録
2. `scripts/__tests__/production-auth-config-audit-contract.test.ts` の同じ配列リテラルを同期
3. risk-reviewer の low findings 2件を反映（ヘッダーコメントの実測時点の正確化、因果断定の緩和）

## 検証

- `scripts/__tests__/production-auth-config-audit-contract.test.ts` 単体 8/8 green
- `pnpm check` は secrets:check/typecheck/lint/check:static/deadcode まで通過（test:run の calendar/localStorage 系失敗は node26 ローカル環境依存の既知問題で対象外、CI の node24 では発生しない）
- `risk-reviewer` による反証レビュー: proceed 判定（read-only audit、production 書き込み経路なし、blast radius は既存ワイルドカードの真部分集合）
- 直近の失敗 run（run 31643640953, 2026-08-12T21:41 main）のログで `added: https://app.dayopt.app/auth/reset-password` のみ・`removed:` なしを確認。pin変更後は過不足なく green になる見込み

## 注意

このファイルは audit contract 保護対象外（`.github/workflows/production-config-audit.yml` L57 に明記）。trusted dispatch は不要。

Closes #2023