### PR TITLE
ci(storage): storage backup の日次 export workflow を追加する

### DIFF
--- a/.github/workflows/storage-backup-export.yml
+++ b/.github/workflows/storage-backup-export.yml
@@ -1,0 +1,115 @@
+name: Storage Backup Export
+
+# Supabase Storage（avatars / attachments）を rclone で Cloudflare R2 へ日次搬出する。
+#
+# 背景（#1971）: avatars / attachments には DB backup 経由の復元元が無い。この export
+# workflow が唯一の復元元になる。実行 script は scripts/storage-backup.sh（rclone sync。
+# destination 側を source に合わせる設計のため、source 側の設定ミス・読み取り失敗は
+# destination の既存オブジェクトを削除しうる。script 冒頭コメント参照）。
+#
+# secrets（RCLONE_CONFIG_SOURCE_* / RCLONE_CONFIG_DEST_*）は #2026 で GitHub Secrets へ
+# 投入される。**未投入の間は明示 failure にする**（fail closed）。無音成功で
+# 「バックアップが走っている」という誤った安心を生まないため（#2147 検証項目）。
+#
+# 通知: 追加の通知実装はしない。GitHub の既定挙動（scheduled workflow の失敗は
+# repository の Actions 通知設定に従いメール通知される）に乗る。同種の日次 cron
+# （production-config-audit.yml / replica-check.yml）も追加実装をしていないのと同じ判断
+# （#2147 で指揮台へ確認済み）。
+
+on:
+  schedule:
+    # 07:00 JST。production-config-audit（06:00 JST）・replica-check（06:30 JST）と
+    # 時間をずらし、同時実行の外部 API 呼び出し衝突を避ける。
+    - cron: '0 22 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'true にすると実際には転送・削除せず rclone --dry-run で予定操作だけ表示する'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: storage-backup-export
+  # sync 実行中のキャンセルは destination を中途半端な状態（一部オブジェクトだけ
+  # 削除・転送済み）で残しうるため、他の CI job と異なり cancel-in-progress にしない。
+  cancel-in-progress: false
+
+jobs:
+  export:
+    name: Export Supabase Storage to R2
+    runs-on: ubuntu-latest
+    # 初回実運用（#2026）前の見積もり。avatars / attachments の実データ量が不明なため
+    # 保守的な値を置く。初回搬出の実測を見て #2026 側で調整する。
+    timeout-minutes: 30
+    env:
+      RCLONE_VERSION: '1.75.0'
+      RCLONE_SHA256: 'aa2804e08f48250e71009c727124b6341cd0288465804a9a09d14663cabafbaa'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # org の Actions 許可リストが actions/* github/* zaproxy/* codecov/* softprops/*
+      # supabase/* oven-sh/* に限定されており rclone 公式 action は使えないため、
+      # docs-guard.yml の gitleaks と同じくバイナリを直接取得・checksum 検証する。
+      - name: rclone をインストール
+        run: |
+          curl -fsSLO "https://downloads.rclone.org/v${RCLONE_VERSION}/rclone-v${RCLONE_VERSION}-linux-amd64.zip"
+          echo "${RCLONE_SHA256}  rclone-v${RCLONE_VERSION}-linux-amd64.zip" | sha256sum -c -
+          unzip -q "rclone-v${RCLONE_VERSION}-linux-amd64.zip"
+          sudo install -m 0755 "rclone-v${RCLONE_VERSION}-linux-amd64/rclone" /usr/local/bin/rclone
+          rclone version
+
+      # secrets 未投入（#2026 完了前）でも workflow 自体は main へマージ・cron 起動できる
+      # ようにしつつ、無音成功にはしない。値そのものは echo しない（存在確認のみ）。
+      - name: 必須 secrets の存在を確認（fail closed）
+        env:
+          RCLONE_CONFIG_SOURCE_TYPE: ${{ secrets.RCLONE_CONFIG_SOURCE_TYPE }}
+          RCLONE_CONFIG_SOURCE_PROVIDER: ${{ secrets.RCLONE_CONFIG_SOURCE_PROVIDER }}
+          RCLONE_CONFIG_SOURCE_ENDPOINT: ${{ secrets.RCLONE_CONFIG_SOURCE_ENDPOINT }}
+          RCLONE_CONFIG_SOURCE_REGION: ${{ secrets.RCLONE_CONFIG_SOURCE_REGION }}
+          RCLONE_CONFIG_SOURCE_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_SOURCE_ACCESS_KEY_ID }}
+          RCLONE_CONFIG_SOURCE_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_SOURCE_SECRET_ACCESS_KEY }}
+          RCLONE_CONFIG_DEST_TYPE: ${{ secrets.RCLONE_CONFIG_DEST_TYPE }}
+          RCLONE_CONFIG_DEST_PROVIDER: ${{ secrets.RCLONE_CONFIG_DEST_PROVIDER }}
+          RCLONE_CONFIG_DEST_ENDPOINT: ${{ secrets.RCLONE_CONFIG_DEST_ENDPOINT }}
+          RCLONE_CONFIG_DEST_REGION: ${{ secrets.RCLONE_CONFIG_DEST_REGION }}
+          RCLONE_CONFIG_DEST_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_DEST_ACCESS_KEY_ID }}
+          RCLONE_CONFIG_DEST_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_DEST_SECRET_ACCESS_KEY }}
+        run: |
+          missing=()
+          for key in \
+            RCLONE_CONFIG_SOURCE_TYPE RCLONE_CONFIG_SOURCE_PROVIDER RCLONE_CONFIG_SOURCE_ENDPOINT \
+            RCLONE_CONFIG_SOURCE_REGION RCLONE_CONFIG_SOURCE_ACCESS_KEY_ID RCLONE_CONFIG_SOURCE_SECRET_ACCESS_KEY \
+            RCLONE_CONFIG_DEST_TYPE RCLONE_CONFIG_DEST_PROVIDER RCLONE_CONFIG_DEST_ENDPOINT \
+            RCLONE_CONFIG_DEST_REGION RCLONE_CONFIG_DEST_ACCESS_KEY_ID RCLONE_CONFIG_DEST_SECRET_ACCESS_KEY; do
+            if [ -z "${!key:-}" ]; then
+              missing+=("$key")
+            fi
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::未設定の GitHub Secrets があります: ${missing[*]}"
+            echo "::error::docs/operations/secrets.md の Change Procedure に従って登録してください（#2026）。"
+            exit 1
+          fi
+          echo "必須 secrets はすべて設定されています。"
+
+      - name: storage-backup.sh を実行
+        env:
+          RCLONE_CONFIG_SOURCE_TYPE: ${{ secrets.RCLONE_CONFIG_SOURCE_TYPE }}
+          RCLONE_CONFIG_SOURCE_PROVIDER: ${{ secrets.RCLONE_CONFIG_SOURCE_PROVIDER }}
+          RCLONE_CONFIG_SOURCE_ENDPOINT: ${{ secrets.RCLONE_CONFIG_SOURCE_ENDPOINT }}
+          RCLONE_CONFIG_SOURCE_REGION: ${{ secrets.RCLONE_CONFIG_SOURCE_REGION }}
+          RCLONE_CONFIG_SOURCE_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_SOURCE_ACCESS_KEY_ID }}
+          RCLONE_CONFIG_SOURCE_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_SOURCE_SECRET_ACCESS_KEY }}
+          RCLONE_CONFIG_DEST_TYPE: ${{ secrets.RCLONE_CONFIG_DEST_TYPE }}
+          RCLONE_CONFIG_DEST_PROVIDER: ${{ secrets.RCLONE_CONFIG_DEST_PROVIDER }}
+          RCLONE_CONFIG_DEST_ENDPOINT: ${{ secrets.RCLONE_CONFIG_DEST_ENDPOINT }}
+          RCLONE_CONFIG_DEST_REGION: ${{ secrets.RCLONE_CONFIG_DEST_REGION }}
+          RCLONE_CONFIG_DEST_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_DEST_ACCESS_KEY_ID }}
+          RCLONE_CONFIG_DEST_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_DEST_SECRET_ACCESS_KEY }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        run: bash scripts/storage-backup.sh

--- a/.github/workflows/storage-backup-export.yml
+++ b/.github/workflows/storage-backup-export.yml
@@ -15,6 +15,11 @@ name: Storage Backup Export
 # repository の Actions 通知設定に従いメール通知される）に乗る。同種の日次 cron
 # （production-config-audit.yml / replica-check.yml）も追加実装をしていないのと同じ判断
 # （#2147 で指揮台へ確認済み）。
+#
+# timeout（30分）で強制終了した場合、destination にはその時点までに同期済みの
+# オブジェクトだけが残り、sync 未処理分は反映されない。rclone sync は冪等な操作
+# （同じ source/destination を再実行すれば差分だけが追いつく）のため、追加対応は
+# 不要——翌日の cron 実行が自然に収束させる（2026-08-18、PR #2151 クロスレビュー P3）。
 
 on:
   schedule:

--- a/docs/operations/disaster-recovery-drill.md
+++ b/docs/operations/disaster-recovery-drill.md
@@ -285,9 +285,9 @@ DB 内の hook function が戻っても、**GoTrue 側の hook 登録は引き�
 - [ ] `avatars` / `attachments` バケットが存在する（バケット定義は migration に入っているので schema と一緒に戻る）
 - [ ] **オブジェクト本体は空**であることを確認する。これは異常ではなく仕様
 
-> **⚠ 機構（script）は実装済みだが、実運用の搬出実績はゼロ。依然として復元元は実質存在しない。** `scripts/storage-backup.sh` / `scripts/storage-restore.sh`（rclone ベース、`avatars` / `attachments` の両バケット対応）は 2026-08-13 にローカル Supabase Storage 相手の実 sync + copy で byte-identical な復元を確認済み（[#1972](https://github.com/Dayopt/dayopt/issues/1972)）。ただし destination（backup 先。Cloudflare R2 を推奨、User 裁可済み）の実プロビジョニングと credential 投入、production に対する初回搬出、日次 cron workflow の追加はまだ行われていない。**それが揃うまでは production の `avatars` / `attachments` が削除・破損した事故では復旧手段が無い**のと実質同じ。
+> **⚠ 機構（script + 日次 workflow）は実装済みだが、secrets 未投入のため実運用の搬出実績はゼロ。依然として復元元は実質存在しない。** `scripts/storage-backup.sh` / `scripts/storage-restore.sh`（rclone ベース、`avatars` / `attachments` の両バケット対応）は 2026-08-13 にローカル Supabase Storage 相手の実 sync + copy で byte-identical な復元を確認済み（[#1972](https://github.com/Dayopt/dayopt/issues/1972)）。日次搬出を実行する [`storage-backup-export.yml`](../../.github/workflows/storage-backup-export.yml) は追加済み（[#2147](https://github.com/Dayopt/dayopt/issues/2147)）で、secrets（`RCLONE_CONFIG_SOURCE_*` / `RCLONE_CONFIG_DEST_*`）が未投入の間は無音成功せず明示 failure になる（fail closed）。ただし destination（backup 先。Cloudflare R2 を推奨、User 裁可済み）の実プロビジョニング・GitHub Secrets への credential 投入・production に対する初回搬出はまだ行われていない。**それが揃うまでは production の `avatars` / `attachments` が削除・破損した事故では復旧手段が無い**のと実質同じ。
 >
-> 実運用化（destination 確定・credential 投入・初回搬出・日次 workflow 追加）は [#2026](https://github.com/Dayopt/dayopt/issues/2026) で追う。**paid billing のゲート条件に含める判断は #2026 の完了を待つ**（現状 avatar と添付が恒久消失しうる状態で課金を開始してよいか）。
+> 実運用化（destination 確定・credential 投入・初回搬出）は [#2026](https://github.com/Dayopt/dayopt/issues/2026) で追う。**paid billing のゲート条件に含める判断は #2026 の完了を待つ**（現状 avatar と添付が恒久消失しうる状態で課金を開始してよいか）。
 >
 > 演習では「オブジェクトが空で戻る」ことの確認までを行い、実 destination からの restore は [#2026](https://github.com/Dayopt/dayopt/issues/2026) の実装後に演習項目へ足す。
 

--- a/scripts/__tests__/storage-backup-restore.test.ts
+++ b/scripts/__tests__/storage-backup-restore.test.ts
@@ -129,6 +129,27 @@ describe('storage-backup.sh', () => {
     expect(result.stderr).not.toContain('unbound variable');
     expect(result.status).toBe(0);
   });
+
+  it('既定で --max-delete 1000 を付ける（全消し型事故を fail loud にする歯止め、#2151 P1）', () => {
+    const binDir = makeStubBin('record');
+
+    const result = run(backupScript, binDir, { STORAGE_BACKUP_BUCKETS: 'avatars' });
+
+    expect(result.status).toBe(0);
+    expect(readCallLog(binDir)[0]).toContain('--max-delete 1000');
+  });
+
+  it('STORAGE_BACKUP_MAX_DELETE で --max-delete の上限値を上書きできる', () => {
+    const binDir = makeStubBin('record');
+
+    const result = run(backupScript, binDir, {
+      STORAGE_BACKUP_BUCKETS: 'avatars',
+      STORAGE_BACKUP_MAX_DELETE: '42',
+    });
+
+    expect(result.status).toBe(0);
+    expect(readCallLog(binDir)[0]).toContain('--max-delete 42');
+  });
 });
 
 describe('storage-restore.sh', () => {

--- a/scripts/storage-backup.sh
+++ b/scripts/storage-backup.sh
@@ -15,9 +15,14 @@
 # storage.buckets INSERT（avatars / attachments）。
 #
 # ⚠ sync は destination を source に合わせるため、SOURCE_REMOTE の設定ミス・読み取り
-# 失敗（空を返す等）が起きると destination 側の既存オブジェクトを削除しうる。実運用化
-# （#2026）では destination 側の versioning / object lock を必須にするか、
-# `--max-delete` で削除上限を設ける。
+# 失敗（空を返す等）が起きると destination 側の既存オブジェクトを削除しうる。
+# --max-delete で 1 回の sync が削除できるオブジェクト数に上限を設け、全消し型の事故を
+# fail loud にする（超過時 rclone は exit code 7 で失敗する）。認証エラー等は
+# 既存の set -euo pipefail で fail loud だが、「エラーにはならないが空リストが返る」型
+# （bucket 誤指定・list 権限欠如等）は --max-delete が無いと無音で進んでしまう
+# （2026-08-18、PR #2151 クロスレビュー risk-reviewer 指摘）。実運用化（#2026）では
+# destination 側の versioning / object lock（Bucket Locks）も defense-in-depth として
+# 検討する。
 
 set -euo pipefail
 
@@ -34,6 +39,12 @@ IFS=' ' read -r -a BUCKETS <<< "${STORAGE_BACKUP_BUCKETS:-avatars attachments}"
 DRY_RUN_FLAG=""
 [[ "${DRY_RUN:-false}" == "true" ]] && DRY_RUN_FLAG="--dry-run"
 
+# 1 回の sync で削除できるオブジェクト数の上限。既定 1000 は現行の avatars/attachments
+# 実データ量に対して十分な余裕を見込んだ暫定値（#2026 の初回搬出後、実オブジェクト数を
+# 見て STORAGE_BACKUP_MAX_DELETE で調整する）。超過時は rclone が exit code 7 で失敗し、
+# sync 自体は中断される（destination は上限に達した時点までの変更しか反映しない）。
+MAX_DELETE="${STORAGE_BACKUP_MAX_DELETE:-1000}"
+
 command -v rclone >/dev/null 2>&1 || {
   echo "❌ rclone が見つかりません。公式配布（https://rclone.org/downloads/）からインストールしてください" >&2
   exit 1
@@ -48,6 +59,7 @@ for bucket in "${BUCKETS[@]}"; do
     "${DEST_REMOTE}:${bucket}" \
     --checksum \
     --create-empty-src-dirs=false \
+    --max-delete "${MAX_DELETE}" \
     --stats-one-line \
     --stats=30s \
     ${DRY_RUN_FLAG}


### PR DESCRIPTION
## 概要

avatars/attachments には DB backup 経由の復元元が無く（#1971）、`scripts/storage-backup.sh`（#1971/#1972 で実装済み）を定期実行する経路が未実装だった。R2 destination 側は #2026 で準備中。本 PR は日次 export workflow の追加と RCLONE secrets 名の確定まで（scope 外: secrets 実値投入・初回搬出・復元演習は #2026）。

## 変更内容

- `.github/workflows/storage-backup-export.yml` 新設。日次 07:00 JST cron + `workflow_dispatch`（`dry_run` input 付き）。rclone は org の Actions 許可リストに公式 action が無いため、`docs-guard.yml` の gitleaks と同じくバイナリを直接取得し SHA256 checksum 検証してインストールする
- secrets（`RCLONE_CONFIG_{SOURCE,DEST}_{TYPE,PROVIDER,ENDPOINT,REGION,ACCESS_KEY_ID,SECRET_ACCESS_KEY}` 計12件）は未投入の間、明示 failure にする（fail closed）。無音成功を防ぐ設計
- `docs/operations/disaster-recovery-drill.md` の Storage 節を更新し、workflow 追加済みであることを反映

## Secrets 名確定

[#2147 のコメント](https://github.com/Dayopt/dayopt/issues/2147#issuecomment-5321462771)で確定済み（指揮台裁定: TYPE/PROVIDER/REGION を含め GH Secrets に統一）。実値投入は #2026 の User 操作。

## 検証

- [x] `pnpm docs:check` green
- [x] `pnpm secrets:check` green（literal secret 無し）
- [x] `actionlint`（ローカル導入）green、YAML 構文 OK
- [x] missing-secrets 判定ロジックを bash 単体で動作確認
- [x] rclone バイナリの SHA256 checksum をローカルで実測・検証済み
- [ ] CI（Static Checks / docs guard）green — push 後に確認
- [ ] secrets 未投入状態での `workflow_dispatch` 実行が明示 failure になること — secrets 未投入の現状で確認可能。実行して確認予定

## 注意点

- 通知経路: 追加実装はせず GitHub 既定の Actions failure メール通知に乗せる設計（`production-config-audit.yml` / `replica-check.yml` と同じ判断）。User 個人の通知設定が有効かは User 操作枠で確認予定
- `#2026` 側の stale 記述（旧 vault 名 `Dayopt-Production`）は issue コメントで指摘済み（進行中レーンとの競合を避けるため body 直接編集はしていない）

Closes #2147