### PR TITLE
chore(tooling): 新Sentry CLIをMCPと併用するAI設定を追加する

### DIFF
--- a/.claude/rules/mcp-usage.md
+++ b/.claude/rules/mcp-usage.md
@@ -92,8 +92,28 @@ claude mcp remove uptimerobot -s user
   - 未承認 / 期限切れなら `/mcp` で `sentry` を承認する（github / vercel と同じフロー）。承認後の OAuth トークンは Claude 側にキャッシュされ、desktop アプリ起動・zsh ターミナル起動のどちらでも動く。
   - 疎通確認は `whoami` または `find_organizations`（`dayopt` org が返れば OK。OAuth ではログインユーザー権限で org/project が見えるため、旧 integration token 時代の「`find_organizations` が `[]`」制約は解消）。
 - **`Authorization Expired` / 401 が出たら**: `/mcp` で `sentry` を再承認する。OAuth トークンの失効サイン。env トークン (`SENTRY_ACCESS_TOKEN`) 注入経路はもう使わない（hosted OAuth へ移行済み）。
-- **フォールバック**: MCP が通らない間は Sentry Web UI / `sentry-cli` を使う。
+- **フォールバック**: MCP が通らない間は Sentry Web UI、または下記の Sentry CLI を使う。
 - **境界ケース**: 「再現できますか？」とユーザーに尋ねる前に Sentry で対象 issue を探す。ヒットすればスタックトレースから直接原因を特定できるので、ユーザーの手間を省ける。
+
+### Sentry CLI（`sentry` コマンド、cli.sentry.dev）
+
+エージェント向けの issue 閲覧・Seer 分析ツール（2026-08-14 評価、#2073）。**既存の `sentry-cli`（sourcemap upload 等のビルドツール、npm package）とは別物。** コマンド名が紛らわしいため区別する。
+
+MCP（上記）との分担は `github`（gh CLI + github MCP）と同型: **メインセッションの構造化・横断調査は MCP、subagent・レーン・script からの単発参照は CLI**（MCP は session 単位の配線が要るため届かない場所を CLI が埋める）。**この併用は暫定で、月次 gardening が Sentry MCP の実利用を検証し、CLI で足りていれば MCP 撤去（完全 CLI 化）を再検討する**（User の元々の意向は CLI 寄せ）。
+
+- **Invoke when**:
+  - MCP の配線が無い場所（subagent 内、script、CI）から Sentry issue を参照したい時
+  - 単純な単発取得（1 issue の閲覧、org/project 一覧）で MCP を起動するほどではない時
+- **Before use**:
+  - インストール: `curl -fsS https://cli.sentry.dev/install | bash`（初回のみ。install script は getsentry/cli 公式 GitHub Release からバイナリを取得し、Sentry 自身の DSN への匿名エラーテレメトリのみを送る正規パターンと確認済み）
+  - **認証は env var 方式のみを使う。`sentry auth login`（ブラウザ OAuth）は使わない**:
+    ```bash
+    SENTRY_AUTH_TOKEN="op://Dayopt-Shared/sentry-cli-readonly/credential" op run -- sentry <command>
+    ```
+    token は read-only scope（project:read, org:read, event:read, member:read, team:read）で発行済み。env var 方式では token がディスクに一切残らないことを実測確認済み（`~/.sentry/cli.db` の `auth` table は 0 rows）
+  - `~/.sentry/cli.db`（SQLite）はローカル cache DB。token は保存されないが、repo のディレクトリツリー構造（monorepo 検出用）はキャッシュされる。secret ではないが認識しておく
+- **主要コマンド**: `sentry issue list [org/project] --query "<query>"` / `sentry issue view <id>` / `sentry issue explain <id>`（Seer root cause）/ `sentry org list` / `sentry project list` / `sentry release list`。対応表は issue #2073 のコメントを参照
+- **境界ケース**: write 系コマンド（`issue resolve` 等）はこの token では想定運用外（read-only scope のため拒否される想定、未実測）。write が必要な場面は Sentry Web UI を使う
 
 ### Supabase（`supabase-local`=ローカル / `supabase`=cloud）
 

--- a/docs/operations/log/2026-08-13-incident-turnstile-secret.md
+++ b/docs/operations/log/2026-08-13-incident-turnstile-secret.md
@@ -3,6 +3,7 @@ status: frozen
 date: 2026-08-13
 last_verified: 2026-08-13
 issue: 2031
+partially_superseded_2026_08_14_turnstile-timing: docs/operations/log/2026-08-14-incident-turnstile-secret-timing-correction.md
 ---
 
 # production の Turnstile secret が invalid で signup が全滅した

--- a/docs/operations/log/2026-08-14-incident-turnstile-secret-timing-correction.md
+++ b/docs/operations/log/2026-08-14-incident-turnstile-secret-timing-correction.md
@@ -1,0 +1,37 @@
+---
+status: frozen
+date: 2026-08-14
+last_verified: 2026-08-14
+issue: 2031
+---
+
+# Turnstile secret incident の初出時刻と影響範囲を訂正する
+
+[2026-08-13-incident-turnstile-secret.md](./2026-08-13-incident-turnstile-secret.md) は「signup が全滅」と記録したが、2026-08-14 の実測（手作業レーン Sonnet + User、Supabase Dashboard Logs Explorer）で、初出時刻と主な被害対象がいずれも誤りだったと判明した。本 log はこの訂正を記録する。詳細は GitHub Issue [#2031](https://github.com/Dayopt/dayopt/issues/2031) の 2026-08-14 コメントに一次データがある。
+
+## 訂正内容
+
+**手法**: Supabase Dashboard Logs Explorer で `Auth Logs` source を対象に `event_message LIKE '%captcha_failed%'` を timestamp ASC で全件取得（過去3日間、計30件）。うち 1 件（`2026-08-11T01:34:09Z`、error: `no captcha_token found`）は client が token 未送信の別種エラーで、本 incident（`invalid-input-secret`）とは無関係と判断し除外。残り 29 件が対象クラスタ。
+
+**真の初出時刻**: `2026-08-12T05:23:47Z`（request_id `019ff46d-3c53-7c87-af62-e874c633847f`、path `/token`）。従来の incident ログに記録した `2026-08-12T23:13:09Z` は初出ではなく、**User が signup で気づいた瞬間**（後述の第二バーストの最後の 1 件）だった。実際の障害開始は記録より約 18 時間早い。
+
+**path 別内訳（invalid-input-secret クラスタ、計 29 件）**:
+
+| path                            | 件数  | 備考                                                |
+| ------------------------------- | ----- | --------------------------------------------------- |
+| `/token`（login）               | 24 件 | 05:23:47〜23:06:51 に分布。最多・最長時間影響       |
+| `/signup`                       | 3 件  | 23:12:43〜23:13:09（User が気づいた瞬間のクラスタ） |
+| `/recover`（password recovery） | 2 件  | 05:30:18, 05:30:22                                  |
+
+**時間パターン**: 第一バースト（05:23〜06:35、24 件）→ 約 16.5 時間の沈黙 → 第二バースト（23:06〜23:13、4 件、User の signup テスト時）。remote_addr は全件同一（User 自身のテスト操作と推定）。
+
+## 含意
+
+「signup が全滅」という従来の記述は不正確で、**実際は login（`/token`）が最も長時間・最多で影響を受けていた**。login 失敗は [2026-08-13-incident-turnstile-secret.md](./2026-08-13-incident-turnstile-secret.md) の「検知できなかった理由」節が指摘するとおりエラーメッセージが汎用化される設計のため、ユーザーが「パスワード間違いかも」と誤認して見過ごしていた可能性がある。
+
+元 log の「起きた事実」節にある初出時刻・request_id（`2026-08-12T23:13:09Z` / `019ff840-4624-70d8-a574-4f083eb9cd9c`）は「User が signup で気づいた瞬間」の記録として引き続き有効だが、「初出」としては本訂正の値（`2026-08-12T05:23:47Z`）を優先する。
+
+## 関連
+
+- GitHub Issue #2031（本 incident、手順 2 完了コメント）
+- [2026-08-13-incident-turnstile-secret.md](./2026-08-13-incident-turnstile-secret.md)（訂正対象の元 log）


### PR DESCRIPTION
Closes #2073
Refs #2031

## 概要

- #2073: 新Sentry CLI（cli.sentry.dev）を評価。read-onlyトークンでの認証・read系動作・token非永続化を実測確認し、既存 Sentry MCP との併用（gh CLI + github MCP と同型の分担）を`mcp-usage.md`へ反映した。対応表・実測結果は issue #2073 のコメントに記録済み。この併用は暫定運用で、月次 gardening が MCP 実利用を検証し完全 CLI 化を再検討する。
- #2031: incident ログ「production の Turnstile secret が invalid で signup が全滅した」の初出時刻・影響範囲を、Supabase Auth Logs の実測に基づき部分訂正（凍結log契約の `partially_superseded_*` frontmatter key + 新規訂正log）で修正した。

## 検証

- `pnpm docs:check` green
- `pnpm docs:check:claude-links` green