### PR TITLE
docs: 運用フォローアップ3件（gardening claude-security走査 / private化前提訂正 / marker書式）

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -271,9 +271,11 @@ Actions 課金は **PR ごとの固定費が支配的**（2026-07-25 実測）:
 
 [PR #1657](https://github.com/Dayopt/dayopt/pull/1657) は #1534 / #1535 を 1 PR に束ねた。当時は「1 issue = 1 PR の意図的な例外」としてユーザーの明示指示を根拠にしていた。本節はこの例外を既定に反転させたもの。
 
-### Actions 経済の規律（策定日: 2026-08-12）
+### Actions 経済の規律（策定日: 2026-08-12、根拠は 2026-08-11 の private 化保留決定を反映）
 
-**2026-09 の private 化で無料枠が月 2,000 分になる。** private repo に切り替わると push 回数が直接の予算制約になるため、§なぜ束ねるか の PR 本数の議論に加えて、1 PR の中での push 回数そのものを絞る規律を敷く（#1934 参照）。
+**private 化は保留し、public を維持する**（[2026-08-11 の決定ログ](../../docs/engineering/log/2026-08-11-codeql-disabled-and-visibility-decision.md)）。当初想定していた「2026-09 に private 化して無料枠が月 2,000 分になる」という前提は撤回済み。決め手は算術: private 換算コストは ~17,000 分/月に対し Free 枠は 2,000 分で 88% の削減が要るが、CodeQL・Docs Guard を全廃しても CI 単体が ~11,900 分を占めるため「CI 削減が完了したら private 化する」という条件が成立しない。public を維持する限り GitHub-hosted runner は実質無制限で、push 回数それ自体が無料枠の予算制約にはならない。
+
+それでも本節の規律は変えない。public のままでも CI run 自体の待ち時間・`concurrency: cancel-in-progress` による手戻り（§なぜ束ねるか）は push 回数に比例して増えるため、§なぜ束ねるか の PR 本数の議論に加えて、1 PR の中での push 回数そのものを絞る規律を敷く（#1934 参照）。
 
 - **レビューの指摘対応は round 単位で 1 push に束ねる。** 1 push = 軽量 CI 1 run なので、指摘が来るたびに 1 件ずつ直して push すると round 数だけ CI run が増える。ある PR では指摘対応が 8 巡 = 8 run になった実例がある。1 round で出た指摘をすべて拾ってから push する
 - **軽微な fix の追い push をしない。** typo や 1 行修正を見つけても即 push せず、次の round（レビュー対応や機能追加）に同乗させる
@@ -336,7 +338,7 @@ product の `next build` と bundle 検査（client bundle への secret 混入 
 
 ### なぜ 2 段階か
 
-2026-08-03 実測: 3 日間で CI 38 run / 15 PR。push 2.5 回に対して merge 前に必要な全量検証は 1 回で、全 push で重量層まで走らせると月 ~11,000 課金分ペース（Free 枠 2,000 分の 5 倍超）だった。検証の量は減らさず、走るタイミングを merge 前 1 回に寄せる。同じ原理で Integration Tests の push:main トリガー（up-to-date gate により PR 検証と同一 tree の再検証だった）を廃止し、Production Config Audit（Vercel 側 drift の検査で PR diff と無関係）を draft skip + 日次 cron に変えた。
+2026-08-03 実測: 3 日間で CI 38 run / 15 PR。push 2.5 回に対して merge 前に必要な全量検証は 1 回で、全 push で重量層まで走らせると月 ~11,000 課金分ペースだった（この試算時点では private 化後の Free 枠 2,000 分/月を基準に「5 倍超」と評価していたが、private 化は 2026-08-11 に保留決定済み。§Actions 経済の規律 参照。public 維持下でも CI run の待ち時間・concurrency cancel の手戻りは push 回数に比例するため、検証の量は減らさず走るタイミングを merge 前 1 回に寄せる判断自体は変えていない）。同じ原理で Integration Tests の push:main トリガー（up-to-date gate により PR 検証と同一 tree の再検証だった）を廃止し、Production Config Audit（Vercel 側 drift の検査で PR diff と無関係）を draft skip + 日次 cron に変えた。
 
 ## マージ方式
 

--- a/.claude/skills/gardening/SKILL.md
+++ b/.claude/skills/gardening/SKILL.md
@@ -54,7 +54,7 @@ Routine の draft PR が存在する前提で、ユーザーと Main が以下�
 2. **レビュー待ちリストの裁定** — superseded 判定、昇格の採否、AI 設定棚卸しの実施可否を決める
 3. **判断層の検証**（`CLAUDE.md` §シンプルルール） — ①今月このルールに戻った場面はあったか（1 度も戻らないルールは削る候補）②無言で破られたルールは無いか（あれば今から理由を言語化）③先月触らなかった機能はどれか（ルール 5。削除候補は dispatch intake で起票）④**判断ジャーナル集計** — `gh search issues --repo Dayopt/dayopt --label judgment:diverged --include-prs --limit 200` で現在ラベルが付く全分岐（issue / PR）を取得し、結果を観測できた事例に判定コメントを追記してラベルを外す。判定済み事例だけを母集団に `.claude/rules/orchestration.md` §権限の既定 の境界を実測で更新する（可逆な采配を Fable 決定 + opt-out にする試行運用の恒久化 / 巻き戻しの判定もここで行う）
 4. **実行層の検証**（`.claude/rules/workflow.md` §Pause point） — ⑤各チェックは今月何かを捕まえたか ⑥pause point の迂回の痕跡は無いか ⑦機械へ昇格できる項目は無いか
-5. **深掘りスキャン** — `/claude-security` の「Scan codebase」はユーザーのみ起動できる（`disable-model-invocation: true`）。前回スキャンからの経過を添えて実施を判断する
+5. **深掘りスキャン** — claude-security プラグイン（multi-agent のリポジトリ全体走査 + 敵対検証 + patch 生成）を月次の 1 項目として月 1 回転する。per-PR には重すぎる（1 回で数百万 token 級）ため per-PR 層（plan-review / レーン反証 / 指揮台クロスレビュー）には組み込まず、変更同士の合成で開く穴（per-PR レビューの構造的死角）を拾う backstop と位置づける。専用セッションで、**User の明示同意の下で起動**する（プラグインは大量 token 消費の明示 opt-in が前提の設計。`/claude-security` の「Scan codebase」はユーザーのみ起動できる、`disable-model-invocation: true`）。走行レーンの無い静かな盤面で行う（同日に通常レーンを並走させない — findings が in-flight 変更と衝突して triage が濁る）。findings は全件 issue 化して通常の編成へ流す。patch の適用は findings の triage 後に個別判断する。初回実施は 2026-09 の gardening
 6. 3・4 で所見が出たら `docs/product/log/YYYY-MM-DD-simple-rules-review.md` に記録する。項目や pause point を変える場合はメタルール（**1 つ足すときは 1 つ削る**）に従い `/decision` で決定ログを残す
 
 ## 故障モード

--- a/.claude/skills/pr-cross-review/SKILL.md
+++ b/.claude/skills/pr-cross-review/SKILL.md
@@ -87,7 +87,11 @@ P1/P2 の review comment とは別に、**1 件の summary comment** を issue �
 
 指摘対応の fix push や追従（想定外に発生した場合）で HEAD が変わったら、`旧HEAD..新HEAD` の差分だけを対象に re-review し、新しい HEAD SHA を指す summary comment を投稿し直す。全量の再レビューを毎回要求しない。gate は「取得窓（直近 100 件）内に、現在の HEAD を指す有効な `[internal-review]` marker が 1 件以上あること」を見る（過去の marker を明示的に無効化する仕組みは無く、古い head を指す marker はそもそも一致しないため実質的に効かなくなる）。
 
+**書式を誤った marker は窓内に残ると gate を塞ぎ続ける。** gate は「最新の marker」だけでなく窓内の**全 marker を any 判定**する（`scripts/git/finish-branch.sh` の `INTERNAL_REVIEW_CLAIMS_FINDINGS`）ため、正しい書式の新しい marker を投稿しても、窓内に残る誤書式の古い marker 1 件（例: §投稿フォーマット の zerolike 判定に落ちる注釈付き `P1: なし（…）`）が非ゼロ申告と誤認され続け、対応する review comment が無いまま停止する。復旧は当該コメントの削除または編集のみ（新しい marker の追加投稿では解決しない）。PR [#2053](https://github.com/Dayopt/dayopt/pull/2053) の初運用でこの型で 2 度停止し、汚染 marker を削除してから通過した。
+
 ## 投稿フォーマット
+
+**P1/P2 行でゼロ件を申告する時は、値を `なし` / `0` / `0件` / `0 件` / `None` のいずれかのみにする。同一行に注釈・括弧書きを付けない。**gate の zerolike 判定（`scripts/git/finish-branch.sh` の `zerolike`）は完全一致の正規表現のため、`P1: なし（注釈…）` のような括弧注釈付きはゼロ件と認識されず非ゼロ申告と誤認され、対応する review comment が見つからず gate が停止する。ゼロ件の理由や補足を書きたい場合は別行にするか P3 / 経緯欄へ書く（非ゼロ件数を申告する行は下の例の P2 のように注釈を付けてよい。zerolike 判定の対象外なので gate 判定に影響しない）。
 
 ```
 [internal-review]


### PR DESCRIPTION
## Summary

今日の運用改修（#2051 / #2053 / #2056）のフォローアップ 3 件を束ねた docs-only PR。

- **#2059**: 月次 gardening の人間パート「深掘りスキャン」に claude-security プラグインのフル走査を追加。per-PR には重すぎる（1 回で数百万 token 級）ため月 1 回転の backstop として位置づけ、User の明示同意の下で専用セッション実施。初回 2026-09
- **#2057**: `.claude/rules/workflow.md` §Actions 経済の規律 / §なぜ2段階か が「2026-09 private 化で無料枠が月 2,000 分になる」という stale 前提を書いていた（2026-08-11 に private 化は無期限保留・public 維持と決定済み）。根拠を現状の決定ログへ差し替え。規律本体（push 束ね・round単位のまとめ等）は変更しない
- **#2058**: pr-cross-review スキルに `[internal-review]` marker の P1/P2 ゼロ件申告時の書式制約（同一行注釈禁止）と、書式違反 marker が gate の any 判定で残り続ける時の復旧経路（当該コメント削除/編集）を明記。PR #2053 の初運用実例（2 度停止→汚染 marker 削除で通過）を参照

## 一次情報照合

- `scripts/git/finish-branch.sh` の `zerolike` 正規表現・`INTERNAL_REVIEW_CLAIMS_FINDINGS` の any 判定ロジックを `rg` で確認
- PR #2053 の実際の marker コメント履歴を `gh pr view --json comments` で確認（誤書式 marker への言及あり）
- `docs/engineering/log/2026-08-11-codeql-disabled-and-visibility-decision.md` の数値（~17,000分/月・Free枠2,000分・88%削減要・CI単体~11,900分）を `rg` で確認

## Test plan

- [x] `pnpm docs:check` green
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm lint:boundaries` / `pnpm quality:deadcode:ci` green（`pnpm check` チェーンの一部として実行、test:run 到達前まで通過）
- [x] `pnpm test:run` は 10 file / 85 test fail、すべて `localStorage` / zustand persist 系。ローカル Node 26 環境依存の既知 quirk（CI は Node 24 で pass）。docs-only 変更でコード非接触のため無関係と判断

Closes #2059
Closes #2057
Closes #2058