### PR TITLE
fix(external-calendar): listCalendars の in-flight リクエストが deadline を overshoot しないようにする

### DIFF
--- a/apps/product/src/features/external-calendar/server/__tests__/google-provider.test.ts
+++ b/apps/product/src/features/external-calendar/server/__tests__/google-provider.test.ts
@@ -685,6 +685,26 @@ describe('googleCalendarAdapter.listCalendars', () => {
     }
   });
 
+  // #2089 内製クロスレビュー指摘: page loop の deadline チェックと実際のリクエスト送信の間に
+  // わずかでも時間が経つと、残り予算が負になりうる。Math.max(0, ...) のクランプが無いと
+  // 負の ms が AbortSignal.timeout に渡ってしまう分岐を直接固定する。
+  it('deadline チェック直後に残り予算が負になっても signal timeout は 0 にクランプする', async () => {
+    fetchMock().mockResolvedValueOnce(jsonResponse({ items: [] }));
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+    const nowSpy = vi
+      .spyOn(Date, 'now')
+      .mockReturnValueOnce(9_999) // page loop の deadline チェック: まだ通過
+      .mockReturnValueOnce(10_001); // signal timeout 計算時点では既に締切を超過している
+
+    try {
+      await googleCalendarAdapter.listCalendars(SESSION, 10_000);
+      expect(timeoutSpy).toHaveBeenCalledWith(0);
+    } finally {
+      nowSpy.mockRestore();
+      timeoutSpy.mockRestore();
+    }
+  });
+
   it('deadlineAt が無ければ signal の timeout は従来どおり GOOGLE_API_TIMEOUT_MS のまま', async () => {
     fetchMock().mockResolvedValueOnce(jsonResponse({ items: [] }));
     const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');

--- a/apps/product/src/features/external-calendar/server/__tests__/google-provider.test.ts
+++ b/apps/product/src/features/external-calendar/server/__tests__/google-provider.test.ts
@@ -14,7 +14,7 @@ vi.mock('@/lib/logger', () => ({
 }));
 vi.mock('@/lib/sentry', () => ({ captureUnexpectedError }));
 
-import { googleCalendarAdapter } from '../providers/google';
+import { GOOGLE_API_TIMEOUT_MS, googleCalendarAdapter } from '../providers/google';
 import { CalendarProviderError, type ProviderSession } from '../providers/types';
 
 const SESSION: ProviderSession = { accessToken: 'access-token-abc', rotatedRefreshToken: null };
@@ -433,6 +433,7 @@ describe('googleCalendarAdapter.syncCalendar', () => {
     const nowSpy = vi
       .spyOn(Date, 'now')
       .mockReturnValueOnce(0) // 1 ページ目の判定: まだ余裕がある
+      .mockReturnValueOnce(0) // 1 ページ目のリクエストの signal timeout 計算（#2089）
       .mockReturnValueOnce(deadlineAt); // 2 ページ目の判定: 締切に達した
 
     const result = await googleCalendarAdapter.syncCalendar(SESSION, {
@@ -652,6 +653,7 @@ describe('googleCalendarAdapter.listCalendars', () => {
     const nowSpy = vi
       .spyOn(Date, 'now')
       .mockReturnValueOnce(0) // 1 ページ目の判定: まだ余裕がある
+      .mockReturnValueOnce(0) // 1 ページ目のリクエストの signal timeout 計算（#2089）
       .mockReturnValueOnce(deadlineAt); // 2 ページ目の判定: 締切に達した
 
     try {
@@ -662,6 +664,75 @@ describe('googleCalendarAdapter.listCalendars', () => {
     } finally {
       nowSpy.mockRestore();
     }
+  });
+
+  // #2089: 各ページ送信「前」の deadline チェックを通過した直後の 1 リクエストが、固定 15s の
+  // signal timeout のせいで deadline を大きく超えて走り続けないことを固定する。
+  it('deadline 直前では signal の timeout を残り予算まで絞る', async () => {
+    fetchMock().mockResolvedValueOnce(
+      jsonResponse({ items: [{ id: 'primary', summary: 'Work' }] }),
+    );
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(9_900);
+
+    try {
+      await googleCalendarAdapter.listCalendars(SESSION, 10_000);
+      // 残り予算 100ms < GOOGLE_API_TIMEOUT_MS なので、signal の timeout は 100ms に絞られる
+      expect(timeoutSpy).toHaveBeenCalledWith(100);
+    } finally {
+      nowSpy.mockRestore();
+      timeoutSpy.mockRestore();
+    }
+  });
+
+  it('deadlineAt が無ければ signal の timeout は従来どおり GOOGLE_API_TIMEOUT_MS のまま', async () => {
+    fetchMock().mockResolvedValueOnce(jsonResponse({ items: [] }));
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+
+    try {
+      await googleCalendarAdapter.listCalendars(SESSION);
+      expect(timeoutSpy).toHaveBeenCalledWith(GOOGLE_API_TIMEOUT_MS);
+    } finally {
+      timeoutSpy.mockRestore();
+    }
+  });
+
+  // #2089: 送信前チェックを通過した直後に rate limit された場合、in-flight リクエスト自体は
+  // signal timeout で締切近くに収まるが、retry の sleep（最大 base+jitter=2s）を律儀に待つと
+  // そこで deadline を超過する。残り予算が sleep 下限にも満たないなら retry せず即座に投げ、
+  // 総経過時間を deadline 付近に抑える。
+  it('deadline 直前で rate limit されたら retry の sleep をスキップし、即座にエラーを返す', async () => {
+    fetchMock().mockResolvedValue(googleError('userRateLimitExceeded', 429));
+    vi.useFakeTimers();
+    const deadlineAt = Date.now() + 10; // retry の base sleep（1s）にも満たない残り予算
+
+    const promise = googleCalendarAdapter
+      .listCalendars(SESSION, deadlineAt)
+      .catch((error: unknown) => error);
+
+    // retry の sleep（最大 base+jitter=2s）が仮にスケジュールされていても使い切れる時間だけ
+    // 進める。それでも 2 回目の fetch が起きなければ、sleep 自体がスケジュールされなかった証拠。
+    await vi.advanceTimersByTimeAsync(2_000);
+    const error = await promise;
+
+    expect(fetchMock()).toHaveBeenCalledTimes(1);
+    expect(error).toBeInstanceOf(CalendarProviderError);
+    expect((error as CalendarProviderError).kind).toBe('rate_limited');
+  });
+
+  it('残余予算が十分にあれば、rate limit を従来どおり 1 回リトライする', async () => {
+    fetchMock()
+      .mockResolvedValueOnce(googleError('userRateLimitExceeded', 429))
+      .mockResolvedValueOnce(jsonResponse({ items: [{ id: 'primary', summary: 'Work' }] }));
+    vi.useFakeTimers();
+    const deadlineAt = Date.now() + 60_000; // 十分な残余予算
+
+    const promise = googleCalendarAdapter.listCalendars(SESSION, deadlineAt);
+    await vi.runAllTimersAsync();
+    const calendars = await promise;
+
+    expect(fetchMock()).toHaveBeenCalledTimes(2);
+    expect(calendars).toEqual([{ id: 'primary', name: 'Work', primary: false }]);
   });
 
   it('deadlineAt が既に過ぎていれば最初のページも取得しない', async () => {

--- a/apps/product/src/features/external-calendar/server/providers/google.ts
+++ b/apps/product/src/features/external-calendar/server/providers/google.ts
@@ -186,10 +186,15 @@ async function requestWithRateLimitRetry(
   } catch (error) {
     if (!(error instanceof CalendarProviderError) || error.kind !== 'rate_limited') throw error;
 
-    // 残り予算が retry の sleep 下限（RATE_LIMIT_RETRY_BASE_MS）にも満たないなら retry しない。
-    // ここで粘っても deadline 超過が確定しているだけなので、次回 run に委ねたほうが良い
-    // （RATE_LIMIT_RETRY_BASE_MS のコメントと同じ「粘るより次回 cron へ」の方針。#2089）。
-    if (deadlineAt !== undefined && deadlineAt - Date.now() <= RATE_LIMIT_RETRY_BASE_MS) {
+    // 残り予算が retry の sleep の最大値（base + jitter 上限）にも満たないなら retry しない。
+    // 閾値を sleep 下限（base）だけにすると、jitter が上振れた場合に sleep だけで deadline を
+    // 最大 jitter 分（~1s）超過しうる（内製クロスレビュー指摘、#2089）。ここで粘っても
+    // deadline 超過が確定しているだけなので、次回 run に委ねたほうが良い
+    // （RATE_LIMIT_RETRY_BASE_MS のコメントと同じ「粘るより次回 cron へ」の方針）。
+    if (
+      deadlineAt !== undefined &&
+      deadlineAt - Date.now() <= RATE_LIMIT_RETRY_BASE_MS + RATE_LIMIT_RETRY_JITTER_MS
+    ) {
       throw error;
     }
 

--- a/apps/product/src/features/external-calendar/server/providers/google.ts
+++ b/apps/product/src/features/external-calendar/server/providers/google.ts
@@ -128,12 +128,28 @@ function classifyStatus(status: number, reason: string | undefined): CalendarPro
   return 'permanent';
 }
 
-async function requestGoogleApi(url: URL, accessToken: string): Promise<unknown> {
+/**
+ * `deadlineAt` までの残り予算と `GOOGLE_API_TIMEOUT_MS` の小さい方を signal の timeout にする。
+ *
+ * page loop の deadline チェック（syncCalendar / listCalendars）は各リクエスト送信「前」にしか
+ * 判定しないため、これが無いとチェック通過直後の 1 リクエストが deadline を大きく超えて
+ * 走り続けうる（#2089）。`deadlineAt` 未指定（無制限呼び出し）では従来どおり固定 15s のまま。
+ */
+function requestTimeoutMs(deadlineAt: number | undefined): number {
+  if (deadlineAt === undefined) return GOOGLE_API_TIMEOUT_MS;
+  return Math.max(0, Math.min(GOOGLE_API_TIMEOUT_MS, deadlineAt - Date.now()));
+}
+
+async function requestGoogleApi(
+  url: URL,
+  accessToken: string,
+  deadlineAt?: number,
+): Promise<unknown> {
   let response: Response;
   try {
     response = await fetch(url, {
       headers: { authorization: `Bearer ${accessToken}` },
-      signal: AbortSignal.timeout(GOOGLE_API_TIMEOUT_MS),
+      signal: AbortSignal.timeout(requestTimeoutMs(deadlineAt)),
     });
   } catch {
     throw new CalendarProviderError('google calendar api is unreachable', 'transient');
@@ -160,14 +176,25 @@ async function requestGoogleApi(url: URL, accessToken: string): Promise<unknown>
 }
 
 /** レート制限のときだけ 1 回リトライする。 */
-async function requestWithRateLimitRetry(url: URL, accessToken: string): Promise<unknown> {
+async function requestWithRateLimitRetry(
+  url: URL,
+  accessToken: string,
+  deadlineAt?: number,
+): Promise<unknown> {
   try {
-    return await requestGoogleApi(url, accessToken);
+    return await requestGoogleApi(url, accessToken, deadlineAt);
   } catch (error) {
     if (!(error instanceof CalendarProviderError) || error.kind !== 'rate_limited') throw error;
 
+    // 残り予算が retry の sleep 下限（RATE_LIMIT_RETRY_BASE_MS）にも満たないなら retry しない。
+    // ここで粘っても deadline 超過が確定しているだけなので、次回 run に委ねたほうが良い
+    // （RATE_LIMIT_RETRY_BASE_MS のコメントと同じ「粘るより次回 cron へ」の方針。#2089）。
+    if (deadlineAt !== undefined && deadlineAt - Date.now() <= RATE_LIMIT_RETRY_BASE_MS) {
+      throw error;
+    }
+
     await sleep(RATE_LIMIT_RETRY_BASE_MS + Math.floor(Math.random() * RATE_LIMIT_RETRY_JITTER_MS));
-    return await requestGoogleApi(url, accessToken);
+    return await requestGoogleApi(url, accessToken, deadlineAt);
   }
 }
 
@@ -370,7 +397,7 @@ async function syncCalendar(
 
     let payload: unknown;
     try {
-      payload = await requestWithRateLimitRetry(url, session.accessToken);
+      payload = await requestWithRateLimitRetry(url, session.accessToken, params.deadlineAt);
     } catch (error) {
       if (error instanceof CalendarProviderError && error.kind === 'cursor_invalid') {
         // 呼び出し側が cursor を捨てて full sync をやり直す。途中まで集めた分は
@@ -470,7 +497,7 @@ async function listCalendars(
     const url = new URL(`${GOOGLE_CALENDAR_API_BASE}/users/me/calendarList`);
     if (pageToken !== null) url.searchParams.set('pageToken', pageToken);
 
-    const payload = await requestWithRateLimitRetry(url, session.accessToken);
+    const payload = await requestWithRateLimitRetry(url, session.accessToken, deadlineAt);
     const parsed = googleCalendarListResponseSchema.safeParse(payload);
     if (!parsed.success) {
       throw new CalendarProviderError(


### PR DESCRIPTION
## 背景

PR #2087（#2079: listProviderCalendars の wall-clock 予算化）のクロスレビュー（risk-reviewer 指摘、指揮台採用）で検出（#2089）。

`listCalendars`（`providers/google.ts`）の deadline チェックは各ページの**リクエスト送信前**にしか判定しない。判定を通過した後の1リクエストは `AbortSignal.timeout(GOOGLE_API_TIMEOUT_MS)`（15s）+ rate limit 時の1回リトライ（backoff 1-2s + もう1回15s）で最悪 ~32s かかりうる。`api/trpc/[trpc]` route の `maxDuration=60` を超えるため、この経路では結局 hard kill されうる。

## やったこと

構造的に閉じる案（class 解）: `requestGoogleApi`（`providers/google.ts`）に渡す `AbortSignal` を、固定の `GOOGLE_API_TIMEOUT_MS` ではなく残り予算（`deadlineAt - Date.now()`）と `GOOGLE_API_TIMEOUT_MS` の小さい方から作るよう変更した。`requestGoogleApi` / `requestWithRateLimitRetry` は `syncCalendar` と `listCalendars` の共有関数のため、この修正は両方に効く。

rate limit retry の sleep 側にも、残り予算が sleep の実際の上限（`RATE_LIMIT_RETRY_BASE_MS` + `RATE_LIMIT_RETRY_JITTER_MS`）に満たなければ retry せず即座に throw するガードを追加し、sleep だけで deadline を超過する隙間を閉じた（push 前の内製クロスレビューで、当初 sleep 下限のみを閾値にしていた指摘を受けて修正）。

`deadlineAt` が渡されない（無制限）呼び出しでは、`Date.now()` の追加呼び出し自体が発生せず挙動が変わらないことをテストで固定した。

## 検証

- deadline 直前で rate limit された場合に retry の sleep がスキップされ、総経過時間が deadline 付近に抑えられることを固定する test
- signal の timeout が残り予算に絞られること／`deadlineAt` 未指定では従来どおり `GOOGLE_API_TIMEOUT_MS` のままであることを固定する test
- 残余予算が十分にあれば従来どおり1回リトライする regression test
- page loop の deadline チェック直後に残り予算が負になっても signal timeout が 0 にクランプされることを固定する test（内製クロスレビュー指摘）
- 既存の `wall-clock 予算を超えたら次ページを取りに行かず deadline_exceeded を throw する` 系 test 群（syncCalendar / listCalendars 両方）への影響なし

`pnpm vitest run` 対象ファイル 50/50 pass、`tsc --noEmit` / `eslint`（対象ファイル）ともにエラーなし。

## レビュー

push 前に `behavior-verifier` へ反証レビューを実施済み（blocker無し）。指摘2件（retry-skip 閾値と sleep 上限の不一致、負残余クランプ分岐の test 欠如）は同一 round で反映済み。

Closes #2089