### PR TITLE
docs(web): 公開docs未翻訳4ファイルのen版を追加する

### DIFF
--- a/apps/web/content/docs/en/plan/calendar.mdx
+++ b/apps/web/content/docs/en/plan/calendar.mdx
@@ -1,0 +1,134 @@
+---
+title: 'Use the Calendar'
+description: "How to use Dayopt's Calendar. Switching views, moving between dates, creating and editing Blocks, display settings, and keyboard shortcuts."
+tags: ['calendar', 'tutorial', 'getting-started', 'schedule']
+author: 'Dayopt Team'
+publishedAt: '2026-08-17'
+updatedAt: '2026-08-17'
+order: 2
+featured: true
+category: 'plan'
+slug: 'calendar'
+draft: true
+
+ai:
+  relatedQuestions:
+    - 'How do I switch calendar views?'
+    - 'How do I move to a different day?'
+    - 'How do I create a Plan from the calendar?'
+    - 'What keyboard shortcuts work on the calendar?'
+    - 'Can I hide weekends?'
+  prerequisites:
+    - 'Signed up for a Dayopt account'
+    - 'Signed in to Dayopt'
+  relatedDocs:
+    - '/docs/plans'
+  chunkStrategy: 'h2'
+  searchable: true
+  difficulty: 'beginner'
+  contentType: 'tutorial'
+---
+
+# Use the Calendar
+
+The Calendar is where you work in Dayopt. Your Plans and Records show up here. This page covers how to switch views and use the basic controls.
+
+## Switch views
+
+There are three view types.
+
+| View             | Use it for                      | Shortcut           |
+| ---------------- | ------------------------------- | ------------------ |
+| **Day view**     | Looking closely at one day      | `Cmd+1`            |
+| **2–7 day view** | Comparing several days at once  | `Cmd+3` and others |
+| **Week view**    | Seeing a whole week at a glance | —                  |
+
+Switch views from the button in the header. You can show anywhere from 2 to 7 days. Shortcuts are set for 3, 5, and 7 days.
+
+| Shortcut | Action      |
+| -------- | ----------- |
+| `Cmd+1`  | Show 1 day  |
+| `Cmd+3`  | Show 3 days |
+| `Cmd+5`  | Show 5 days |
+| `Cmd+7`  | Show 7 days |
+
+## Move between dates
+
+| Action           | Result                        |
+| ---------------- | ----------------------------- |
+| `Cmd+←`          | Go to the previous period     |
+| `Cmd+→`          | Go to the next period         |
+| `Cmd+T`          | Jump back to today            |
+| Swipe left/right | Move between periods (mobile) |
+
+How far you move depends on the view you're in. In 3-day view, you move 3 days at a time.
+
+## Create a Block
+
+Plans and Records on the calendar are both called "Blocks". There are four ways to create one.
+
+| Method        | How                                               |
+| ------------- | ------------------------------------------------- |
+| **Click**     | Click an open time slot                           |
+| **Drag**      | Drag across a time range to set the start and end |
+| **`C`**       | Create a Block                                    |
+| **`Shift+C`** | Create a 15-minute Block starting now             |
+
+Creating a Block opens the Inspector, a detail panel where you can edit the title, date, time, tags, and notes.
+
+For more on editing Plans, see [Create Plans](/docs/plans).
+
+## Drag to move or resize
+
+- **Move** — drag a Block to a different time slot
+- **Resize** — drag the bottom edge to change the end time
+
+Press `Escape` while dragging to cancel.
+
+## Delete a Block
+
+Select a Block and press `Delete` or `Backspace`. You can also right-click a Block and choose delete from the menu.
+
+## Copy and paste
+
+Press `Cmd+C` to copy a Block, then click where you want it and press `Cmd+V`. The title, duration, and tags carry over.
+
+## Adjust the display
+
+Change how the calendar looks from the view settings.
+
+| Setting           | What it does                                                 |
+| ----------------- | ------------------------------------------------------------ |
+| Show weekends     | Whether Saturday and Sunday are shown (`Cmd+W` toggles this) |
+| Show week numbers | Shows the week number on the left edge                       |
+| Density           | Compact / Standard / Comfortable                             |
+
+Density changes the height of each hour. Use Compact on busy days and Comfortable when you're scheduling in fine detail.
+
+## Search Blocks
+
+Press `Cmd+K` to open search. Find a Block by title and jump to its date.
+
+## Keyboard shortcuts
+
+Press `Shift+?` to see every shortcut you can currently use.
+
+| Shortcut            | Action                       |
+| ------------------- | ---------------------------- |
+| `Shift+?`           | Open the shortcut list       |
+| `Cmd+←` / `Cmd+→`   | Go to previous / next period |
+| `Cmd+T`             | Jump to today                |
+| `Cmd+1` `3` `5` `7` | Show 1 / 3 / 5 / 7 days      |
+| `Cmd+W`             | Toggle weekends              |
+| `Cmd+K`             | Search Blocks                |
+| `C`                 | Create a Block               |
+| `Shift+C`           | Create a Block starting now  |
+| `Cmd+C` / `Cmd+V`   | Copy / paste                 |
+| `Delete`            | Delete the selected Block    |
+| `Escape`            | Close the Inspector          |
+
+On Windows and Linux, use `Ctrl` instead of `Cmd`.
+
+## Next steps
+
+1. **[Create Plans](/docs/plans)** — how to create, edit, and complete Plans

--- a/apps/web/content/docs/en/troubleshooting/account-troubleshooting.mdx
+++ b/apps/web/content/docs/en/troubleshooting/account-troubleshooting.mdx
@@ -1,0 +1,147 @@
+---
+title: "Can't sign in"
+description: 'Common sign-in, password, and authentication problems and how to fix them.'
+tags: ['troubleshooting', 'account', 'login', 'password', 'authentication']
+author: 'Dayopt Team'
+publishedAt: '2026-08-17'
+updatedAt: '2026-08-17'
+order: 3
+featured: false
+category: 'troubleshooting'
+slug: 'account-troubleshooting'
+draft: true
+
+# === AI/RAG metadata ===
+ai:
+  relatedQuestions:
+    - "I can't sign in"
+    - 'I forgot my password'
+    - "I'm not getting the email"
+    - 'My account is locked'
+    - "My two-factor code doesn't work"
+  chunkStrategy: 'h2'
+  searchable: true
+  difficulty: 'beginner'
+  contentType: 'troubleshooting'
+---
+
+# Can't sign in
+
+Fixes for common sign-in and account problems.
+
+---
+
+## Can't sign in
+
+### Wrong email or password
+
+**Check:**
+
+- The email is spelled correctly
+- Caps Lock isn't on
+- You're signing in with the right account
+
+**Fix:**
+
+1. Try "Forgot your password?" to reset it
+2. Try a different browser or a private window
+
+### Account locked
+
+Too many failed sign-in attempts locks your account for security.
+
+**Fix:**
+
+- Wait 15 minutes and try again
+- Still locked? [Contact support](/contact)
+
+---
+
+## Forgot your password
+
+### Reset your password
+
+1. Click "Forgot your password?" on the sign-in screen
+2. Enter your registered email address
+3. Click the link in the email you receive
+4. Set a new password
+
+### Not getting the reset email
+
+**Check:**
+
+- Your spam folder
+- You used the email you registered with
+- The email address is spelled correctly
+
+**Still nothing?**
+
+- Wait a few minutes, then resend
+- [Contact support](/contact)
+
+---
+
+## Two-factor authentication (2FA) problems
+
+### Verification code doesn't work
+
+**Check:**
+
+- Your device's clock is accurate (auto-set is best)
+- You're using the right authenticator app
+- The code hasn't expired (codes refresh every 30 seconds)
+
+### Lost your authenticator device
+
+**Fix:**
+
+1. Sign in with a backup code (saved when you set up 2FA)
+2. No backup code? [Contact support](/contact)
+
+---
+
+## Not receiving emails
+
+### Confirmation or notification emails aren't arriving
+
+**Check:**
+
+- Your spam folder
+- `noreply@dayopt.io` is on your allow list
+- Your email address is registered correctly
+
+**Fix:**
+
+1. Check your email address in settings
+2. Click "Resend confirmation email"
+3. Still nothing after 5 minutes? Try a different email address
+
+---
+
+## Deleting your account
+
+### I want to delete my account
+
+**Steps:**
+
+1. Go to Settings > Account > "Delete account"
+2. Enter your password to confirm
+3. Click the link in the confirmation email
+
+**Note:**
+
+- Deletion can't be undone
+- Cancel any active subscription first
+
+---
+
+## Still stuck?
+
+If none of this helps, [contact us](/contact) and our support team will help.
+
+Including the following makes it faster:
+
+- Your registered email address
+- What's going wrong
+- What you've already tried
+- A screenshot, if you have one

--- a/apps/web/content/docs/en/troubleshooting/app.mdx
+++ b/apps/web/content/docs/en/troubleshooting/app.mdx
@@ -1,0 +1,148 @@
+---
+title: "App is slow or won't start"
+description: 'Common app performance and display problems and how to fix them.'
+tags: ['troubleshooting', 'app', 'performance', 'crash', 'bug']
+author: 'Dayopt Team'
+publishedAt: '2026-08-17'
+updatedAt: '2026-08-17'
+order: 2
+featured: false
+category: 'troubleshooting'
+slug: 'app'
+draft: true
+
+# === AI/RAG metadata ===
+ai:
+  relatedQuestions:
+    - "The app won't start"
+    - "It's running slow"
+    - 'The screen is frozen'
+    - 'The app keeps crashing'
+    - 'Something looks wrong on screen'
+    - "A button isn't working"
+    - "My changes aren't showing up"
+  chunkStrategy: 'h2'
+  searchable: true
+  difficulty: 'beginner'
+  contentType: 'troubleshooting'
+---
+
+# App is slow or won't start
+
+Fixes for common app performance and display problems. Dayopt runs in your web browser or as a PWA (Progressive Web App) added to your home screen. It isn't installed from the App Store or Google Play.
+
+---
+
+## App won't start
+
+### Basic steps
+
+1. **Restart your device.** This solves most problems.
+2. **Update your browser.** Make sure Chrome, Safari, or whichever browser you use is up to date.
+3. **Remove and re-add the home screen app.** Delete the icon, then add it again from your browser.
+
+### Still won't start?
+
+**Check:**
+
+- Your device has enough free storage
+- Your browser and OS are up to date (or a supported version)
+- Other websites and apps open normally
+
+---
+
+## Running slow
+
+### Steps to improve performance
+
+1. **Close unused apps and tabs.** Anything running in the background competes for resources.
+2. **Clear your cache.** Clear Dayopt's cache from your browser or device settings.
+3. **Restart your device.** This frees up memory.
+
+### If the web app is slow
+
+- **Try a different browser.** Recent versions of Chrome, Firefox, or Safari work best.
+- **Disable extensions.** Ad blockers and similar extensions can interfere.
+- **Try a private window.** This checks whether an extension is the cause.
+
+---
+
+## Changes aren't showing up
+
+Dayopt updates automatically the next time you open the app. There's no manual update step.
+
+If it still looks or behaves like an old version:
+
+1. Close the app completely, then open it again.
+2. Still stuck? Clear Dayopt's cache from your browser or device settings.
+3. If only the home screen icon looks outdated, delete it and add it to your home screen again (your device caches the icon image separately).
+
+---
+
+## App keeps crashing
+
+### Frequent crashes
+
+1. **Close the app completely and reopen it.** It switches to the latest version the next time you open it.
+2. **Update your device or browser OS.**
+3. **Remove and re-add the home screen app.**
+
+### Crashes during a specific action
+
+**Note down:**
+
+- Which screen it happens on
+- What you were doing when it happened
+- Whether it happens every time or only sometimes
+
+Share this with us via [contact support](/contact) so we can help faster.
+
+---
+
+## Something looks wrong on screen
+
+### Layout looks broken
+
+**On the web app:**
+
+1. Reset your browser zoom to 100% (Ctrl/Cmd + 0)
+2. Clear your browser cache
+3. Try a different browser
+
+**On the home screen PWA:**
+
+1. Rotate your device and rotate it back
+2. Restart the app
+
+### Text is missing or garbled
+
+- Check your device's language setting
+- Check Dayopt's language setting (Settings > Display > Language). Dayopt supports Japanese and English.
+
+---
+
+## A button isn't working
+
+### Taps or clicks aren't registering
+
+1. **Refresh the screen.** Pull down to reload (mobile) or press F5 (web).
+2. **Restart the app.**
+3. **Restart your device.**
+
+### Only one specific button doesn't work
+
+- It might be a Pro plan feature (the Free plan limits tag count and some review metrics)
+
+---
+
+## Still stuck?
+
+If none of this helps, [contact us](/contact) and our support team will help.
+
+Including the following makes it faster:
+
+- Your device name and OS version
+- The browser you're using and its version
+- A detailed description of the problem
+- Steps to reproduce it, if possible
+- A screenshot or screen recording, if you have one

--- a/apps/web/content/docs/en/troubleshooting/sync.mdx
+++ b/apps/web/content/docs/en/troubleshooting/sync.mdx
@@ -1,0 +1,133 @@
+---
+title: "Sync isn't working or data is missing"
+description: 'Common data storage, Google Calendar sync, and backup problems and how to fix them.'
+tags: ['troubleshooting', 'sync', 'data', 'backup', 'restore']
+author: 'Dayopt Team'
+publishedAt: '2026-08-17'
+updatedAt: '2026-08-17'
+order: 1
+featured: false
+category: 'troubleshooting'
+slug: 'sync'
+draft: true
+
+# === AI/RAG metadata ===
+ai:
+  relatedQuestions:
+    - "My data isn't syncing"
+    - "My changes aren't showing up"
+    - 'My data disappeared'
+    - "I can't see my data on another device"
+    - 'I got a sync error'
+    - "My Google Calendar events aren't showing up"
+  relatedDocs:
+    - '/docs/app'
+    - '/docs'
+  chunkStrategy: 'h2'
+  searchable: true
+  difficulty: 'beginner'
+  contentType: 'troubleshooting'
+---
+
+# Sync isn't working or data is missing
+
+Fixes for problems with saving Plans and Records, Google Calendar sync, and backups.
+
+---
+
+## Plans and Records aren't showing up on another device
+
+Dayopt saves your Plans and Records to the cloud, but doesn't push them in real time. It fetches the latest data when you open the app or interact with it.
+
+### Check
+
+- Wi-Fi or mobile data is on
+- Other apps can reach the internet
+- If you're using a VPN, try turning it off
+- You're signed in to the right account (data doesn't carry over between accounts)
+
+### Restart the app
+
+1. Fully close the app
+2. Wait a few seconds, then reopen it
+3. Reload the screen to fetch the latest data
+
+### If you made changes while offline
+
+You can still view saved data while offline, but **changes made while offline aren't saved.** If you close or reload the screen before reconnecting, that change is lost. Make the same change again once you're back online.
+
+---
+
+## Changes aren't showing up
+
+### Clear your cache
+
+**On the web app:**
+
+1. Clear your browser cache
+2. Reload the page (Ctrl/Cmd + Shift + R)
+
+**On the home screen PWA:**
+
+1. Clear Dayopt's cache from your device settings
+2. Restart the app
+
+### Check on another device
+
+- Confirm you're signed in with the same account on the other device
+- Reload the screen, then check again
+
+---
+
+## Data disappeared or can't be found
+
+### Check these first
+
+1. **Check the date you're viewing.** Are you on a different day or period?
+2. **Check your filters.** Is a tag filter hiding it?
+3. **Check the account.** Are you signed in to a different account?
+
+### Restoring data
+
+Dayopt doesn't have a trash. Use **Undo**, which appears right after you delete something.
+
+Beyond that, restoring from an export is your only option. Go to Settings > Data controls > Export to download a JSON backup — we recommend doing this regularly.
+
+Restoring from a backup file isn't available yet.
+
+---
+
+## Editing the same data at the same time
+
+If you edit the same Plan or Record on two devices at once, there's no confirmation prompt — whichever save happens last wins. If you notice an unexpected overwrite, fix it manually.
+
+---
+
+## Google Calendar sync isn't working
+
+Google Calendar sync runs automatically every 15 minutes. To sync right away, go to the Integrations tab in settings and click "Sync now".
+
+### Common errors and fixes
+
+| Error                                                           | Cause                                      | Fix                                                             |
+| --------------------------------------------------------------- | ------------------------------------------ | --------------------------------------------------------------- |
+| "Google access has expired. Reconnect the same Google account." | Google's authorization expired             | Click "Reconnect" and re-authorize with the same Google account |
+| "Google Calendar is temporarily rate limited. Try again later." | Temporary limit on Google's side           | Wait and try again                                              |
+| "Google Calendar is temporarily unavailable. Try again later."  | Temporary outage on Google's side          | Wait and try again                                              |
+| "Some calendars could not be synced."                           | Some of the selected calendars failed      | Review which calendars you're syncing and try again             |
+| "Syncing is taking longer than expected."                       | A large number of events slowed processing | Wait and try again                                              |
+
+If none of this helps, disconnect and reconnect the integration.
+
+---
+
+## Still stuck?
+
+If none of this helps, [contact us](/contact) and our support team will help.
+
+Including the following makes it faster:
+
+- Your device and OS
+- The browser you're using
+- The error message, if you got one
+- When the problem happened


### PR DESCRIPTION
## 背景

account-troubleshooting / plan/calendar / troubleshooting/app / troubleshooting/sync の en 版が #1686 close 後も未翻訳のまま残っていた（2026-08 gardening の公開コンテンツ監査で検出）。ja 版を原文として en 版を新規作成する。app / sync は 2026-08-17 の ja 全面更新（PWA専業・自動更新・cloud保存の記述、PR #2117）を反映する。

## 内容

- `apps/web/content/docs/en/troubleshooting/account-troubleshooting.mdx`（新規）
- `apps/web/content/docs/en/troubleshooting/app.mdx`（新規）
- `apps/web/content/docs/en/troubleshooting/sync.mdx`（新規）
- `apps/web/content/docs/en/plan/calendar.mdx`（新規）

UI 文言（設定メニューの階層名、Google Calendar 同期のエラーメッセージ等）は `apps/product/messages/en/settings.json` の実キーで裏取りして一致させた。用語は `docs/product/glossary.md` に従い Plan / Record / Block / Tag / Sign in を使用。

## draft: true について

**4 ページは `draft: true` で merge される。** 4ファイルとも本番に存在しない完全新規 URL のため、`docs-writing` SKILL.md の「既存公開 page の更新では draft を付けない」例外には当たらず、「`draft: true` は新規 page の初期値」という通常規約を適用した。

**公開には User の英文レビュー後に draft を外す follow-up が必要。** merge で issue が閉じても、公開はまだ完了していない。draft 外しは指揮台が User 操作枠に載せる。

## 検証

- `pnpm --filter @dayopt/web validate:content` — 新規4ファイルにエラーなし
- `pnpm docs:coverage` — account-troubleshooting・calendar が「draft（本文あり・公開待ち）」として正しく現れることを確認
- `pnpm docs:check` — pass
- `pnpm lint:i18n` — pass

Closes #2129