### PR TITLE
docs(web): privacy.mdxへAxiomサブプロセッサーを追記し30日通知を開始する

### DIFF
--- a/apps/web/content/legal/en/privacy.mdx
+++ b/apps/web/content/legal/en/privacy.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Privacy Policy'
 description: 'How Dayopt handles your personal information'
-lastUpdated: 'Last Updated: 2026-08-12'
+lastUpdated: 'Last Updated: 2026-08-17'
 ---
 
 <PrivacyDocument
@@ -80,6 +80,8 @@ lastUpdated: 'Last Updated: 2026-08-12'
           "Google LLC — Gmail is the access-controlled destination mailbox used to receive, manage, and reply to support correspondence. Data location depends on Google's infrastructure and account configuration.",
         cloudflare:
           "Cloudflare, Inc. — Turnstile bot protection for forms. A Turnstile token and the requester's IP address are sent to Cloudflare for verification. Data is processed on Cloudflare's global network.",
+        axiom:
+          "Axiom, Inc. — Storage and search of runtime and build logs delivered via Vercel Log Drains. Includes our application's structured logs. Request log path and query strings are excluded from what we send. Data location: United States.",
         changes:
           'We will notify you at least 30 days before engaging a new sub-processor or making material changes to existing sub-processor arrangements.',
       },

--- a/apps/web/content/legal/en/privacy.mdx
+++ b/apps/web/content/legal/en/privacy.mdx
@@ -81,7 +81,7 @@ lastUpdated: 'Last Updated: 2026-08-17'
         cloudflare:
           "Cloudflare, Inc. — Turnstile bot protection for forms. A Turnstile token and the requester's IP address are sent to Cloudflare for verification. Data is processed on Cloudflare's global network.",
         axiom:
-          "Axiom, Inc. — Storage and search of runtime and build logs delivered via Vercel Log Drains. Includes our application's structured logs. Request log path and query strings are excluded from what we send. Data location: United States.",
+          "Axiom, Inc. — Storage and search of runtime and build logs delivered via Vercel Log Drains. Includes our application's structured logs and Vercel request log metadata such as IP address and browser/user-agent information. Request log path and query strings are excluded from what we send. Data location: United States.",
         changes:
           'We will notify you at least 30 days before engaging a new sub-processor or making material changes to existing sub-processor arrangements.',
       },

--- a/apps/web/content/legal/ja/privacy.mdx
+++ b/apps/web/content/legal/ja/privacy.mdx
@@ -80,7 +80,7 @@ lastUpdated: '最終更新日: 2026-08-17'
         cloudflare:
           'Cloudflare, Inc. — フォームのbot対策としてTurnstileを使用します。検証のため、Turnstile tokenと送信元IPアドレスをCloudflareへ送ります。データはCloudflareのglobal networkで処理されます。',
         axiom:
-          'Axiom, Inc. — Vercel Log Drains経由のruntime・buildログの保管・検索。アプリの構造化ログを含みます。URLのクエリ文字列を含むリクエストログのpath・queryは送信対象から除外します。データ保管場所：米国。',
+          'Axiom, Inc. — Vercel Log Drains経由のruntime・buildログの保管・検索。アプリの構造化ログと、IPアドレス・ブラウザ情報などのVercelリクエストログのメタデータを含みます。リクエストログのpath・queryは送信対象から除外します。データ保管場所：米国。',
         changes:
           '新しいサブプロセッサーの導入または既存のサブプロセッサー契約の重要な変更を行う場合、少なくとも30日前に通知します。',
       },

--- a/apps/web/content/legal/ja/privacy.mdx
+++ b/apps/web/content/legal/ja/privacy.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'プライバシーポリシー'
 description: 'Dayoptにおける個人情報の取り扱いについて'
-lastUpdated: '最終更新日: 2026-08-12'
+lastUpdated: '最終更新日: 2026-08-17'
 ---
 
 <PrivacyDocument
@@ -79,6 +79,8 @@ lastUpdated: '最終更新日: 2026-08-12'
           'Google LLC — Gmailを、お問い合わせの受信・管理・返信に使用するアクセス制限付きメールボックスとして利用します。データ保管場所はGoogleのインフラおよびアカウント設定により異なります。',
         cloudflare:
           'Cloudflare, Inc. — フォームのbot対策としてTurnstileを使用します。検証のため、Turnstile tokenと送信元IPアドレスをCloudflareへ送ります。データはCloudflareのglobal networkで処理されます。',
+        axiom:
+          'Axiom, Inc. — Vercel Log Drains経由のruntime・buildログの保管・検索。アプリの構造化ログを含みます。URLのクエリ文字列を含むリクエストログのpath・queryは送信対象から除外します。データ保管場所：米国。',
         changes:
           '新しいサブプロセッサーの導入または既存のサブプロセッサー契約の重要な変更を行う場合、少なくとも30日前に通知します。',
       },

--- a/apps/web/src/app/[locale]/(marketing)/legal/__tests__/legal-document-contract.test.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/legal/__tests__/legal-document-contract.test.tsx
@@ -130,8 +130,8 @@ const LEGAL_CONTRACT_CASES: readonly LegalContractCase[] = [
     slug: 'privacy',
     metadataTitle: 'Privacy Policy - Dayopt',
     metadataDescription: 'How Dayopt handles your personal information',
-    lastUpdated: 'Last Updated: 2026-08-12',
-    bodyHash: 'a86ca17c88ab7f268be8589dc16e193f560e01d53c766a3dfe3011e444307d75',
+    lastUpdated: 'Last Updated: 2026-08-17',
+    bodyHash: '8198861163c88c4e90d87da44d2202a107ed1295caad03301d7419c3fff7d576',
     hrefs: ['/legal/cookies'],
     counts: { h2: 20, h3: 0, tables: 0, lists: 16 },
   },
@@ -191,8 +191,8 @@ const LEGAL_CONTRACT_CASES: readonly LegalContractCase[] = [
     slug: 'privacy',
     metadataTitle: 'プライバシーポリシー - Dayopt',
     metadataDescription: 'Dayoptにおける個人情報の取り扱いについて',
-    lastUpdated: '最終更新日: 2026-08-12',
-    bodyHash: '707f5af5e9ad3b0829641d15116ca1e8378f27cf8f0f8ddf8276e43eac7b6b02',
+    lastUpdated: '最終更新日: 2026-08-17',
+    bodyHash: 'dc289fb46553f751e50ee5443315c9250fba518e424124fe806acad7cfbbb033',
     // PrivacyDocument の Link は @dayopt/i18n/navigation 経由（localizeHref 対象）。
     // as-needed prefix により ja は /ja が付く。
     hrefs: ['/ja/legal/cookies'],

--- a/apps/web/src/app/[locale]/(marketing)/legal/__tests__/legal-document-contract.test.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/legal/__tests__/legal-document-contract.test.tsx
@@ -131,7 +131,7 @@ const LEGAL_CONTRACT_CASES: readonly LegalContractCase[] = [
     metadataTitle: 'Privacy Policy - Dayopt',
     metadataDescription: 'How Dayopt handles your personal information',
     lastUpdated: 'Last Updated: 2026-08-17',
-    bodyHash: '8198861163c88c4e90d87da44d2202a107ed1295caad03301d7419c3fff7d576',
+    bodyHash: '3ce8648f59685487d6cd70b2d012b8155deefbbc64e24752d597ab2ba4af2edf',
     hrefs: ['/legal/cookies'],
     counts: { h2: 20, h3: 0, tables: 0, lists: 16 },
   },
@@ -192,7 +192,7 @@ const LEGAL_CONTRACT_CASES: readonly LegalContractCase[] = [
     metadataTitle: 'プライバシーポリシー - Dayopt',
     metadataDescription: 'Dayoptにおける個人情報の取り扱いについて',
     lastUpdated: '最終更新日: 2026-08-17',
-    bodyHash: 'dc289fb46553f751e50ee5443315c9250fba518e424124fe806acad7cfbbb033',
+    bodyHash: '36908111bf623bf80628127ffa4b1aaf190d6975df5b2180d892aa985bf7a47f',
     // PrivacyDocument の Link は @dayopt/i18n/navigation 経由（localizeHref 対象）。
     // as-needed prefix により ja は /ja が付く。
     hrefs: ['/ja/legal/cookies'],

--- a/apps/web/src/app/[locale]/(marketing)/legal/_components/legal-standard-document.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/legal/_components/legal-standard-document.tsx
@@ -84,6 +84,7 @@ const PRIVACY_SECTIONS: readonly SectionLayout[] = [
           'cloudflareEmail',
           'google',
           'cloudflare',
+          'axiom',
         ],
       },
       { type: 'note', key: 'changes' },

--- a/docs/operations/legal.md
+++ b/docs/operations/legal.md
@@ -25,7 +25,7 @@ Legal（利用規約・プライバシーポリシー等）の実体パスと改
 
 利用規約・プライバシーポリシー等を改定したら、**なぜ改定したか**を `/decision` で記録する（本文の diff は git history が正本、decision には理由だけ書く）。
 
-例: [ADR-008 cookie consent banner](./log/2026-02-16-cookie-consent-banner.md)、[ADR-009 cookie consent required](./log/2026-02-18-cookie-consent-required.md) は過去の cookie 同意まわりの意思決定記録（このディレクトリ新設以前のもの）。[2026-08-12 privacy Google Calendar 節追加](./log/2026-08-12-privacy-google-calendar-section.md) は GCP sensitive scope 審査（#1963）に向けた最新例。
+例: [ADR-008 cookie consent banner](./log/2026-02-16-cookie-consent-banner.md)、[ADR-009 cookie consent required](./log/2026-02-18-cookie-consent-required.md) は過去の cookie 同意まわりの意思決定記録（このディレクトリ新設以前のもの）。[2026-08-12 privacy Google Calendar 節追加](./log/2026-08-12-privacy-google-calendar-section.md) は GCP sensitive scope 審査（#1963）に向けた最新例。[2026-08-17 Axiom サブプロセッサー追記](./log/2026-08-17-axiom-subprocessor-notice.md) は Vercel Log Drains 導入（#1701 Phase 3）の legal 前提（30 日前通知）に向けた例。
 
 ## このファイルに書かないこと
 

--- a/docs/operations/log/2026-08-17-axiom-subprocessor-notice.md
+++ b/docs/operations/log/2026-08-17-axiom-subprocessor-notice.md
@@ -1,0 +1,31 @@
+---
+status: frozen
+date: 2026-08-17
+---
+
+# Axiom をサブプロセッサーとして privacy.mdx に追記し、30 日通知の時計を開始した
+
+## 背景・当時の前提
+
+`docs/operations/monitoring.md` §Log Drains（Axiom）が定める Drain 作成手順は、Axiom が Vercel Log Drains 経由で runtime / build ログ（アプリの構造化ログに加え、Vercel 自身の request log を含みうる）を保管・検索する新規サブプロセッサーであることを前提にしていた。privacy.mdx の subProcessors 節は「新しいサブプロセッサーの導入は少なくとも 30 日前に通知する」と約束済みのため、この通知を済ませないまま Drain を作成すると公開ポリシー違反になる（2026-08-14 の内製クロスレビューで P1 指摘として検出、#1701 Phase 3 の残作業として着手保留になっていた）。
+
+あわせて、Log Drain が運ぶ Vercel 自身の request log には iCal feed の URL（`/api/v1/calendar/{token}.ics`、token が path に入る長期 bearer credential）や OAuth callback の `code` / `state`（query）が含まれうるため、path / query を送信対象に含めるかどうかも Drain 作成前に確定させる必要があった。
+
+## 決定と理由
+
+指揮台 Fable が User 承認を得て、以下 2 点を確定した（[#1701 コメント](https://github.com/Dayopt/dayopt/issues/1701#issuecomment-5311774981)）:
+
+1. **送信フィールド**: request log の **path / query は Drain 対象から除外する**。iCal feed token（path 内の長期 bearer credential）と OAuth code/state（query）が Axiom へ恒久記録されるのを構造的に避けるため。デバッグ用途は Sentry + アプリの構造化ログでカバーし、不足が実測されたら除外の緩和を別途判断する
+2. **legal 前提の着手**: privacy.mdx（`apps/web/content/legal/{ja,en}/privacy.mdx`）の subProcessors 節へ Axiom を追記し、30 日前通知の時計をこの追記の production 公開日から起算する。Drain の実作成はその 30 日後以降に User が実施する（`EXPLICIT AUTHORITY`、monitoring.md の手順どおり）
+
+## 却下した選択肢と、なぜ捨てたか
+
+- **request log の path / query も含めて送る**: デバッグ時の利便性は上がるが、iCal token という長期 bearer credential を第三者 store（Axiom）へ恒久記録することになり、feed 利用者のカレンダー閲覧権が漏洩した場合の被害範囲が repo 外へ広がる。デバッグは既存の Sentry + 構造化ログで足りると判断した
+- **Drain 作成後に事後通知する**: privacy.mdx の既存の約束（少なくとも 30 日前の事前通知）に反するため不可
+
+## 影響・やること
+
+- `apps/web/content/legal/{ja,en}/privacy.mdx` の subProcessors 節に Axiom エントリを追加し、`lastUpdated` を更新（本 PR）
+- `apps/web/src/app/[locale]/(marketing)/legal/_components/legal-standard-document.tsx` の `PRIVACY_SECTIONS` 内 subProcessors の list keys に `axiom` を追加（本 PR。追加しないと data に書いても描画されない）
+- `docs/operations/monitoring.md` §Log Drains（Axiom）手順 1・2 を、確定した内容（除外方針・legal 前提着手済み）に更新（本 PR）
+- 30 日時計の起点はこの変更が **production へ deploy された日**（merge 日ではない）。Drain 作成（monitoring.md 手順 3 以降）は起点から 30 日以上空けてから、User が `EXPLICIT AUTHORITY` として実施する

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -115,6 +115,7 @@ Product / Webのbrowserを含むProduction検証、alert email、source map、tr
    - Vercel team dashboard → **Settings → Drains** で、作成された Drain の status が `enabled` であることを確認する
    - Axiom dashboard → `vercel` dataset で、直近デプロイのログが実際に届いていることを確認する（`vercelProjectName` フィールドで product / web を区別できる）。手順 2 で除外を決めたフィールド（iCal token 等）が実際に含まれていないことも合わせて確認する
    - Spend Management の **Activity** セクション（team dashboard サイドバー）で、上限設定が反映されていることを確認する
+   - Axiom は dataset 作成時にリージョンを US East / EU Central の 2 択で選ぶ。privacy.mdx の Axiom サブプロセッサー記載（Data location: United States）を真に保つため、dataset のリージョンが **US East** であることを Axiom dashboard の dataset 設定で確認する
 6. **rollback**（`[hours]`） — Vercel team dashboard → Settings → Drains から該当 Drain を disable、または Integrations 画面から Axiom を uninstall する。課金は停止時点までの転送量分のみ
 
 ### 運用上の注意

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -99,14 +99,13 @@ Product / Webのbrowserを含むProduction検証、alert email、source map、tr
 ### 手順
 
 1. **legal 前提（Drain 作成より先に完了させる）** — Axiom は Dayopt の privacy policy が個別列挙するサブプロセッサーに該当しうる新規追加で、privacy.mdx は「導入の少なくとも 30 日前に通知」を約束している。手順どおり Drain を作るだけでは、この約束を素通りして公開ポリシー違反になる
-   - `apps/web/content/docs` の privacy.mdx（ja / en 両方）へ Axiom をサブプロセッサーとして追記する
-   - 追記から実際の Drain 有効化まで **30 日以上**空ける（通知タイミングの起点は追記 publish 日）
-   - サブプロセッサー追加の意思決定を `docs/operations/legal.md` §改定の記録 に従って decision ログへ残す
-   - この judgment（サブプロセッサーを追加するかどうか）自体が `EXPLICIT AUTHORITY`。下記の技術手順より先に User が判断する
+   - **完了（2026-08-17、#1701 コメント参照）**: `apps/web/content/legal/{ja,en}/privacy.mdx` の subProcessors 節へ Axiom を追記済み。決定の記録は `docs/operations/log/2026-08-17-axiom-subprocessor-notice.md`
+   - **30 日時計の起点はこの追記が production へ公開された日**（merge 日ではなく deploy 日）。Drain 作成はその 30 日後以降に行う。公開日は該当 PR の merge 後、Vercel Production deployment のタイムスタンプで確認する
+   - この judgment（サブプロセッサーを追加するかどうか）自体が `EXPLICIT AUTHORITY` で、User 承認済み（#1701 コメント）
 2. **Drain が送信するフィールドの確定（legal 前提と並行して検討可、Drain 作成より先に確定させる）** — Log Drain はアプリの構造化ログだけでなく **Vercel 自身の request log**（path / query / clientIp / userAgent 等）を運ぶ。既存の `@/lib/logger` sanitize 方針（本ファイル §Sentry runtime contract）はアプリコードが出す構造化ログにしか及ばず、Vercel の request log には適用されない
    - **具体的な露出**: (a) iCal feed の URL（`/api/v1/calendar/{token}.ics`）は token が URL path に入る長期 bearer credential で、request log に path が含まれる設定だと Drain 経由で Axiom に恒久記録される（= feed 利用者のカレンダー閲覧権が第三者 store に写る） (b) OAuth callback の `code` / `state` が query に入る
-   - Drain 作成時に「request log の path / query を対象に含めるか」を確定する。含める場合は iCal token の扱い（対象からの除外、または Axiom 側 retention とアクセス制限の明記）を先に決める
-   - **上記が確定するまで Drain を作成しない**
+   - **確定（2026-08-17、#1701 コメント参照）**: request log の path / query は Drain 対象から除外する。iCal feed token・OAuth code/state の Axiom への恒久記録を構造的に避けるための判断で、デバッグ用途は Sentry + アプリ構造化ログでカバーする。不足が実測されたら除外の緩和を別途判断する
+   - **上記の除外設定を Drain 作成時（下記手順 4）に反映する**
 3. **Spend Management の上限設定** — 無料枠なしの従量課金への対策。Vercel team dashboard → **Settings → Billing → Spend Management** を有効化し、USD 上限額を設定する。Owner または Billing role が必要
    - **上限額の設定は通知のみで、支出を自動的に止めない。** 「production を自動一時停止」オプションを別途有効化しない限り、上限到達後もログ転送と課金は継続する。本番影響が大きいため既定では自動一時停止を有効化せず、通知（50% / 75% / 100%、**Settings → My Notifications** で Web / Email、必要なら SMS を有効化）を受けた人間が手動で対応する運用とする
    - 閾値通知を受けた時の一次対応は下記 rollback（Drain disable）を参照。solo 運用のため対応までの遅延は保証されない — 上限額は「気づかず膨らむ額」の許容上限として、実コストより余裕を持たせて設定する


### PR DESCRIPTION
## 概要

#1701 Phase 3（Vercel Log Drains / Axiom）の legal 前提。privacy policy が約束する「新規サブプロセッサーは少なくとも30日前に通知」を満たすため、Axiomをsub-processorとして`privacy.mdx`へ追記し、30日通知の時計を開始する。

## 変更内容

- `apps/web/content/legal/{ja,en}/privacy.mdx`: subProcessors節にAxiomエントリを追加（Vercel Log Drains経由のruntime/buildログ保管・検索。request logのpath/queryは送信対象から除外）。`lastUpdated`も更新
- `apps/web/src/app/[locale]/(marketing)/legal/_components/legal-standard-document.tsx`: `PRIVACY_SECTIONS`のsubProcessors list keysに`axiom`を追加（data側だけでは描画されないため必須）
- `docs/operations/monitoring.md`: §Log Drains（Axiom）手順1・2を確定内容へ更新（legal前提の着手完了・送信フィールド除外方針の確定を反映）
- `docs/operations/log/2026-08-17-axiom-subprocessor-notice.md`: 決定記録を新規作成

## 決定の根拠

[#1701 issue コメント](https://github.com/Dayopt/dayopt/issues/1701#issuecomment-5311774981)（指揮台 Fable、User承認済み）に基づく2点の確定判断:

1. request logのpath/queryはDrain対象から除外する
2. legal前提（本PR）の30日通知の時計は、この変更がproductionへ公開された日から起算する

Drainの実作成（monitoring.md手順3以降）はこの30日後以降にUserが`EXPLICIT AUTHORITY`として実施する。

Refs #1701