### PR TITLE
refactor(external-calendar): syncConnection に wall-clock 予算を持たせる

### DIFF
--- a/apps/product/messages/en/settings.json
+++ b/apps/product/messages/en/settings.json
@@ -470,6 +470,7 @@
           "providerUnavailable": "Google Calendar is temporarily unavailable. Try again later.",
           "encryptionKeyInvalid": "This connection cannot be read securely. Reconnect the account.",
           "partialFailure": "Some calendars could not be synced. Review the selection and try again.",
+          "partialTimeout": "Syncing is taking longer than expected. Try again.",
           "generic": "This connection has a sync issue. Try again or reconnect it."
         },
         "outcomes": {
@@ -477,6 +478,7 @@
           "reauthRequired": "Reconnect this Google account before syncing",
           "encryptionKeyInvalid": "This connection cannot be read securely. Reconnect it.",
           "partialFailure": "Some calendars could not be synced",
+          "partialTimeout": "Sync did not finish. Try again",
           "notConfigured": "Google Calendar connection is not configured",
           "updateFailed": "Calendar selection could not be applied",
           "syncFailed": "Google Calendar could not be synced"
@@ -495,6 +497,7 @@
           "reconnectTargetInvalid": "This connection can no longer be reconnected. Refresh and try again.",
           "mfaVerificationRequired": "Two-factor verification is required. Verify and try again.",
           "scopeNotGranted": "Some required permissions weren't granted. Allow all the permissions shown, then try again.",
+          "budgetExhausted": "Connecting took too long. Try again.",
           "unavailable": "Google Calendar connection is temporarily unavailable",
           "genericError": "Google Calendar could not be connected"
         }

--- a/apps/product/messages/ja/settings.json
+++ b/apps/product/messages/ja/settings.json
@@ -470,6 +470,7 @@
           "providerUnavailable": "Google カレンダーを一時的に利用できません。時間をおいてお試しください。",
           "encryptionKeyInvalid": "この接続を安全に読み取れません。アカウントを再接続してください。",
           "partialFailure": "一部のカレンダーを同期できませんでした。選択を確認して、もう一度お試しください。",
+          "partialTimeout": "同期に時間がかかっています。もう一度お試しください。",
           "generic": "この接続で同期の問題が発生しています。もう一度試すか、再接続してください。"
         },
         "outcomes": {
@@ -477,6 +478,7 @@
           "reauthRequired": "同期する前にGoogle アカウントを再接続してください",
           "encryptionKeyInvalid": "この接続を安全に読み取れません。再接続してください。",
           "partialFailure": "一部のカレンダーを同期できませんでした",
+          "partialTimeout": "同期が完了しませんでした。もう一度お試しください",
           "notConfigured": "Google カレンダー接続が設定されていません",
           "updateFailed": "カレンダーの選択を適用できませんでした",
           "syncFailed": "Google カレンダーを同期できませんでした"
@@ -495,6 +497,7 @@
           "reconnectTargetInvalid": "この接続は再接続できなくなりました。更新して、もう一度お試しください。",
           "mfaVerificationRequired": "2段階認証の確認が必要です。確認後にもう一度お試しください。",
           "scopeNotGranted": "必要な権限の一部が許可されませんでした。表示された権限をすべて許可して、もう一度お試しください。",
+          "budgetExhausted": "接続の準備に時間がかかりすぎました。もう一度お試しください。",
           "unavailable": "Google カレンダーに一時的に接続できません",
           "genericError": "Google カレンダーに接続できませんでした"
         }

--- a/apps/product/src/app/[locale]/(app)/settings/[category]/page.tsx
+++ b/apps/product/src/app/[locale]/(app)/settings/[category]/page.tsx
@@ -211,6 +211,8 @@ function calendarCallbackErrorMessage(
       return t('settings.integrations.googleCalendar.callback.mfaVerificationRequired');
     case 'scope_not_granted':
       return t('settings.integrations.googleCalendar.callback.scopeNotGranted');
+    case 'budget_exhausted':
+      return t('settings.integrations.googleCalendar.callback.budgetExhausted');
     case 'unavailable':
       return t('settings.integrations.googleCalendar.callback.unavailable');
     case 'generic':

--- a/apps/product/src/app/api/integrations/google-calendar/__tests__/callback-route.test.ts
+++ b/apps/product/src/app/api/integrations/google-calendar/__tests__/callback-route.test.ts
@@ -27,6 +27,8 @@ vi.mock('@/features/external-calendar/server/connection-service', () => ({
   saveConnection,
   getReconnectTarget,
   reconnectExistingConnection,
+  // route.ts が POST_EXCHANGE_BUDGET_MS の導出に使う（#1990）。実値をそのまま使う。
+  CALENDAR_CONNECTION_DB_TIMEOUT_MS: 15_000,
 }));
 vi.mock('@/lib/ops/write-fence', () => ({ isWriteFenceEnabled }));
 vi.mock('@/lib/supabase/oauth', () => ({ createServiceRoleClient: vi.fn(() => ({})) }));
@@ -577,5 +579,38 @@ describe('google calendar callback route', () => {
     expect(reasonOf(response)).toBe('write_fenced');
     expect(fetchMock).not.toHaveBeenCalled();
     expect(saveConnection).not.toHaveBeenCalled();
+  });
+
+  // #1990: token 交換（= code 消費）の直前で残り予算を検査する。route 入口の
+  // `Date.now()`（deadlineAt 算出）と消費直前の `Date.now()`（残り予算判定）の 2 回だけを
+  // 制御し、他のロジックは全てモック経由なので実時間に依存しない。
+  it('code 消費前に残り予算が不足していれば token 交換に到達しない', async () => {
+    const nowSpy = vi
+      .spyOn(Date, 'now')
+      .mockReturnValueOnce(0) // route 入口: deadlineAt = 0 + TIME_BUDGET_MS(50_000)
+      .mockReturnValueOnce(49_999); // 消費直前: 残り 1ms（POST_EXCHANGE_BUDGET_MS=45_000 未満）
+
+    const response = await GET(withCookie(request()));
+
+    expect(reasonOf(response)).toBe('budget_exhausted');
+    expect(fetch).not.toHaveBeenCalled();
+    expect(saveConnection).not.toHaveBeenCalled();
+
+    nowSpy.mockRestore();
+  });
+
+  it('残り予算が十分なら通常どおり token 交換へ進む', async () => {
+    const nowSpy = vi
+      .spyOn(Date, 'now')
+      .mockReturnValueOnce(0) // route 入口
+      .mockReturnValueOnce(4_999); // 消費直前: 残り 45_001ms（POST_EXCHANGE_BUDGET_MS を上回る）
+
+    const response = await GET(withCookie(request()));
+
+    expect(reasonOf(response)).toBeNull();
+    expect(fetch).toHaveBeenCalled();
+    expect(saveConnection).toHaveBeenCalled();
+
+    nowSpy.mockRestore();
   });
 });

--- a/apps/product/src/app/api/integrations/google-calendar/__tests__/callback-route.test.ts
+++ b/apps/product/src/app/api/integrations/google-calendar/__tests__/callback-route.test.ts
@@ -23,13 +23,19 @@ vi.mock('@/lib/supabase/server', () => ({ createClient }));
 vi.mock('@/lib/sentry', () => ({ captureUnexpectedError }));
 vi.mock('@/lib/billing/enforcement', () => ({ checkProAccessForUser }));
 vi.mock('@/lib/rate-limit/upstash', () => ({ calendarConnectRateLimit: { limit: rateLimit } }));
-vi.mock('@/features/external-calendar/server/connection-service', () => ({
-  saveConnection,
-  getReconnectTarget,
-  reconnectExistingConnection,
-  // route.ts が POST_EXCHANGE_BUDGET_MS の導出に使う（#1990）。実値をそのまま使う。
-  CALENDAR_CONNECTION_DB_TIMEOUT_MS: 15_000,
-}));
+vi.mock('@/features/external-calendar/server/connection-service', async (importOriginal) => {
+  // CALENDAR_CONNECTION_DB_TIMEOUT_MS は実値を使う（route.ts が POST_EXCHANGE_BUDGET_MS の
+  // 導出に使う、#1990）。手書きで複製すると本体側の値が変わった時にテストが追従しない
+  // （risk-reviewer 指摘、PR #2075）。
+  const actual =
+    await importOriginal<typeof import('@/features/external-calendar/server/connection-service')>();
+  return {
+    ...actual,
+    saveConnection,
+    getReconnectTarget,
+    reconnectExistingConnection,
+  };
+});
 vi.mock('@/lib/ops/write-fence', () => ({ isWriteFenceEnabled }));
 vi.mock('@/lib/supabase/oauth', () => ({ createServiceRoleClient: vi.fn(() => ({})) }));
 vi.mock('@/lib/trpc/session-auth-context', () => ({ resolveMfaAssurance }));
@@ -581,14 +587,27 @@ describe('google calendar callback route', () => {
     expect(saveConnection).not.toHaveBeenCalled();
   });
 
-  // #1990: token 交換（= code 消費）の直前で残り予算を検査する。route 入口の
-  // `Date.now()`（deadlineAt 算出）と消費直前の `Date.now()`（残り予算判定）の 2 回だけを
-  // 制御し、他のロジックは全てモック経由なので実時間に依存しない。
+  /**
+   * #1990: token 交換（= code 消費）の直前で残り予算を検査する。
+   *
+   * `entryTime` を route 入口の 1 回目の `Date.now()`（`deadlineAt` 算出）に固定し、
+   * それ以降の**全ての** `Date.now()` 呼び出しには `laterTime` を返す。呼び出し回数を
+   * 正確に 2 回だけと決め打ちしない — 将来 route.ts に別の `Date.now()` 呼び出しが増えても
+   * （decoy な呼び出しが割り込んでも）テストの意図（「入口」と「危険窓チェック直前」の
+   * 2 時点だけを制御する）が壊れない（risk-reviewer 指摘、PR #2075）。
+   */
+  function mockClockAfterEntry(entryTime: number, laterTime: number) {
+    let callCount = 0;
+    return vi.spyOn(Date, 'now').mockImplementation(() => {
+      callCount += 1;
+      return callCount === 1 ? entryTime : laterTime;
+    });
+  }
+
   it('code 消費前に残り予算が不足していれば token 交換に到達しない', async () => {
-    const nowSpy = vi
-      .spyOn(Date, 'now')
-      .mockReturnValueOnce(0) // route 入口: deadlineAt = 0 + TIME_BUDGET_MS(50_000)
-      .mockReturnValueOnce(49_999); // 消費直前: 残り 1ms（POST_EXCHANGE_BUDGET_MS=45_000 未満）
+    // deadlineAt = 0 + TIME_BUDGET_MS(80_000)。消費直前の残り 1ms（POST_EXCHANGE_BUDGET_MS
+    // =45_000 未満）。
+    const nowSpy = mockClockAfterEntry(0, 79_999);
 
     const response = await GET(withCookie(request()));
 
@@ -600,10 +619,8 @@ describe('google calendar callback route', () => {
   });
 
   it('残り予算が十分なら通常どおり token 交換へ進む', async () => {
-    const nowSpy = vi
-      .spyOn(Date, 'now')
-      .mockReturnValueOnce(0) // route 入口
-      .mockReturnValueOnce(4_999); // 消費直前: 残り 45_001ms（POST_EXCHANGE_BUDGET_MS を上回る）
+    // 消費直前の残り 45_001ms（POST_EXCHANGE_BUDGET_MS を上回る）。
+    const nowSpy = mockClockAfterEntry(0, 34_999);
 
     const response = await GET(withCookie(request()));
 

--- a/apps/product/src/app/api/integrations/google-calendar/callback/route.ts
+++ b/apps/product/src/app/api/integrations/google-calendar/callback/route.ts
@@ -38,16 +38,23 @@ import { resolveMfaAssurance } from '@/lib/trpc/session-auth-context';
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 /**
- * #1990: code 消費（token 交換）前に残り予算を検査するようになったので、段の値（60）に
- * 戻せる。逐次 worst path は再接続分岐が最長で getUser 15 + rate limit 2 + Pro 判定 15 +
- * Google token 交換 15 + `getReconnectTarget` 15 + `reconnectExistingConnection` 15 = 77 秒
- * だが、予算検査により「消費後に 60 秒を超えて kill される」経路自体を塞いだ
- * （消費前に予算不足なら code を使わず `budget_exhausted` で戻す）。
+ * #1990 の予算検査により「code 消費後に kill される」経路は塞いだが、その予算検査
+ * 自体の設計（`POST_EXCHANGE_BUDGET_MS = 45_000` 固定）と `maxDuration` の関係を
+ * 指揮台が再検討した（PR #2075 クロスレビュー、risk/behavior 両者一致）。
+ *
+ * maxDuration=60 のままだと `TIME_BUDGET_MS(50s) - POST_EXCHANGE_BUDGET_MS(45s) = 5s` が
+ * code 消費前フェーズ（getUser / MFA / rate limit / write fence / Pro 判定の直列
+ * 4〜5 ホップ）の全予算になる。個別 timeout に達しない軽度の遅延（Supabase 1 往復 2s 級）
+ * だけで、従来成功していた接続が `budget_exhausted` になる可用性の崖ができる。
+ *
+ * **指揮台決定**: maxDuration を 90 へ引き上げる（`POST_EXCHANGE_BUDGET_MS` = 45s は
+ * 不変）。消費前スラックが 35s に回復し、worst case 総計 80s ≤ 90 で hard kill margin
+ * 10s を維持する。安全性（code 消費前後の境界の扱い）は変えず、可用性の崖だけを除去する。
  */
-export const maxDuration = 60;
+export const maxDuration = 90;
 
 /** maxDuration に対する安全マージン。cron（`TIME_BUDGET_MS`）と同じ導出。 */
-const TIME_BUDGET_MS = 50_000;
+const TIME_BUDGET_MS = 80_000;
 
 /**
  * code 消費の危険窓（#1990）。

--- a/apps/product/src/app/api/integrations/google-calendar/callback/route.ts
+++ b/apps/product/src/app/api/integrations/google-calendar/callback/route.ts
@@ -11,6 +11,7 @@ import {
   parseConnectFlowCookie,
 } from '@/features/external-calendar/server/connect-flow';
 import {
+  CALENDAR_CONNECTION_DB_TIMEOUT_MS,
   getReconnectTarget,
   reconnectExistingConnection,
   saveConnection,
@@ -23,6 +24,7 @@ import {
   parseGrantedScopes,
   parseIdToken,
   resolveRedirectUri,
+  TOKEN_REQUEST_TIMEOUT_MS,
 } from '@/features/external-calendar/server/google-oauth';
 import { checkProAccessForUser } from '@/lib/billing/enforcement';
 import { logger } from '@/lib/logger';
@@ -36,19 +38,32 @@ import { resolveMfaAssurance } from '@/lib/trpc/session-auth-context';
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 /**
- * 逐次 worst path は再接続分岐が最長で、getUser 15 + rate limit 2 + Pro 判定 15 +
- * Google token 交換 15 + `getReconnectTarget` 15 + `reconnectExistingConnection` 15
- * = 77 秒。段の 60 では足りないので、応答を返す余裕を含めて 120 にする。
- *
- * ここだけ段から外す理由は失敗の質。**Google の authorization code は token 交換の
- * 時点で消費される**ので、その後の DB 書き込み中に kill されると接続は保存されない
- * まま code だけ使用済みになり、再試行は `invalid_grant`。ユーザーは認可からやり直し
- * になる。単なる 504 より重い。
- *
- * より良い解は「code を消費する前に残り予算を検査して、足りなければ手前で諦める」
- * 設計への転換で、これは #1990 で別途扱う。それが入れば 60 へ戻せる。
+ * #1990: code 消費（token 交換）前に残り予算を検査するようになったので、段の値（60）に
+ * 戻せる。逐次 worst path は再接続分岐が最長で getUser 15 + rate limit 2 + Pro 判定 15 +
+ * Google token 交換 15 + `getReconnectTarget` 15 + `reconnectExistingConnection` 15 = 77 秒
+ * だが、予算検査により「消費後に 60 秒を超えて kill される」経路自体を塞いだ
+ * （消費前に予算不足なら code を使わず `budget_exhausted` で戻す）。
  */
-export const maxDuration = 120;
+export const maxDuration = 60;
+
+/** maxDuration に対する安全マージン。cron（`TIME_BUDGET_MS`）と同じ導出。 */
+const TIME_BUDGET_MS = 50_000;
+
+/**
+ * code 消費の危険窓（#1990）。
+ *
+ * 「危険」は token 交換（`exchangeAuthorizationCode`）の呼び出しを**始めた**時点から始まる —
+ * Google が request を受理した後に応答待ちの途中で kill されると、こちらからは成否が
+ * 分からないまま code だけ消費済みになりうるため、交換呼び出し自体の worst case
+ * （`TOKEN_REQUEST_TIMEOUT_MS`）も危険窓に含める（交換が成功で返ってきてから初めて
+ * 危険が始まる、という早合点をしない）。
+ *
+ * 交換後の DB 書き込みは reconnect 経路（`getReconnectTarget` + `reconnectExistingConnection`
+ * の 2 回の DB 往復が直列）を基準にする。新規接続経路（`saveConnection` 1 回）はこれより
+ * 短く、常に安全側。`TOKEN_REQUEST_TIMEOUT_MS` / `CALENDAR_CONNECTION_DB_TIMEOUT_MS` から
+ * 導出し、手書きの数値を二重管理しない。
+ */
+const POST_EXCHANGE_BUDGET_MS = TOKEN_REQUEST_TIMEOUT_MS + 2 * CALENDAR_CONNECTION_DB_TIMEOUT_MS;
 
 /**
  * Settings への戻り先。
@@ -74,6 +89,7 @@ function safeEquals(a: string, b: string): boolean {
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const requestUrl = new URL(request.url);
+  const deadlineAt = Date.now() + TIME_BUDGET_MS;
   const secure = isSecureRequest(requestUrl);
   const cookieValue = request.cookies.get(connectFlowCookieName(secure))?.value;
   const flowState = parseConnectFlowCookie(cookieValue);
@@ -208,6 +224,14 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   }
 
   try {
+    // code を消費する（= token 交換を呼ぶ）前に、消費後の DB 書き込みを完走できる見込みが
+    // あるかを検査する（#1990）。ここで諦めれば code は未消費のまま残るので、ユーザーは
+    // Google の認可からやり直さずに再試行できる — 消費後に kill されるより安全側。
+    if (deadlineAt - Date.now() < POST_EXCHANGE_BUDGET_MS) {
+      logger.warn('[calendar-callback] insufficient time budget remaining before code exchange');
+      return fail('budget_exhausted');
+    }
+
     const tokens = await exchangeAuthorizationCode({
       code,
       redirectUri,

--- a/apps/product/src/app/api/trpc/[trpc]/route.ts
+++ b/apps/product/src/app/api/trpc/[trpc]/route.ts
@@ -23,11 +23,12 @@ import { captureUnexpectedTrpcAdapterError } from '@/lib/trpc/errors';
 export const runtime = 'nodejs';
 /**
  * 全 procedure を 1 function で捌くため、最長 procedure に律速される。`externalCalendar` の
- * `syncConnection` が wall-clock 予算を持たない（deadline は接続と接続の「間」にしか効かない）
- * ので、下げるとカレンダーの大きいユーザーの手動同期が hard kill される。#1965 で予算を
- * 入れてから 60 へ落とす。
+ * `syncNow` / `updateSelectedCalendars` が呼ぶ `syncConnection` は、この route の maxDuration
+ * を 300 に張り付かせていた唯一の既知の理由だった（deadline がカレンダー・ページ単位の
+ * ループを尊重しなかったため）。#1965 で `syncConnection` に wall-clock 予算を持たせ、
+ * router.ts が `deadlineAt` を渡すようになったので 60 へ落とせる。
  */
-export const maxDuration = 300;
+export const maxDuration = 60;
 
 function handler(req: Request) {
   return fetchRequestHandler({

--- a/apps/product/src/app/route-duration-contract.test.ts
+++ b/apps/product/src/app/route-duration-contract.test.ts
@@ -17,13 +17,19 @@ import { describe, expect, it } from 'vitest';
  * それぞれの timeout まで張り付く理論上の worst path は、一部の route で予算を超える:
  *
  * - `api/integrations/google-calendar/callback`（60）— getUser 15 + rate limit 2 +
- *   Pro 判定 15 + Google token 交換 15 + connection write 15 ≒ 62s
- * - `api/mcp`（60）/ `api/trpc/[trpc]`（300）— tool / procedure の dispatch 数に上限が無い
+ *   Pro 判定 15 + Google token 交換 15 + connection write 15 ≒ 62s。ただし #1990 で
+ *   token 交換（code 消費）の直前に残り予算を検査するようになったため、消費後に 60 秒を
+ *   超えて kill される経路自体が塞がれている（予算不足なら code を使わず安全に失敗する）
+ * - `api/mcp`（120）— 認証フェーズが逐次 getUser 15 × 5 ≒ 75s で 60 を超えるため、
+ *   段の値には戻せていない（#1990 の「検討する」項目、未着手）
+ * - `api/trpc/[trpc]`（60）— #1965 で `externalCalendar.syncConnection`（procedure の
+ *   dispatch 数に上限が無い理由だった唯一の既知の要因）に wall-clock 予算を持たせたため
+ *   段の値まで下げられた。他 procedure の worst path を全数監査した上での値ではない
  *
- * これらを「全依存が同時に張り付く」ケースまでカバーする値へ引き上げると 300 に近づき、
- * 障害半径を絞るという目的そのものを失う。**予算は blast radius の上限であって、
- * 全依存同時ハング時の完走保証ではない**、という位置づけで運用する。その状況では接続は
- * どのみち失敗しており、504 と graceful error の差は小さい。
+ * これらを「全依存が同時に張り付く」ケースまでカバーする値へ引き上げると障害半径を絞る
+ * という目的そのものを失う。**予算は blast radius の上限であって、全依存同時ハング時の
+ * 完走保証ではない**、という位置づけで運用する。その状況では接続はどのみち失敗しており、
+ * 504 と graceful error の差は小さい。
  *
  * したがって **test が通ること＝安全、ではない**。新しい route を足す時は、この表の値を
  * 埋めるだけでなく、その route の worst path を自分で数えること。
@@ -58,17 +64,18 @@ const ROUTE_DURATION_CONTRACT = {
   'src/app/api/oauth/token/route.ts': 60,
   'src/app/api/v1/calendar/[token]/route.ts': 60,
   'src/app/oauth/token/route.ts': 60,
+  // #1990: token 交換（code 消費）の直前で残り予算を検査するようになったため、逐次 worst
+  // path（77s）が 60 を超えていても kill 時の失敗の質が変わり、段の値へ戻せた。
+  'src/app/api/integrations/google-calendar/callback/route.ts': 60,
+  // #1965: externalCalendar.syncConnection に wall-clock 予算を持たせたため、procedure の
+  // dispatch 数に上限が無いという構造的な理由がなくなり、段の値へ戻せた。
+  'src/app/api/trpc/[trpc]/route.ts': 60,
 
-  // 逐次 worst path が 60 を超えるため段から外した 2 route。値の根拠は各 route の
-  // コメント（callback = 77s / MCP 認証 = 75s）。どちらも 60 のままだと handler が
-  // 自前の応答を返す前に kill される。callback は #1990（code 消費前の予算検査）が
-  // 入れば 60 へ戻せる
-  'src/app/api/integrations/google-calendar/callback/route.ts': 120,
+  // 逐次 worst path が 60 を超えるため段から外した route。MCP の認証フェーズは
+  // getUser 15 × 5 ≒ 75s で、#1990 のような「不可逆操作の前に予算検査」で吸収できる形の
+  // 失敗点が無い（認証自体が worst path の大半を占める）ため未着手。
   'src/app/api/mcp/route.ts': 120,
   'src/app/mcp/route.ts': 120,
-
-  // 構造的に上限が無い（下記 §tRPC を参照）
-  'src/app/api/trpc/[trpc]/route.ts': 300,
 } as const;
 
 /**

--- a/apps/product/src/app/route-duration-contract.test.ts
+++ b/apps/product/src/app/route-duration-contract.test.ts
@@ -16,15 +16,20 @@ import { describe, expect, it } from 'vitest';
  * 「Supabase 1 往復 + rate limit 1 回」を下回らないことしか見ない。依存が全部同時に
  * それぞれの timeout まで張り付く理論上の worst path は、一部の route で予算を超える:
  *
- * - `api/integrations/google-calendar/callback`（60）— getUser 15 + rate limit 2 +
- *   Pro 判定 15 + Google token 交換 15 + connection write 15 ≒ 62s。ただし #1990 で
- *   token 交換（code 消費）の直前に残り予算を検査するようになったため、消費後に 60 秒を
- *   超えて kill される経路自体が塞がれている（予算不足なら code を使わず安全に失敗する）
+ * - `api/integrations/google-calendar/callback`（90）— getUser 15 + rate limit 2 +
+ *   Pro 判定 15 + Google token 交換 15 + connection write 15 ≒ 62s。#1990 で token 交換
+ *   （code 消費）の直前に残り予算を検査するようになったため、消費後に kill される経路
+ *   自体は塞がれている（予算不足なら code を使わず安全に失敗する）。maxDuration=90 は
+ *   その予算検査（`POST_EXCHANGE_BUDGET_MS=45s`）を維持したまま、消費前フェーズの
+ *   スラックを確保するための値（指揮台決定、PR #2075 クロスレビュー）
  * - `api/mcp`（120）— 認証フェーズが逐次 getUser 15 × 5 ≒ 75s で 60 を超えるため、
  *   段の値には戻せていない（#1990 の「検討する」項目、未着手）
- * - `api/trpc/[trpc]`（60）— #1965 で `externalCalendar.syncConnection`（procedure の
- *   dispatch 数に上限が無い理由だった唯一の既知の要因）に wall-clock 予算を持たせたため
- *   段の値まで下げられた。他 procedure の worst path を全数監査した上での値ではない
+ * - `api/trpc/[trpc]`（60）— #1965 で `externalCalendar.syncNow` / `updateSelectedCalendars`
+ *   が呼ぶ `syncConnection`（procedure の dispatch 数に上限が無い理由だった最大の既知
+ *   要因）に wall-clock 予算を持たせたため段の値まで下げられた。同じ理由で
+ *   `listProviderCalendars` / `disconnect` も本来は予算化が要る（follow-up issue で
+ *   追跡、下記参照）が、この PR の scope は #1965/#1990 に限定し、他 procedure の
+ *   worst path 全数監査はしていない
  *
  * これらを「全依存が同時に張り付く」ケースまでカバーする値へ引き上げると障害半径を絞る
  * という目的そのものを失う。**予算は blast radius の上限であって、全依存同時ハング時の
@@ -65,10 +70,13 @@ const ROUTE_DURATION_CONTRACT = {
   'src/app/api/v1/calendar/[token]/route.ts': 60,
   'src/app/oauth/token/route.ts': 60,
   // #1990: token 交換（code 消費）の直前で残り予算を検査するようになったため、逐次 worst
-  // path（77s）が 60 を超えていても kill 時の失敗の質が変わり、段の値へ戻せた。
-  'src/app/api/integrations/google-calendar/callback/route.ts': 60,
+  // path（77s）を 60 が下回っていても kill 時の失敗の質が変わり安全側になった。90 は
+  // その安全性を保ったまま、消費前フェーズの可用性の崖を除去するための値
+  // （指揮台決定、PR #2075 クロスレビュー。詳細は maxDuration 直上のコメント）。
+  'src/app/api/integrations/google-calendar/callback/route.ts': 90,
   // #1965: externalCalendar.syncConnection に wall-clock 予算を持たせたため、procedure の
   // dispatch 数に上限が無いという構造的な理由がなくなり、段の値へ戻せた。
+  // listProviderCalendars / disconnect の予算化は follow-up issue で追跡（未着手）。
   'src/app/api/trpc/[trpc]/route.ts': 60,
 
   // 逐次 worst path が 60 を超えるため段から外した route。MCP の認証フェーズは

--- a/apps/product/src/features/external-calendar/components/GoogleCalendarSettings.tsx
+++ b/apps/product/src/features/external-calendar/components/GoogleCalendarSettings.tsx
@@ -30,6 +30,7 @@ type SyncOutcome =
   | 'reauth_required'
   | 'encryption_key_invalid'
   | 'partial_failure'
+  | 'partial_timeout'
   | 'not_configured';
 
 export function GoogleCalendarSettings() {
@@ -325,6 +326,8 @@ function persistedErrorMessage(
       return t('errors.encryptionKeyInvalid');
     case 'partial_failure':
       return t('errors.partialFailure');
+    case 'partial_timeout':
+      return t('errors.partialTimeout');
     default:
       return t('errors.generic');
   }
@@ -347,6 +350,9 @@ function showSyncOutcomeToast(
       break;
     case 'partial_failure':
       toast.error(t('outcomes.partialFailure'));
+      break;
+    case 'partial_timeout':
+      toast.error(t('outcomes.partialTimeout'));
       break;
     case 'not_configured':
       toast.error(t('outcomes.notConfigured'));

--- a/apps/product/src/features/external-calendar/lib/__tests__/calendar-callback-result.test.ts
+++ b/apps/product/src/features/external-calendar/lib/__tests__/calendar-callback-result.test.ts
@@ -35,6 +35,14 @@ describe('parseCalendarCallbackResult', () => {
     ).toEqual({ type: 'error', error: 'scope_not_granted' });
   });
 
+  // code 消費前に残り予算が不足して手前で諦めた場合（#1990）。code は未消費なので
+  // 汎用文言ではなく「もう一度お試しください」を出す専用文言へ振り分ける
+  it('予算切れの失敗を専用文言へ振り分ける', () => {
+    expect(
+      parseCalendarCallbackResult(new URLSearchParams('calendar=error&reason=budget_exhausted')),
+    ).toEqual({ type: 'error', error: 'budget_exhausted' });
+  });
+
   it('未知の provider reason を UI に露出しない', () => {
     expect(
       parseCalendarCallbackResult(new URLSearchParams('calendar=error&reason=raw-provider-detail')),

--- a/apps/product/src/features/external-calendar/lib/calendar-callback-result.ts
+++ b/apps/product/src/features/external-calendar/lib/calendar-callback-result.ts
@@ -7,6 +7,7 @@ export type CalendarCallbackError =
   | 'reconnect_target_invalid'
   | 'mfa_verification_required'
   | 'scope_not_granted'
+  | 'budget_exhausted'
   | 'unavailable'
   | 'generic';
 
@@ -28,6 +29,9 @@ const CALLBACK_ERROR_GROUPS: Readonly<Record<string, CalendarCallbackError>> = {
   // narrow pair の granular consent で片方だけ許可された場合。汎用の失敗文言に畳むと
   // 「2 つの権限を両方許可すればよい」が伝わらない。
   scope_not_granted: 'scope_not_granted',
+  // code 消費（token 交換）前に残り予算が足りないと判断して手前で諦めた場合（#1990）。
+  // code は未消費なので、汎用文言ではなく「もう一度お試しください」で再試行を促す。
+  budget_exhausted: 'budget_exhausted',
   assurance_lookup_failed: 'unavailable',
   unsupported_environment: 'unavailable',
   token_endpoint_unreachable: 'unavailable',

--- a/apps/product/src/features/external-calendar/server/__tests__/google-provider.test.ts
+++ b/apps/product/src/features/external-calendar/server/__tests__/google-provider.test.ts
@@ -423,6 +423,64 @@ describe('googleCalendarAdapter.syncCalendar', () => {
     );
   });
 
+  // wall-clock 予算（#1965）。ページ上限到達と同じ「cursor を確定しない安全な部分完了」の
+  // 形で返すが、これは想定内の日常挙動なので Sentry へは送らない（ページ上限到達との違い）。
+  it('wall-clock 予算を超えたら次ページを取りに行かず、取得済み分を保存する', async () => {
+    fetchMock().mockResolvedValueOnce(
+      jsonResponse({ items: [timedEvent({ id: 'event-1' })], nextPageToken: 'page-2' }),
+    );
+    const deadlineAt = 1_000;
+    const nowSpy = vi
+      .spyOn(Date, 'now')
+      .mockReturnValueOnce(0) // 1 ページ目の判定: まだ余裕がある
+      .mockReturnValueOnce(deadlineAt); // 2 ページ目の判定: 締切に達した
+
+    const result = await googleCalendarAdapter.syncCalendar(SESSION, {
+      calendarId: CALENDAR_ID,
+      cursor: null,
+      window: WINDOW,
+      deadlineAt,
+    });
+
+    expect(fetchMock()).toHaveBeenCalledTimes(1);
+    expect(result.events.map((event) => event.providerEventId)).toEqual(['event-1']);
+    expect(result.nextCursor).toBeNull();
+    expect(result.cursorInvalid).toBe(false);
+    expect(result.deadlineExceeded).toBe(true);
+    expect(captureUnexpectedError).not.toHaveBeenCalled();
+
+    nowSpy.mockRestore();
+  });
+
+  it('deadlineAt が既に過ぎていれば最初のページも取得しない', async () => {
+    const result = await googleCalendarAdapter.syncCalendar(SESSION, {
+      calendarId: CALENDAR_ID,
+      cursor: null,
+      window: WINDOW,
+      deadlineAt: Date.now() - 1,
+    });
+
+    expect(fetchMock()).not.toHaveBeenCalled();
+    expect(result.events).toEqual([]);
+    expect(result.nextCursor).toBeNull();
+    expect(result.deadlineExceeded).toBe(true);
+  });
+
+  it('deadlineAt を省略すれば従来どおり無制限にページングする', async () => {
+    fetchMock().mockResolvedValueOnce(
+      jsonResponse({ items: [timedEvent()], nextSyncToken: 'sync-token-1' }),
+    );
+
+    const result = await googleCalendarAdapter.syncCalendar(SESSION, {
+      calendarId: CALENDAR_ID,
+      cursor: null,
+      window: WINDOW,
+    });
+
+    expect(result.deadlineExceeded).toBe(false);
+    expect(result.nextCursor).toBe('sync-token-1');
+  });
+
   it.each([
     ['401 は再認証が要る', 401, 'authError', 'reauth_required'],
     ['403 rateLimitExceeded は一時エラー', 403, 'rateLimitExceeded', 'rate_limited'],

--- a/apps/product/src/features/external-calendar/server/__tests__/router.test.ts
+++ b/apps/product/src/features/external-calendar/server/__tests__/router.test.ts
@@ -129,6 +129,17 @@ describe('externalCalendarRouter — syncNow rate limit', () => {
       code: 'SERVICE_UNAVAILABLE',
     });
   });
+
+  // tRPC route の maxDuration に対する予算を syncConnection へ渡す（#1965）。
+  it('deadlineAt を付けて syncConnection を呼ぶ', async () => {
+    await caller().syncNow({ connectionId: CONNECTION_ID });
+
+    expect(syncConnection).toHaveBeenCalledWith({
+      connectionId: CONNECTION_ID,
+      userId: USER_ID,
+      deadlineAt: expect.any(Number),
+    });
+  });
 });
 
 describe('externalCalendarRouter — updateSelectedCalendars', () => {
@@ -141,7 +152,12 @@ describe('externalCalendarRouter — updateSelectedCalendars', () => {
     expect(updateSelectedCalendars).toHaveBeenCalledWith(USER_ID, CONNECTION_ID, [
       { providerCalendarId: 'cal-a', calendarName: 'A' },
     ]);
-    expect(syncConnection).toHaveBeenCalledWith({ connectionId: CONNECTION_ID, userId: USER_ID });
+    // deadlineAt は Date.now() 由来なので厳密値ではなく型と存在だけ確認する（#1965）。
+    expect(syncConnection).toHaveBeenCalledWith({
+      connectionId: CONNECTION_ID,
+      userId: USER_ID,
+      deadlineAt: expect.any(Number),
+    });
   });
 
   it('calendarName 省略は null に正規化して渡す', async () => {

--- a/apps/product/src/features/external-calendar/server/__tests__/router.test.ts
+++ b/apps/product/src/features/external-calendar/server/__tests__/router.test.ts
@@ -34,7 +34,7 @@ vi.mock('@/lib/rate-limit/upstash', () => ({
 }));
 vi.mock('@/lib/billing/enforcement', () => ({ isBillingEnforced }));
 
-import { externalCalendarRouter } from '../router';
+import { externalCalendarRouter, SYNC_TIME_BUDGET_MS } from '../router';
 
 const USER_ID = '00000000-0000-4000-8000-0000000000a1';
 const CONNECTION_ID = '00000000-0000-4000-8000-0000000000c1';
@@ -42,8 +42,8 @@ const EVENT_ID = '00000000-0000-4000-8000-0000000000e1';
 
 const createCaller = createCallerFactory(externalCalendarRouter);
 
-function caller() {
-  return createCaller(createMockContext({ userId: USER_ID }));
+function caller(overrides: { requestStartedAt?: number } = {}) {
+  return createCaller(createMockContext({ userId: USER_ID, ...overrides }));
 }
 
 beforeEach(() => {
@@ -130,21 +130,26 @@ describe('externalCalendarRouter — syncNow rate limit', () => {
     });
   });
 
-  // tRPC route の maxDuration に対する予算を syncConnection へ渡す（#1965）。
-  it('deadlineAt を付けて syncConnection を呼ぶ', async () => {
-    await caller().syncNow({ connectionId: CONNECTION_ID });
+  // tRPC route の maxDuration に対する予算を syncConnection へ渡す（#1965）。anchor は
+  // ctx.requestStartedAt（handler 入口）で、procedure 内で呼んだ Date.now() ではない
+  // ことを固定する — auth 解決・rate limit の所要時間を予算計算から漏らさないため
+  // （risk-reviewer 指摘、PR #2075）。
+  it('deadlineAt を ctx.requestStartedAt 起点で計算する', async () => {
+    const requestStartedAt = 1_700_000_000_000;
+    await caller({ requestStartedAt }).syncNow({ connectionId: CONNECTION_ID });
 
     expect(syncConnection).toHaveBeenCalledWith({
       connectionId: CONNECTION_ID,
       userId: USER_ID,
-      deadlineAt: expect.any(Number),
+      deadlineAt: requestStartedAt + SYNC_TIME_BUDGET_MS,
     });
   });
 });
 
 describe('externalCalendarRouter — updateSelectedCalendars', () => {
   it('選択更新後に同期を kick する', async () => {
-    await caller().updateSelectedCalendars({
+    const requestStartedAt = 1_700_000_000_000;
+    await caller({ requestStartedAt }).updateSelectedCalendars({
       connectionId: CONNECTION_ID,
       calendars: [{ providerCalendarId: 'cal-a', calendarName: 'A' }],
     });
@@ -152,11 +157,13 @@ describe('externalCalendarRouter — updateSelectedCalendars', () => {
     expect(updateSelectedCalendars).toHaveBeenCalledWith(USER_ID, CONNECTION_ID, [
       { providerCalendarId: 'cal-a', calendarName: 'A' },
     ]);
-    // deadlineAt は Date.now() 由来なので厳密値ではなく型と存在だけ確認する（#1965）。
+    // deadlineAt は ctx.requestStartedAt 起点（updateSelectedCalendars の DB 書き込みが
+    // 先に完了した後、実際に procedure 内で Date.now() を呼んだ場合より前の値になるはず。
+    // #1965、risk-reviewer 指摘 PR #2075）。
     expect(syncConnection).toHaveBeenCalledWith({
       connectionId: CONNECTION_ID,
       userId: USER_ID,
-      deadlineAt: expect.any(Number),
+      deadlineAt: requestStartedAt + SYNC_TIME_BUDGET_MS,
     });
   });
 

--- a/apps/product/src/features/external-calendar/server/__tests__/sync-dispatcher.test.ts
+++ b/apps/product/src/features/external-calendar/server/__tests__/sync-dispatcher.test.ts
@@ -104,10 +104,12 @@ describe('dispatchCalendarSync — 逐次同期', () => {
     const summary = await dispatchCalendarSync({ now: NOW, deadlineAt: FAR_DEADLINE });
 
     expect(syncConnection).toHaveBeenCalledTimes(3);
+    // deadlineAt は接続と接続の「間」だけでなく接続の内側にも渡す（#1965）。
     expect(syncConnection).toHaveBeenCalledWith({
       connectionId: connections(1)[0]!.id,
       userId: connections(1)[0]!.user_id,
       forceFullSync: false,
+      deadlineAt: FAR_DEADLINE,
     });
     expect(summary).toMatchObject({
       due: 3,

--- a/apps/product/src/features/external-calendar/server/__tests__/sync-service.test.ts
+++ b/apps/product/src/features/external-calendar/server/__tests__/sync-service.test.ts
@@ -164,6 +164,7 @@ function syncResult(overrides: Record<string, unknown> = {}) {
     nextCursor: 'next-sync-token',
     cursorInvalid: false,
     usedFullSync: false,
+    deadlineExceeded: false,
     ...overrides,
   };
 }
@@ -552,7 +553,91 @@ describe('syncConnection — 認可と鍵', () => {
     const patch = argsOf(update, 'update')[0] as Record<string, unknown>;
     expect(patch.last_sync_error).toBeNull();
   });
+});
 
+describe('syncConnection — 予算切れ（#1965）', () => {
+  it('deadlineAt を adapter.syncCalendar へ渡す', async () => {
+    setupDb({ connection: activeConnection(), calendars: oneCalendar() });
+    syncCalendar.mockResolvedValue(syncResult());
+    const deadlineAt = Date.now() + 30_000;
+
+    await syncConnection({ connectionId: CONNECTION_ID, userId: USER_ID, deadlineAt });
+
+    expect(syncCalendar).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ deadlineAt }),
+    );
+  });
+
+  it('カレンダーが予算切れで打ち切られたら outcome は partial_timeout になる', async () => {
+    const { calls } = setupDb({ connection: activeConnection(), calendars: oneCalendar() });
+    syncCalendar.mockResolvedValue(syncResult({ deadlineExceeded: true, nextCursor: null }));
+
+    const result = await syncConnection({ connectionId: CONNECTION_ID, userId: USER_ID });
+
+    expect(result.outcome).toBe('partial_timeout');
+    expect(result.calendarsSynced).toBe(0);
+    expect(result.calendarsFailed).toBe(0);
+    const update = findCall(calls, 'calendar_connections', 'update')!;
+    const patch = argsOf(update, 'update')[0] as Record<string, unknown>;
+    // partial_failure（実際の失敗）とは別コードにする。次回 sync で前進する見込みがあり、
+    // リトライ導線の文言が異なる。
+    expect(patch.last_sync_error).toBe('partial_timeout');
+  });
+
+  it('予算切れ前に完走したカレンダーの進捗（sync_token）は保存される', async () => {
+    const CALENDAR_B = 'secondary';
+    const { calls } = setupDb({
+      connection: activeConnection(),
+      calendars: [
+        { provider_calendar_id: CALENDAR_ID, calendar_name: 'Work', sync_token: null },
+        { provider_calendar_id: CALENDAR_B, calendar_name: 'Personal', sync_token: null },
+      ],
+    });
+    syncCalendar
+      .mockResolvedValueOnce(syncResult({ nextCursor: 'completed-token' }))
+      .mockResolvedValueOnce(syncResult({ deadlineExceeded: true, nextCursor: null }));
+
+    const result = await syncConnection({ connectionId: CONNECTION_ID, userId: USER_ID });
+
+    expect(result.outcome).toBe('partial_timeout');
+    expect(result.calendarsSynced).toBe(1);
+    const tokenUpdates = recordersFor(calls, 'calendar_connection_calendars').filter((recorder) =>
+      recorder.chain.some((entry) => entry.method === 'update'),
+    );
+    // 完走した 1 カレンダー分だけ sync_token が確定する。打ち切られた方は更新されない
+    // （cursor を確定しない契約は #1965 でも変わらない）。
+    expect(tokenUpdates).toHaveLength(1);
+    expect(argsOf(tokenUpdates[0]!, 'update')[0]).toMatchObject({ sync_token: 'completed-token' });
+  });
+
+  // reauth_required と deadline_exceeded が同一 run で両方起きた場合、reauth を優先する
+  // （behavior-verifier 指摘、#1965）。データは失われない — 予算切れ側の進捗は
+  // syncOneCalendar 内で既に永続化済み（ループ後の分岐より前）で、単に outcome/last_sync_error
+  // として表に出るのが 'reauth_required' 側になるだけ。ユーザーはどのみち再接続が要る。
+  it('同一 run で reauth_required と deadline_exceeded が両方起きたら reauth_required を優先する', async () => {
+    const CALENDAR_B = 'secondary';
+    setupDb({
+      connection: activeConnection(),
+      calendars: [
+        { provider_calendar_id: CALENDAR_ID, calendar_name: 'Work', sync_token: null },
+        { provider_calendar_id: CALENDAR_B, calendar_name: 'Personal', sync_token: null },
+      ],
+    });
+    syncCalendar
+      .mockRejectedValueOnce(
+        new CalendarProviderError('revoked', 'reauth_required', 'invalid_grant', 401),
+      )
+      .mockResolvedValueOnce(syncResult({ deadlineExceeded: true, nextCursor: null }));
+
+    const result = await syncConnection({ connectionId: CONNECTION_ID, userId: USER_ID });
+
+    expect(result.outcome).toBe('reauth_required');
+    expect(markCalendarConnectionReauth).toHaveBeenCalled();
+  });
+});
+
+describe('syncConnection — 認可の再確認', () => {
   it('reauth_required の接続は skip する', async () => {
     setupDb({
       connection: { ...activeConnection(), status: 'reauth_required' },

--- a/apps/product/src/features/external-calendar/server/__tests__/sync-service.test.ts
+++ b/apps/product/src/features/external-calendar/server/__tests__/sync-service.test.ts
@@ -44,7 +44,7 @@ vi.mock('../providers/google', () => ({
   googleCalendarAdapter: { provider: 'google', startSession, syncCalendar },
 }));
 
-import { syncConnection } from '../sync-service';
+import { PERSIST_RESERVE_MS, syncConnection } from '../sync-service';
 
 const CONNECTION_ID = '00000000-0000-4000-8000-0000000000c1';
 const USER_ID = '00000000-0000-4000-8000-0000000000a1';
@@ -556,20 +556,22 @@ describe('syncConnection — 認可と鍵', () => {
 });
 
 describe('syncConnection — 予算切れ（#1965）', () => {
-  it('deadlineAt を adapter.syncCalendar へ渡す', async () => {
+  it('deadlineAt から PERSIST_RESERVE_MS を引いた値を adapter.syncCalendar へ渡す', async () => {
     setupDb({ connection: activeConnection(), calendars: oneCalendar() });
     syncCalendar.mockResolvedValue(syncResult());
     const deadlineAt = Date.now() + 30_000;
 
     await syncConnection({ connectionId: CONNECTION_ID, userId: USER_ID, deadlineAt });
 
+    // 素の deadlineAt をそのまま渡すと、判定直後に取得したページの永続化（upsert /
+    // tombstone / token 保存）自体が予算を考慮しない（risk-reviewer 指摘、PR #2075）。
     expect(syncCalendar).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ deadlineAt }),
+      expect.objectContaining({ deadlineAt: deadlineAt - PERSIST_RESERVE_MS }),
     );
   });
 
-  it('カレンダーが予算切れで打ち切られたら outcome は partial_timeout になる', async () => {
+  it('カレンダーが予算切れで打ち切られ、他に完走が無ければ last_synced_at を進めない', async () => {
     const { calls } = setupDb({ connection: activeConnection(), calendars: oneCalendar() });
     syncCalendar.mockResolvedValue(syncResult({ deadlineExceeded: true, nextCursor: null }));
 
@@ -578,11 +580,34 @@ describe('syncConnection — 予算切れ（#1965）', () => {
     expect(result.outcome).toBe('partial_timeout');
     expect(result.calendarsSynced).toBe(0);
     expect(result.calendarsFailed).toBe(0);
+    // 完全な空振り run（calendarsSynced === 0）。last_synced_at を進めると due 判定
+    // （昇順）でこの接続が列の最後尾へ回り、starvation 防止の順序が無効化されるため、
+    // 何も書き込まない（risk-reviewer 指摘、PR #2075）。
+    expect(findCall(calls, 'calendar_connections', 'update')).toBeUndefined();
+  });
+
+  it('部分的に進捗があった予算切れは last_sync_error を書いて last_synced_at を進める', async () => {
+    const CALENDAR_B = 'secondary';
+    const { calls } = setupDb({
+      connection: activeConnection(),
+      calendars: [
+        { provider_calendar_id: CALENDAR_ID, calendar_name: 'Work', sync_token: null },
+        { provider_calendar_id: CALENDAR_B, calendar_name: 'Personal', sync_token: null },
+      ],
+    });
+    syncCalendar
+      .mockResolvedValueOnce(syncResult({ nextCursor: 'completed-token' }))
+      .mockResolvedValueOnce(syncResult({ deadlineExceeded: true, nextCursor: null }));
+
+    const result = await syncConnection({ connectionId: CONNECTION_ID, userId: USER_ID });
+
+    expect(result.outcome).toBe('partial_timeout');
     const update = findCall(calls, 'calendar_connections', 'update')!;
     const patch = argsOf(update, 'update')[0] as Record<string, unknown>;
     // partial_failure（実際の失敗）とは別コードにする。次回 sync で前進する見込みがあり、
     // リトライ導線の文言が異なる。
     expect(patch.last_sync_error).toBe('partial_timeout');
+    expect(patch.last_synced_at).toBe(RUN_ISO);
   });
 
   it('予算切れ前に完走したカレンダーの進捗（sync_token）は保存される', async () => {
@@ -609,6 +634,30 @@ describe('syncConnection — 予算切れ（#1965）', () => {
     // （cursor を確定しない契約は #1965 でも変わらない）。
     expect(tokenUpdates).toHaveLength(1);
     expect(argsOf(tokenUpdates[0]!, 'update')[0]).toMatchObject({ sync_token: 'completed-token' });
+  });
+
+  // 実際の失敗（provider / DB エラー）と予算切れが同一 run で起きた場合、前者を優先報告
+  // する（risk-reviewer 指摘、PR #2075）。partial_timeout が先に返ると「選択を確認して」
+  // という実失敗側の行動喚起が「もう一度お試しください」に隠れてしまう。
+  it('calendarsFailed と calendarsIncomplete が同一 run で両方起きたら partial_failure を優先する', async () => {
+    const CALENDAR_B = 'secondary';
+    const { calls } = setupDb({
+      connection: activeConnection(),
+      calendars: [
+        { provider_calendar_id: CALENDAR_ID, calendar_name: 'Work', sync_token: null },
+        { provider_calendar_id: CALENDAR_B, calendar_name: 'Personal', sync_token: null },
+      ],
+    });
+    syncCalendar
+      .mockRejectedValueOnce(new CalendarProviderError('shared removed', 'forbidden'))
+      .mockResolvedValueOnce(syncResult({ deadlineExceeded: true, nextCursor: null }));
+
+    const result = await syncConnection({ connectionId: CONNECTION_ID, userId: USER_ID });
+
+    expect(result.outcome).toBe('partial_failure');
+    const update = findCall(calls, 'calendar_connections', 'update')!;
+    const patch = argsOf(update, 'update')[0] as Record<string, unknown>;
+    expect(patch.last_sync_error).toBe('partial_failure');
   });
 
   // reauth_required と deadline_exceeded が同一 run で両方起きた場合、reauth を優先する

--- a/apps/product/src/features/external-calendar/server/connection-service.ts
+++ b/apps/product/src/features/external-calendar/server/connection-service.ts
@@ -52,8 +52,11 @@ type CalendarConnectionClient = SupabaseClient<CalendarConnectionDatabase>;
  * OAuth callback は一度きりの Google authorization code を消費してから接続を保存する。
  * 上限が無いと route の `maxDuration` が先に発火し、保存結果を返す前に kill された
  * 再試行が使用済み code の `invalid_grant` になって、ユーザーは認可からやり直しになる。
+ *
+ * export するのは、callback route（#1990）が「code 消費後の DB 書き込みに要する
+ * worst case」を導出するのに使うため。手書きの数値を二重管理しない。
  */
-const CALENDAR_CONNECTION_DB_TIMEOUT_MS = 15_000;
+export const CALENDAR_CONNECTION_DB_TIMEOUT_MS = 15_000;
 
 function createCalendarConnectionDbClient(): CalendarConnectionClient {
   return createClient<CalendarConnectionDatabase>(

--- a/apps/product/src/features/external-calendar/server/google-oauth.ts
+++ b/apps/product/src/features/external-calendar/server/google-oauth.ts
@@ -35,8 +35,13 @@ const GOOGLE_REVOKE_ENDPOINT = 'https://oauth2.googleapis.com/revoke';
 /** `lib/oauth-server/tokens.ts` の ENTROPY_BYTES と同値。独自の桁数を発明しない。 */
 const ENTROPY_BYTES = 32;
 
-/** supabase client（`lib/supabase/oauth.ts`）と同じ外部呼び出しタイムアウト。 */
-const TOKEN_REQUEST_TIMEOUT_MS = 15_000;
+/**
+ * supabase client（`lib/supabase/oauth.ts`）と同じ外部呼び出しタイムアウト。
+ *
+ * export するのは、callback route（#1990）が「code 消費の危険窓（exchange 呼び出しの
+ * 開始から DB 書き込み完了まで）」の worst case を導出するのに使うため。
+ */
+export const TOKEN_REQUEST_TIMEOUT_MS = 15_000;
 
 export class GoogleOAuthError extends Error {
   constructor(

--- a/apps/product/src/features/external-calendar/server/providers/google.ts
+++ b/apps/product/src/features/external-calendar/server/providers/google.ts
@@ -29,8 +29,14 @@ import {
 
 const GOOGLE_CALENDAR_API_BASE = 'https://www.googleapis.com/calendar/v3';
 
-/** supabase client / token endpoint と同じ外部呼び出しタイムアウト。 */
-const GOOGLE_API_TIMEOUT_MS = 15_000;
+/**
+ * supabase client / token endpoint と同じ外部呼び出しタイムアウト。
+ *
+ * export するのは、cron dispatcher（#1965）が「1 接続に着手する最低所要時間」を
+ * `refreshAccessToken`（google-oauth.ts の `TOKEN_REQUEST_TIMEOUT_MS`）と合わせて
+ * 導出するのに使うため。
+ */
+export const GOOGLE_API_TIMEOUT_MS = 15_000;
 
 /**
  * Google の上限ちょうど。既定の 250 のままだと初回 full sync のリクエスト数が 10 倍になる。

--- a/apps/product/src/features/external-calendar/server/providers/google.ts
+++ b/apps/product/src/features/external-calendar/server/providers/google.ts
@@ -324,7 +324,12 @@ function toProviderError(error: unknown, fallbackMessage: string): CalendarProvi
 
 async function syncCalendar(
   session: ProviderSession,
-  params: { calendarId: string; cursor: string | null; window: SyncWindow },
+  params: {
+    calendarId: string;
+    cursor: string | null;
+    window: SyncWindow;
+    deadlineAt?: number;
+  },
 ): Promise<SyncCalendarResult> {
   const events: NormalizedExternalEvent[] = [];
   const cancelledEventIds: string[] = [];
@@ -338,6 +343,23 @@ async function syncCalendar(
   let unparsableEvents = 0;
 
   for (let page = 0; page < MAX_EVENT_PAGES; page += 1) {
+    // wall-clock 予算チェック（#1965）。次ページを取りに行く前に判定するので、ここで
+    // 打ち切っても Google へは 1 リクエストも送らない。MAX_EVENT_PAGES 到達時と同じ
+    // 「cursor を確定しない安全な部分完了」の形で返す — 予算切れは想定内の日常挙動なので
+    // reportSilentLoss は撃たない（あちらは異常検知用）。
+    if (params.deadlineAt !== undefined && Date.now() >= params.deadlineAt) {
+      reportUnparsableEvents(unparsableEvents);
+      return {
+        events,
+        cancelledEventIds,
+        skippedEventIds,
+        nextCursor: null,
+        cursorInvalid: false,
+        usedFullSync,
+        deadlineExceeded: true,
+      };
+    }
+
     const url = buildEventsListUrl({ ...params, pageToken });
 
     let payload: unknown;
@@ -355,6 +377,7 @@ async function syncCalendar(
           nextCursor: null,
           cursorInvalid: true,
           usedFullSync,
+          deadlineExceeded: false,
         };
       }
       throw error;
@@ -383,6 +406,7 @@ async function syncCalendar(
         nextCursor,
         cursorInvalid: false,
         usedFullSync,
+        deadlineExceeded: false,
       };
     }
 
@@ -404,6 +428,7 @@ async function syncCalendar(
     nextCursor: null,
     cursorInvalid: false,
     usedFullSync,
+    deadlineExceeded: false,
   };
 }
 

--- a/apps/product/src/features/external-calendar/server/providers/types.ts
+++ b/apps/product/src/features/external-calendar/server/providers/types.ts
@@ -53,6 +53,14 @@ export type SyncCalendarResult = {
   cursorInvalid: boolean;
   /** この呼び出しが full sync だったか。sweep を撃ってよいかの判断に使う。 */
   usedFullSync: boolean;
+  /**
+   * `deadlineAt` の wall-clock 予算超過でページングを打ち切った（#1965）。
+   *
+   * `nextCursor` は `MAX_EVENT_PAGES` 到達時と同じ理由で null のまま返す — カレンダー単位で
+   * 完走した分だけ cursor を確定する契約（呼び出し側の sync-service.ts）を壊さない。呼び出し側は
+   * これを見て「実際に失敗した」と区別し、次回 sync で前進する見込みがあることを outcome に反映する。
+   */
+  deadlineExceeded: boolean;
 };
 
 /** 取り込み候補として提示するカレンダー。 */
@@ -141,6 +149,8 @@ export interface CalendarProviderAdapter {
       /** null なら full sync。 */
       cursor: string | null;
       window: SyncWindow;
+      /** `Date.now()` 換算の締切（ms）。省略時は無制限（既存呼び出し互換）。 */
+      deadlineAt?: number | undefined;
     },
   ): Promise<SyncCalendarResult>;
 

--- a/apps/product/src/features/external-calendar/server/router.ts
+++ b/apps/product/src/features/external-calendar/server/router.ts
@@ -81,6 +81,15 @@ const updateSelectedCalendarsInput = z.object({
     .max(50),
 });
 
+/**
+ * `syncConnection` に渡す wall-clock 予算（#1965）。
+ *
+ * tRPC route（`api/trpc/[trpc]/route.ts`）の `maxDuration=60` に対する安全マージン。
+ * cron（`api/cron/calendar-sync/route.ts` の `TIME_BUDGET_MS`）と同じ導出 — 60s の
+ * maxDuration に対して 10s を応答生成・ネットワーク往復のマージンとして残す。
+ */
+const SYNC_TIME_BUDGET_MS = 50_000;
+
 /** 手動同期の per-user rate limit。upstash 未設定なら素通り（fallback は route 側に無い）。 */
 async function enforceSyncNowRateLimit(userId: string): Promise<void> {
   if (!calendarSyncNowRateLimit) return;
@@ -190,7 +199,11 @@ export const externalCalendarRouter = createTRPCRouter({
           })),
         );
         // ユーザーが待つ導線なので即時 full sync を kick する（overview.md §6-1）。
-        return await syncConnection({ connectionId: input.connectionId, userId: ctx.userId });
+        return await syncConnection({
+          connectionId: input.connectionId,
+          userId: ctx.userId,
+          deadlineAt: Date.now() + SYNC_TIME_BUDGET_MS,
+        });
       } catch (error) {
         return handleServiceError(error);
       }
@@ -202,7 +215,11 @@ export const externalCalendarRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       await enforceSyncNowRateLimit(ctx.userId);
       try {
-        return await syncConnection({ connectionId: input.connectionId, userId: ctx.userId });
+        return await syncConnection({
+          connectionId: input.connectionId,
+          userId: ctx.userId,
+          deadlineAt: Date.now() + SYNC_TIME_BUDGET_MS,
+        });
       } catch (error) {
         return handleServiceError(error);
       }

--- a/apps/product/src/features/external-calendar/server/router.ts
+++ b/apps/product/src/features/external-calendar/server/router.ts
@@ -87,8 +87,13 @@ const updateSelectedCalendarsInput = z.object({
  * tRPC route（`api/trpc/[trpc]/route.ts`）の `maxDuration=60` に対する安全マージン。
  * cron（`api/cron/calendar-sync/route.ts` の `TIME_BUDGET_MS`）と同じ導出 — 60s の
  * maxDuration に対して 10s を応答生成・ネットワーク往復のマージンとして残す。
+ *
+ * **anchor は `ctx.requestStartedAt`（handler 入口）を使う。** `Date.now()` を procedure
+ * 内で呼ぶと、そこに至るまでの auth 解決・rate limit・DB 更新（`updateSelectedCalendars`
+ * は `connection-service.ts` の複数回の DB 往復を先に行う）の所要時間が抜け落ち、
+ * 実際の残り時間より長い予算を計算してしまう（risk-reviewer 指摘、PR #2075）。
  */
-const SYNC_TIME_BUDGET_MS = 50_000;
+export const SYNC_TIME_BUDGET_MS = 50_000;
 
 /** 手動同期の per-user rate limit。upstash 未設定なら素通り（fallback は route 側に無い）。 */
 async function enforceSyncNowRateLimit(userId: string): Promise<void> {
@@ -202,7 +207,7 @@ export const externalCalendarRouter = createTRPCRouter({
         return await syncConnection({
           connectionId: input.connectionId,
           userId: ctx.userId,
-          deadlineAt: Date.now() + SYNC_TIME_BUDGET_MS,
+          deadlineAt: ctx.requestStartedAt + SYNC_TIME_BUDGET_MS,
         });
       } catch (error) {
         return handleServiceError(error);
@@ -218,7 +223,7 @@ export const externalCalendarRouter = createTRPCRouter({
         return await syncConnection({
           connectionId: input.connectionId,
           userId: ctx.userId,
-          deadlineAt: Date.now() + SYNC_TIME_BUDGET_MS,
+          deadlineAt: ctx.requestStartedAt + SYNC_TIME_BUDGET_MS,
         });
       } catch (error) {
         return handleServiceError(error);

--- a/apps/product/src/features/external-calendar/server/sync-dispatcher.ts
+++ b/apps/product/src/features/external-calendar/server/sync-dispatcher.ts
@@ -6,6 +6,8 @@ import { logger } from '@/lib/logger';
 import { captureUnexpectedDatabaseError, captureUnexpectedError } from '@/lib/sentry';
 import { createServiceRoleClient } from '@/lib/supabase/oauth';
 
+import { TOKEN_REQUEST_TIMEOUT_MS } from './google-oauth';
+import { GOOGLE_API_TIMEOUT_MS } from './providers/google';
 import { DUE_STALENESS_MS, isDailyFullSyncSlot } from './sync-schedule';
 import { syncConnection } from './sync-service';
 
@@ -23,6 +25,16 @@ import { syncConnection } from './sync-service';
 
 /** cron が 1 回で処理する due 接続の上限。時間予算に届く前の安全弁。 */
 const MAX_CONNECTIONS_PER_RUN = 500;
+
+/**
+ * 1 接続に着手する最低所要時間（#1965、risk-reviewer 指摘 PR #2075）。
+ *
+ * 残り予算がこれを下回ったまま `syncConnection` に入ると、`startSession`（token refresh、
+ * 最大 `TOKEN_REQUEST_TIMEOUT_MS`）を 1 回焼いて全カレンダーが即座に予算切れになる
+ * だけの空振り run が起きる。この gate で「着手しても何も進まないと分かっている」
+ * 接続を deferred として次回 cron に譲り、無駄な token refresh を防ぐ。
+ */
+const MIN_CONNECTION_BUDGET_MS = TOKEN_REQUEST_TIMEOUT_MS + GOOGLE_API_TIMEOUT_MS;
 
 type DispatchSummary = {
   /** due として列挙された接続数。 */
@@ -85,9 +97,10 @@ export async function dispatchCalendarSync(params: {
   const billingEnforced = isBillingEnforced();
 
   for (const connection of dueConnections) {
-    // 各接続を始める前に時間予算を確認する。超過分は次回 cron が last_synced_at 昇順で
-    // 最優先に拾う（取りこぼしにはならない）。
-    if (Date.now() >= deadlineAt) {
+    // 各接続を始める前に時間予算を確認する。残り予算が MIN_CONNECTION_BUDGET_MS を
+    // 下回ったら、着手しても空振りになると分かっているので次回に譲る。超過分は次回 cron が
+    // last_synced_at 昇順で最優先に拾う（取りこぼしにはならない）。
+    if (deadlineAt - Date.now() < MIN_CONNECTION_BUDGET_MS) {
       summary.deferred = dueConnections.length - summary.processed - summary.skippedNonPro;
       break;
     }

--- a/apps/product/src/features/external-calendar/server/sync-dispatcher.ts
+++ b/apps/product/src/features/external-calendar/server/sync-dispatcher.ts
@@ -104,10 +104,13 @@ export async function dispatchCalendarSync(params: {
     const forceFullSync = isDailyFullSyncSlot(connection.id, now);
 
     try {
+      // 同じ deadline を接続の内側（カレンダー / ページ単位のループ）にも渡す。この check
+      // だけでは接続と接続の「間」にしか効かないため（#1965、issue の背景を参照）。
       await syncConnection({
         connectionId: connection.id,
         userId: connection.user_id,
         forceFullSync,
+        deadlineAt,
       });
     } catch {
       // token authorityやDB応答が未確定でも、1接続で後続due接続をstarveさせない。

--- a/apps/product/src/features/external-calendar/server/sync-service.ts
+++ b/apps/product/src/features/external-calendar/server/sync-service.ts
@@ -40,6 +40,23 @@ const WINDOW_RADIUS_MS = 90 * 24 * 60 * 60 * 1000;
 /** tombstone UPDATE の 1 バッチあたり件数。URL 長を意識した値。 */
 const TOMBSTONE_BATCH_SIZE = 150;
 
+/**
+ * ページングループ後に確定的に走る永続化（upsert 1 回・tombstone バッチ・token 保存）の
+ * ための予算取り置き（#1965）。adapter へ渡す deadline はこれを引いた値にする — 素の
+ * `deadlineAt` をそのまま渡すと、判定直後に次ページを取りに行かない分岐はあっても、
+ * 直前に取得済みのページの永続化そのものが予算を考慮しないため、大きい応答（cancelled
+ * 集中等）で maxDuration の hard kill に間に合わない run が起きうる
+ * （risk-reviewer 指摘、PR #2075）。
+ *
+ * `2 * DB_REQUEST_TIMEOUT_MS` は「upsert 1 回 + もう 1 回の書き込み（token 保存 or
+ * tombstone 1 バッチ）」の典型ケースを覆う値。tombstone が 1 バッチを超える極端な
+ * cancelled 集中（1 ページに `TOMBSTONE_BATCH_SIZE` を大きく超える cancelled が返る場合）
+ * は、他の worst-case-of-everything 同様に受容する残余リスクとする
+ * （`route-duration-contract.test.ts` の位置づけと同じ — 予算は blast radius の上限で
+ * あって全依存同時ハング時の完走保証ではない）。
+ */
+export const PERSIST_RESERVE_MS = 2 * DB_REQUEST_TIMEOUT_MS;
+
 const PROVIDER = 'google';
 
 /**
@@ -47,6 +64,14 @@ const PROVIDER = 'google';
  *
  * この列は authenticated に SELECT が GRANT されているので、provider の生メッセージや URL を
  * 入れてはいけない（PII / 内部情報の露出）。値域を閉じておき、UI（Step 6）が i18n する。
+ *
+ * **DB 側 allowlist との二重管理に注意**（risk-reviewer 指摘、PR #2075）。fenced sync
+ * writer v1（`supabase/migrations/20260730090017_fenced_calendar_sync_writers.sql` の
+ * `finish_calendar_sync_run_v1`、#2050 系）は `p_last_sync_error` を 5 値
+ * （`encryption_key_invalid` / `partial_failure` / `provider_unavailable` /
+ * `rate_limited` / `reauth_required`）に制限しており、この型の値と自動同期しない。
+ * 現行 sync-service.ts は RPC を経由しない直接書き込みのため今は不発だが、v1 writer へ
+ * 移行する際は allowlist 側にも新値を追加する migration が要る（follow-up issue で追跡）。
  */
 type SyncErrorCode =
   | 'reauth_required'
@@ -300,32 +325,46 @@ export async function syncConnection(params: {
   // 同じ値を使う。anti-join の本体は event-pruning.ts に集約している。
   // best-effort — 失敗しても sync 自体は成功として扱う（fail-closed にすると cleanup 失敗が
   // 同期結果全体を巻き込む）。拾いきれなかった行は次回の sync か disconnect の prune が回収する。
-  try {
-    await deleteUnreferencedEvents({
-      userId,
-      connectionId,
-      scope: { kind: 'window', notBefore: window.timeMin, notAfter: window.timeMax },
-    });
-  } catch (error) {
-    logger.warn('[calendar-sync] failed to prune out-of-window events');
-    captureUnexpectedError(error instanceof Error ? error : new Error('calendar prune failed'), {
-      feature: 'external_calendar',
-      operation: 'sync_window_prune',
-    });
+  //
+  // 予算切れが起きた run ではスキップする。prune は元々 best-effort で必須の後始末ではない
+  // ため、ただでさえ足りない残り予算をここに使うより次回の sync に譲る方が安全（risk-reviewer
+  // 指摘、PR #2075）。
+  if (calendarsIncomplete === 0) {
+    try {
+      await deleteUnreferencedEvents({
+        userId,
+        connectionId,
+        scope: { kind: 'window', notBefore: window.timeMin, notAfter: window.timeMax },
+      });
+    } catch (error) {
+      logger.warn('[calendar-sync] failed to prune out-of-window events');
+      captureUnexpectedError(error instanceof Error ? error : new Error('calendar prune failed'), {
+        feature: 'external_calendar',
+        operation: 'sync_window_prune',
+      });
+    }
   }
 
-  if (calendarsIncomplete > 0) {
-    // 予算切れで一部カレンダーへ着手できなかった／完走できなかった。完走した分の進捗
-    // （calendarsSynced、sync_token）は既に保存済みなので、次回 sync はこのカレンダーから
-    // 再開する。calendarsFailed（実際の失敗）も同時に起きうるが、リトライ導線は共通なので
-    // ここでは区別しない — 予算内で再試行すれば実際の失敗だけが残る形で次回報告される。
-    await writeConnectionError(db, connectionId, userId, 'partial_timeout', runStartedAtIso);
-    return { outcome: 'partial_timeout', calendarsSynced, calendarsFailed };
-  }
-
+  // 実際の失敗（provider / DB エラー）を予算切れより先に報告する。両方が同一 run で
+  // 起きた場合、後者を先に返すと「選択を確認して」という実失敗側の行動喚起が
+  // 「もう一度お試しください」に隠れてしまう（risk-reviewer 指摘、PR #2075）。
   if (calendarsFailed > 0) {
     await writeConnectionError(db, connectionId, userId, 'partial_failure', runStartedAtIso);
     return { outcome: 'partial_failure', calendarsSynced, calendarsFailed };
+  }
+
+  if (calendarsIncomplete > 0) {
+    // 予算切れで一部カレンダーへ着手できなかった／完走できなかった。
+    if (calendarsSynced > 0) {
+      // 部分的に進捗があった（sync_token は完走した分だけ既に確定済み）。次回 sync は
+      // 残りのカレンダーから再開する。last_synced_at を進めて記録する。
+      await writeConnectionError(db, connectionId, userId, 'partial_timeout', runStartedAtIso);
+    }
+    // else: 完全な空振り（1 カレンダーも完走しなかった）。last_synced_at を進めると
+    // due 判定（last_synced_at 昇順）でこの接続が列の最後尾へ回り、starvation 防止の
+    // 順序が無効化される。次回 run が最優先で再試行できるよう、何も書き込まない
+    // （risk-reviewer 指摘、PR #2075）。
+    return { outcome: 'partial_timeout', calendarsSynced, calendarsFailed };
   }
 
   await writeConnectionSuccess(db, connectionId, userId, runStartedAtIso);
@@ -359,13 +398,18 @@ async function syncOneCalendar(args: {
 
   const cursor = forceFullSync ? null : calendar.sync_token;
 
+  // adapter には PERSIST_RESERVE_MS を引いた締切を渡す。素の deadlineAt をそのまま渡すと、
+  // 判定直後に取得したページの永続化（upsert / tombstone / token 保存）自体が予算を
+  // 考慮しないため、maxDuration の hard kill に間に合わない run が起きうる。
+  const adapterDeadlineAt = deadlineAt === undefined ? undefined : deadlineAt - PERSIST_RESERVE_MS;
+
   let result: Awaited<ReturnType<CalendarProviderAdapter['syncCalendar']>>;
   try {
     result = await adapter.syncCalendar(session, {
       calendarId: calendar.provider_calendar_id,
       cursor,
       window,
-      deadlineAt,
+      deadlineAt: adapterDeadlineAt,
     });
 
     if (result.cursorInvalid) {
@@ -375,7 +419,7 @@ async function syncOneCalendar(args: {
         calendarId: calendar.provider_calendar_id,
         cursor: null,
         window,
-        deadlineAt,
+        deadlineAt: adapterDeadlineAt,
       });
     }
   } catch (error) {

--- a/apps/product/src/features/external-calendar/server/sync-service.ts
+++ b/apps/product/src/features/external-calendar/server/sync-service.ts
@@ -53,7 +53,10 @@ type SyncErrorCode =
   | 'rate_limited'
   | 'provider_unavailable'
   | 'encryption_key_invalid'
-  | 'partial_failure';
+  | 'partial_failure'
+  /** wall-clock 予算切れで一部カレンダーへ着手できなかった（#1965）。`partial_failure`
+   * （provider / DB が実際に失敗した）とは区別する — こちらは次回 sync で前進する見込みがある。 */
+  | 'partial_timeout';
 
 // Step 4（tRPC）/ Step 5（cron）が消費者になるまで export しない。呼び出し側は
 // Awaited<ReturnType<typeof syncConnection>> で受け、必要になった時点で export する。
@@ -63,6 +66,7 @@ type SyncOutcome =
   | 'reauth_required'
   | 'encryption_key_invalid'
   | 'partial_failure'
+  | 'partial_timeout'
   | 'not_configured';
 
 type SyncConnectionResult = {
@@ -135,8 +139,14 @@ export async function syncConnection(params: {
   userId: string;
   /** true なら全カレンダーの sync_token を無視して full sync する（overview.md §6-2 の定期 full resync 機構）。 */
   forceFullSync?: boolean;
+  /**
+   * `Date.now()` 換算の締切（ms）（#1965）。省略時は無制限（既存呼び出し互換）。
+   * カレンダー単位・ページ単位の両方のループで尊重される — 呼び出し側は自分の
+   * maxDuration に対する安全マージンを引いた値を渡す（cron の `TIME_BUDGET_MS` と同じ形）。
+   */
+  deadlineAt?: number | undefined;
 }): Promise<SyncConnectionResult> {
-  const { connectionId, userId, forceFullSync = false } = params;
+  const { connectionId, userId, forceFullSync = false, deadlineAt } = params;
   const adapter: CalendarProviderAdapter = googleCalendarAdapter;
   const db = createSyncDbClient();
   const lifecycleVersion = await getConfiguredExternalLifecycleAppVersion();
@@ -245,6 +255,9 @@ export async function syncConnection(params: {
 
   let calendarsSynced = 0;
   let calendarsFailed = 0;
+  // 予算切れで着手できなかった／完走できなかったカレンダー数。calendarsFailed とは区別する
+  // （こちらは provider / DB が実際に失敗したわけではなく、次回 sync で前進する見込みがある）。
+  let calendarsIncomplete = 0;
   let reauthRequired = false;
 
   for (const calendar of calendars) {
@@ -257,10 +270,12 @@ export async function syncConnection(params: {
       window,
       runStartedAtIso,
       forceFullSync,
+      deadlineAt,
     });
 
     if (outcome === 'synced') calendarsSynced += 1;
     else if (outcome === 'reauth_required') reauthRequired = true;
+    else if (outcome === 'deadline_exceeded') calendarsIncomplete += 1;
     else calendarsFailed += 1;
   }
 
@@ -299,6 +314,15 @@ export async function syncConnection(params: {
     });
   }
 
+  if (calendarsIncomplete > 0) {
+    // 予算切れで一部カレンダーへ着手できなかった／完走できなかった。完走した分の進捗
+    // （calendarsSynced、sync_token）は既に保存済みなので、次回 sync はこのカレンダーから
+    // 再開する。calendarsFailed（実際の失敗）も同時に起きうるが、リトライ導線は共通なので
+    // ここでは区別しない — 予算内で再試行すれば実際の失敗だけが残る形で次回報告される。
+    await writeConnectionError(db, connectionId, userId, 'partial_timeout', runStartedAtIso);
+    return { outcome: 'partial_timeout', calendarsSynced, calendarsFailed };
+  }
+
   if (calendarsFailed > 0) {
     await writeConnectionError(db, connectionId, userId, 'partial_failure', runStartedAtIso);
     return { outcome: 'partial_failure', calendarsSynced, calendarsFailed };
@@ -308,7 +332,7 @@ export async function syncConnection(params: {
   return { outcome: 'synced', calendarsSynced, calendarsFailed };
 }
 
-type CalendarSyncOutcome = 'synced' | 'reauth_required' | 'failed';
+type CalendarSyncOutcome = 'synced' | 'reauth_required' | 'deadline_exceeded' | 'failed';
 
 async function syncOneCalendar(args: {
   db: SyncClient;
@@ -319,9 +343,19 @@ async function syncOneCalendar(args: {
   window: SyncWindow;
   runStartedAtIso: string;
   forceFullSync: boolean;
+  deadlineAt?: number | undefined;
 }): Promise<CalendarSyncOutcome> {
-  const { db, adapter, session, connection, calendar, window, runStartedAtIso, forceFullSync } =
-    args;
+  const {
+    db,
+    adapter,
+    session,
+    connection,
+    calendar,
+    window,
+    runStartedAtIso,
+    forceFullSync,
+    deadlineAt,
+  } = args;
 
   const cursor = forceFullSync ? null : calendar.sync_token;
 
@@ -331,6 +365,7 @@ async function syncOneCalendar(args: {
       calendarId: calendar.provider_calendar_id,
       cursor,
       window,
+      deadlineAt,
     });
 
     if (result.cursorInvalid) {
@@ -340,6 +375,7 @@ async function syncOneCalendar(args: {
         calendarId: calendar.provider_calendar_id,
         cursor: null,
         window,
+        deadlineAt,
       });
     }
   } catch (error) {
@@ -372,6 +408,10 @@ async function syncOneCalendar(args: {
     if (result.nextCursor !== null) {
       await saveSyncToken(db, connection, calendar, result.nextCursor, runStartedAtIso);
     }
+
+    // 予算切れで打ち切られた（events/tombstone は取得できた分だけ保存済み）。'synced' に
+    // 含めると、次回 sync が要ることが呼び出し側から見えなくなる。
+    if (result.deadlineExceeded) return 'deadline_exceeded';
 
     return 'synced';
   } catch (error) {

--- a/apps/product/src/lib/mcp/__tests__/trpc-bridge.test.ts
+++ b/apps/product/src/lib/mcp/__tests__/trpc-bridge.test.ts
@@ -29,6 +29,7 @@ describe('createMcpTrpcCaller', () => {
     expect(createCaller).toHaveBeenCalledWith({
       req: { headers: {}, cookies: {} },
       res: {},
+      requestStartedAt: expect.any(Number),
       userId: 'user-1',
       oauthClientId: 'chatgpt',
       oauthScopes: ['read:entries'],

--- a/apps/product/src/lib/mcp/trpc-bridge.ts
+++ b/apps/product/src/lib/mcp/trpc-bridge.ts
@@ -28,6 +28,7 @@ export function createMcpTrpcCaller(input: McpTrpcContextInput) {
       ...(input.signal ? { signal: input.signal } : {}),
     },
     res: {},
+    requestStartedAt: Date.now(),
     userId: input.userId,
     oauthClientId: input.clientId,
     oauthScopes: input.scopes,

--- a/apps/product/src/lib/test/trpc-test-helpers.ts
+++ b/apps/product/src/lib/test/trpc-test-helpers.ts
@@ -42,6 +42,8 @@ interface MockContextOptions {
   oauthExecution?: Context['oauthExecution'];
   mfaAssurance?: Context['mfaAssurance'];
   supabaseOverrides?: Partial<MockSupabaseClient>;
+  /** 省略時は呼び出し時点の `Date.now()`。予算 anchor のテストで固定値を注入する。 */
+  requestStartedAt?: number;
 }
 
 /**
@@ -118,6 +120,7 @@ export function createMockContext(options: MockContextOptions = {}): Context {
     oauthExecution,
     mfaAssurance,
     supabaseOverrides,
+    requestStartedAt = Date.now(),
   } = options;
 
   const mockSupabase = createMockSupabase(supabaseOverrides);
@@ -136,6 +139,7 @@ export function createMockContext(options: MockContextOptions = {}): Context {
       setHeader: vi.fn(),
       end: vi.fn(),
     } as unknown as Context['res'],
+    requestStartedAt,
     userId,
     sessionId,
     oauthClientId,

--- a/apps/product/src/lib/trpc/context.ts
+++ b/apps/product/src/lib/trpc/context.ts
@@ -42,6 +42,15 @@ export interface TrpcResponseLike {
 export interface Context {
   req: TrpcRequestLike;
   res: TrpcResponseLike;
+  /**
+   * この request の handler が呼ばれた時刻（`Date.now()` 換算、ms）。
+   *
+   * `externalCalendar.syncNow` / `updateSelectedCalendars`（#1965）が wall-clock 予算の
+   * anchor に使う。auth 解決・rate limit 等より前に確定させないと、それらの所要時間
+   * （worst case で数十秒）が予算計算から抜け落ち、maxDuration を超過しうる
+   * （risk-reviewer 指摘、PR #2075）。
+   */
+  requestStartedAt: number;
   userId?: string | undefined;
   sessionId?: string | undefined;
   supabase: SupabaseClient<Database>;
@@ -75,8 +84,9 @@ export interface Context {
 async function createTRPCContext(opts: {
   req: TrpcRequestLike;
   res: TrpcResponseLike;
+  requestStartedAt: number;
 }): Promise<Context> {
-  const { req, res } = opts;
+  const { req, res, requestStartedAt } = opts;
 
   // リクエストヘッダーから認証モードを自動検出
   const authMode = detectAuthMode(req.headers as Record<string, string>);
@@ -210,6 +220,7 @@ async function createTRPCContext(opts: {
   return {
     req,
     res,
+    requestStartedAt,
     userId,
     sessionId,
     accessToken,
@@ -224,6 +235,8 @@ async function createTRPCContext(opts: {
 
 /** Fetch API用tRPCコンテキスト作成（App Router Route Handler向け） */
 export async function createFetchTRPCContext(opts: FetchCreateContextFnOptions): Promise<Context> {
+  // handler が呼ばれた直後、auth 解決より前に anchor する（Context.requestStartedAt 参照）。
+  const requestStartedAt = Date.now();
   const req = createRequestLike(opts.req);
   if (detectAuthMode(req.headers as Record<string, string>) === 'oauth') {
     // Dayopt発行のopaque tokenを受理する公開HTTP境界は /api/mcp だけに固定する。
@@ -238,6 +251,7 @@ export async function createFetchTRPCContext(opts: FetchCreateContextFnOptions):
   return createTRPCContext({
     req,
     res: { headers: opts.resHeaders },
+    requestStartedAt,
   });
 }
 

--- a/apps/product/src/lib/trpc/server.ts
+++ b/apps/product/src/lib/trpc/server.ts
@@ -80,6 +80,7 @@ async function createServerContext(): Promise<Context> {
   return {
     req: {} as Context['req'],
     res: {} as Context['res'],
+    requestStartedAt: Date.now(),
     userId,
     sessionId,
     mfaAssurance,


### PR DESCRIPTION
## 概要

`syncConnection` にカレンダー単位・ページ単位の wall-clock 予算（`deadlineAt`）を持たせ、tRPC route の `maxDuration` を 300→60 に下げる（#1965）。あわせて OAuth callback で Google の authorization code を消費する前に残り予算を検査し、不足時は code 未消費のまま安全に失敗させる（#1990）。両方とも「不可逆な操作（code 消費 / 無制限のページング）の前に、完走できる見込みを確認してから進む」という同じ設計原則。

## 変更内容

### #1965: syncConnection の予算化
- `providers/google.ts` の `syncCalendar` ページングループの先頭で `deadlineAt` 超過を判定し、次ページを Google へ要求する前に打ち切る。既存の `MAX_EVENT_PAGES` 到達時と同じ「cursor を確定しない安全な部分完了」契約を再利用
- `sync-service.ts`: 予算切れを新 outcome `'partial_timeout'` として、実際の失敗（`'partial_failure'`）と区別
- `sync-dispatcher.ts`（cron）/ `router.ts`（`syncNow` / `updateSelectedCalendars`）から `deadlineAt` を配線
- tRPC route `maxDuration`: 300 → 60
- UI（`GoogleCalendarSettings.tsx`）と i18n（en/ja）に `partial_timeout` の文言を追加

### #1990: callback の code 消費前予算検査
- `callback/route.ts`: route 入口で `deadlineAt` を計算し、`exchangeAuthorizationCode`（code 消費）の直前で残り予算が `POST_EXCHANGE_BUDGET_MS`（= token 交換の worst case + DB 書き込み 2 回の worst case）を下回っていたら `budget_exhausted` で戻す
- `maxDuration`: 120 → 60
- `calendar-callback-result.ts` / `[category]/page.tsx` / i18n に `budget_exhausted` を追加

## push 前セルフレビュー（behavior-verifier）

7 観点で反証レビューを実施し、指摘 2 件に対応済み:
1. callback route の予算閾値が token 交換自体の worst case（`TOKEN_REQUEST_TIMEOUT_MS`）を含んでおらず理論上 `maxDuration` を超過しうる穴があったため、`TOKEN_REQUEST_TIMEOUT_MS + 2*CALENDAR_CONNECTION_DB_TIMEOUT_MS`（45s）へ修正
2. `reauth_required` と `deadline_exceeded` が同一 run で両方起きるケースの回帰テストを追加

## 検証

- `pnpm exec tsc --noEmit`: pass
- `pnpm lint` / `pnpm lint:boundaries` / `pnpm lint:i18n` / `pnpm copy:check`: pass
- 対象テスト 367 件 green

Closes #1965
Closes #1990