### PR TITLE
chore(calendar): probe URL追従とCalendarEvent改名の小粒cleanup束

### DIFF
--- a/apps/product/src/app/[locale]/(app)/(workspace)/_composition/__tests__/createCalendarEventClipboardTimeblock.test.ts
+++ b/apps/product/src/app/[locale]/(app)/(workspace)/_composition/__tests__/createCalendarEventClipboardTimeblock.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import type { CalendarEvent } from '@/features/calendar';
+import type { CalendarDisplayEvent } from '@/features/calendar';
 
 import { createCalendarEventClipboardTimeblock } from '../createCalendarEventClipboardTimeblock';
 
-function makeEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+function makeEvent(overrides: Partial<CalendarDisplayEvent> = {}): CalendarDisplayEvent {
   return {
     id: 'plan-1',
     title: '読書',
@@ -39,7 +39,7 @@ describe('createCalendarEventClipboardTimeblock', () => {
     });
   });
 
-  it('種別を持たないCalendarEventはコピー対象にしない', () => {
+  it('種別を持たないCalendarDisplayEventはコピー対象にしない', () => {
     expect(createCalendarEventClipboardTimeblock(makeEvent({ kind: undefined }))).toBeNull();
   });
 });

--- a/apps/product/src/app/[locale]/(app)/(workspace)/_composition/createCalendarEventClipboardTimeblock.ts
+++ b/apps/product/src/app/[locale]/(app)/(workspace)/_composition/createCalendarEventClipboardTimeblock.ts
@@ -1,9 +1,9 @@
-import type { CalendarEvent } from '@/features/calendar';
+import type { CalendarDisplayEvent } from '@/features/calendar';
 import { createClipboardTimeblock, type ClipboardTimeblock } from '@/features/timeblock';
 
 /** Calendar の表示時刻を保ったまま、既存の貼り付け用データへ変換する。 */
 export function createCalendarEventClipboardTimeblock(
-  entry: CalendarEvent,
+  entry: CalendarDisplayEvent,
 ): ClipboardTimeblock | null {
   if (!entry.kind) return null;
 

--- a/apps/product/src/app/[locale]/(app)/(workspace)/_composition/useCalendarCrudHandlers.ts
+++ b/apps/product/src/app/[locale]/(app)/(workspace)/_composition/useCalendarCrudHandlers.ts
@@ -12,7 +12,7 @@ import { useCallback, useMemo } from 'react';
 import { addHours, startOfHour } from 'date-fns';
 import { useTranslations } from 'next-intl';
 
-import type { CalendarEvent } from '@/features/calendar';
+import type { CalendarDisplayEvent } from '@/features/calendar';
 import {
   useCalendarEventKeyboard,
   useCalendarHandlers,
@@ -32,14 +32,14 @@ interface CalendarCrudHandlersInput {
   /** Inspector で選択中の Timeblock ID */
   selectedTimeblockId: string | null;
   /** フィルタ済みイベント一覧（キーボード操作でタイトル取得に使用） */
-  filteredEvents: CalendarEvent[];
+  filteredEvents: CalendarDisplayEvent[];
   /** 現在の表示日付（キーボード操作で過去日判定に使用） */
   currentDate: Date;
 }
 
 interface CalendarCrudHandlersResult {
   disabledTimeblockId: string | null;
-  onEntryClick: (entry: CalendarEvent) => void;
+  onEntryClick: (entry: CalendarDisplayEvent) => void;
   onTimeRangeSelect: (selection: {
     date: Date;
     startHour: number;
@@ -48,7 +48,7 @@ interface CalendarCrudHandlersResult {
     endMinute: number;
   }) => void;
   onUpdateEntry: (
-    timeblockIdOrTimeblock: string | CalendarEvent,
+    timeblockIdOrTimeblock: string | CalendarDisplayEvent,
     updates?: {
       startTime: Date;
       endTime: Date;
@@ -57,11 +57,11 @@ interface CalendarCrudHandlersResult {
     },
   ) => void | Promise<void> | Promise<{ skipToast: true } | void>;
   onDeleteTimeblock: (timeblockId: string) => Promise<boolean>;
-  onDeleteTimeblockConfirm: (entry: CalendarEvent) => void;
-  onViewStats: (entry: CalendarEvent) => void;
-  onCopy: (entry: CalendarEvent) => void;
-  onSkip: (entry: CalendarEvent) => void;
-  onUnskip: (entry: CalendarEvent) => void;
+  onDeleteTimeblockConfirm: (entry: CalendarDisplayEvent) => void;
+  onViewStats: (entry: CalendarDisplayEvent) => void;
+  onCopy: (entry: CalendarDisplayEvent) => void;
+  onSkip: (entry: CalendarDisplayEvent) => void;
+  onUnskip: (entry: CalendarDisplayEvent) => void;
 }
 
 // =============================================================================
@@ -123,7 +123,7 @@ export function useCalendarCrudHandlers({
   }, [selectedTimeblockId, filteredEvents]);
 
   const handleCopy = useCallback(
-    (entry: CalendarEvent) => {
+    (entry: CalendarDisplayEvent) => {
       const timeblock = createCalendarEventClipboardTimeblock(entry);
       if (!timeblock) return;
       copyTimeblock(timeblock);

--- a/apps/product/src/app/[locale]/(app)/(workspace)/_composition/useCalendarDataLayer.ts
+++ b/apps/product/src/app/[locale]/(app)/(workspace)/_composition/useCalendarDataLayer.ts
@@ -9,7 +9,7 @@
 
 import { useEffect, useMemo } from 'react';
 
-import type { CalendarEvent, CalendarViewType, ViewDateRange } from '@/features/calendar';
+import type { CalendarDisplayEvent, CalendarViewType, ViewDateRange } from '@/features/calendar';
 import { useCalendarData } from '@/features/calendar';
 import type { ExternalCalendarEvent } from '@/features/external-calendar';
 import { logger } from '@/lib/logger';
@@ -28,8 +28,8 @@ interface CalendarDataLayerInput {
 
 interface CalendarDataLayerResult {
   viewDateRange: ViewDateRange;
-  filteredEvents: CalendarEvent[];
-  allCalendarEvents: CalendarEvent[];
+  filteredEvents: CalendarDisplayEvent[];
+  allCalendarEvents: CalendarDisplayEvent[];
   /** 外部カレンダーの未変換予定（ghost）。取得失敗時は空配列で、calendar 全体は落とさない */
   externalEvents: ExternalCalendarEvent[];
   /** バックグラウンド再取得を含む取得中フラグ */

--- a/apps/product/src/features/calendar/components/CalendarController.tsx
+++ b/apps/product/src/features/calendar/components/CalendarController.tsx
@@ -21,7 +21,11 @@ import {
 import { CalendarTimeblockActionsProvider } from '../contexts/CalendarTimeblockActionsContext';
 import { useCalendarKeyboard } from '../hooks/keyboard/useCalendarKeyboard';
 import { useCalendarContextMenu } from '../hooks/useCalendarContextMenu';
-import type { CalendarEvent, CalendarViewType, ViewDateRange } from '../types/calendar.types';
+import type {
+  CalendarDisplayEvent,
+  CalendarViewType,
+  ViewDateRange,
+} from '../types/calendar.types';
 
 import { CalendarViewRenderer } from './controller/components';
 import { initializePreload } from './controller/utils';
@@ -50,8 +54,8 @@ interface CalendarControllerProps {
 
   // --- Data ---
   viewDateRange: ViewDateRange;
-  filteredTimeblocks: CalendarEvent[];
-  allTimeblocks: CalendarEvent[];
+  filteredTimeblocks: CalendarDisplayEvent[];
+  allTimeblocks: CalendarDisplayEvent[];
   /** 外部カレンダーの未変換予定（ghost）。読み取り専用で tag フィルタの対象外 */
   externalEvents?: ExternalCalendarEvent[] | undefined;
 
@@ -62,7 +66,7 @@ interface CalendarControllerProps {
   disabledTimeblockId: string | null;
 
   // --- Timeblock click handlers ---
-  onEntryClick: (entry: CalendarEvent) => void;
+  onEntryClick: (entry: CalendarDisplayEvent) => void;
   onTimeRangeSelect: (selection: {
     date: Date;
     startHour: number;
@@ -73,7 +77,7 @@ interface CalendarControllerProps {
 
   // --- Timeblock CRUD ---
   onUpdateEntry: (
-    timeblockIdOrTimeblock: string | CalendarEvent,
+    timeblockIdOrTimeblock: string | CalendarDisplayEvent,
     updates?: {
       startTime: Date;
       endTime: Date;
@@ -83,14 +87,14 @@ interface CalendarControllerProps {
   onDeleteTimeblock: (timeblockId: string) => void;
 
   // --- Context menu actions ---
-  onDeleteTimeblockConfirm: (entry: CalendarEvent) => void;
-  onViewStats: (entry: CalendarEvent) => void;
-  onCopy: (entry: CalendarEvent) => void;
+  onDeleteTimeblockConfirm: (entry: CalendarDisplayEvent) => void;
+  onViewStats: (entry: CalendarDisplayEvent) => void;
+  onCopy: (entry: CalendarDisplayEvent) => void;
   // plan ⇄ record 変換は time model に procedure が存在しないため optional（渡さなければメニュー非表示）
-  onMarkUnplanned?: ((entry: CalendarEvent) => void) | undefined;
-  onRestorePlanned?: ((entry: CalendarEvent) => void) | undefined;
-  onSkip: (entry: CalendarEvent) => void;
-  onUnskip: (entry: CalendarEvent) => void;
+  onMarkUnplanned?: ((entry: CalendarDisplayEvent) => void) | undefined;
+  onRestorePlanned?: ((entry: CalendarDisplayEvent) => void) | undefined;
+  onSkip: (entry: CalendarDisplayEvent) => void;
+  onUnskip: (entry: CalendarDisplayEvent) => void;
 
   // --- Navigation handlers ---
   onNavigate: (direction: 'prev' | 'next' | 'today') => void;
@@ -160,7 +164,7 @@ export function CalendarController({
   const { contextMenuEvent, contextMenuPosition, handleEventContextMenu, handleCloseContextMenu } =
     useCalendarContextMenu();
   const handleDuplicate = useCallback(
-    (entry: CalendarEvent) => {
+    (entry: CalendarDisplayEvent) => {
       const startAt = entry.startDate ?? entry.displayStartDate;
       const endAt = entry.endDate ?? entry.displayEndDate;
       const kind = entry.kind ?? resolveTimeblockDestination(endAt);

--- a/apps/product/src/features/calendar/components/controller/hooks/useCalendarData.ts
+++ b/apps/product/src/features/calendar/components/controller/hooks/useCalendarData.ts
@@ -24,7 +24,11 @@ import {
 import { applyTimezoneToDisplayDates } from '../../../lib/plan-data-adapter';
 import { expandRecordRowsToRecordEvents } from '../../../lib/record-event-adapter';
 
-import type { CalendarEvent, CalendarViewType, ViewDateRange } from '../../../types/calendar.types';
+import type {
+  CalendarDisplayEvent,
+  CalendarViewType,
+  ViewDateRange,
+} from '../../../types/calendar.types';
 import { isMultiDayView } from '../../../types/calendar.types';
 
 /** 表示範囲の行を先頭に保ったまま、関連取得で得た同一行を id 単位で統合する。 */
@@ -46,8 +50,8 @@ interface UseCalendarDataOptions {
 
 interface UseCalendarDataResult {
   viewDateRange: ViewDateRange;
-  filteredEvents: CalendarEvent[];
-  allCalendarEvents: CalendarEvent[];
+  filteredEvents: CalendarDisplayEvent[];
+  allCalendarEvents: CalendarDisplayEvent[];
   /**
    * 外部カレンダーの未変換予定（ghost）。読み取り専用で、タグフィルタの対象にしない
    * （外部予定にタグは無い）。取得に失敗しても空配列になるだけで、calendar 全体は落とさない。
@@ -358,7 +362,7 @@ export function useCalendarData({
   // 未分類(タグなし)フィルターの表示切替も同様にリアクティブ依存として渡す（#1576）
 
   // Step 8 の表示互換射影。既存のカードと DnD の段階的置換が完了するまで
-  // CalendarEvent は view model としてだけ維持し、データ取得は time model に固定する。
+  // CalendarDisplayEvent は view model としてだけ維持し、データ取得は time model に固定する。
   const allCalendarEvents = useMemo(() => {
     const visiblePlans = plansQuery.data ?? [];
     const visibleRecords = recordsQuery.data ?? [];

--- a/apps/product/src/features/calendar/components/controller/hooks/useCalendarHandlers.ts
+++ b/apps/product/src/features/calendar/components/controller/hooks/useCalendarHandlers.ts
@@ -6,7 +6,7 @@ import { useTimeblockInspectorStore } from '@/features/timeblock';
 import { logger } from '@/lib/logger';
 import { useInlineCreateStore } from '../../../stores/useInlineCreateStore';
 
-import type { CalendarEvent } from '../../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../../types/calendar.types';
 import type { DateTimeSelection } from '../../views/shared';
 
 /** エントリクリック・時間範囲選択など、カレンダー共通のUIイベントハンドラーを提供するフック */
@@ -22,7 +22,7 @@ export function useCalendarHandlers() {
 
   // エントリクリックハンドラー
   const handleTimeblockClick = useCallback(
-    (entry: CalendarEvent) => {
+    (entry: CalendarDisplayEvent) => {
       openTimeblockInspector(entry.id, entry.kind ?? 'plan');
 
       logger.log('Opening Timeblock Inspector:', {

--- a/apps/product/src/features/calendar/components/views/DayView/DayView.stories.tsx
+++ b/apps/product/src/features/calendar/components/views/DayView/DayView.stories.tsx
@@ -4,7 +4,7 @@ import { fn } from 'storybook/test';
 import { PRESET_USER_SETTINGS } from '@dayopt/storybook/mocks/presets';
 import { StoryTRPCProvider } from '@dayopt/storybook/mocks/trpc';
 import { computeCalendarDayDiffs } from '../../../lib/day-diff';
-import type { CalendarEvent, ViewDateRange } from '../../../types/calendar.types';
+import type { CalendarDisplayEvent, ViewDateRange } from '../../../types/calendar.types';
 
 import { DayView } from './DayView';
 
@@ -37,7 +37,7 @@ function makeDate(base: Date, hour: number, minute = 0): Date {
   return d;
 }
 
-const basePlan: CalendarEvent = {
+const basePlan: CalendarDisplayEvent = {
   id: 'plan-1',
   title: 'チームミーティング',
   description: '週次の進捗確認',
@@ -56,7 +56,7 @@ const basePlan: CalendarEvent = {
   origin: 'planned',
 };
 
-const mockPlans: CalendarEvent[] = [
+const mockPlans: CalendarDisplayEvent[] = [
   basePlan,
   {
     ...basePlan,
@@ -93,7 +93,7 @@ const mockPlans: CalendarEvent[] = [
 ];
 
 /** 期限切れ未完了エントリ（昨日のタスク）*/
-const overdueEntry: CalendarEvent = {
+const overdueEntry: CalendarDisplayEvent = {
   ...basePlan,
   id: 'overdue-1',
   title: '期限切れタスク（昨日）',
@@ -216,7 +216,7 @@ export const WithOverdueEntry: Story = {
 // Preset Sample Day — オンボーディング後の初回表示イメージ
 // ─────────────────────────────────────────────────────────
 
-const presetBase: CalendarEvent = {
+const presetBase: CalendarDisplayEvent = {
   id: '',
   title: '',
   status: 'open',
@@ -240,8 +240,8 @@ function preset(
   startHour: number,
   startMin: number,
   durationMin: number,
-  extra?: Partial<CalendarEvent>,
-): CalendarEvent {
+  extra?: Partial<CalendarDisplayEvent>,
+): CalendarDisplayEvent {
   const start = makeDate(today, startHour, startMin);
   const end = new Date(start);
   end.setMinutes(end.getMinutes() + durationMin);
@@ -260,9 +260,9 @@ function preset(
 }
 
 /** 過去エントリ（記録済み）の共通props */
-const closed: Partial<CalendarEvent> = { status: 'closed', timeblockState: 'past' };
+const closed: Partial<CalendarDisplayEvent> = { status: 'closed', timeblockState: 'past' };
 
-const presetSampleEntries: CalendarEvent[] = [
+const presetSampleEntries: CalendarDisplayEvent[] = [
   // 過去（記録済み）
   preset('preset-1', 'Morning Run', 'var(--tag-teal)', 8, 0, 30, {
     ...closed,

--- a/apps/product/src/features/calendar/components/views/DayView/__tests__/useDayView.test.ts
+++ b/apps/product/src/features/calendar/components/views/DayView/__tests__/useDayView.test.ts
@@ -6,10 +6,10 @@ vi.mock('@/lib/hooks/useUserPreferences', () => ({
     selector({ timezone: 'Asia/Tokyo' }),
 }));
 
-import type { CalendarEvent } from '../../../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../../../types/calendar.types';
 import { useDayView } from '../hooks/useDayView';
 
-const createMockEntry = (overrides: Partial<CalendarEvent> = {}): CalendarEvent => ({
+const createMockEntry = (overrides: Partial<CalendarDisplayEvent> = {}): CalendarDisplayEvent => ({
   id: `entry-${Math.random().toString(36).slice(2)}`,
   title: 'Test Entry',
   startDate: new Date('2026-03-30T10:00:00'),

--- a/apps/product/src/features/calendar/components/views/MultiDayView/hooks/useMultiDayView.ts
+++ b/apps/product/src/features/calendar/components/views/MultiDayView/hooks/useMultiDayView.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 
-import type { CalendarEvent } from '../../../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../../../types/calendar.types';
 import { useCurrentPeriod, useDateUtilities, useTimeblocksByDate } from '../../shared';
 
 /** useMultiDayView フックのオプション */
@@ -8,14 +8,14 @@ interface UseMultiDayViewOptions {
   centerDate: Date;
   dayCount: number;
   timezone: string;
-  events?: CalendarEvent[];
+  events?: CalendarDisplayEvent[];
   showWeekends?: boolean;
 }
 
 /** useMultiDayView フックの戻り値 */
 interface UseMultiDayViewReturn {
   displayDates: Date[];
-  eventsByDate: Record<string, CalendarEvent[]>;
+  eventsByDate: Record<string, CalendarDisplayEvent[]>;
   centerIndex: number;
   todayIndex: number;
   isCurrentDay: boolean;

--- a/apps/product/src/features/calendar/components/views/WeekView/WeekView.stories.tsx
+++ b/apps/product/src/features/calendar/components/views/WeekView/WeekView.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { fn } from 'storybook/test';
 
-import type { CalendarEvent, ViewDateRange } from '../../../types/calendar.types';
+import type { CalendarDisplayEvent, ViewDateRange } from '../../../types/calendar.types';
 
 import { WeekView } from './WeekView';
 
@@ -65,7 +65,7 @@ function makeDate(base: Date, hour: number, minute = 0): Date {
   return d;
 }
 
-const basePlan: CalendarEvent = {
+const basePlan: CalendarDisplayEvent = {
   id: 'plan-1',
   title: 'チームミーティング',
   startDate: makeDate(today, 10, 0),
@@ -84,7 +84,7 @@ const basePlan: CalendarEvent = {
 };
 
 // 週の各日に分散したプラン
-const mockPlans: CalendarEvent[] = [
+const mockPlans: CalendarDisplayEvent[] = [
   // 月曜
   {
     ...basePlan,
@@ -145,7 +145,7 @@ const mockPlans: CalendarEvent[] = [
 ];
 
 /** 期限切れ未完了エントリ（先週のタスク）*/
-const overdueEntry: CalendarEvent = {
+const overdueEntry: CalendarDisplayEvent = {
   ...basePlan,
   id: 'overdue-1',
   title: '期限切れタスク（先週）',

--- a/apps/product/src/features/calendar/components/views/WeekView/__tests__/useWeekTimeblocks.test.ts
+++ b/apps/product/src/features/calendar/components/views/WeekView/__tests__/useWeekTimeblocks.test.ts
@@ -1,10 +1,10 @@
 import { renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
-import type { CalendarEvent } from '../../../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../../../types/calendar.types';
 import { useWeekTimeblocks } from '../hooks/useWeekTimeblocks';
 
-const createMockEntry = (overrides: Partial<CalendarEvent> = {}): CalendarEvent => ({
+const createMockEntry = (overrides: Partial<CalendarDisplayEvent> = {}): CalendarDisplayEvent => ({
   id: `entry-${Math.random().toString(36).slice(2)}`,
   title: 'Test Entry',
   startDate: new Date('2026-03-30T10:00:00'),

--- a/apps/product/src/features/calendar/components/views/WeekView/hooks/useWeekTimeblocks.ts
+++ b/apps/product/src/features/calendar/components/views/WeekView/hooks/useWeekTimeblocks.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import { layoutEntryToVerticalPosition } from '../../../../lib/grid';
 import { calculateTimeblockLayouts, type TimeblockLayout } from '../../../../lib/layout';
-import type { CalendarEvent } from '../../../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../../../types/calendar.types';
 
 import type {
   UseWeekEntriesOptions,
@@ -29,7 +29,7 @@ export function useWeekTimeblocks({
 }: UseWeekEntriesOptions): UseWeekEntriesReturn {
   // エントリを日付ごとにグループ化（raw startDate + ユーザーTZの日付キーで判定）
   const entriesByDate = useMemo(() => {
-    const grouped: Record<string, CalendarEvent[]> = {};
+    const grouped: Record<string, CalendarDisplayEvent[]> = {};
 
     // 各日付のキーを初期化
     weekDates.forEach((date) => {
@@ -82,7 +82,7 @@ export function useWeekTimeblocks({
           ? entriesByDate[dateKey]
           : null) || [];
 
-      // CalendarEventをTimedTimeblock形式に変換（calculateTimeblockLayouts用）
+      // CalendarDisplayEventをTimedTimeblock形式に変換（calculateTimeblockLayouts用）
       const timedEntries = dayEntries
         .filter((entry) => !!entry.displayStartDate)
         .map((entry) => ({
@@ -96,7 +96,7 @@ export function useWeekTimeblocks({
 
       // TimeblockLayoutをWeekEntryPositionに変換
       layouts.forEach((layout: TimeblockLayout, index: number) => {
-        const entry = layout.entry as CalendarEvent;
+        const entry = layout.entry as CalendarDisplayEvent;
         const { top, height } = layoutEntryToVerticalPosition(
           new Date(layout.entry.start),
           new Date(layout.entry.end),

--- a/apps/product/src/features/calendar/components/views/shared/components/CalendarDragSelection/__tests__/selection-move.test.ts
+++ b/apps/product/src/features/calendar/components/views/shared/components/CalendarDragSelection/__tests__/selection-move.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import type { CalendarEvent } from '../../../../../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../../../../../types/calendar.types';
 import { computeSelectionMove, type SelectionMoveInput } from '../selection-move';
 
 // 未来日に固定して overlap 判定の kind が 'plan' になるようにする
@@ -27,12 +27,12 @@ function makeInput(overrides: Partial<SelectionMoveInput> = {}): SelectionMoveIn
   };
 }
 
-function makePlan(startHour: number, endHour: number): CalendarEvent {
+function makePlan(startHour: number, endHour: number): CalendarDisplayEvent {
   const startDate = new Date(date);
   startDate.setHours(startHour, 0, 0, 0);
   const endDate = new Date(date);
   endDate.setHours(endHour, 0, 0, 0);
-  return { id: 'plan-1', kind: 'plan', startDate, endDate } as CalendarEvent;
+  return { id: 'plan-1', kind: 'plan', startDate, endDate } as CalendarDisplayEvent;
 }
 
 describe('computeSelectionMove', () => {

--- a/apps/product/src/features/calendar/components/views/shared/components/CalendarDragSelection/selection-move.ts
+++ b/apps/product/src/features/calendar/components/views/shared/components/CalendarDragSelection/selection-move.ts
@@ -15,7 +15,7 @@ import {
 } from '../../../../../domain/interaction/selection-rules';
 import { pixelsToTime } from '../../../../../domain/interaction/time-math';
 import { checkClientSideOverlapByKind } from '../../../../../lib/overlap';
-import type { CalendarEvent } from '../../../../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../../../../types/calendar.types';
 import type { TimeRange } from './types';
 import { DRAG_CONSTANTS } from './types';
 
@@ -30,7 +30,7 @@ export interface SelectionMoveInput {
   /** これまでにドラッグ判定済みか */
   hasDragged: boolean;
   date: Date;
-  plans: CalendarEvent[];
+  plans: CalendarDisplayEvent[];
   /** 直前のスナップ位置（ハプティック発火判定用） */
   lastSnap: { startMin: number; endMin: number } | null;
 }
@@ -87,7 +87,7 @@ export function resolveInstantSelection(
   start: HourMinute,
   date: Date,
   defaultDuration: number,
-  plans: CalendarEvent[],
+  plans: CalendarDisplayEvent[],
 ): { selection: DateSelectionRange; isOverlapping: boolean } {
   const selection = createInstantSelection(start, date, defaultDuration);
   const startTime = new Date(date);

--- a/apps/product/src/features/calendar/components/views/shared/components/CalendarDragSelection/types.ts
+++ b/apps/product/src/features/calendar/components/views/shared/components/CalendarDragSelection/types.ts
@@ -4,7 +4,7 @@
 
 import type { TimeFormat } from '@dayopt/domain';
 
-import type { CalendarEvent } from '../../../../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../../../../types/calendar.types';
 
 /** ドラッグ選択の時間範囲（時・分単位） */
 export interface TimeRange {
@@ -35,7 +35,7 @@ export interface CalendarDragSelectionProps {
   /** ドラッグ選択を無効にする */
   disabled?: boolean | undefined;
   /** 重複チェック用のプラン一覧 */
-  plans?: CalendarEvent[] | undefined;
+  plans?: CalendarDisplayEvent[] | undefined;
   /** 新規作成時の既定時間（分） */
   defaultDuration: number;
   /** ユーザー設定に基づく時刻表記 */
@@ -49,7 +49,7 @@ export interface UseDragSelectionOptions {
   disabled?: boolean | undefined;
   onTimeRangeSelect?: ((selection: DateTimeSelection) => void) | undefined;
   onDoubleClick?: ((selection: DateTimeSelection) => void) | undefined;
-  plans?: CalendarEvent[] | undefined;
+  plans?: CalendarDisplayEvent[] | undefined;
   hourHeight?: number | undefined;
   defaultDuration: number;
   timeFormat: TimeFormat;

--- a/apps/product/src/features/calendar/components/views/shared/components/CalendarGridContent.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/CalendarGridContent.tsx
@@ -35,7 +35,7 @@ import {
 } from '../../../../lib/two-lane-layout';
 import { useActivityDraftStore } from '../../../../stores/useActivityDraftStore';
 import { useCalendarDragStore } from '../../../../stores/useCalendarDragStore';
-import type { CalendarEvent } from '../../../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../../../types/calendar.types';
 import { HOURS_PER_DAY } from '../constants/grid.constants';
 import { useResponsiveHourHeight } from '../hooks/useResponsiveHourHeight';
 import type { DateTimeSelection } from './CalendarDragSelection';
@@ -60,9 +60,9 @@ function shiftOptionalDate(
 }
 
 export function buildDragPreviewEntry(
-  entry: CalendarEvent,
+  entry: CalendarDisplayEvent,
   previewTime: { start: Date; end: Date },
-): CalendarEvent {
+): CalendarDisplayEvent {
   const baseStart = entry.startDate ?? entry.plannedStartDate ?? entry.displayStartDate;
   const deltaMs = baseStart ? previewTime.start.getTime() - baseStart.getTime() : 0;
   const duration = Math.max(
@@ -102,19 +102,19 @@ interface CalendarGridContentProps {
   /** この列が担当する日付 */
   date: Date;
   /** 表示するエントリ一覧 */
-  entries: CalendarEvent[];
+  entries: CalendarDisplayEvent[];
   /** ビューモード（useInteraction に渡す） */
   viewMode?: 'day' | '3day' | '5day' | 'week';
   /** この列の日付インデックス（DayView=0, Week/MultiDay=列番号） */
   dayIndex: number;
   /** 重複チェック用の全イベント（週/複数日ビュー用） */
-  allEventsForOverlapCheck?: CalendarEvent[];
+  allEventsForOverlapCheck?: CalendarDisplayEvent[];
   /** 表示日付リスト（週/複数日ビュー用） */
   displayDates?: Date[];
   /** エントリクリック */
-  onEntryClick?: ((entry: CalendarEvent) => void) | undefined;
+  onEntryClick?: ((entry: CalendarDisplayEvent) => void) | undefined;
   /** エントリ右クリック */
-  onEntryContextMenu?: ((entry: CalendarEvent, e: React.MouseEvent) => void) | undefined;
+  onEntryContextMenu?: ((entry: CalendarDisplayEvent, e: React.MouseEvent) => void) | undefined;
   /** D&D/リサイズ時の更新コールバック */
   onEventUpdate?:
     | ((
@@ -285,7 +285,7 @@ export const CalendarGridContent = React.memo(function CalendarGridContent({
   const isDragging = state.mode === 'dragging';
   const isResizing = state.mode === 'resizing';
 
-  // Step 8: 2レーン座標（plan=左/record=右）。entries は既に kind 付き CalendarEvent。
+  // Step 8: 2レーン座標（plan=左/record=右）。entries は既に kind 付き CalendarDisplayEvent。
   const twoLaneStyles = React.useMemo(
     () =>
       calculateTwoLaneStylesForCalendarEvents(visibleEntries, HOUR_HEIGHT, planLaneWidthPercent),

--- a/apps/product/src/features/calendar/components/views/shared/components/TimeblockContextMenu.stories.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/TimeblockContextMenu.stories.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { fn } from 'storybook/test';
 
-import type { CalendarEvent } from '../../../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../../../types/calendar.types';
 import { EventContextMenu } from './TimeblockContextMenu';
 
 // ─────────────────────────────────────────────────────────
@@ -14,7 +14,7 @@ const past = new Date('2026-03-18T10:00:00');
 const pastEnd = new Date('2026-03-18T11:00:00');
 
 /** 完了済み planned entry（全項目表示の前提） */
-const completedPlannedEntry: CalendarEvent = {
+const completedPlannedEntry: CalendarDisplayEvent = {
   id: 'entry-1',
   kind: 'plan',
   title: 'デザインレビュー',
@@ -37,7 +37,7 @@ const completedPlannedEntry: CalendarEvent = {
 };
 
 /** タグなし entry（振り返り非表示） */
-const noTagEntry: CalendarEvent = {
+const noTagEntry: CalendarDisplayEvent = {
   ...completedPlannedEntry,
   id: 'entry-2',
   tagId: null,
@@ -46,7 +46,7 @@ const noTagEntry: CalendarEvent = {
 /** 未来の planned entry（記録が存在し得ないため「予定外にする」非表示） */
 const futureStart = new Date('2099-01-01T10:00:00');
 const futureEnd = new Date('2099-01-01T11:00:00');
-const upcomingPlannedEntry: CalendarEvent = {
+const upcomingPlannedEntry: CalendarDisplayEvent = {
   ...completedPlannedEntry,
   id: 'entry-3',
   startDate: futureStart,
@@ -60,7 +60,7 @@ const upcomingPlannedEntry: CalendarEvent = {
 };
 
 /** Unplanned entry（計画に戻す表示） */
-const unplannedEntry: CalendarEvent = {
+const unplannedEntry: CalendarDisplayEvent = {
   ...completedPlannedEntry,
   id: 'entry-4',
   kind: 'record',
@@ -97,7 +97,7 @@ function ContextMenuTrigger({
   entry,
   menuProps,
 }: {
-  entry: CalendarEvent;
+  entry: CalendarDisplayEvent;
   menuProps?: Partial<React.ComponentProps<typeof EventContextMenu>>;
 }) {
   const [menuState, setMenuState] = useState<{ x: number; y: number } | null>(null);

--- a/apps/product/src/features/calendar/components/views/shared/components/TimeblockContextMenu.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/TimeblockContextMenu.tsx
@@ -6,20 +6,20 @@ import { useTranslations } from 'next-intl';
 
 import { getTimeblockMenuItems } from '@/features/timeblock';
 import { cn, overlaySurface } from '@dayopt/components';
-import type { CalendarEvent } from '../../../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../../../types/calendar.types';
 
 interface TimeblockContextMenuProps {
-  entry: CalendarEvent;
+  entry: CalendarDisplayEvent;
   position: { x: number; y: number };
   onClose: () => void;
-  onDelete?: ((entry: CalendarEvent) => void) | undefined;
-  onViewStats?: ((entry: CalendarEvent) => void) | undefined;
-  onCopy?: ((entry: CalendarEvent) => void) | undefined;
-  onDuplicate?: ((entry: CalendarEvent) => void) | undefined;
-  onMarkUnplanned?: ((entry: CalendarEvent) => void) | undefined;
-  onRestorePlanned?: ((entry: CalendarEvent) => void) | undefined;
-  onSkip?: ((entry: CalendarEvent) => void) | undefined;
-  onUnskip?: ((entry: CalendarEvent) => void) | undefined;
+  onDelete?: ((entry: CalendarDisplayEvent) => void) | undefined;
+  onViewStats?: ((entry: CalendarDisplayEvent) => void) | undefined;
+  onCopy?: ((entry: CalendarDisplayEvent) => void) | undefined;
+  onDuplicate?: ((entry: CalendarDisplayEvent) => void) | undefined;
+  onMarkUnplanned?: ((entry: CalendarDisplayEvent) => void) | undefined;
+  onRestorePlanned?: ((entry: CalendarDisplayEvent) => void) | undefined;
+  onSkip?: ((entry: CalendarDisplayEvent) => void) | undefined;
+  onUnskip?: ((entry: CalendarDisplayEvent) => void) | undefined;
 }
 
 /** エントリの右クリックコンテキストメニューコンポーネント */

--- a/apps/product/src/features/calendar/components/views/shared/components/TwoLaneTimeblockRenderer.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/TwoLaneTimeblockRenderer.tsx
@@ -23,14 +23,14 @@ import {
   calendarEventToRecordEvent,
 } from '../../../../lib/calendar-event-to-lane-event';
 import type { TwoLanePosition } from '../../../../lib/two-lane-layout';
-import type { CalendarEvent } from '../../../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../../../types/calendar.types';
 import { PlanLaneCard } from './TwoLane/PlanLaneCard';
 import { RecordLaneCard } from './TwoLane/RecordLaneCard';
 
 interface TwoLaneEntryRendererProps {
-  entry: CalendarEvent;
+  entry: CalendarDisplayEvent;
   position: TwoLanePosition;
-  allEvents: CalendarEvent[];
+  allEvents: CalendarDisplayEvent[];
   isDragging: boolean;
   isResizing: boolean;
   interactionState: InteractionState;
@@ -39,8 +39,8 @@ interface TwoLaneEntryRendererProps {
   showDayDiffMarker?: boolean | undefined;
   compactCards: boolean;
   timeFormat: TimeFormat;
-  onEntryClick?: ((entry: CalendarEvent) => void) | undefined;
-  onEntryContextMenu?: ((entry: CalendarEvent, e: React.MouseEvent) => void) | undefined;
+  onEntryClick?: ((entry: CalendarDisplayEvent) => void) | undefined;
+  onEntryContextMenu?: ((entry: CalendarDisplayEvent, e: React.MouseEvent) => void) | undefined;
   onPointerDown: (
     timeblockId: string,
     e: React.MouseEvent,
@@ -62,13 +62,13 @@ interface TwoLaneEntryRendererProps {
 }
 
 /** auto_migrated record はドラッグ/リサイズを禁止する。 */
-function isDragDisabled(entry: CalendarEvent): boolean {
+function isDragDisabled(entry: CalendarDisplayEvent): boolean {
   if (entry.recordSource === 'auto_migrated') return true;
   return false;
 }
 
 /** 過去Planは時間変更を禁止するが、Recordレーンへの記録dropは許可する。 */
-function isResizeDisabled(entry: CalendarEvent, now: number): boolean {
+function isResizeDisabled(entry: CalendarDisplayEvent, now: number): boolean {
   if (entry.kind === 'plan') {
     const end = entry.endDate?.getTime();
     return end != null && end <= now;

--- a/apps/product/src/features/calendar/components/views/shared/components/__tests__/CalendarGridContent.test.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/__tests__/CalendarGridContent.test.tsx
@@ -3,7 +3,7 @@ import type React from 'react';
 import { render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import type { CalendarEvent } from '../../../../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../../../../types/calendar.types';
 
 const ghostMock = vi.hoisted(() => ({
   timeblockId: null as string | null,
@@ -92,7 +92,7 @@ vi.mock('../TwoLaneTimeblockRenderer', () => ({
     position,
     showDayDiffMarker,
   }: {
-    entry: CalendarEvent;
+    entry: CalendarDisplayEvent;
     position: { left: number; width: number };
     showDayDiffMarker?: boolean;
   }) => (
@@ -114,8 +114,8 @@ import {
 
 function makeCalendarEvent(
   kind: 'plan' | 'record',
-  overrides: Partial<CalendarEvent> = {},
-): CalendarEvent {
+  overrides: Partial<CalendarDisplayEvent> = {},
+): CalendarDisplayEvent {
   const startDate = new Date('2026-07-15T09:00:00.000Z');
   const endDate = new Date('2026-07-15T10:00:00.000Z');
 
@@ -315,7 +315,7 @@ describe('CalendarGridContent', () => {
       origin: 'planned' as const,
       timeblockState: 'upcoming' as const,
       kind: 'plan' as const,
-    } satisfies CalendarEvent;
+    } satisfies CalendarDisplayEvent;
     const second = {
       ...first,
       id: 'entry-2',
@@ -323,7 +323,7 @@ describe('CalendarGridContent', () => {
       endDate: new Date('2026-06-04T11:00:00.000Z'),
       displayStartDate: new Date('2026-06-04T10:00:00.000Z'),
       displayEndDate: new Date('2026-06-04T11:00:00.000Z'),
-    } satisfies CalendarEvent;
+    } satisfies CalendarDisplayEvent;
 
     render(
       <CalendarGridContent

--- a/apps/product/src/features/calendar/components/views/shared/components/__tests__/TimeblockContextMenu.test.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/__tests__/TimeblockContextMenu.test.tsx
@@ -1,14 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import type { CalendarEvent } from '../../../../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../../../../types/calendar.types';
 import { EventContextMenu } from '../TimeblockContextMenu';
 
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string) => key,
 }));
 
-const migratedRecord: CalendarEvent = {
+const migratedRecord: CalendarDisplayEvent = {
   id: 'record-1',
   kind: 'record',
   title: '移行済み実績',

--- a/apps/product/src/features/calendar/components/views/shared/hooks/useMultiDayTimeblockPositions.ts
+++ b/apps/product/src/features/calendar/components/views/shared/hooks/useMultiDayTimeblockPositions.ts
@@ -4,7 +4,7 @@ import { isValid } from 'date-fns';
 
 import { getDateKey } from '@/lib/date';
 import { layoutEntryToVerticalPosition } from '../../../../lib/grid';
-import type { CalendarEvent } from '../../../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../../../types/calendar.types';
 
 import { HOUR_HEIGHT as DEFAULT_HOUR_HEIGHT } from '../constants/grid.constants';
 import { getTimeblockStackIndex } from '../utils/timeblockStacking';
@@ -15,7 +15,7 @@ import type { TimeblockPosition } from './useViewTimeblocks';
 /** useMultiDayTimeblockPositions フックのオプション */
 interface UseMultiDayEntryPositionsOptions {
   displayDates: Date[];
-  entries: CalendarEvent[];
+  entries: CalendarDisplayEvent[];
   hourHeight?: number;
   timezone: string;
 }
@@ -23,7 +23,7 @@ interface UseMultiDayEntryPositionsOptions {
 /** useMultiDayTimeblockPositions フックの戻り値 */
 interface UseMultiDayEntryPositionsReturn {
   timeblockPositions: TimeblockPosition[];
-  entriesByDate: Map<string, CalendarEvent[]>;
+  entriesByDate: Map<string, CalendarDisplayEvent[]>;
 }
 
 /**
@@ -41,7 +41,7 @@ export function useMultiDayTimeblockPositions({
 }: UseMultiDayEntryPositionsOptions): UseMultiDayEntryPositionsReturn {
   // 日付別にエントリをグループ化（raw startDate + ユーザーTZの日付キーで判定）
   const entriesByDate = useMemo(() => {
-    const grouped = new Map<string, CalendarEvent[]>();
+    const grouped = new Map<string, CalendarDisplayEvent[]>();
 
     displayDates.forEach((date) => {
       const dateKey = getDateKey(date, timezone);
@@ -66,7 +66,7 @@ export function useMultiDayTimeblockPositions({
   const allConvertedEntries = useMemo(() => {
     const converted: Array<{
       dateKey: string;
-      entry: CalendarEvent;
+      entry: CalendarDisplayEvent;
       start: Date;
       end: Date;
       id: string;
@@ -89,7 +89,7 @@ export function useMultiDayTimeblockPositions({
 
   // O(1)ルックアップ用Map（allConvertedEntries.find() の O(n*m) を回避）
   const timeblockMap = useMemo(() => {
-    const map = new Map<string, CalendarEvent>();
+    const map = new Map<string, CalendarDisplayEvent>();
     for (const item of allConvertedEntries) {
       map.set(item.id, item.entry);
     }
@@ -111,7 +111,7 @@ export function useMultiDayTimeblockPositions({
   // レイアウト情報をTimeblockPositionに変換
   const timeblockPositions = useMemo((): TimeblockPosition[] => {
     return timeblockLayouts.map((layout: TimeblockLayout, index: number) => {
-      const entry = timeblockMap.get(layout.entry.id) ?? (layout.entry as CalendarEvent);
+      const entry = timeblockMap.get(layout.entry.id) ?? (layout.entry as CalendarDisplayEvent);
       const { top, height } = layoutEntryToVerticalPosition(
         new Date(layout.entry.start),
         new Date(layout.entry.end),

--- a/apps/product/src/features/calendar/components/views/shared/hooks/useTimeblocksByDate.ts
+++ b/apps/product/src/features/calendar/components/views/shared/hooks/useTimeblocksByDate.ts
@@ -5,21 +5,21 @@
 import { useMemo } from 'react';
 
 import { getDateKey } from '@/lib/date';
-import type { CalendarEvent } from '../../../../types/base.types';
+import type { CalendarDisplayEvent } from '../../../../types/base.types';
 import { isValidEvent } from '../utils/dateHelpers';
 import { sortAgendaEventsByDateKeys, sortEventsByDateKeys } from '../utils/timeblockSorting';
 
 /** useTimeblocksByDate フックのオプション */
 interface UseEntriesByDateOptions {
   dates: Date[];
-  entries: CalendarEvent[];
+  entries: CalendarDisplayEvent[];
   sortType?: 'standard' | 'agenda';
   timezone?: string;
 }
 
 /** useTimeblocksByDate フックの戻り値 */
 interface UseEntriesByDateReturn {
-  entriesByDate: Record<string, CalendarEvent[]>;
+  entriesByDate: Record<string, CalendarDisplayEvent[]>;
   totalEntries: number;
   hasEntries: boolean;
 }
@@ -41,7 +41,7 @@ export function useTimeblocksByDate({
   timezone,
 }: UseEntriesByDateOptions): UseEntriesByDateReturn {
   const entriesByDate = useMemo(() => {
-    const grouped: Record<string, CalendarEvent[]> = {};
+    const grouped: Record<string, CalendarDisplayEvent[]> = {};
 
     // Step 1: 各日付のキーを初期化
     dates.forEach((date) => {

--- a/apps/product/src/features/calendar/components/views/shared/hooks/useViewTimeblocks.ts
+++ b/apps/product/src/features/calendar/components/views/shared/hooks/useViewTimeblocks.ts
@@ -4,7 +4,7 @@ import { isValid } from 'date-fns';
 
 import { getDateKey } from '@/lib/date';
 import { layoutEntryToVerticalPosition } from '../../../../lib/grid';
-import type { CalendarEvent } from '../../../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../../../types/calendar.types';
 
 import { HOUR_HEIGHT } from '../constants/grid.constants';
 import { getTimeblockStackIndex } from '../utils/timeblockStacking';
@@ -13,14 +13,14 @@ import { useTimeblockLayoutCalculator, type TimeblockLayout } from './useTimeblo
 
 interface UseViewEntriesOptions {
   date: Date;
-  entries: CalendarEvent[];
+  entries: CalendarDisplayEvent[];
   hourHeight?: number;
   timezone: string;
 }
 
 /** グリッド上のエントリ描画位置情報 */
 export interface TimeblockPosition {
-  plan: CalendarEvent;
+  plan: CalendarDisplayEvent;
   top: number;
   height: number;
   left: number;
@@ -32,7 +32,7 @@ export interface TimeblockPosition {
 }
 
 interface UseViewEntriesReturn {
-  dayEntries: CalendarEvent[];
+  dayEntries: CalendarDisplayEvent[];
   timeblockPositions: TimeblockPosition[];
   maxConcurrentEntries: number;
   skippedEntriesCount: number;
@@ -70,7 +70,7 @@ export function useViewTimeblocks({
     return result;
   }, [date, entries, timezone]);
 
-  // CalendarEventをuseTimeblockLayoutCalculatorで期待される形式に変換
+  // CalendarDisplayEventをuseTimeblockLayoutCalculatorで期待される形式に変換
   // displayStartDate/displayEndDateを使用してTZ対応の位置計算を実現
   const convertedEntries = useMemo(() => {
     return dayEntries.map((entry) => ({
@@ -93,12 +93,12 @@ export function useViewTimeblocks({
       );
 
       return {
-        plan: layout.entry as CalendarEvent,
+        plan: layout.entry as CalendarDisplayEvent,
         top,
         height,
         left: layout.left,
         width: layout.width,
-        zIndex: getTimeblockStackIndex(layout.entry as CalendarEvent, index),
+        zIndex: getTimeblockStackIndex(layout.entry as CalendarDisplayEvent, index),
         column: layout.column,
         totalColumns: layout.totalColumns,
         opacity: layout.totalColumns > 1 ? 0.95 : 1.0,

--- a/apps/product/src/features/calendar/components/views/shared/utils/__tests__/timeblockSorting.test.ts
+++ b/apps/product/src/features/calendar/components/views/shared/utils/__tests__/timeblockSorting.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { CalendarEvent } from '../../../../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../../../../types/calendar.types';
 
 import {
   sortAgendaEventsByDateKeys,
@@ -9,7 +9,7 @@ import {
   sortEventsForAgenda,
 } from '../timeblockSorting';
 
-function makeTimeblock(id: string, startDate: Date | null): CalendarEvent {
+function makeTimeblock(id: string, startDate: Date | null): CalendarDisplayEvent {
   return {
     id,
     title: `Entry ${id}`,
@@ -65,7 +65,7 @@ describe('timeblockSorting', () => {
 
   describe('sortEventsByDateKeys', () => {
     it('各日付キーのイベントをソートする', () => {
-      const eventsByDate: Record<string, CalendarEvent[]> = {
+      const eventsByDate: Record<string, CalendarDisplayEvent[]> = {
         '2026-02-21': [
           makeTimeblock('b', new Date('2026-02-21T14:00:00')),
           makeTimeblock('a', new Date('2026-02-21T09:00:00')),
@@ -95,7 +95,7 @@ describe('timeblockSorting', () => {
 
   describe('sortAgendaEventsByDateKeys', () => {
     it('各日付キーのイベントをAgenda用にソートする', () => {
-      const eventsByDate: Record<string, CalendarEvent[]> = {
+      const eventsByDate: Record<string, CalendarDisplayEvent[]> = {
         '2026-02-21': [
           makeTimeblock('b', new Date('2026-02-21T14:00:00')),
           makeTimeblock('a', new Date('2026-02-21T09:00:00')),

--- a/apps/product/src/features/calendar/components/views/shared/utils/timeblockSorting.ts
+++ b/apps/product/src/features/calendar/components/views/shared/utils/timeblockSorting.ts
@@ -3,10 +3,10 @@
  * 全ビューで共通使用される重複ソート処理をまとめる
  */
 
-import type { CalendarEvent } from '../../../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../../../types/calendar.types';
 
 /** イベントを開始時刻順でソート（WeekView / MultiDayViewで使用） */
-export function sortEventsByTime(events: CalendarEvent[]): CalendarEvent[] {
+export function sortEventsByTime(events: CalendarDisplayEvent[]): CalendarDisplayEvent[] {
   return [...events].sort((a, b) => {
     const aTime = a.startDate ? a.startDate.getTime() : 0;
     const bTime = b.startDate ? b.startDate.getTime() : 0;
@@ -16,8 +16,8 @@ export function sortEventsByTime(events: CalendarEvent[]): CalendarEvent[] {
 
 /** 日付キー別イベントマップをそれぞれ時刻順でソート */
 export function sortEventsByDateKeys(
-  eventsByDate: Record<string, CalendarEvent[]>,
-): Record<string, CalendarEvent[]> {
+  eventsByDate: Record<string, CalendarDisplayEvent[]>,
+): Record<string, CalendarDisplayEvent[]> {
   const sorted = { ...eventsByDate };
 
   Object.keys(sorted).forEach((dateKey) => {
@@ -28,14 +28,14 @@ export function sortEventsByDateKeys(
 }
 
 /** AgendaView用のイベントソート（時刻順） */
-export function sortEventsForAgenda(events: CalendarEvent[]): CalendarEvent[] {
+export function sortEventsForAgenda(events: CalendarDisplayEvent[]): CalendarDisplayEvent[] {
   return sortEventsByTime(events);
 }
 
 /** 日付キー別イベントマップをAgendaView用にソート */
 export function sortAgendaEventsByDateKeys(
-  eventsByDate: Record<string, CalendarEvent[]>,
-): Record<string, CalendarEvent[]> {
+  eventsByDate: Record<string, CalendarDisplayEvent[]>,
+): Record<string, CalendarDisplayEvent[]> {
   const sorted = { ...eventsByDate };
 
   Object.keys(sorted).forEach((dateKey) => {

--- a/apps/product/src/features/calendar/components/views/shared/utils/timeblockStacking.ts
+++ b/apps/product/src/features/calendar/components/views/shared/utils/timeblockStacking.ts
@@ -1,10 +1,10 @@
-import type { CalendarEvent } from '../../../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../../../types/calendar.types';
 
 const UNPLANNED_STACK_OFFSET = 100;
 
 /** 同じ時間帯で重なる予定より、予定外記録を前面に出すための z-index を返す。 */
 export function getTimeblockStackIndex(
-  entry: Pick<CalendarEvent, 'origin'>,
+  entry: Pick<CalendarDisplayEvent, 'origin'>,
   orderIndex: number,
   base = 10,
 ): number {

--- a/apps/product/src/features/calendar/contexts/CalendarTimeblockActionsContext.tsx
+++ b/apps/product/src/features/calendar/contexts/CalendarTimeblockActionsContext.tsx
@@ -10,14 +10,14 @@
 
 import { createContext } from 'react';
 
-import type { CalendarEvent } from '../types/calendar.types';
+import type { CalendarDisplayEvent } from '../types/calendar.types';
 
 interface CalendarEntryActions {
-  onEntryClick?: ((entry: CalendarEvent) => void) | undefined;
-  onEntryContextMenu?: ((entry: CalendarEvent, e: React.MouseEvent) => void) | undefined;
+  onEntryClick?: ((entry: CalendarDisplayEvent) => void) | undefined;
+  onEntryContextMenu?: ((entry: CalendarDisplayEvent, e: React.MouseEvent) => void) | undefined;
   onUpdateEntry?:
     | ((
-        timeblockIdOrTimeblock: string | CalendarEvent,
+        timeblockIdOrTimeblock: string | CalendarDisplayEvent,
         updates?: {
           startTime: Date;
           endTime: Date;

--- a/apps/product/src/features/calendar/hooks/operations/__tests__/useTimeblockContextActions.test.tsx
+++ b/apps/product/src/features/calendar/hooks/operations/__tests__/useTimeblockContextActions.test.tsx
@@ -1,7 +1,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { CalendarEvent } from '../../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../../types/calendar.types';
 
 const mocks = vi.hoisted(() => ({
   push: vi.fn(),
@@ -37,7 +37,7 @@ const taggedEntry = {
   tagId: 'tag-1',
   startDate: new Date(2026, 2, 25, 9),
   actualStartDate: null,
-} as unknown as CalendarEvent;
+} as unknown as CalendarDisplayEvent;
 
 describe('useTimeblockContextActions - Review navigation', () => {
   beforeEach(() => {

--- a/apps/product/src/features/calendar/hooks/operations/useTimeblockContextActions.ts
+++ b/apps/product/src/features/calendar/hooks/operations/useTimeblockContextActions.ts
@@ -9,7 +9,7 @@ import { useTimeblockWriteMutations } from '@/features/timeblock';
 import { toast } from '@/lib/toast';
 
 import { buildReportPath } from '../../lib/panel-url';
-import type { CalendarEvent } from '../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../types/calendar.types';
 
 /**
  * コンテキストメニューで使用する plan / record 操作アクションを提供するフック
@@ -24,7 +24,7 @@ export function useTimeblockContextActions() {
   const { deleteRecord, deletePlan, skipPlan, unskipPlan } = useTimeblockWriteMutations();
 
   const handleDeleteTimeblock = useCallback(
-    (entry: CalendarEvent) => {
+    (entry: CalendarDisplayEvent) => {
       if (entry.recordSource === 'auto_migrated') return;
       if ((entry.kind ?? 'plan') === 'plan') {
         deletePlan.mutate({ id: entry.id, expectedUpdatedAt: entry.version });
@@ -36,7 +36,7 @@ export function useTimeblockContextActions() {
   );
 
   const handleViewStats = useCallback(
-    (entry: CalendarEvent) => {
+    (entry: CalendarDisplayEvent) => {
       if (!entry.tagId) return;
       // カレンダー内パネル（CalendarReviewRail）は廃止済み（#2181 Step 4）。
       // tagId によるセグメント絞り込みは Step 5（セグメント配線）で復元する。
@@ -46,7 +46,7 @@ export function useTimeblockContextActions() {
   );
 
   const handleSkip = useCallback(
-    (entry: CalendarEvent) => {
+    (entry: CalendarDisplayEvent) => {
       if (entry.kind !== 'plan') return;
       skipPlan.mutate(
         { id: entry.id, expectedUpdatedAt: entry.version },
@@ -57,7 +57,7 @@ export function useTimeblockContextActions() {
   );
 
   const handleUnskip = useCallback(
-    (entry: CalendarEvent) => {
+    (entry: CalendarDisplayEvent) => {
       if (entry.kind !== 'plan') return;
       unskipPlan.mutate(
         { id: entry.id, expectedUpdatedAt: entry.version },

--- a/apps/product/src/features/calendar/hooks/operations/useTimeblockOperations.ts
+++ b/apps/product/src/features/calendar/hooks/operations/useTimeblockOperations.ts
@@ -8,7 +8,7 @@ import { logger } from '@/lib/logger';
 import { toast } from '@/lib/toast';
 
 import type { TimeblockDestination } from '@/features/timeblock';
-import type { CalendarEvent } from '../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../types/calendar.types';
 
 interface TimeModelCacheRow {
   id: string;
@@ -124,7 +124,7 @@ export const useTimeblockOperations = () => {
   // Timeblock更新ハンドラー（ドラッグ&ドロップ / リサイズ用）
   const handleUpdateTimeblock = useCallback(
     async (
-      timeblockIdOrTimeblock: string | CalendarEvent,
+      timeblockIdOrTimeblock: string | CalendarDisplayEvent,
       updates?: {
         startTime: Date;
         endTime: Date;
@@ -150,7 +150,7 @@ export const useTimeblockOperations = () => {
         return;
       }
 
-      // kind が既知（CalendarEvent object 経由）ならそのレーンだけ、未知なら両レーンを探す。
+      // kind が既知（CalendarDisplayEvent object 経由）ならそのレーンだけ、未知なら両レーンを探す。
       // previous 値は常にキャッシュ由来（渡された event 自身は更新後プレビューの可能性があるため）。
       const knownKind =
         typeof timeblockIdOrTimeblock !== 'string' ? timeblockIdOrTimeblock.kind : undefined;

--- a/apps/product/src/features/calendar/hooks/useCalendarContextMenu.ts
+++ b/apps/product/src/features/calendar/hooks/useCalendarContextMenu.ts
@@ -1,19 +1,19 @@
 import { useCallback, useState } from 'react';
 
-import type { CalendarEvent } from '../types/calendar.types';
+import type { CalendarDisplayEvent } from '../types/calendar.types';
 
 /**
  * カレンダープランのコンテキストメニュー状態を管理するフック
  */
 export const useCalendarContextMenu = () => {
-  const [contextMenuEvent, setContextMenuEvent] = useState<CalendarEvent | null>(null);
+  const [contextMenuEvent, setContextMenuEvent] = useState<CalendarDisplayEvent | null>(null);
   const [contextMenuPosition, setContextMenuPosition] = useState<{ x: number; y: number } | null>(
     null,
   );
 
   // プランの右クリックハンドラー（タッチデバイスでは無効）
   const handleEventContextMenu = useCallback(
-    (plan: CalendarEvent, mouseEvent: React.MouseEvent) => {
+    (plan: CalendarDisplayEvent, mouseEvent: React.MouseEvent) => {
       // タッチデバイスからの contextmenu イベントは無視（長押しで発火するため）
       if (window.matchMedia('(pointer: coarse)').matches) return;
       setContextMenuEvent(plan);

--- a/apps/product/src/features/calendar/index.ts
+++ b/apps/product/src/features/calendar/index.ts
@@ -27,7 +27,7 @@ export { ActivityChipRow } from './components/activity-filter/components/Activit
 // Types
 // =============================================================================
 export type {
-  CalendarEvent,
+  CalendarDisplayEvent,
   CalendarViewType,
   MultiDayViewType,
   ViewDateRange,

--- a/apps/product/src/features/calendar/interaction/__tests__/useInteraction.test.ts
+++ b/apps/product/src/features/calendar/interaction/__tests__/useInteraction.test.ts
@@ -3,10 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { TimeblockRect } from '../../domain/interaction/types';
 import { useCalendarDragStore } from '../../stores/useCalendarDragStore';
-import type { CalendarEvent } from '../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../types/calendar.types';
 import { useInteraction, type UseInteractionProps } from '../useInteraction';
 
-const baseEvent: CalendarEvent = {
+const baseEvent: CalendarDisplayEvent = {
   id: 'entry-1',
   title: 'test entry',
   startDate: new Date('2026-01-15T09:00:00'),
@@ -17,7 +17,7 @@ const baseEvent: CalendarEvent = {
   actualEndDate: null,
   kind: 'plan',
   version: '2026-01-15T08:00:00.000000Z',
-} as unknown as CalendarEvent;
+} as unknown as CalendarDisplayEvent;
 
 const rect: TimeblockRect = { top: 540, left: 0, width: 200, height: 60 };
 const now = new Date('2026-01-15T12:00:00').getTime();
@@ -353,7 +353,7 @@ describe('useInteraction handleResizeStart guard', () => {
 describe('useInteraction resize completion', () => {
   it('通常 entry の resize 完了時は actual 固定フラグを渡さない', () => {
     const onEventUpdate = vi.fn();
-    const matchingEntry: CalendarEvent = {
+    const matchingEntry: CalendarDisplayEvent = {
       ...baseEvent,
       origin: 'planned',
       plannedStartDate: baseEvent.startDate,
@@ -392,7 +392,7 @@ describe('useInteraction resize completion', () => {
 
   it('予定と記録がズレた entry の resize 完了時も actual 固定フラグは渡さない（自動記録モデルでは planned のみ更新）', () => {
     const onEventUpdate = vi.fn();
-    const overtimeEntry: CalendarEvent = {
+    const overtimeEntry: CalendarDisplayEvent = {
       ...baseEvent,
       origin: 'planned',
       plannedStartDate: baseEvent.startDate,
@@ -431,13 +431,13 @@ describe('useInteraction optimistic version', () => {
     const onEventUpdate = vi.fn();
     const originalVersion = '2026-01-15T08:00:00.000001Z';
     const refreshedVersion = '2026-01-15T08:00:00.000002Z';
-    const originalEvent: CalendarEvent = {
+    const originalEvent: CalendarDisplayEvent = {
       ...baseEvent,
       kind: 'record',
       version: originalVersion,
     };
     const { result, rerender } = renderHook(
-      ({ events }: { events: CalendarEvent[] }) =>
+      ({ events }: { events: CalendarDisplayEvent[] }) =>
         useInteraction(makeProps({ events, onEventUpdate })),
       { initialProps: { events: [originalEvent] } },
     );

--- a/apps/product/src/features/calendar/interaction/interaction-runtime.ts
+++ b/apps/product/src/features/calendar/interaction/interaction-runtime.ts
@@ -11,7 +11,7 @@ import type React from 'react';
 
 import type { useHapticFeedback } from '../hooks/accessibility/useHapticFeedback';
 import type { useCalendarDragStore } from '../stores/useCalendarDragStore';
-import type { CalendarEvent } from '../types/calendar.types';
+import type { CalendarDisplayEvent } from '../types/calendar.types';
 
 import type {
   InteractionAction,
@@ -25,9 +25,9 @@ export interface UseInteractionProps {
   /** Base date of the current view */
   date: Date;
   /** Events for the current view */
-  events: CalendarEvent[];
+  events: CalendarDisplayEvent[];
   /** Events for overlap checking (defaults to events) */
-  allEventsForOverlapCheck?: CalendarEvent[];
+  allEventsForOverlapCheck?: CalendarDisplayEvent[];
   /** Displayed dates (week/multi-day views) */
   displayDates?: Date[];
   /** View mode */
@@ -53,7 +53,7 @@ export interface UseInteractionProps {
   /** Plan を Record レーンへdropした時の記録化 */
   onPlanRecord?: ((planId: string, range: TimeRange) => void) | undefined;
   /** Callback when an event is clicked (not dragged) */
-  onEventClick?: (event: CalendarEvent) => void;
+  onEventClick?: (event: CalendarDisplayEvent) => void;
   /** Callback when a time range is selected on the grid */
   onTimeRangeSelect?: (selection: {
     date: Date;
@@ -100,8 +100,8 @@ type CalendarDragStoreState = ReturnType<typeof useCalendarDragStore.getState>;
 
 /** latestRef.current の形。stable dispatch から毎回読む可変依存の束 */
 export interface InteractionRuntime {
-  events: CalendarEvent[];
-  allEvents: CalendarEvent[];
+  events: CalendarDisplayEvent[];
+  allEvents: CalendarDisplayEvent[];
   hourHeight: number;
   planLaneWidthPercent: number;
   date: Date;

--- a/apps/product/src/features/calendar/lib/__tests__/calendar-event-to-lane-event.test.ts
+++ b/apps/product/src/features/calendar/lib/__tests__/calendar-event-to-lane-event.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import type { CalendarEvent } from '../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../types/calendar.types';
 import { calendarEventToRecordEvent } from '../calendar-event-to-lane-event';
 
 const startDate = new Date('2026-07-10T09:00:00.000Z');
 const endDate = new Date('2026-07-10T09:30:00.000Z');
 
-function makeRecordEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+function makeRecordEvent(overrides: Partial<CalendarDisplayEvent> = {}): CalendarDisplayEvent {
   return {
     id: 'record-1',
     title: 'Deep Work',

--- a/apps/product/src/features/calendar/lib/__tests__/day-diff.test.ts
+++ b/apps/product/src/features/calendar/lib/__tests__/day-diff.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import type { CalendarEvent } from '../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../types/calendar.types';
 import { computeCalendarDayDiffs, filterCalendarDayDiffEntries } from '../day-diff';
 
 const now = new Date('2026-06-18T23:00:00.000Z');
 
-function entry(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+function entry(overrides: Partial<CalendarDisplayEvent> = {}): CalendarDisplayEvent {
   const start = new Date('2026-06-18T09:00:00.000Z');
   const end = new Date('2026-06-18T10:00:00.000Z');
 

--- a/apps/product/src/features/calendar/lib/__tests__/layout.test.ts
+++ b/apps/product/src/features/calendar/lib/__tests__/layout.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { CalendarEvent } from '../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../types/calendar.types';
 
 import type { TimedTimeblock } from '../../types/timeblock.types';
 
@@ -41,8 +41,8 @@ function createTimedEntry(
 }
 
 function createCalendarEvent(
-  overrides: Partial<CalendarEvent> & { startDate: Date; endDate: Date },
-): CalendarEvent {
+  overrides: Partial<CalendarDisplayEvent> & { startDate: Date; endDate: Date },
+): CalendarDisplayEvent {
   return {
     id: 'test-1',
     title: 'Test Event',
@@ -57,7 +57,7 @@ function createCalendarEvent(
     updatedAt: new Date(),
     origin: 'planned',
     ...overrides,
-  } as CalendarEvent;
+  } as CalendarDisplayEvent;
 }
 
 // ========================================

--- a/apps/product/src/features/calendar/lib/__tests__/overlap-edge-cases.test.ts
+++ b/apps/product/src/features/calendar/lib/__tests__/overlap-edge-cases.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import type { CalendarEvent } from '../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../types/calendar.types';
 
 import { checkClientSideOverlap } from '../overlap';
 
 function createEvent(
-  overrides: Partial<CalendarEvent> & { id: string; startDate: Date; endDate: Date },
-): CalendarEvent {
+  overrides: Partial<CalendarDisplayEvent> & { id: string; startDate: Date; endDate: Date },
+): CalendarDisplayEvent {
   return {
     title: 'Test',
     displayStartDate: overrides.startDate,
@@ -20,7 +20,7 @@ function createEvent(
     updatedAt: new Date(),
     origin: 'planned',
     ...overrides,
-  } as CalendarEvent;
+  } as CalendarDisplayEvent;
 }
 
 describe('checkClientSideOverlap — エッジケース', () => {

--- a/apps/product/src/features/calendar/lib/__tests__/overlap.test.ts
+++ b/apps/product/src/features/calendar/lib/__tests__/overlap.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { hasTwoLayerTimeConflict } from '@dayopt/domain';
 
-import type { CalendarEvent } from '../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../types/calendar.types';
 
 import {
   buildNewTimeblockOverlapTarget,
@@ -11,8 +11,8 @@ import {
 } from '../overlap';
 
 function createEvent(
-  overrides: Partial<CalendarEvent> & { id: string; startDate: Date; endDate: Date },
-): CalendarEvent {
+  overrides: Partial<CalendarDisplayEvent> & { id: string; startDate: Date; endDate: Date },
+): CalendarDisplayEvent {
   return {
     title: 'Test',
     displayStartDate: overrides.startDate,
@@ -26,7 +26,7 @@ function createEvent(
     updatedAt: new Date(),
     origin: 'planned',
     ...overrides,
-  } as CalendarEvent;
+  } as CalendarDisplayEvent;
 }
 
 describe('buildNewTimeblockOverlapTarget', () => {

--- a/apps/product/src/features/calendar/lib/__tests__/plan-record-drop.test.ts
+++ b/apps/product/src/features/calendar/lib/__tests__/plan-record-drop.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { CalendarEvent } from '../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../types/calendar.types';
 import { buildPlanRecordDropInput } from '../plan-record-drop';
 
 const plan = {
@@ -12,7 +12,7 @@ const plan = {
   kind: 'plan',
   startDate: new Date('2026-07-14T09:00:00.000Z'),
   endDate: new Date('2026-07-14T10:00:00.000Z'),
-} as CalendarEvent;
+} as CalendarDisplayEvent;
 
 describe('buildPlanRecordDropInput', () => {
   it('Planの内容とdrop先のpreview rangeから関連Record入力を作る', () => {

--- a/apps/product/src/features/calendar/lib/__tests__/timeblock-time.test.ts
+++ b/apps/product/src/features/calendar/lib/__tests__/timeblock-time.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import type { CalendarEvent } from '../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../types/calendar.types';
 import { hasCalendarActualRangeDiff } from '../timeblock-time';
 
-function makeTimeblock(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+function makeTimeblock(overrides: Partial<CalendarDisplayEvent> = {}): CalendarDisplayEvent {
   const start = new Date('2026-06-10T08:00:00.000Z');
   const end = new Date('2026-06-10T09:00:00.000Z');
   return {

--- a/apps/product/src/features/calendar/lib/calendar-event-to-lane-event.ts
+++ b/apps/product/src/features/calendar/lib/calendar-event-to-lane-event.ts
@@ -1,8 +1,8 @@
 /**
- * `CalendarEvent`（Step 8 の time model 射影）から TwoLane カード用の
+ * `CalendarDisplayEvent`（Step 8 の time model 射影）から TwoLane カード用の
  * `PlanEvent` / `RecordEvent` 表示型へ変換するアダプタ。
  *
- * `useCalendarData` は Plan / Record から CalendarEvent を作る際に kind/planId/recordSource を
+ * `useCalendarData` は Plan / Record から CalendarDisplayEvent を作る際に kind/planId/recordSource を
  * 既に埋めているため、ここではCalendarが取得した関連イベント（`allEvents`）から
  * Plan の記録済み判定に必要な情報だけを逆引きする。Record の差分は
  * `useCalendarData` が 1 Plan : N Record を集約して代表 Record に事前計算する。
@@ -10,10 +10,10 @@
 
 import type { PlanEvent, PlanEventStatus, RecordEvent } from '@/features/timeblock';
 
-import type { CalendarEvent } from '../types/calendar.types';
+import type { CalendarDisplayEvent } from '../types/calendar.types';
 
 function resolvePlanEventStatus(
-  event: CalendarEvent,
+  event: CalendarDisplayEvent,
   isRecorded: boolean,
   now: Date,
 ): PlanEventStatus {
@@ -26,10 +26,10 @@ function resolvePlanEventStatus(
   return 'upcoming';
 }
 
-/** kind='plan' の CalendarEvent を PlanLaneCard 用の PlanEvent へ変換する */
+/** kind='plan' の CalendarDisplayEvent を PlanLaneCard 用の PlanEvent へ変換する */
 export function calendarEventToPlanEvent(
-  event: CalendarEvent,
-  allEvents: ReadonlyArray<CalendarEvent>,
+  event: CalendarDisplayEvent,
+  allEvents: ReadonlyArray<CalendarDisplayEvent>,
   now: Date = new Date(),
 ): PlanEvent {
   const isRecorded = allEvents.some((e) => e.kind === 'record' && e.planId === event.id);
@@ -48,8 +48,8 @@ export function calendarEventToPlanEvent(
   };
 }
 
-/** kind='record' の CalendarEvent を RecordLaneCard 用の RecordEvent へ変換する */
-export function calendarEventToRecordEvent(event: CalendarEvent): RecordEvent {
+/** kind='record' の CalendarDisplayEvent を RecordLaneCard 用の RecordEvent へ変換する */
+export function calendarEventToRecordEvent(event: CalendarDisplayEvent): RecordEvent {
   return {
     id: event.id,
     title: event.title,

--- a/apps/product/src/features/calendar/lib/day-diff.ts
+++ b/apps/product/src/features/calendar/lib/day-diff.ts
@@ -1,4 +1,4 @@
-import type { CalendarEvent } from '../types/calendar.types';
+import type { CalendarDisplayEvent } from '../types/calendar.types';
 
 type CalendarDayDiffKind = 'unplanned' | 'missed' | 'shifted' | 'resized';
 
@@ -65,14 +65,14 @@ function minutesBetween(a: Date | null, b: Date | null): number {
   return Math.round((b.getTime() - a.getTime()) / 60_000);
 }
 
-function plannedRange(entry: CalendarEvent): { start: Date | null; end: Date | null } {
+function plannedRange(entry: CalendarDisplayEvent): { start: Date | null; end: Date | null } {
   return {
     start: entry.plannedStartDate ?? entry.startDate,
     end: entry.plannedEndDate ?? entry.endDate,
   };
 }
 
-function actualRange(entry: CalendarEvent): { start: Date | null; end: Date | null } {
+function actualRange(entry: CalendarDisplayEvent): { start: Date | null; end: Date | null } {
   if (entry.origin === 'unplanned') {
     return {
       start: entry.actualStartDate ?? entry.startDate,
@@ -111,10 +111,10 @@ function clipRange(
 }
 
 export function filterCalendarDayDiffEntries(
-  entries: readonly CalendarEvent[],
+  entries: readonly CalendarDisplayEvent[],
   bounds: CalendarDayDiffOptions,
   isEntryVisible: (activityId: string | null) => boolean,
-): CalendarEvent[] {
+): CalendarDisplayEvent[] {
   return entries.filter((entry) => {
     if (!isEntryVisible(entry.activityId ?? null)) return false;
 
@@ -126,7 +126,7 @@ export function filterCalendarDayDiffEntries(
 }
 
 function makeItem(
-  entry: CalendarEvent,
+  entry: CalendarDisplayEvent,
   kind: CalendarDayDiffKind,
   planned: { start: Date | null; end: Date | null },
   actual: { start: Date | null; end: Date | null },
@@ -156,7 +156,7 @@ function makeItem(
 }
 
 export function computeCalendarDayDiffs(
-  entries: readonly CalendarEvent[],
+  entries: readonly CalendarDisplayEvent[],
   options: CalendarDayDiffOptions | Date = {},
 ): CalendarDayDiffResult {
   if (entries.length === 0) return EMPTY_RESULT;

--- a/apps/product/src/features/calendar/lib/overlap.ts
+++ b/apps/product/src/features/calendar/lib/overlap.ts
@@ -6,7 +6,7 @@
  */
 
 import { hasTwoLayerTimeConflict, rangesOverlap, type TwoLayerOverlapTarget } from '@dayopt/domain';
-import type { CalendarEvent } from '../types/calendar.types';
+import type { CalendarDisplayEvent } from '../types/calendar.types';
 
 export function buildNewTimeblockOverlapTarget(
   startTime: Date,
@@ -36,7 +36,7 @@ export function buildNewTimeblockOverlapTarget(
  * @returns 他のイベントと重複している場合true
  */
 export function checkClientSideOverlap(
-  events: CalendarEvent[],
+  events: CalendarDisplayEvent[],
   draggedEventId: string,
   previewStartTime: Date,
   previewEndTime: Date,
@@ -89,18 +89,18 @@ export function checkClientSideOverlap(
 
 /**
  * ドラッグ/リサイズ中の kind-aware 重複判定（plan×plan / record×record のみ禁止、plan×record は許可）。
- * time model 化された CalendarEvent（`kind` 付き）専用。checkClientSideOverlap の
+ * time model 化された CalendarDisplayEvent（`kind` 付き）専用。checkClientSideOverlap の
  * 旧二層判定（planned/actual layer）は record-with-plan を origin:'planned' として誤扱いするため、
  * ドラッグ移動先が同一 kind の他イベントと重ならないかだけを見るこちらに置き換える。
  */
 export function checkClientSideOverlapByKind(
-  events: CalendarEvent[],
+  events: CalendarDisplayEvent[],
   draggedEventId: string,
   previewStartTime: Date,
   previewEndTime: Date,
   options: {
     /** レーン間ドラッグ時に、ドラッグ元ではなくdrop先のkindで判定する。 */
-    targetKind?: NonNullable<CalendarEvent['kind']>;
+    targetKind?: NonNullable<CalendarDisplayEvent['kind']>;
     now?: number;
   } = {},
 ): boolean {
@@ -121,10 +121,10 @@ export function checkClientSideOverlapByKind(
 }
 
 /**
- * CalendarEvent を重複判定用の2レイヤー表現に変換する。
+ * CalendarDisplayEvent を重複判定用の2レイヤー表現に変換する。
  * actual レイヤーは effective actual（確定済み actual、なければ過去 planned の自動記録）。
  */
-function toOverlapEntry(event: CalendarEvent, now: number) {
+function toOverlapEntry(event: CalendarDisplayEvent, now: number) {
   const plannedStart =
     event.plannedStartDate ?? (event.origin === 'planned' ? event.startDate : null);
   const plannedEnd = event.plannedEndDate ?? (event.origin === 'planned' ? event.endDate : null);

--- a/apps/product/src/features/calendar/lib/plan-data-adapter.ts
+++ b/apps/product/src/features/calendar/lib/plan-data-adapter.ts
@@ -1,17 +1,20 @@
 /**
  * カレンダー固有のデータ変換ユーティリティ
  *
- * CalendarEvent のタイムゾーン適用を行う。
+ * CalendarDisplayEvent のタイムゾーン適用を行う。
  */
 
 import { convertToTimezone } from '@/lib/date/timezone';
 
-import type { CalendarEvent } from '../types/calendar.types';
+import type { CalendarDisplayEvent } from '../types/calendar.types';
 
 /**
- * CalendarEvent の displayStartDate/displayEndDate をユーザーTZに変換
+ * CalendarDisplayEvent の displayStartDate/displayEndDate をユーザーTZに変換
  */
-export function applyTimezoneToDisplayDates(plan: CalendarEvent, timezone: string): CalendarEvent {
+export function applyTimezoneToDisplayDates(
+  plan: CalendarDisplayEvent,
+  timezone: string,
+): CalendarDisplayEvent {
   if (!plan.startDate) {
     return plan;
   }

--- a/apps/product/src/features/calendar/lib/plan-event-adapter.ts
+++ b/apps/product/src/features/calendar/lib/plan-event-adapter.ts
@@ -1,7 +1,7 @@
 /**
  * `plans` テーブル行 -> `PlanEvent` 変換アダプター（Step 5、read 側専用）
  *
- * `entry-adapter.ts`（entries -> CalendarEvent）と同じ配置パターンで、
+ * `entry-adapter.ts`（entries -> CalendarDisplayEvent）と同じ配置パターンで、
  * plans -> PlanEvent の射影を担う。書き込み・DnD 保存先判定は Step 6。
  */
 

--- a/apps/product/src/features/calendar/lib/plan-record-drop.ts
+++ b/apps/product/src/features/calendar/lib/plan-record-drop.ts
@@ -1,4 +1,4 @@
-import type { CalendarEvent } from '../types/calendar.types';
+import type { CalendarDisplayEvent } from '../types/calendar.types';
 
 interface PlanRecordDropRange {
   start: Date;
@@ -20,7 +20,7 @@ interface PlanRecordDropInput {
  * Plan 自身の予定時間は変更せず、drop 先の範囲を実績時間の source of truth とする。
  */
 export function buildPlanRecordDropInput(
-  plan: CalendarEvent,
+  plan: CalendarDisplayEvent,
   range: PlanRecordDropRange,
 ): PlanRecordDropInput {
   return {

--- a/apps/product/src/features/calendar/lib/record-event-adapter.ts
+++ b/apps/product/src/features/calendar/lib/record-event-adapter.ts
@@ -1,7 +1,7 @@
 /**
  * Record の物理テーブル `records` の行 -> `RecordEvent` 変換アダプター（read 側専用）
  *
- * `entry-adapter.ts`（entries -> CalendarEvent）と同じ配置パターンで、
+ * `entry-adapter.ts`（entries -> CalendarDisplayEvent）と同じ配置パターンで、
  * 物理 `records` -> RecordEvent の境界射影を担う。
  */
 

--- a/apps/product/src/features/calendar/lib/timeblock-time.ts
+++ b/apps/product/src/features/calendar/lib/timeblock-time.ts
@@ -1,7 +1,9 @@
-import type { CalendarEvent } from '../types/calendar.types';
+import type { CalendarDisplayEvent } from '../types/calendar.types';
 
 /** planned entry の予定と記録が、リサイズ開始前から異なっているかを判定する。 */
-export function hasCalendarActualRangeDiff(entry: CalendarEvent | null | undefined): boolean {
+export function hasCalendarActualRangeDiff(
+  entry: CalendarDisplayEvent | null | undefined,
+): boolean {
   if (entry?.origin !== 'planned') return false;
 
   const plannedStart = entry.plannedStartDate ?? entry.startDate;

--- a/apps/product/src/features/calendar/lib/two-lane-layout.ts
+++ b/apps/product/src/features/calendar/lib/two-lane-layout.ts
@@ -13,7 +13,7 @@
 
 import type { PlanEvent, RecordEvent } from '@/features/timeblock';
 
-import type { CalendarEvent } from '../types/calendar.types';
+import type { CalendarDisplayEvent } from '../types/calendar.types';
 
 export interface TwoLanePosition {
   /** px */
@@ -146,12 +146,12 @@ export function calculateTwoLaneLayout({
 }
 
 /**
- * `CalendarEvent[]`（Step 8 の time model 射影、`kind` 付き）から直接 2 レーン座標を計算する。
- * `TwoLaneTimeblockRenderer` はインタラクション状態（drag/resize preview）を CalendarEvent 単位で
+ * `CalendarDisplayEvent[]`（Step 8 の time model 射影、`kind` 付き）から直接 2 レーン座標を計算する。
+ * `TwoLaneTimeblockRenderer` はインタラクション状態（drag/resize preview）を CalendarDisplayEvent 単位で
  * 持つ既存 `useInteraction` をそのまま使うため、PlanEvent/RecordEvent への変換を経由しない。
  */
 export function calculateTwoLaneStylesForCalendarEvents(
-  events: ReadonlyArray<CalendarEvent>,
+  events: ReadonlyArray<CalendarDisplayEvent>,
   hourHeight: number,
   planLaneWidthPercent: number = DEFAULT_PLAN_LANE_WIDTH_PERCENT,
 ): Record<string, TwoLanePosition> {

--- a/apps/product/src/features/calendar/stores/__tests__/useCalendarDragStore.test.ts
+++ b/apps/product/src/features/calendar/stores/__tests__/useCalendarDragStore.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import type { CalendarEvent } from '../../types/calendar.types';
+import type { CalendarDisplayEvent } from '../../types/calendar.types';
 
 import { useCalendarDragStore } from '../useCalendarDragStore';
 
-const mockCalendarEvent: CalendarEvent = {
+const mockCalendarEvent: CalendarDisplayEvent = {
   id: 'plan-1',
   title: 'テストプラン',
   startDate: new Date('2026-02-21T10:00:00'),

--- a/apps/product/src/features/calendar/stores/useCalendarDragStore.ts
+++ b/apps/product/src/features/calendar/stores/useCalendarDragStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
-import type { CalendarEvent } from '../types/calendar.types';
+import type { CalendarDisplayEvent } from '../types/calendar.types';
 
 /**
  * カレンダーのドラッグ状態を管理するストア
@@ -14,7 +14,7 @@ interface CalendarDragState {
   /** ドラッグ中のTimeblockID */
   draggedEntryId: string | null;
   /** ドラッグ中のTimeblockデータ */
-  draggedEntry: CalendarEvent | null;
+  draggedEntry: CalendarDisplayEvent | null;
   /** 元の日付インデックス */
   originalDateIndex: number;
   /** 現在のターゲット日付インデックス */
@@ -34,7 +34,7 @@ interface CalendarDragActions {
   /** カレンダー内ドラッグ開始 */
   startDrag: (
     timeblockId: string,
-    entry: CalendarEvent,
+    entry: CalendarDisplayEvent,
     dateIndex: number,
     lane?: 'plan' | 'record',
   ) => void;

--- a/apps/product/src/features/calendar/types/base.types.ts
+++ b/apps/product/src/features/calendar/types/base.types.ts
@@ -3,12 +3,12 @@
  * 全カレンダービューで共通するプロパティ
  */
 
-// CalendarEvent, ViewDateRange, CalendarViewType を Source of Truth から直接エクスポート
-export type { CalendarEvent, CalendarViewType, ViewDateRange } from './calendar.types';
+// CalendarDisplayEvent, ViewDateRange, CalendarViewType を Source of Truth から直接エクスポート
+export type { CalendarDisplayEvent, CalendarViewType, ViewDateRange } from './calendar.types';
 import type { ExternalCalendarEvent } from '@/features/external-calendar';
 
 import type { DateTimeSelection } from '../components/views/shared';
-import type { CalendarEvent, CalendarViewType, ViewDateRange } from './calendar.types';
+import type { CalendarDisplayEvent, CalendarViewType, ViewDateRange } from './calendar.types';
 
 /**
  * 全ビューで共通する最小限のプロパティ
@@ -16,15 +16,16 @@ import type { CalendarEvent, CalendarViewType, ViewDateRange } from './calendar.
  */
 interface BaseViewProps {
   // Core data
-  entries: CalendarEvent[];
+  entries: CalendarDisplayEvent[];
   currentDate: Date;
 
   // Display options
   className?: string | undefined;
 
   // Timeblock handlers（最小限）
-  onEntryClick?: ((entry: CalendarEvent) => void) | undefined;
-  onEntryContextMenu?: ((entry: CalendarEvent, mouseEvent: React.MouseEvent) => void) | undefined;
+  onEntryClick?: ((entry: CalendarDisplayEvent) => void) | undefined;
+  onEntryContextMenu?:
+    ((entry: CalendarDisplayEvent, mouseEvent: React.MouseEvent) => void) | undefined;
 }
 
 /**
@@ -35,7 +36,7 @@ export interface GridViewProps extends BaseViewProps {
   // Core data
   dateRange: ViewDateRange;
   /** 全エントリ（期限切れ未完了表示用、日付フィルタリング前） */
-  allTimeblocks?: CalendarEvent[] | undefined;
+  allTimeblocks?: CalendarDisplayEvent[] | undefined;
   /**
    * 外部カレンダーの未変換予定（ghost、#1962）。読み取り専用で `entries` とは別に持つ。
    * plan / record と違い DB の EXCLUDE 制約が無いため重なり、座標計算も別系統になる。
@@ -55,7 +56,7 @@ export interface GridViewProps extends BaseViewProps {
   // Timeblock handlers（グリッド操作用）
   onUpdateEntry?:
     | ((
-        timeblockIdOrTimeblock: string | CalendarEvent,
+        timeblockIdOrTimeblock: string | CalendarDisplayEvent,
         updates?: {
           startTime: Date;
           endTime: Date;
@@ -78,7 +79,7 @@ export interface GridViewProps extends BaseViewProps {
  * 4箇所で重複していた TimeblockPosition を統一
  */
 export interface BaseEntryPosition {
-  plan: CalendarEvent;
+  plan: CalendarDisplayEvent;
   top: number;
   height: number;
   left: number;

--- a/apps/product/src/features/calendar/types/calendar.types.ts
+++ b/apps/product/src/features/calendar/types/calendar.types.ts
@@ -1,6 +1,7 @@
-// CalendarEvent は features/timeblock/types/calendar-event.ts が canonical source
-// (Timeblock の表示射影型のため owner は entry)
-export type { CalendarEvent } from '@/features/timeblock';
+// CalendarDisplayEvent は features/timeblock/types/calendar-event.ts の CalendarEvent が
+// canonical source (Timeblock の表示射影型のため owner は entry)。calendar 側では別名で
+// re-export し、timeblock canonical 名との衝突（誤 import の温床）を避ける（#2221）。
+export type { CalendarEvent as CalendarDisplayEvent } from '@/features/timeblock';
 
 // CalendarViewType 関連は feature 内の lib/constants が canonical source
 export { getMultiDayCount, isMultiDayView } from '../lib/constants';

--- a/apps/product/src/features/calendar/types/day-view.types.ts
+++ b/apps/product/src/features/calendar/types/day-view.types.ts
@@ -1,7 +1,7 @@
 import type { CSSProperties } from 'react';
 
 import type { GridViewProps } from './base.types';
-import type { CalendarEvent } from './calendar.types';
+import type { CalendarDisplayEvent } from './calendar.types';
 import type { TimeSlot } from './grid.types';
 
 /** DayViewの固有Props（GridViewPropsを継承して時間グリッド機能を使用） */
@@ -10,14 +10,14 @@ export type DayViewProps = GridViewProps;
 /** useDayView フックのオプション */
 export interface UseDayViewOptions {
   date: Date;
-  entries: CalendarEvent[];
-  onEntryUpdate?: (entry: CalendarEvent) => void;
+  entries: CalendarDisplayEvent[];
+  onEntryUpdate?: (entry: CalendarDisplayEvent) => void;
   timezone: string;
 }
 
 /** useDayView フックの戻り値 */
 export interface UseDayViewReturn {
-  dayEntries: CalendarEvent[];
+  dayEntries: CalendarDisplayEvent[];
   timeblockStyles: Record<string, CSSProperties>;
   isToday: boolean;
   timeSlots: TimeSlot[];
@@ -26,20 +26,20 @@ export interface UseDayViewReturn {
 /** useDayEntries フックのオプション */
 export interface UseDayEntriesOptions {
   date: Date;
-  entries: CalendarEvent[];
+  entries: CalendarDisplayEvent[];
   timezone: string;
 }
 
 /** useDayEntries フックの戻り値 */
 export interface UseDayEntriesReturn {
-  dayEntries: CalendarEvent[];
+  dayEntries: CalendarDisplayEvent[];
   timeblockPositions: TimeblockPosition[];
   maxConcurrentEntries: number;
 }
 
 /** エントリの計算済み位置情報 */
 export interface TimeblockPosition {
-  plan: CalendarEvent;
+  plan: CalendarDisplayEvent;
   top: number;
   height: number;
   left: number;

--- a/apps/product/src/features/calendar/types/timeblock.types.ts
+++ b/apps/product/src/features/calendar/types/timeblock.types.ts
@@ -2,10 +2,10 @@
  * エントリ関連の型定義
  */
 
-import type { CalendarEvent } from './calendar.types';
+import type { CalendarDisplayEvent } from './calendar.types';
 
 /** 時間指定エントリ型（startDate/endDateをstart/endにエイリアス） */
-export type TimedTimeblock = CalendarEvent & {
+export type TimedTimeblock = CalendarDisplayEvent & {
   start: Date; // startDateのエイリアス
   end: Date; // endDateのエイリアス
   isReadOnly?: boolean;
@@ -13,7 +13,7 @@ export type TimedTimeblock = CalendarEvent & {
 
 /** カラム割り当て済みのエントリ列情報 */
 export interface TimeblockColumn {
-  entries: CalendarEvent[];
+  entries: CalendarDisplayEvent[];
   columnIndex: number;
   totalColumns: number;
 }

--- a/apps/product/src/features/calendar/types/week-view.types.ts
+++ b/apps/product/src/features/calendar/types/week-view.types.ts
@@ -1,7 +1,7 @@
 import type { ExternalCalendarEvent } from '@/features/external-calendar';
 
 import type { BaseEntryPosition, GridViewProps } from './base.types';
-import type { CalendarEvent } from './calendar.types';
+import type { CalendarDisplayEvent } from './calendar.types';
 
 import type { DateTimeSelection } from '../components/views/shared';
 
@@ -13,20 +13,21 @@ export interface WeekViewProps extends GridViewProps {
 /** WeekGrid コンポーネントのプロパティ */
 export interface WeekGridProps {
   weekDates: Date[];
-  events: CalendarEvent[];
+  events: CalendarDisplayEvent[];
   /** 全エントリ（期限切れ未完了表示用） */
-  allTimeblocks?: CalendarEvent[] | undefined;
+  allTimeblocks?: CalendarDisplayEvent[] | undefined;
   /** 外部カレンダーの未変換予定（ghost、読み取り専用） */
   externalEvents?: ExternalCalendarEvent[] | undefined;
-  eventsByDate: Record<string, CalendarEvent[]>;
+  eventsByDate: Record<string, CalendarDisplayEvent[]>;
   todayIndex: number;
   /** DnDを無効化するTimeblock ID（Inspector表示中のTimeblock など） */
   disabledTimeblockId?: string | null | undefined;
-  onEventClick?: ((entry: CalendarEvent) => void) | undefined;
-  onEventContextMenu?: ((entry: CalendarEvent, mouseEvent: React.MouseEvent) => void) | undefined;
+  onEventClick?: ((entry: CalendarDisplayEvent) => void) | undefined;
+  onEventContextMenu?:
+    ((entry: CalendarDisplayEvent, mouseEvent: React.MouseEvent) => void) | undefined;
   onEventUpdate?:
     | ((
-        timeblockIdOrTimeblock: string | CalendarEvent,
+        timeblockIdOrTimeblock: string | CalendarDisplayEvent,
         updates?: {
           startTime: Date;
           endTime: Date;
@@ -45,11 +46,11 @@ export interface WeekGridProps {
 /** useWeekView フックのオプション */
 export interface UseWeekViewOptions {
   startDate: Date;
-  events: CalendarEvent[];
+  events: CalendarDisplayEvent[];
   timezone: string;
   weekStartsOn?: 0 | 1 | 6;
   onEventUpdate?: (
-    timeblockIdOrTimeblock: string | CalendarEvent,
+    timeblockIdOrTimeblock: string | CalendarDisplayEvent,
     updates?: {
       startTime: Date;
       endTime: Date;
@@ -61,7 +62,7 @@ export interface UseWeekViewOptions {
 /** useWeekView フックの戻り値 */
 export interface UseWeekViewReturn {
   weekDates: Date[];
-  eventsByDate: Record<string, CalendarEvent[]>;
+  eventsByDate: Record<string, CalendarDisplayEvent[]>;
   todayIndex: number;
   scrollToNow: () => void;
   isCurrentWeek: boolean;
@@ -70,14 +71,14 @@ export interface UseWeekViewReturn {
 /** useWeekTimeblocks フックのオプション */
 export interface UseWeekEntriesOptions {
   weekDates: Date[];
-  events: CalendarEvent[];
+  events: CalendarDisplayEvent[];
   hourHeight?: number;
   timezone: string;
 }
 
 /** useWeekTimeblocks フックの戻り値 */
 export interface UseWeekEntriesReturn {
-  entriesByDate: Record<string, CalendarEvent[]>;
+  entriesByDate: Record<string, CalendarDisplayEvent[]>;
   timeblockPositions: WeekEntryPosition[];
   maxConcurrentEntries: number;
 }

--- a/apps/product/src/lib/test/e2e/usability-probe-setup.ts
+++ b/apps/product/src/lib/test/e2e/usability-probe-setup.ts
@@ -135,7 +135,7 @@ async function main() {
     await page.locator('input[type="email"], input[name="email"]').first().fill(email);
     await page.locator('input[type="password"]').first().fill(password);
     await page.locator('button[type="submit"]').first().click();
-    await page.waitForURL(/\/ja\/(day|week)/i, { timeout: 15_000 });
+    await page.waitForURL(/\/ja\/calendar/i, { timeout: 15_000 });
 
     mkdirSync(dirname(STORAGE_STATE_PATH), { recursive: true });
     await context.storageState({ path: STORAGE_STATE_PATH });


### PR DESCRIPTION
## 概要

レーン E（小粒 cleanup 束）。dispatch 記録は #2242 コメント（2026-08-20、指揮台 Fable）。

1. **#2245**: `usability-probe-setup.ts` の `waitForURL` を epic #2181 の URL 統一（`/calendar`）へ追従させる。login 後の遷移先が旧正規表現 `/ja/(day|week)` に一致せず TimeoutError で失敗していた
2. **#2221**: `features/calendar/types/calendar.types.ts` の `CalendarEvent`（timeblock canonical の re-export）を `CalendarDisplayEvent` へ改名し、同名による import ミスの温床を解消する。calendar-local の全消費者を追従。timeblock canonical 版への直接参照はそのまま `CalendarEvent` を維持
3. **#2242**（anchorRect/z-token 整理）は PR #2244（Inspector 右パネル化）merge 待ちのため本 PR には未着手。merge 後に追従し実装を積む

## 検証

- `pnpm exec tsc --noEmit -p .`（apps/product）: エラーなし
- `pnpm lint` / `pnpm lint:boundaries` / `pnpm lint:tokens`: green
- `pnpm exec prettier --check`: 全ファイル準拠
- `pnpm quality:deadcode:ci`（knip）: 新規指摘なし
- `pnpm test:run`: rename 対象ファイルを個別実行し全 pass（67 tests）。全体実行で発生する 75 件の失敗は localStorage/zustand-persist/cookie-consent 系で、Node v26 ローカル環境依存の既知問題（rename と無関係、CI の node24 では pass する前提）
- #2245 の live 検証（probe:setup exit 0）は環境制約により未実施。merge 前に指揮台が代行実測予定

Closes #2245
Closes #2221
Refs #2242