### PR TITLE
docs(gardening): 2026年8月 月次ガーデニング journal（自動パート代行）

### DIFF
--- a/docs/business/channels/reddit.md
+++ b/docs/business/channels/reddit.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_verified: 2026-07-14
+last_verified: 2026-08-17
 ---
 
 # Reddit

--- a/docs/business/channels/x.md
+++ b/docs/business/channels/x.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_verified: 2026-07-14
+last_verified: 2026-08-17
 ---
 
 # X (Twitter)

--- a/docs/business/pricing.md
+++ b/docs/business/pricing.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_verified: 2026-07-14
+last_verified: 2026-08-17
 code:
   - packages/billing/src/pricing.ts
   - packages/billing/src/plans.ts

--- a/docs/engineering/accessibility.md
+++ b/docs/engineering/accessibility.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_verified: 2026-07-03
+last_verified: 2026-08-17
 code: apps/product/src
 ---
 
@@ -12,11 +12,11 @@ Dayopt のアクセシビリティ対応基準と実装パターン。基準ス�
 
 ## 基準スコア
 
-| ツール                 | 基準      | タイミング             |
-| ---------------------- | --------- | ---------------------- |
-| Lighthouse CI          | 95点以上  | mainマージ時にチェック |
-| eslint-plugin-jsx-a11y | エラー0件 | コミット時にチェック   |
-| axe-core               | 警告確認  | 開発時にコンソール表示 |
+| ツール                 | 基準      | タイミング                            |
+| ---------------------- | --------- | ------------------------------------- |
+| Lighthouse CI          | 90点以上  | `pnpm perf:lighthouse`（手動実行）    |
+| eslint-plugin-jsx-a11y | エラー0件 | コミット時（lint-staged）+ CI の lint |
+| axe-core               | 警告確認  | 開発時にコンソール表示                |
 
 ## WCAG AA コントラスト基準
 
@@ -35,21 +35,21 @@ Dayopt のアクセシビリティ対応基準と実装パターン。基準ス�
 - [ ] フォーカス状態が視覚的に明確
 - [ ] キーボードで操作可能（Tab, Enter, Space, Escape）
 - [ ] カラーコントラストがWCAG AA準拠（4.5:1以上）
-- [ ] `npm run a11y:check` がパス
+- [ ] `pnpm lint` がパス（jsx-a11y ルールを含む）
 
 ### PR作成前
 
-- [ ] `npm run lint` がパス
+- [ ] `pnpm lint` がパス
 - [ ] 開発サーバーでaxe-coreの警告を確認
 - [ ] Tabキーで全要素にアクセス可能
 - [ ] スクリーンリーダーでテスト（VoiceOver / NVDA）
 
 ## コマンド
 
-| コマンド             | 説明                            |
-| -------------------- | ------------------------------- |
-| `npm run a11y:check` | ESLint jsx-a11yルールでチェック |
-| `npm run a11y:full`  | 自動修正付きチェック            |
+| コマンド               | 説明                                    |
+| ---------------------- | --------------------------------------- |
+| `pnpm lint`            | ESLint（jsx-a11yルール含む）でチェック  |
+| `pnpm perf:lighthouse` | Lighthouse CI（accessibility 90点以上） |
 
 ## 参考リンク
 
@@ -94,7 +94,7 @@ shadcn/ui（Radix UI）コンポーネントの a11y 対応状況。
 OSの「視覚効果を減らす」設定を検出。
 
 ```tsx
-import { useReducedMotion } from '@/hooks/useReducedMotion';
+import { useReducedMotion } from '@/features/calendar/hooks/accessibility/useReducedMotion';
 
 function AnimatedComponent() {
   const prefersReducedMotion = useReducedMotion();
@@ -189,7 +189,7 @@ className = 'aria-disabled:pointer-events-none aria-disabled:opacity-50';
 </main>
 ```
 
-> Dayoptでは `src/components/layout/base-layout-content.tsx` で実装済み。
+> Dayoptでは `src/app/[locale]/(app)/_shell/base-layout-content.tsx` で実装済み。
 
 ### 基本キー
 

--- a/docs/engineering/i18n.md
+++ b/docs/engineering/i18n.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_verified: 2026-07-14
+last_verified: 2026-08-17
 ---
 
 # i18n ガイド — Copy System + next-intl adapter
@@ -74,9 +74,9 @@ apps/
 ├── product/
 │   ├── messages/
 │   │   ├── en/   auth.json, calendar.json, common.json, contact.json,
-│   │   │         email.json, entry.json, error.json, legal.json,
-│   │   │         navigation.json, oauth.json, record.json,
-│   │   │         settings.json, sidebar.json, tags.json
+│   │   │         email.json, error.json, legal.json, navigation.json,
+│   │   │         oauth.json, settings.json, shortcuts.json, sidebar.json,
+│   │   │         tags.json, timeblock.json
 │   │   └── ja/   (同構造)
 │   └── src/lib/i18n/
 │       ├── request.ts        # namespace 自動検出、メッセージロード
@@ -164,7 +164,7 @@ t('toolbar.today'); // → calendar.toolbar.today
 
 ## ネームスペース一覧
 
-### apps/product（13 namespace）
+### apps/product（14 namespace）
 
 | ネームスペース | 用途                                              |
 | -------------- | ------------------------------------------------- |
@@ -173,15 +173,15 @@ t('toolbar.today'); // → calendar.toolbar.today
 | `common`       | 共通 UI（複数トップレベルキーを持つ例外ファイル） |
 | `contact`      | お問い合わせ                                      |
 | `email`        | メールテンプレート                                |
-| `entry`        | エントリ機能                                      |
 | `error`        | グローバルエラー                                  |
 | `legal`        | 法的文書                                          |
 | `navigation`   | ナビゲーション                                    |
 | `oauth`        | OAuth 認証                                        |
-| `record`       | レコード                                          |
 | `settings`     | 設定画面                                          |
+| `shortcuts`    | キーボードショートカット                          |
 | `sidebar`      | サイドバー                                        |
 | `tags`         | タグ機能                                          |
+| `timeblock`    | タイムブロック（プラン/レコード共通の編集 UI）    |
 
 ### apps/web（4 namespace）
 

--- a/docs/engineering/log/2026-08-01-journal.md
+++ b/docs/engineering/log/2026-08-01-journal.md
@@ -1,0 +1,150 @@
+---
+status: frozen
+date: 2026-08-01
+last_verified: 2026-08-17
+---
+
+# 2026年8月 Journal
+
+## 2026-08-17 — 月次ガーデニング（自動パート代行）
+
+Routine（`.claude/skills/gardening/SKILL.md` 自動パート）の初回 scheduled 実行は 2026-09-01 予定（Routine化自体が 2026-08-09 導入のため）。当月 5 日を過ぎても journal の draft PR が存在しなかったため、User の指示により指揮台配下のレーンが自動パート（step 1〜9）を代行した。**価値判断（ルールの足し引き・superseded 判定・削除候補の確定）は一切行わず、すべてレビュー待ちリストへ回した。**
+
+### 前月（7月）の蒸留
+
+2026年7月は日次 diary（6月の `2026-06-01-journal.md` 形式）を維持していなかったため、`git log --merges`（マージ commit 244件）、`gh pr list --state merged`（実測155件）、`gh issue list --state closed`（実測151件）、`docs/engineering/log/2026-07-*.md` 全28ファイルから当月ダイジェストを新規に組み立てた。
+
+#### エンジニアリング領域のテーマ（主要9件）
+
+1. **time-model-split（entries → plans/logs/external_calendar_events）**: Plan/Record への entity 再設計。8段階のfeat/refactorシリーズ（PR #1552, #1554, #1557, #1570-1577, #1581, #1584）。旧 `features/entry` を `features/timeblock` へ改名（ADR-027）。chronotype/充実度（fulfillment）の完全撤去も同時期（PR #1626, #1635, #1637）
+2. **Actions課金の実測駆動最適化とPR粒度の反転**: repo private化（PR #1732）を機に実測（job統合11→4、Docs Guard 4→1、main push CI廃止）を実施し、「PR本数がコストの支配変数（PR 1本≈44課金分、O(N²)で並行コスト増）」という結論から、PR粒度の既定を「1 issue=1 PR」から「機能単位で束ねる」へ反転（`2026-07-26-pr-granularity-actions-cost.md`）
+3. **内製AIレビューpipeline（ai-review）の新設と堅牢化**: Gemini 3.1 Pro有料枠 + 危険クラスpath限定の自前pipelineを新設（PR #1747, #1755）。無料枠は「Proモデルが無料枠に存在しない」ため却下（7/27）。`pull_request_target`化・concurrency/timeout不等式・sticky comment認証の3件の踏み抜きを追加で修正（7/30、PR #1767）。この一連が 2026-08-13 の内製クロスレビュー全面移行の前段
+4. **Secrets/MCP/env境界の一本化**: MCP定義をrepoから撤去しglobal設定へ一本化（`2026-07-23-mcp-global-consolidation.md`）。env fileへのAIアクセス制限をnarrow化
+5. **worktree/branch運用の統一と指揮台モデルの確立**: branch命名統一・`pnpm branch:finish`ワンセット化 → main checkoutを「常にmainに置く指揮台」に固定する判断（`2026-07-30-main-checkout-role.md`）。進捗はissue・設計はdocsに分離する運用も同日確定
+6. **Supabase migration/schema運用の文書化**: baseline squash計画を確定するも実施は見送り（142migration中51件が是正系、`2026-07-23-migration-baseline-squash-plan.md`）
+7. **認証・セキュリティ強化とdependabot対応**: SECURITY DEFINER RPCのuser_id検証等 security fix 5連発（PR #1466-1510）。7/27にはGoogle単独ログイン化・認証メールpipeline全欠陥修復（PR #1744-1746）
+8. **Vercel deployment policy適用と実効性検証**: 7/14に決定するもHobbyプランでは未適用、7/24 Pro移行後に適用、7/31に両アプリでBLOCKED応答を実地確認しenforcement有効化を確定
+9. **docs構造の全面再編（ADR-024）**: `docs/`をストック/ログに分離する大規模再編（PR #1451, #1456）
+
+#### product 領域
+
+time-model-split（ADR-025）とアナリティクス方針の限定（ADR-026: 見積もり係数・差分・週次補正の3点のみ）から始まり、実装後の calendar UI feedback ラッシュ（07-14〜07-17、約25件）に移行した。傾向は「旧UI残骸の一掃」「Plan/Recordの2レーン表現への統一」。block-search は3回 supersede（複製UI統合→開くだけに限定→タグ+メモへ対象を揃える）という連鎖収束を経て確定。sidebar footer/help メニューも4回連続で配置修正が入った。7/27 note では公開 docs が未実装機能（Energy Mapping・AI Reflection等）を主張していたことが監査で発覚し修正済み。
+
+#### operations 領域
+
+19件中14件がincident/audit系。約半数（7件）が secrets/env/deployment設定の齟齬に起因（Vercel scope監査2件、Upstash env欠落、Resend From domain連鎖3件、Supabase migration停止、Auth本番設定）。7/21のResend関連3件は同一事象の連鎖（後者が前者を`superseded_by`で訂正）。もう一つの塊は本番schemaとmigration履歴の乖離（7/08→7/12→7/16）で、いずれも「migration履歴上は適用済みでも物理schemaと不一致」という同型パターン。7/27には認証メールパイプラインで4段独立の欠陥が連鎖検出された。
+
+#### business 領域
+
+創業者監査(07-05): 本番DB実測（ユーザー2名、直近30日新規登録0）を基に、市場接触ゼロ・未検証前提6件・手戻りリスク5件を洗い出し、7/30/90日の実行方針を決定。公開コンテンツ4件(07-23〜07-27): releases→blog統合、LP-docs乖離監査で別製品テンプレの誤公開発見（`pnpm docs:coverage`新設）、docs第1階層のタスクベース再編、FAQのみURL階層化。
+
+#### 主要な決定（根拠ファイル付き）
+
+- MCP定義はglobal設定のみを正とし、repoから全撤去 — `2026-07-23-mcp-global-consolidation.md`
+- PR粒度の既定を「機能のまとまり単位で束ねる」へ反転 — `2026-07-26-pr-granularity-actions-cost.md`
+- ai-reviewは有料枠+Gemini 3.1 Proで運用し、無料枠は不採用 — `2026-07-27-ai-review-free-tier-rejected.md`
+- main checkoutを指揮台に固定し、規模によらず全コード変更をworktreeで行う — `2026-07-30-main-checkout-role.md`
+- 進捗はissue、設計の中身はdocsに分離 — `2026-07-30-issue-docs-split.md`
+- baseline squashは計画のみ確定し実施は次のリリース境界まで待つ — `2026-07-23-migration-baseline-squash-plan.md`
+
+#### 主要な学び
+
+- CI最適化は「stepの秒数から按分推定」ではなく変更前後の複数回実測で判断する（coverage廃止の見積もりを2回下方修正し最終的に効果ゼロと判明）
+- `pull_request`トリガーはworkflowファイル自体がPR管理下にあるため、scriptだけbase版に差し替えても secret 持ち出しは防げない。`pull_request_target`が必須
+- `gh pr checks`は同名checkを畳むが`statusCheckRollup`は畳まない — merge gateの偽陽性/偽陰性の温床
+- Supabase型生成は`stripe_webhook_events.status`のCHECK制約リテラルユニオンを推論しない既知quirk
+- 機能削除の順序規律（コード削除→deploy→Sentry確認→migration drop）は前回squashで写経漏れの実障害を出しており、今回のsquash計画にも明示的リスク項目として組み込まれた
+
+#### 数値（Actions経済メトリクス）
+
+- 7月マージPR数: **155件**（`gh pr list --state merged`実測）。git merge commit数244件のうち「Merge pull request #」形式は147件
+- 7月close issue数: **151件**（`gh issue list --state closed`実測）
+- Actions実行run数（実測、全workflow・全トリガー種別）: **2,340件**
+- Actions課金概算: `.claude/rules/workflow.md`記載の実測比率（PR 1本≈44課金分）を155PRに外挿すると **約6,820課金分/月**。7/24〜26にjob統合・PR粒度反転が発生しており月内で単価が変動しているため上振れ/下振れ双方の余地がある概算値（run単位の実測2,340件との直接突合せは未実施）
+
+### 外部レビュー指摘の class 分類 → 機械化変換
+
+7月マージPR（外部レビューは Codex、内製クロスレビュー全面移行は 2026-08-13）から review 活性度の高い15件をサンプリングして分類した。
+
+- **TZ再解釈（壁時計/instant）**: #1620に2指摘。既知class、既存issue #2017で既に機械化対応済み。**新規issue不要**
+- **Release scriptのTOCTOU/staleness再検証漏れ**: #1712に多数の同型指摘。`.claude/rules/workflow.md` §同型指摘の打ち切り が明示する既知class、`docs/engineering/infra.md` §release の並行性モデル に境界明文化済み。**新規issue不要**
+- **migration/backfillのstaleness・重複state未検証**: #1554/#1557/#1584（time-model-split epic内）で3回出現。ただし単一の一回限りの移行epic（完了・アーカイブ済み）内での是正であり、将来別featureで再発する汎用パターンとは言い難いため**機械化issue起票は見送り**（参考記録のみ）
+- **env の placeholder 値が健全判定をすり抜ける**: #1546（auth env診断）と#1634（本番ヘルスチェック誤判定修正）という**独立した2 feature**で同型の指摘が出現。共有の検出ユーティリティ・lintは無い（`rg`で確認）。既存issue・境界文書なし。**新規issue [#2104](https://github.com/Dayopt/dayopt/issues/2104) を起票**
+
+### ストック鮮度 triage（上位10件）
+
+`docs:check`対象ディレクトリ配下の`.md`（各log/除く）+ `docs/strategy.md`を`last_verified`昇順で上位10件検証した。
+
+| ストック                                   | 旧 last_verified | 対応                                                                                                                 |
+| ------------------------------------------ | ---------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `docs/engineering/data/db/rls-snapshot.md` | frontmatterなし  | 対象外・触らず（自動生成ファイル、レビュー待ちリストへ）                                                             |
+| `docs/engineering/accessibility.md`        | 2026-07-03       | 内容修正+更新（Lighthouse基準90点/手動実行、a11y:check廃止をpnpm lintへ、import path 2箇所修正）                     |
+| `docs/engineering/timezone.md`             | 2026-07-13       | 内容修正+更新（`tzDayStart`等のAPIリネームに追従: `toTZStartISO`/`toTZEndISO`/`getDateKey`、middleware.ts→proxy.ts） |
+| `docs/business/channels/reddit.md`         | 2026-07-14       | last_verified日付のみ更新（内容に変更なし）                                                                          |
+| `docs/business/channels/x.md`              | 2026-07-14       | last_verified日付のみ更新                                                                                            |
+| `docs/business/pricing.md`                 | 2026-07-14       | last_verified日付のみ更新（BILLING_ENFORCED既定値等、コードと一致確認）                                              |
+| `docs/engineering/frontend-state.md`       | 2026-07-14       | 対応不要（既に`status: superseded`）                                                                                 |
+| `docs/engineering/i18n.md`                 | 2026-07-14       | 内容修正+更新（namespace一覧13→14、entry/record→shortcuts/timeblockへ）                                              |
+| `docs/engineering/storybook.md`            | 2026-07-14       | last_verified日付のみ更新                                                                                            |
+| `docs/product/glossary.md`                 | 2026-07-14       | last_verified日付のみ更新                                                                                            |
+
+`last_verified`が2026-07-14同着で残った`docs/product/principles.md`は次回優先候補。
+
+### Notes 昇格候補
+
+前月ドメインlog（product 41件、operations 19件、business 5件）を確認。ほぼ全件が既存stockに反映済みだった。
+
+- **product**: 昇格候補なし。block-search連鎖・chronotype/fulfillment削除・plan-record-relationship-ux・sidebar help menuはいずれも`docs/product/specs/`に反映確認済み
+- **operations**: 昇格候補なし。全incidentが恒久ドキュメント（`docs/operations/contact-email.md`、`supabase`skill、`disaster-recovery-drill.md`、`security.md`）へ反映確認済み
+- **business**: `docs/business/log/2026-07-05-founder-audit.md`（創業者監査）が**昇格候補**。BEP試算の未検証扱いは`business-model.md`に一部反映されたが、監査本体（未検証前提6件・手戻りリスク・1人+AI体制の死角・7/30/90日実行方針）はどのstock文書からもリンクされていない。90日方針の進捗確認先が無い状態
+
+### スモークテスト（1問）
+
+「現行の billing entitlement（`BILLING_ENFORCED`フラグとproProcedureのゲート挙動）をdocsだけで説明できるか」を検証。`docs/product/specs/billing.md`の記述（「`BILLING_ENFORCED`の既定値は`false`で、その間`proProcedure`は認証後にゲートせず通過する」）を`apps/product/src/lib/billing/enforcement.ts`と突き合わせ、**一致を確認（PASS）**。ギャップログの作成は不要だった。
+
+### 並行レーン sweep（月次 backstop、`dispatch`skill操作C）
+
+- **Dependabot alerts**: open 1件（`extract-zip`、HIGH、GHSA-jmr9-qjv8-65gv、未パッチ）
+- **operations log残タスク**: `2026-07-08-vercel-predeploy-security-audit.md`のうち「Development scope の encrypted secrets 見直し」だけ対応issueが見つからず。**新規issue [#2107](https://github.com/Dayopt/dayopt/issues/2107) を起票**。他の残タスクは全件issue化済み（#1558, #1502, #1667, #1796）
+- **NOT_PLANNED close issue**: 34件を確認、放置懸念のあった2件（#2004, #1995）も深掘りの結果いずれも妥当にclose済み。**問題なし**
+- **生成系スクリプト**: `api:spec`成功、`types:generate:local`成功（ただしdatabase.types.ts driftを検出、revert済み・commit無し）、`rls:snapshot`成功・差分なし
+
+### 公開コンテンツ監査（`docs-audit`skill）
+
+`pnpm docs:coverage`＋既存docs/issue突合で検出。
+
+- **未カバー機能**: external-calendar（spec未登録）、"API and MCP access"（LP約束だがspec未登録）。**新規issue [#2105](https://github.com/Dayopt/dayopt/issues/2105) を起票**
+- **鮮度乖離**: `ja/troubleshooting/app.mdx`・`sync.mdx`が2025-01-16のまま更新なし（約1年半、PWA/precacheの継続的な変更が未反映の可能性）。**新規issue [#2106](https://github.com/Dayopt/dayopt/issues/2106) を起票**。`account-troubleshooting.mdx`・`ja/plan/calendar.mdx`は3週間程度の乖離でこちらはレビュー待ちリストへ（優先度が読みにくいため）
+- **en/ja翻訳の不足**: account-troubleshooting / calendar / app / sync の4ファイルが未翻訳。**既存issue #1686（2026-07-27にCLOSED）と対象が重複するが、実際には未完了に見える**。reopenすべきか新規issueにすべきかはレビュー待ちリストへ
+
+### セキュリティ sweep
+
+- **`pnpm security:check`**: exit code 1（failure）。`extract-zip`（Dependabot既知）に加え、`nanoid`（`@storybook/*`経由、HIGH、GHSA-2v37-7h3g-55p8）を検出。Dependabot alert一覧に出ていない不一致あり。**新規issue [#2108](https://github.com/Dayopt/dayopt/issues/2108) を起票**
+- **Supabase advisors**: worktree間でローカルDB状態が共有されており（既知quirk、memory `local-supabase-runs-ahead-of-worktree`）、誤情報を避けるため今回は未実施。レビュー待ちリストへ
+
+### 四半期チェック
+
+`docs/engineering/log/2026-07-07-ai-config-audit.md`が直近3ヶ月以内（約1.4ヶ月前）に存在するため、新規audit提案は不要。ただし [#2067](https://github.com/Dayopt/dayopt/issues/2067)（2026-08-13、AI primitive 適合判定・skill/plugin/MCP使用実績の追加観点3件）が正式な`*-ai-config-audit.md`形式ではないまま蓄積されている。次回四半期チェック（2026-10頃）までにformal audit化するか判断が必要。
+
+### 判断ジャーナル集計
+
+`pnpm gardening:judgment-journal`実行結果: **`judgment:diverged`ラベルが付いている issue / PR は現在0件**。`.claude/rules/orchestration.md` §権限の既定 の試行運用（可逆な采配をFable決定+opt-outにする）を恒久化するか巻き戻すかの判定材料は、今回時点ではまだ蓄積されていない。
+
+## レビュー待ちリスト（人間パートへ）
+
+以下は価値判断が必要なため、このレーンでは決定していない。
+
+1. **`docs/engineering/data/db/rls-snapshot.md`のガーデニング対象扱い** — 自動生成ファイル（`last_verified` frontmatterなし、手動編集禁止）。鮮度triageの対象から除外するか、生成日時ベースの別トラッキングを設けるか
+2. **`docs/business/log/2026-07-05-founder-audit.md`の昇格先** — `docs/business/growth.md`か`strategy.md`への参照追加が候補。90日実行方針の進捗確認先を作るかどうか
+3. **`ja/troubleshooting/account-troubleshooting.mdx`・`ja/plan/calendar.mdx`の鮮度乖離（3週間）** — issue化するか静観するか
+4. **既存issue #1686（翻訳追加、2026-07-27 CLOSED）の扱い** — 対象4ファイルのうちaccount-troubleshooting/calendar/app/syncが今も未翻訳。reopenするか新規issueにするか
+5. **Supabase advisors未実施の解消方法** — worktree間でローカルDB状態が共有される既知問題（memory `local-supabase-runs-ahead-of-worktree`）のため今回は未実施。main checkoutから改めて確認するか、cloud advisors（read-only）を使うか
+6. **判断ジャーナル0件という状態そのものの評価** — `.claude/rules/orchestration.md` §権限の既定 の試行運用（可逆な采配のFable決定+opt-out）を恒久化する判断材料が、1ヶ月経っても蓄積されていない。運用が順調で分岐が起きていないのか、記録漏れなのかは指揮台側の観測が必要
+7. **[#2067](https://github.com/Dayopt/dayopt/issues/2067)の gardening 判定対象3件（コメント追記分）** — 「skill発火実績の計測」「feature-dev plugin使用実績」「github MCPの常駐→オンデマンド降格検討」はいずれもセッション横断の実発火状況の観測が要る。このレーンはrepo内の被参照数（`rg`）レベルの確認しかできず、実際にどれだけ発火・使用されたかは指揮台側の transcript 観測に委ねる必要がある
+8. **PR粒度反転（7/26）以降のActions課金の実測検証** — 今回の6,820課金分/月は155PRへの外挿概算。7月中に単価が変動しているため、8月分のActions実測が出た段階で反転の効果を検証すべき
+
+## 実施したステップ・起票issue一覧
+
+- 実施: SKILL.md自動パート step 1-9 全件 + 判断ジャーナル棚卸しの下ごしらえ
+- 起票issue: [#2104](https://github.com/Dayopt/dayopt/issues/2104)（env placeholder機械化）、[#2105](https://github.com/Dayopt/dayopt/issues/2105)（docs spec登録漏れ）、[#2106](https://github.com/Dayopt/dayopt/issues/2106)（troubleshooting鮮度）、[#2107](https://github.com/Dayopt/dayopt/issues/2107)（development scope secrets）、[#2108](https://github.com/Dayopt/dayopt/issues/2108)（nanoid dependabot不一致）
+- レビュー待ちリスト: 8件（上記）

--- a/docs/engineering/log/2026-08-01-journal.md
+++ b/docs/engineering/log/2026-08-01-journal.md
@@ -132,16 +132,16 @@ time-model-split（ADR-025）とアナリティクス方針の限定（ADR-026: 
 
 ## レビュー待ちリスト（人間パートへ）
 
-以下は価値判断が必要なため、このレーンでは決定していない。
+以下は価値判断が必要なため、このレーンでは決定していない。指揮台による一次仕分け（2026-08-17）を各項目に反映する。
 
-1. **`docs/engineering/data/db/rls-snapshot.md`のガーデニング対象扱い** — 自動生成ファイル（`last_verified` frontmatterなし、手動編集禁止）。鮮度triageの対象から除外するか、生成日時ベースの別トラッキングを設けるか
-2. **`docs/business/log/2026-07-05-founder-audit.md`の昇格先** — `docs/business/growth.md`か`strategy.md`への参照追加が候補。90日実行方針の進捗確認先を作るかどうか
-3. **`ja/troubleshooting/account-troubleshooting.mdx`・`ja/plan/calendar.mdx`の鮮度乖離（3週間）** — issue化するか静観するか
-4. **既存issue #1686（翻訳追加、2026-07-27 CLOSED）の扱い** — 対象4ファイルのうちaccount-troubleshooting/calendar/app/syncが今も未翻訳。reopenするか新規issueにするか
-5. **Supabase advisors未実施の解消方法** — worktree間でローカルDB状態が共有される既知問題（memory `local-supabase-runs-ahead-of-worktree`）のため今回は未実施。main checkoutから改めて確認するか、cloud advisors（read-only）を使うか
-6. **判断ジャーナル0件という状態そのものの評価** — `.claude/rules/orchestration.md` §権限の既定 の試行運用（可逆な采配のFable決定+opt-out）を恒久化する判断材料が、1ヶ月経っても蓄積されていない。運用が順調で分岐が起きていないのか、記録漏れなのかは指揮台側の観測が必要
-7. **[#2067](https://github.com/Dayopt/dayopt/issues/2067)の gardening 判定対象3件（コメント追記分）** — 「skill発火実績の計測」「feature-dev plugin使用実績」「github MCPの常駐→オンデマンド降格検討」はいずれもセッション横断の実発火状況の観測が要る。このレーンはrepo内の被参照数（`rg`）レベルの確認しかできず、実際にどれだけ発火・使用されたかは指揮台側の transcript 観測に委ねる必要がある
-8. **PR粒度反転（7/26）以降のActions課金の実測検証** — 今回の6,820課金分/月は155PRへの外挿概算。7月中に単価が変動しているため、8月分のActions実測が出た段階で反転の効果を検証すべき
+1. **`docs/engineering/data/db/rls-snapshot.md`のガーデニング対象扱い** — 自動生成ファイル（`last_verified` frontmatterなし、手動編集禁止）。鮮度triageの対象から除外するか、生成日時ベースの別トラッキングを設けるか（User判断）
+2. **`docs/business/log/2026-07-05-founder-audit.md`の昇格先** — `docs/business/growth.md`か`strategy.md`への参照追加が候補。90日実行方針の進捗確認先を作るかどうか（User判断）
+3. **`ja/troubleshooting/account-troubleshooting.mdx`・`ja/plan/calendar.mdx`の鮮度乖離（3週間）** — issue化するか静観するか（User判断）
+4. **既存issue #1686（翻訳追加、2026-07-27 CLOSED）の扱い** — 対象4ファイルのうちaccount-troubleshooting/calendar/app/syncが今も未翻訳。指揮台の仮推奨: reopenではなく**新規issueを起票し、#1686へ相互リンク**（reopenだと当時closeした経緯・理由が埋もれるため）。最終判断はUser
+5. **Supabase advisors未実施の解消方法** — worktree間でローカルDB状態が共有される既知問題（memory `local-supabase-runs-ahead-of-worktree`）のため今回は未実施。main checkoutから改めて確認するか、cloud advisors（read-only）を使うか（User判断）
+6. **判断ジャーナル0件という状態そのものの評価** — 指揮台の観測: 記録漏れではなく実態。分岐しかけた判断は当日中にUser裁可を先取りする運用で吸収されており、`judgment:diverged`まで至らずに消えている。`.claude/rules/orchestration.md` §権限の既定 の試行運用（可逆な采配のFable決定+opt-out）の恒久化判定は、材料不足のため**もう1か月（2026-09のガーデニングまで）継続**とする
+7. **[#2067](https://github.com/Dayopt/dayopt/issues/2067)の gardening 判定対象3件（コメント追記分）** — 「skill発火実績の計測」「feature-dev plugin使用実績」「github MCPの常駐→オンデマンド降格検討」はセッション横断の実発火状況の観測が要るため、**このレーンのscopeから外し、指揮台が観測して#2067に追記する**
+8. **PR粒度反転（7/26）以降のActions課金の実測検証** — 今回の6,820課金分/月は155PRへの外挿概算。7月中に単価が変動しているため、8月分のActions実測が出た段階で反転の効果を検証すべき（User判断）
 
 ## 実施したステップ・起票issue一覧
 

--- a/docs/engineering/storybook.md
+++ b/docs/engineering/storybook.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_verified: 2026-07-14
+last_verified: 2026-08-17
 code:
   - apps/storybook/.storybook
   - apps/storybook/package.json

--- a/docs/engineering/timezone.md
+++ b/docs/engineering/timezone.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_verified: 2026-07-13
+last_verified: 2026-08-17
 code: apps/product/src/lib/date
 ---
 
@@ -80,7 +80,7 @@ today.setHours(0, 0, 0, 0); // サーバーTZの0時 ≠ ユーザーの0時
 
 ## Layer 2: Boundary Functions
 
-全て `@/lib/date/timezone` からインポート。**TZ文字列を受け取り、UTC ISO文字列を返す。**
+日付境界・時刻判定は `@/lib/date/timezone` から、日付キー生成（`getDateKey`）は `@/lib/date/core` からインポートする。**TZ文字列を受け取り、UTC ISO文字列を返す。**
 
 ### 時刻変換（入力 ↔ 表示）
 
@@ -94,29 +94,31 @@ today.setHours(0, 0, 0, 0); // サーバーTZの0時 ≠ ユーザーの0時
 
 | 関数                                   | 返り値                                 | 用途         |
 | -------------------------------------- | -------------------------------------- | ------------ |
-| `tzDayStart(date, tz)`                 | UTC ISO (`"2026-03-25T15:00:00.000Z"`) | 日の開始境界 |
-| `tzDayEnd(date, tz)`                   | UTC ISO (`"2026-03-26T14:59:59.999Z"`) | 日の終了境界 |
+| `toTZStartISO(date, tz)`               | UTC ISO (`"2026-03-25T15:00:00.000Z"`) | 日の開始境界 |
+| `toTZEndISO(date, tz)`                 | UTC ISO (`"2026-03-26T14:59:59.999Z"`) | 日の終了境界 |
 | `tzWeekStart(date, tz, weekStartsOn?)` | UTC ISO                                | 週の開始境界 |
 | `tzWeekEnd(date, tz, weekStartsOn?)`   | UTC ISO                                | 週の終了境界 |
-| `tzMonthStart(date, tz)`               | UTC ISO                                | 月の開始境界 |
-| `tzMonthEnd(date, tz)`                 | UTC ISO                                | 月の終了境界 |
+
+`date` は `date-fns` のローカルフィールド演算（`setHours` / `startOfDay` / `addDays` 等）で作った壁時計 Date を渡す（instant ではない）。`toZonedTime` / `formatInTimeZone` を `date` に直接掛けると system TZ とのずれで日付がずれるバグを踏む（#2017 で実際に発生）。月境界の TZ 対応関数は現状無く、月グリッド表示は `@/lib/date/core` の TZ 非依存 `startOfMonth` / `endOfMonth`（ナビゲーション用途のみ、クエリ境界には未使用）を使う。
 
 ### 日付判定
 
-| 関数                     | 返り値         | 用途                             |
-| ------------------------ | -------------- | -------------------------------- |
-| `tzToday(tz)`            | `"2026-03-26"` | ユーザーの「今日」               |
-| `tzIsSameDay(a, b, tz)`  | `boolean`      | 2つのUTC瞬間が同じユーザーTZ日か |
-| `tzGetDateKey(date, tz)` | `"2026-03-26"` | グルーピング用日付キー           |
+| 関数                                | 返り値         | 用途                                                            |
+| ----------------------------------- | -------------- | --------------------------------------------------------------- |
+| `getDateKey(date, tz?)`（`./core`） | `"2026-03-26"` | グルーピング用日付キー。`tz` 省略時はローカルフィールド読み取り |
+| `tzIsSameDay(a, b, tz)`             | `boolean`      | 2つのUTC瞬間が同じユーザーTZ日か                                |
+| `isTodayInTimezone(date, tz, now?)` | `boolean`      | 指定 TZ で「今日」と同じ日か                                    |
+
+ユーザーの「今日」の日付文字列が必要な場合は `getDateKey(new Date(), timezone)` を使う（専用の `tzToday` 関数は無い）。
 
 ### 使用例
 
 ```tsx
-import { tzDayStart, tzDayEnd, tzIsSameDay } from '@/lib/date/timezone';
+import { toTZStartISO, toTZEndISO, tzIsSameDay } from '@/lib/date/timezone';
 
 // ✅ 「今日の全エントリ」を取得するクエリ境界
-const startDate = tzDayStart(new Date(), timezone); // "2026-03-25T15:00:00.000Z" (JST)
-const endDate = tzDayEnd(new Date(), timezone); // "2026-03-26T14:59:59.999Z" (JST)
+const startDate = toTZStartISO(new Date(), timezone); // "2026-03-25T15:00:00.000Z" (JST)
+const endDate = toTZEndISO(new Date(), timezone); // "2026-03-26T14:59:59.999Z" (JST)
 const plans = api.plans.list.useQuery({ startDate, endDate });
 
 // ✅ マルチデイ判定
@@ -175,7 +177,7 @@ const dateRange = {
 
 ```tsx
 // ✅ 正しい: TZ対応の日付キー
-const dateKey = tzGetDateKey(entry.start_time, timezone);
+const dateKey = getDateKey(entry.start_time, timezone);
 
 // ❌ 禁止: ローカルTZの .getDate()
 const dateKey = `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
@@ -185,15 +187,15 @@ const dateKey = `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
 
 ## 禁止パターン一覧
 
-| パターン                                    | 問題                     | 代替                           |
-| ------------------------------------------- | ------------------------ | ------------------------------ |
-| `date.setHours(0,0,0,0)` + `.toISOString()` | ブラウザTZの0時をUTC変換 | `tzDayStart(date, tz)`         |
-| `new Date().toISOString()` で日境界生成     | TZずれ                   | `tzDayStart` / `tzDayEnd`      |
-| `.getDate()` / `.getDay()` で日付比較       | ブラウザTZ依存           | `tzIsSameDay` / `tzGetDateKey` |
-| `startOfDay()` + `.toISOString()`           | ローカルTZ→UTC変換ずれ   | `tzDayStart(date, tz)`         |
-| `startOfWeek()` + `.toISOString()`          | 同上                     | `tzWeekStart(date, tz)`        |
-| サーバーで `new Date().setHours(0,0,0,0)`   | サーバーTZ依存           | `tzDayStart(date, userTz)`     |
-| `'Asia/Tokyo'` ハードコードフォールバック   | 非日本ユーザーに不正確   | `'UTC'`                        |
+| パターン                                    | 問題                     | 代替                          |
+| ------------------------------------------- | ------------------------ | ----------------------------- |
+| `date.setHours(0,0,0,0)` + `.toISOString()` | ブラウザTZの0時をUTC変換 | `toTZStartISO(date, tz)`      |
+| `new Date().toISOString()` で日境界生成     | TZずれ                   | `toTZStartISO` / `toTZEndISO` |
+| `.getDate()` / `.getDay()` で日付比較       | ブラウザTZ依存           | `tzIsSameDay` / `getDateKey`  |
+| `startOfDay()` + `.toISOString()`           | ローカルTZ→UTC変換ずれ   | `toTZStartISO(date, tz)`      |
+| `startOfWeek()` + `.toISOString()`          | 同上                     | `tzWeekStart(date, tz)`       |
+| サーバーで `new Date().setHours(0,0,0,0)`   | サーバーTZ依存           | `toTZStartISO(date, userTz)`  |
+| `'Asia/Tokyo'` ハードコードフォールバック   | 非日本ユーザーに不正確   | `'UTC'`                       |
 
 ---
 
@@ -233,11 +235,11 @@ WHERE (r.start_at AT TIME ZONE 'UTC')::DATE >= p_start
       (Intl.DateTimeFormat().resolvedOptions().timeZone)
 
 2. 2回目以降の訪問
-   └→ middleware.ts: Cookie読み取り → x-user-timezone ヘッダー
+   └→ proxy.ts（旧 middleware.ts）: Cookie読み取り → x-user-timezone ヘッダー
    └→ Server Component: ヘッダーからTZ取得 → prefetchに使用
 
 3. TZ設定変更時
-   └→ useUserSettings: Cookie更新 + entries全キャッシュ無効化
+   └→ useUpdateUserSettings: Cookie更新 + entries全キャッシュ無効化
 ```
 
 ---
@@ -268,6 +270,6 @@ Layer 2 (`@/lib/date/timezone.ts`) を唯一の変更点として維持。
 | `src/lib/date/timezone.ts`                           | Layer 2: 全TZユーティリティ（唯一のTZライブラリ） |
 | `src/lib/date/core.ts`                               | TZ非依存の日付計算（加算・比較等）                |
 | `src/lib/hooks/useUserPreferences.ts`                | Layer 1: クライアントTZ参照                       |
-| `src/middleware.ts`                                  | SSR: Cookie → ヘッダー転写                        |
+| `src/proxy.ts`                                       | SSR: Cookie → ヘッダー転写（旧 middleware.ts）    |
 | `supabase/migrations/20260326000000_*.sql`           | DB: TZ対応統計関数                                |
 | `src/lib/date/__tests__/timezone-edge-cases.test.ts` | DST・半時間オフセット等のエッジケーステスト       |

--- a/docs/product/glossary.md
+++ b/docs/product/glossary.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_verified: 2026-07-14
+last_verified: 2026-08-17
 ---
 
 # Dayopt Glossary — 用語集


### PR DESCRIPTION
## 背景

Routine（`.claude/skills/gardening/SKILL.md` 自動パート）の初回 scheduled 実行は 2026-09-01 予定（Routine化自体が 2026-08-09 導入のため）。当月5日を過ぎても journal の draft PR が無かったため、User の指示により指揮台配下のこのレーンが自動パート（step 1〜9）を代行した。

## 実施したステップ

SKILL.md 自動パート step 1〜9 全件 + 判断ジャーナル棚卸しの下ごしらえ（`pnpm gardening:judgment-journal`、結果0件）。

- 前月（7月）の蒸留: マージPR 155件・close issue 151件・全ドメインlog 93件を並行subagentで精読
- 外部レビュー指摘のclass分類: envのplaceholder値が健全判定をすり抜けるclassを検出
- ストック鮮度triage: 上位10件中8件を更新（内容修正5件、日付更新のみ3件）
- Notes昇格候補: founder-audit（創業者監査）のみ未昇格と判定
- スモークテスト: billing entitlementのdocs-code一致を確認、PASS
- 月次backstop・公開コンテンツ監査・セキュリティsweep

## 起票した issue

- Refs #2104（env placeholder機械化）
- Refs #2105（docs spec登録漏れ: external-calendar, API/MCP access）
- Refs #2106（troubleshooting鮮度: app.mdx/sync.mdx 約1年半未更新）
- Refs #2107（development scope secrets見直し未issue化）
- Refs #2108（nanoid HIGH脆弱性のdependabot不一致）
- Refs #2067（AI設定棚卸しの継続対象）

## レビュー待ちリスト（人間パートへ、8件）

journal 末尾に全件記載。指揮台による一次仕分け済み（判断ジャーナル0件は記録漏れでなく実態と観測、#2067のセッション横断発火実績確認は指揮台へ移管、#1686は新規issue+相互リンクを仮推奨）。最終判断はUserの人間パートで行う。

## 検証

- `pnpm docs:check` green
- ストック8件の内容修正はすべて実コード（`rg`）と突合確認済み

---
🤖 Generated with `/gardening` skill（自動パート、指揮台の代行実施）