### PR TITLE
docs(release): v0.34.0リリースノートのスナップショットを保存する

### DIFF
--- a/docs/operations/log/2026-08-20-release-v0.34.0.md
+++ b/docs/operations/log/2026-08-20-release-v0.34.0.md
@@ -1,0 +1,244 @@
+---
+status: frozen
+date: 2026-08-20
+---
+
+# Release v0.34.0
+
+**リリース日**: 2026-08-20
+**バージョン**: 0.34.0
+
+## 🎯 概要
+
+このリリースの中心は2つの大型再設計。(1) タグ機能を全廃し、**アクティビティ／カテゴリー／セグメント**の3構造へ全置換（epic #2162）。(2) カレンダーのURLを`/calendar`と`/report`へ統一し、分析をフルページ化、サイドバーをNotion風タブUIへ刷新（epic #2181、workspace-shell再構成）。あわせて予定/記録のInspectorをポップアップから右サイドパネルへ変更した。
+
+外部カレンダー同期は fenced writer RPC への移行・wall-clock 予算化・prune のUUIDカーソルバグ修正など信頼性向上を継続実施。認証まわりはMFA無限redirectループ、cookie改竄によるMFA検証回避、パスワードリセット3層バグ、captcha起因のメール変更/アカウント削除失敗など多数の実害バグを修理した。運用面ではGitHub Actions予算対応としてCIを4層へ再設計し、per-PRのE2E/Web E2Eをmain push後の層へ移設。STATE.mdを廃止し日次盤面issue運用へ移行、内製クロスレビューをmerge gateの標準に据えた。
+
+---
+
+## 📋 変更内容
+
+### 🎉 新機能
+
+- **タグ機能をアクティビティ / カテゴリー / セグメントの3構造へ刷新**（epic #2162: [#2184](https://github.com/Dayopt/dayopt/pull/2184) [#2199](https://github.com/Dayopt/dayopt/pull/2199) [#2202](https://github.com/Dayopt/dayopt/pull/2202) [#2204](https://github.com/Dayopt/dayopt/pull/2204) [#2201](https://github.com/Dayopt/dayopt/pull/2201) [#2179](https://github.com/Dayopt/dayopt/pull/2179)）
+  - `categories` / `activities` / `segments` / `segment_activities` テーブルを新設し、サイドバー・カレンダー・分析・MCP公開契約をすべてアクティビティ軸へ切り替えた
+  - カテゴリーはネスト2階層（カテゴリー→アクティビティ）に単純化し、色・アイコンはカテゴリーのみが持つ（アクティビティは継承）
+  - セグメント（保存されたアクティビティの組み合わせ）を新設し、`/report` から3軸（アクティビティ／カテゴリー／セグメント）で集計できるようにした
+- **予定/記録のInspectorをポップアップから右サイドパネルへ変更**（[#2244](https://github.com/Dayopt/dayopt/pull/2244)）
+  - モーダルの`FloatingPopover`から、デスクトップレイアウトの3カラム目としてドッキングする非モーダルパネルへ変更。閲覧しながら他の予定も操作できるようになった
+- **カレンダー分析を`/report`フルページへ移行しURLを統一**（epic #2181: [#2222](https://github.com/Dayopt/dayopt/pull/2222) [#2186](https://github.com/Dayopt/dayopt/pull/2186)）
+  - サイドバーをNotion風タブUI（WorkspaceTabs/BottomTabBar）へ再構成し、旧`/day` `/week` `/{n}day`と右パネル分析を`/calendar`・`/report`の2URLへ統一
+- **時間グリッドのviewportフィットとヘッダー入口統合**（[#2161](https://github.com/Dayopt/dayopt/pull/2161)）— 密度プリセットをコンテナ実測高ベースに再定義し、compactは常にスクロールなしでフィットするようにした。ヘッダーの「振り返り」「差分」トグルを1つのセグメント切替へ統合
+- **外部カレンダーの未変換予定（ghost）をPlan/Recordへワンタップ変換・dismiss**（[#1991](https://github.com/Dayopt/dayopt/pull/1991) [#2045](https://github.com/Dayopt/dayopt/pull/2045)）— 取り込み済みの外部予定をカレンダー上に読み取り専用カードとして表示し、変換・不要分の非表示に対応
+- **メールアドレス変更に変更前パスワード再認証を追加**（[#2062](https://github.com/Dayopt/dayopt/pull/2062)）
+- **Settingsに MCP connection の一覧・revoke UIを追加**（[#1902](https://github.com/Dayopt/dayopt/pull/1902) [#1918](https://github.com/Dayopt/dayopt/pull/1918) [#1906](https://github.com/Dayopt/dayopt/pull/1906)）— 接続中のMCPクライアントをスコープの説明文つきで確認・失効できる。一覧はkeysetページングで大量接続にも対応
+- **write fence と Storage backup/restore機構を追加**（[#2035](https://github.com/Dayopt/dayopt/pull/2035) [#2151](https://github.com/Dayopt/dayopt/pull/2151)）— 復元前にAPI層の書き込みを止める仕組みと、avatars/attachmentsの日次バックアップexport workflowを整備（既定disabled、運用基盤の強化）
+
+### 🔧 改善
+
+- **サイドバーをカテゴリー/アクティビティIAへ全面刷新、DnDを撤去**（[#2179](https://github.com/Dayopt/dayopt/pull/2179)）— カテゴリー見出し（色+アイコン+折りたたみ）→ネスト→未分類→アーカイブ済みの構成へ。並び順は名前順固定
+- **dogfoodingフィードバックの反映**（[#2243](https://github.com/Dayopt/dayopt/pull/2243) [#2254](https://github.com/Dayopt/dayopt/pull/2254)）— WorkspaceTabsのセグメントコントロール化、カレンダーヘッダー2行の視覚統合、日付数字の拡大、ショートカット/お問い合わせダイアログが開いた直後に閉じる不具合の根治、Plan/Record 2列固定分割の見直しなど
+- **CIを4層へ再設計し、GitHub Actions予算に対応**（[#2281](https://github.com/Dayopt/dayopt/pull/2281)）— private化前提でE2E/Web E2Eをper-PRトリガーからmain push後+nightlyの層へ移設し、promote前にgreenを要求するpre-flightを追加
+- **production promoteをmain push連動から手動dispatchへ切り替え**（[#2275](https://github.com/Dayopt/dayopt/pull/2275)）
+- **内製クロスレビューをmerge gateの標準にし外部レビュー（Codex）を廃止**（[#2051](https://github.com/Dayopt/dayopt/pull/2051)）。その後、高リスクPR限定でCodexレビューを試行再導入する運用を整備（[#2287](https://github.com/Dayopt/dayopt/pull/2287)）
+- **STATE.mdを廃止し日次盤面issue運用へ移行**（[#2262](https://github.com/Dayopt/dayopt/pull/2262)）— 直列mergeモデルで構造的に鮮度が遅れるroot fileをやめ、issueコメントで運用状態を追う方式へ
+- **DB安全性テストとCIの破壊的変更検知を拡充**（[#2279](https://github.com/Dayopt/dayopt/pull/2279)）— RLS境界テストの未カバーtableを補い、migrationのDROP/DELETE/REVOKE等を検知してPRへ可視化
+- **外部カレンダーsync-serviceをfenced writer RPC群へ移行**（[#2276](https://github.com/Dayopt/dayopt/pull/2276)）— disconnect中のsync書き込みraceをCASフェンスで構造的に閉じた
+- **外部カレンダーAPI呼び出しをwall-clock予算で保護**（[#2075](https://github.com/Dayopt/dayopt/pull/2075) [#2087](https://github.com/Dayopt/dayopt/pull/2087) [#2102](https://github.com/Dayopt/dayopt/pull/2102)）— syncConnection/listProviderCalendars/listCalendarsがVercelのmaxDuration hard killに触れないよう予算切れを明示エラー化
+- **E2E specごとに専用test accountを割りrate limit超過を解消**（[#2255](https://github.com/Dayopt/dayopt/pull/2255)）
+- **計測夜勤Routineを追加**（[#2213](https://github.com/Dayopt/dayopt/pull/2213)）— read-onlyチェックリストで異常を1件1issueとして起票する夜間監視
+- **決済復帰の表示ラグを短縮**（[#1890](https://github.com/Dayopt/dayopt/pull/1890)）— checkout成功復帰時に有限ポーリングでPro反映を待つ
+- **Google Calendar接続のOAuth scopeを最小権限のnarrow pairへ切り替え**（[#2070](https://github.com/Dayopt/dayopt/pull/2070)）
+- **bundle budget計測の精度向上**（[#2125](https://github.com/Dayopt/dayopt/pull/2125) [#2252](https://github.com/Dayopt/dayopt/pull/2252) [#2130](https://github.com/Dayopt/dayopt/pull/2130)）— preview/production差分をSentry分・Supabase credential分に成分分解し予算超過によるproduction デプロイ全滅を解消
+- **root scriptとworkspace packageの整理**（[#2266](https://github.com/Dayopt/dayopt/pull/2266) [#2282](https://github.com/Dayopt/dayopt/pull/2282)）— 重複alias削除、単一consumerのpackageをapp local化
+- 内部改善・運用ドキュメント・secrets棚卸し等（多数、抜粋）: 1Password vault再編・schema drift解消（[#2095](https://github.com/Dayopt/dayopt/pull/2095) [#2083](https://github.com/Dayopt/dayopt/pull/2083) [#2093](https://github.com/Dayopt/dayopt/pull/2093) [#2101](https://github.com/Dayopt/dayopt/pull/2101) [#2116](https://github.com/Dayopt/dayopt/pull/2116) [#1935](https://github.com/Dayopt/dayopt/pull/1935)）、レーン運用・レビュー規約の整備（[#2241](https://github.com/Dayopt/dayopt/pull/2241) [#2038](https://github.com/Dayopt/dayopt/pull/2038) [#2056](https://github.com/Dayopt/dayopt/pull/2056) [#2113](https://github.com/Dayopt/dayopt/pull/2113) [#1954](https://github.com/Dayopt/dayopt/pull/1954) [#1914](https://github.com/Dayopt/dayopt/pull/1914)）、公開docs整備・翻訳追加（[#2131](https://github.com/Dayopt/dayopt/pull/2131) [#2135](https://github.com/Dayopt/dayopt/pull/2135) [#2136](https://github.com/Dayopt/dayopt/pull/2136) [#1976](https://github.com/Dayopt/dayopt/pull/1976) [#1916](https://github.com/Dayopt/dayopt/pull/1916)）、GCP OAuth審査対応（[#1983](https://github.com/Dayopt/dayopt/pull/1983) [#2117](https://github.com/Dayopt/dayopt/pull/2117)）、テスト・型検査の偽green解消（[#2207](https://github.com/Dayopt/dayopt/pull/2207) [#1907](https://github.com/Dayopt/dayopt/pull/1907) [#1891](https://github.com/Dayopt/dayopt/pull/1891) [#1882](https://github.com/Dayopt/dayopt/pull/1882)）、Sentry CLI追加・deps更新（[#2074](https://github.com/Dayopt/dayopt/pull/2074) [#2076](https://github.com/Dayopt/dayopt/pull/2076)）ほか
+
+### 🐛 バグ修正
+
+- **外部カレンダー: orphan grant revoke判定の誤判定を修正**（[#2286](https://github.com/Dayopt/dayopt/pull/2286)）— reconnect失敗時に新規発行されたrefresh tokenがGoogle側に孤立残存する問題
+- **外部カレンダー: prune が本番稼働以来一度も行を削除できていなかった不具合を修正**（[#2000](https://github.com/Dayopt/dayopt/pull/2000)）— UUIDカーソルへの空文字比較バグと、削除失敗の握りつぶしをfail-closedへ変更
+- **外部カレンダー: listCalendarsのdeadline overshootを解消**（[#2102](https://github.com/Dayopt/dayopt/pull/2102)）
+- **外部カレンダー: revoke operationの90日保持境界をcron配線で成立**（[#2054](https://github.com/Dayopt/dayopt/pull/2054)）
+- **外部カレンダー: 同期の失敗を伴わず欠ける4経路の可視化とhardening**（[#1927](https://github.com/Dayopt/dayopt/pull/1927)）
+- **MFA: AAL lookup失敗時の無限redirectループを解消**（[#2152](https://github.com/Dayopt/dayopt/pull/2152)）
+- **MFA: リカバリーコード検証の中途状態解消・MFA無効化通知メール追加**（[#2044](https://github.com/Dayopt/dayopt/pull/2044)）
+- **auth: signup/パスワードリセットのMFA自己復旧・エラー文言を修正**（[#2036](https://github.com/Dayopt/dayopt/pull/2036)）
+- **auth: production パスワードリセットの3層バグを修理**（[#2016](https://github.com/Dayopt/dayopt/pull/2016)）— redirect未到達・MFA有効時のupdateUser失敗・フォームUI崩れ
+- **auth: メール変更失敗の原因無差別化を解消**（[#2071](https://github.com/Dayopt/dayopt/pull/2071)）— GoTrue構成故障がSentryに一切上がっていなかった問題
+- **auth: 認証セッション断・OAuth scope重複・セキュリティメール無痕跡を修正**（[#2267](https://github.com/Dayopt/dayopt/pull/2267)）
+- **auth: 設定食い違い解消・死にコード削除・鍵形式監視・メール確認着地先修正**（[#1958](https://github.com/Dayopt/dayopt/pull/1958)）
+- **billing: 死んでいたserviceCode分岐を復活**（[#1943](https://github.com/Dayopt/dayopt/pull/1943)）— allowlist未登録により支払いエラー文言・再試行ロックが一度も発火していなかった
+- **billing: 決済後の白紙ページを修正**（[#1882](https://github.com/Dayopt/dayopt/pull/1882)）
+- **ops: production デプロイ全滅を復旧**（[#2125](https://github.com/Dayopt/dayopt/pull/2125)）— bundle budget超過によるVercel build failが3〜4日滞留していた
+- **ops: storage-backup-exportのRCLONE予約namespace衝突を修正**（[#2158](https://github.com/Dayopt/dayopt/pull/2158)）
+- **ops: health/rate-limitの観測穴とdead codeを解消**（[#2041](https://github.com/Dayopt/dayopt/pull/2041)）
+- **pwa/calendar: 更新no-op UpdateBannerを削除しTZ再解釈バグをlintで封じる**（[#2061](https://github.com/Dayopt/dayopt/pull/2061)）
+- **i18n: 検査が素通りしていた3箇所を修正**（[#1907](https://github.com/Dayopt/dayopt/pull/1907)）— キー実在チェックの追加で、Inspectorの右クリックメニューに生キーがそのまま表示されていた実出荷不具合を検出・修正
+- **tooling: テスト実行の偽green・生成型の整形ノイズを解消**（[#2207](https://github.com/Dayopt/dayopt/pull/2207)）— `pnpm test:integration`がDB未起動時に無音skipし緑になっていた問題
+
+### ⚠️ 破壊的変更
+
+- **タグ機能を廃止し、アクティビティ / カテゴリー / セグメントの3構造へ全置換**（epic #2162: [#2184](https://github.com/Dayopt/dayopt/pull/2184) [#2199](https://github.com/Dayopt/dayopt/pull/2199) [#2202](https://github.com/Dayopt/dayopt/pull/2202) [#2204](https://github.com/Dayopt/dayopt/pull/2204) [#2201](https://github.com/Dayopt/dayopt/pull/2201) [#2179](https://github.com/Dayopt/dayopt/pull/2179) [#2219](https://github.com/Dayopt/dayopt/pull/2219) [#2258](https://github.com/Dayopt/dayopt/pull/2258)）
+  - DB: `activities` / `categories` / `segments` / `segment_activities` テーブルを新設。ブロックは**1件につき最大1アクティビティの単一所属**へ変更（旧タグの多重所属・親子DnD階層は廃止）
+  - `features/tags` feature を全面撤去。tag CRUD/mutation/archive/merge procedure、design token `--tag-*`、tags i18n namespace、`TagIcon`等の関連コードをすべて削除
+  - MCP公開契約が破壊的変更: OAuth scope `read:tags` → `read:activities`（aliasなしのクリーン置換）、tool `tags.list` → `activities.list` + `categories.list`、`MCP_TOOL_SCHEMA_VERSION` 2 → 3。既存のtags scopeを持つMCPクライアントは接続し直しが必要
+  - **既存データの移行は行っていない**。リリース後、既存のすべてのブロックは「アクティビティなし」になる（積極的な設計判断）
+- **カレンダーのURL構造を統一し、旧ルートと右パネル分析を廃止**（epic #2181: [#2222](https://github.com/Dayopt/dayopt/pull/2222) [#2244](https://github.com/Dayopt/dayopt/pull/2244)）
+  - 正規URLは `/calendar?view=&date=` と `/report?date=&range=` に統一。旧`/day` `/week` `/{n}day`ルートと`?panel=review`は撤去し、redirect（307）で後方互換を維持
+  - 予定/記録のInspectorをモーダルポップアップから非モーダルの右サイドパネルへ変更
+  - サイドバーのドラッグ&ドロップ（DnD）による並び替えを撤去し、名前順固定へ変更
+- **CIからE2E / Web E2Eをper-PRトリガーから撤去**（[#2281](https://github.com/Dayopt/dayopt/pull/2281)）— private化前提のActions予算対応として、main push後+nightlyの層へ移設。per-PRの回帰検出はレーンのローカル影響spec実走義務が引き継ぐ
+
+### 🔒 セキュリティ
+
+- **MFA AAL claimの判定源をserver検証済みへ統一**（[#2145](https://github.com/Dayopt/dayopt/pull/2145)）— session cookieを書き換えることでMFA検証済み判定を回避できる問題を修正
+- **公開エンドポイントの入力上限・レート制御を追加**（[#2053](https://github.com/Dayopt/dayopt/pull/2053)）— Google Calendar接続がMFA未検証セッションから進行できる問題、公開iCalフィードのIP/global集約rate limit欠如、OG画像生成routeの入力長無制限を修正
+- **Google Calendar接続のOAuth scopeを最小権限のnarrow pairへ切り替え**（[#2070](https://github.com/Dayopt/dayopt/pull/2070)）— GCP OAuth sensitive scope審査対応
+- **アカウント削除の再認証をservice-role経由にしcaptchaを構造的に免除**（[#1950](https://github.com/Dayopt/dayopt/pull/1950)）— production のBot Protection下で削除の本人確認が必ず失敗していた問題
+- **設定画面の再認証から公開Authエンドポイント依存を除去**（[#1931](https://github.com/Dayopt/dayopt/pull/1931)）— captcha失敗によりメール変更/パスワード変更が完了できなかった問題をSupabase Auth専用機構（Secure Email Change / current_password検証）へ寄せて解消
+- **nanoid HIGH脆弱性を解消**（[#2137](https://github.com/Dayopt/dayopt/pull/2137)）
+- **service-role専用テーブルのgrantを閉じる**（[#1913](https://github.com/Dayopt/dayopt/pull/1913)）
+- **OAuth retentionのcleanup RPCを追加し、connection一覧のmax_rows切り捨てを閉じる**（[#1906](https://github.com/Dayopt/dayopt/pull/1906) [#1918](https://github.com/Dayopt/dayopt/pull/1918)）— revokeできないconnectionが一覧から見えなくなる問題を解消
+- **private schema のGRANTをdrift検出網へ追加**（[#1901](https://github.com/Dayopt/dayopt/pull/1901)）
+- **Turnstile secret無効時のcaptcha_failedをSentry送信対象化**（[#2122](https://github.com/Dayopt/dayopt/pull/2122)）
+- **production RECOVERY_CODE_PEPPER空文字の再発防止**（[#2119](https://github.com/Dayopt/dayopt/pull/2119)）— build gateへ必須env追加、約40日放置されていた事故の再発防止
+- **write fence機構によるメンテナンスモード中の書き込み防止**（[#2035](https://github.com/Dayopt/dayopt/pull/2035)）— 復元中にAPI層の書き込みが止まらなかった問題への対処
+
+---
+
+## 🔗 関連リンク
+
+### Pull Requests
+
+- [#2287](https://github.com/Dayopt/dayopt/pull/2287) - docs(ops): 日次盤面issueのタイムライン方式を正本化し、高リスクPR限定でCodex再導入ルールを整備する
+- [#2286](https://github.com/Dayopt/dayopt/pull/2286) - fix(external-calendar): orphan grant revoke判定をaccount単位からactive限定へ寄せる
+- [#2284](https://github.com/Dayopt/dayopt/pull/2284) - test/小粒束: E-1到達不能ファイル削除・query wiring集約・localStorage実ラウンドトリップtest・tooltip文字サイズ
+- [#2282](https://github.com/Dayopt/dayopt/pull/2282) - refactor(packages): workspace package を「2 consumer 以上」基準で整理する（slice C）
+- [#2281](https://github.com/Dayopt/dayopt/pull/2281) - ci: private化前提でCIを4層へ再設計し、DoD記載+ランダム抽出監査を運用化する
+- [#2279](https://github.com/Dayopt/dayopt/pull/2279) - test(security): DB安全性束 — RLS境界テスト拡充とmigration破壊的変更検知
+- [#2278](https://github.com/Dayopt/dayopt/pull/2278) - refactor(docs): CLAUDE.md と .claude/rules の正本関係を整合させる
+- [#2276](https://github.com/Dayopt/dayopt/pull/2276) - feat(external-calendar): sync-service.ts を fenced writer RPC 群へ移行する
+- [#2275](https://github.com/Dayopt/dayopt/pull/2275) - ops(release): production promote を main push 連動から手動 dispatch へ切り替える
+- [#2267](https://github.com/Dayopt/dayopt/pull/2267) - fix(auth): 認証セッション断・OAuth scope重複・セキュリティメール無痕跡を修正
+- [#2266](https://github.com/Dayopt/dayopt/pull/2266) - chore(build): root script の完全同一・単純alias 5本を削除する（slice B）
+- [#2262](https://github.com/Dayopt/dayopt/pull/2262) - chore(state): 日次盤面issueへ移行しSTATE.mdを廃止する
+- [#2261](https://github.com/Dayopt/dayopt/pull/2261) - chore(timeblock): anchorRectの未使用コードとz-inspector token記述を整理する
+- [#2258](https://github.com/Dayopt/dayopt/pull/2258) - chore(tags): タグ系機能をactivity軸へ移行しfeatures/tagsを撤去する
+- [#2255](https://github.com/Dayopt/dayopt/pull/2255) - fix(test): E2E specごとに専用test accountを割りrate limit超過を解消する
+- [#2254](https://github.com/Dayopt/dayopt/pull/2254) - fix(ui): dogfoodingフィードバック第2弾（ショートカットrace/Sidebarタブ/カレンダー2列固定）
+- [#2252](https://github.com/Dayopt/dayopt/pull/2252) - chore(build): bundle budgetのpreview補正をSentry分とSupabase credential分に成分分解する
+- [#2251](https://github.com/Dayopt/dayopt/pull/2251) - chore(calendar): probe URL追従とCalendarEvent改名の小粒cleanup束
+- [#2244](https://github.com/Dayopt/dayopt/pull/2244) - feat(timeblock): 予定/記録のInspectorをポップアップから右サイドパネルへ変更する
+- [#2243](https://github.com/Dayopt/dayopt/pull/2243) - fix(calendar): #2181後の dogfooding フィードバック第1弾を反映する
+- [#2241](https://github.com/Dayopt/dayopt/pull/2241) - chore(ops): レーンプロトコル・診断プロトコル・marker生成を整備する
+- [#2225](https://github.com/Dayopt/dayopt/pull/2225) - feat(ops): 運用基盤にSTATE.mdを導入しレーン連絡方式を改訂する
+- [#2222](https://github.com/Dayopt/dayopt/pull/2222) - feat(calendar): analysisをカレンダー右パネルから/reportフルページへ移す（v0.34）
+- [#2219](https://github.com/Dayopt/dayopt/pull/2219) - chore(tags): タグ廃止の非破壊cleanup（Step 7、部分実施）
+- [#2214](https://github.com/Dayopt/dayopt/pull/2214) - docs(projects): surface縮小baselineの実測結果を記録する
+- [#2213](https://github.com/Dayopt/dayopt/pull/2213) - ops(night-watch): 計測夜勤 Routine を実装する（read-only チェックリスト + 1異常1issue + baseline 固定）
+- [#2207](https://github.com/Dayopt/dayopt/pull/2207) - fix(tooling): テスト実行の偽green・生成型の整形ノイズを解消する
+- [#2204](https://github.com/Dayopt/dayopt/pull/2204) - feat(review): タグをアクティビティ/カテゴリー/セグメントへ全置換する（analytics + 語彙全廃）
+- [#2202](https://github.com/Dayopt/dayopt/pull/2202) - feat(calendar): サイドバーとカレンダーの分類をアクティビティへ切り替える（Step 4）
+- [#2201](https://github.com/Dayopt/dayopt/pull/2201) - feat(mcp): MCP 公開契約を activities へ切り替える（Step 6）
+- [#2199](https://github.com/Dayopt/dayopt/pull/2199) - feat(db): plans / records にactivity参照を追加しコマンドRPCをadditiveに拡張する
+- [#2189](https://github.com/Dayopt/dayopt/pull/2189) - docs(records): 2026-08-18の記録系docsを束ねる
+- [#2186](https://github.com/Dayopt/dayopt/pull/2186) - docs(projects): workspace-shell-restructure の全体設計書を追加する
+- [#2184](https://github.com/Dayopt/dayopt/pull/2184) - feat(activities): アクティビティ / カテゴリー の schema と server 層を追加する
+- [#2179](https://github.com/Dayopt/dayopt/pull/2179) - refactor(calendar): サイドバーをカテゴリー/アクティビティ IA へ置換し DnD を撤去する
+- [#2177](https://github.com/Dayopt/dayopt/pull/2177) - docs(projects): tag-model-replacement の全体設計書（凍結版）を追加する
+- [#2161](https://github.com/Dayopt/dayopt/pull/2161) - feat(calendar): 時間グリッドのviewportフィットとヘッダーreview/diff入口統合
+- [#2159](https://github.com/Dayopt/dayopt/pull/2159) - feat(calendar): finalize隔離失敗の観測手段追加 + account_delete settle経路配線 + orphan grant revoke
+- [#2158](https://github.com/Dayopt/dayopt/pull/2158) - fix(ci): storage-backup-export の RCLONE_* env が予約 namespace と衝突して即死する
+- [#2152](https://github.com/Dayopt/dayopt/pull/2152) - fix(auth): MFA AAL lookup失敗時の無限redirectループを解消する
+- [#2151](https://github.com/Dayopt/dayopt/pull/2151) - ci(storage): storage backup の日次 export workflow を追加する
+- [#2145](https://github.com/Dayopt/dayopt/pull/2145) - fix(auth): MFA AAL claimの判定源を3箇所でserver検証済みに統一する
+- [#2143](https://github.com/Dayopt/dayopt/pull/2143) - fix(web): OG画像fallback応答を静的アセット化してcompute costをゼロにする
+- [#2142](https://github.com/Dayopt/dayopt/pull/2142) - docs: 判断帯域最適化の採用分をdecisionテンプレとdocs書き方へ反映する
+- [#2139](https://github.com/Dayopt/dayopt/pull/2139) - docs(operations): human vault の1Password item重複整理をrepoへ反映する
+- [#2138](https://github.com/Dayopt/dayopt/pull/2138) - docs/ops: 公開docsのspec外明示とSupabase CLI credential item分離
+- [#2137](https://github.com/Dayopt/dayopt/pull/2137) - fix(deps): nanoid HIGH脆弱性の解消とDevelopment secrets棚卸し
+- [#2136](https://github.com/Dayopt/dayopt/pull/2136) - docs(web): privacy.mdxへAxiomサブプロセッサーを追記し30日通知を開始する
+- [#2135](https://github.com/Dayopt/dayopt/pull/2135) - docs: LP約束機能の未執筆3ページ（review/data-export/tags）を執筆する
+- [#2131](https://github.com/Dayopt/dayopt/pull/2131) - docs(web): 公開docs未翻訳4ファイルのen版を追加する
+- [#2130](https://github.com/Dayopt/dayopt/pull/2130) - chore(build,operations): deploy 健全性を改善する（preview budget 補正・production 監視追加）
+- [#2128](https://github.com/Dayopt/dayopt/pull/2128) - docs: secrets ローテーション手順とレーン編成規約を更新する
+- [#2125](https://github.com/Dayopt/dayopt/pull/2125) - fix(ops): production デプロイ全滅を復旧しbundle budgetの非対称を記録する
+- [#2122](https://github.com/Dayopt/dayopt/pull/2122) - fix(auth): Turnstile secret無効時のcaptcha_failedをSentry送信の対象にする
+- [#2120](https://github.com/Dayopt/dayopt/pull/2120) - chore(external-calendar,docs): #2109 follow-up と #2118 draft規約の注意を反映する
+- [#2119](https://github.com/Dayopt/dayopt/pull/2119) - fix(ops): production RECOVERY_CODE_PEPPER 空文字の再発防止と env 健全性チェックの機械化
+- [#2117](https://github.com/Dayopt/dayopt/pull/2117) - docs: external-calendar spec登録とtroubleshooting鮮度更新
+- [#2116](https://github.com/Dayopt/dayopt/pull/2116) - chore(secrets): epic #2091 残scopeの設計・手順書を反映する
+- [#2113](https://github.com/Dayopt/dayopt/pull/2113) - docs(rules): 意思決定原則・レビュー判断層・手作業コンシェルジュレーンを恒久化する
+- [#2110](https://github.com/Dayopt/dayopt/pull/2110) - docs(gardening): 2026年8月 月次ガーデニング journal（自動パート代行）
+- [#2102](https://github.com/Dayopt/dayopt/pull/2102) - fix(external-calendar): listCalendars の in-flight リクエストが deadline を overshoot しないようにする
+- [#2101](https://github.com/Dayopt/dayopt/pull/2101) - fix(secrets): integration 注入 env 11 件を台帳の例外として登録する
+- [#2095](https://github.com/Dayopt/dayopt/pull/2095) - chore(secrets): 1Password を信頼境界軸 agent/ci/human へ再編する（cutover）
+- [#2093](https://github.com/Dayopt/dayopt/pull/2093) - chore(secrets): replica ⊆ 台帳の機械検証と secrets 台帳の整合
+- [#2088](https://github.com/Dayopt/dayopt/pull/2088) - chore(docs,ops): 判断ジャーナル自動化・未参照script整理・1Passwordタグ体系docs化
+- [#2087](https://github.com/Dayopt/dayopt/pull/2087) - refactor(external-calendar): listProviderCalendars の予算化 + iCal feed token rotate 契約の固定
+- [#2083](https://github.com/Dayopt/dayopt/pull/2083) - chore(secrets): 1Password schema drift を棚卸しし SUPABASE_ACCESS_TOKEN を production へ一本化する
+- [#2080](https://github.com/Dayopt/dayopt/pull/2080) - chore(ci): Default Function Timeout を production-config-audit で pin する
+- [#2076](https://github.com/Dayopt/dayopt/pull/2076) - chore(deps): size-limit撤去とHaikuユーザビリティプローブの骨格追加
+- [#2075](https://github.com/Dayopt/dayopt/pull/2075) - refactor(external-calendar): syncConnection に wall-clock 予算を持たせる
+- [#2074](https://github.com/Dayopt/dayopt/pull/2074) - chore(tooling): 新Sentry CLIをMCPと併用するAI設定を追加する
+- [#2071](https://github.com/Dayopt/dayopt/pull/2071) - fix(auth): メール変更失敗の原因無差別化を解消しGoTrue構成故障をSentryへ報告する
+- [#2070](https://github.com/Dayopt/dayopt/pull/2070) - fix(external-calendar): OAuth scope を narrow pair へ切り替える
+- [#2068](https://github.com/Dayopt/dayopt/pull/2068) - docs: PR milestone付与規約の追加とAI設定棚卸し反映（docs束）
+- [#2062](https://github.com/Dayopt/dayopt/pull/2062) - feat(auth): メールアドレス変更に変更前パスワード再認証を追加する
+- [#2061](https://github.com/Dayopt/dayopt/pull/2061) - fix(pwa,calendar): 更新no-op UpdateBannerを削除しTZ再解釈バグをlintで封じる
+- [#2060](https://github.com/Dayopt/dayopt/pull/2060) - docs: 運用フォローアップ3件（gardening claude-security走査 / private化前提訂正 / marker書式）
+- [#2056](https://github.com/Dayopt/dayopt/pull/2056) - chore(review): merge gate 診断性強化・残存Codex参照整理・ruleset棚卸し（#2048束）
+- [#2054](https://github.com/Dayopt/dayopt/pull/2054) - fix(external-calendar): revoke operation の保持境界をcron配線で成立させる
+- [#2053](https://github.com/Dayopt/dayopt/pull/2053) - fix: 公開エンドポイントの入力上限・レート制御を追加する
+- [#2051](https://github.com/Dayopt/dayopt/pull/2051) - feat(review): 外部レビュー(Codex)を廃止し内製クロスレビューをmerge gateの標準にする
+- [#2045](https://github.com/Dayopt/dayopt/pull/2045) - feat(external-calendar): ghost の変換・dismiss導線とuser docsを追加する
+- [#2044](https://github.com/Dayopt/dayopt/pull/2044) - fix(auth): リカバリーコード検証の中途状態を解消しMFA無効化通知を送る
+- [#2041](https://github.com/Dayopt/dayopt/pull/2041) - fix(ops): health/rate-limit の観測穴とdead codeを解消する
+- [#2038](https://github.com/Dayopt/dayopt/pull/2038) - chore(hooks): guard境界の見直しと復旧経路の追加（#1993/#1961/#2030 + #1944/#1986/#1987 記録）
+- [#2036](https://github.com/Dayopt/dayopt/pull/2036) - fix(auth): signup/パスワードリセットのMFA自己復旧・エラー文言を修正する
+- [#2035](https://github.com/Dayopt/dayopt/pull/2035) - feat(ops): write fence と storage backup/restore 機構を追加する
+- [#2032](https://github.com/Dayopt/dayopt/pull/2032) - docs: 月次ガーデニング機械化・Cloudflare DNS反映・User操作枠分担・API一覧照合test・GitHubテンプレ機械化・Merge Queue調査見送り
+- [#2025](https://github.com/Dayopt/dayopt/pull/2025) - chore(ci): production-auth-config-audit の uri_allow_list pin に /auth/reset-password を反映する
+- [#2016](https://github.com/Dayopt/dayopt/pull/2016) - fix(auth): production パスワードリセットの3層バグを修理する
+- [#2000](https://github.com/Dayopt/dayopt/pull/2000) - fix(external-calendar): prune の UUID cursor・fail-closed 化・fields マスク・90日保持cron配線
+- [#1998](https://github.com/Dayopt/dayopt/pull/1998) - docs(ai-config): 指揮台運用・dispatch・mcp・legal 束（#1957/#1968/#1969/#1939/#1980）
+- [#1991](https://github.com/Dayopt/dayopt/pull/1991) - feat(external-calendar): 同期ミラーをカレンダー画面に ghost として接続する
+- [#1983](https://github.com/Dayopt/dayopt/pull/1983) - docs(operations): GCP sensitive scope 審査の申請パッケージ
+- [#1976](https://github.com/Dayopt/dayopt/pull/1976) - docs(infra): 実在しない endpoint 記述を消し API 一覧を実装と双方向で同期する
+- [#1974](https://github.com/Dayopt/dayopt/pull/1974) - fix(hooks): env-file ガードを言及の allowlist と中身で判定し、heredoc 誤検知を落とす
+- [#1973](https://github.com/Dayopt/dayopt/pull/1973) - fix(vercel): 全 route handler に静的 maxDuration を付け 300 秒の継承を止める
+- [#1960](https://github.com/Dayopt/dayopt/pull/1960) - docs(operations): production DB 復元演習の手順書と災害復旧手順を用意する
+- [#1958](https://github.com/Dayopt/dayopt/pull/1958) - fix(auth): auth 設定の食い違い解消・死にコード削除・鍵形式の監視・メール確認の着地先
+- [#1954](https://github.com/Dayopt/dayopt/pull/1954) - docs(orchestration): 指揮台運用を恒久化し、外部レビューの実施を merge gate で要求する
+- [#1950](https://github.com/Dayopt/dayopt/pull/1950) - fix(auth): アカウント削除の再認証を service-role 経由にし captcha を免除する
+- [#1943](https://github.com/Dayopt/dayopt/pull/1943) - fix(billing): 死んでいた serviceCode 分岐を復活させ、既存サブスク時の dead end に出口を渡す
+- [#1938](https://github.com/Dayopt/dayopt/pull/1938) - docs(ci): CodeQL を無効化し private 化を保留する決定を記録する
+- [#1936](https://github.com/Dayopt/dayopt/pull/1936) - ci(auth): production の auth 設定と Turnstile site key を監視下に置く
+- [#1935](https://github.com/Dayopt/dayopt/pull/1935) - fix(secrets): Staging vault の production 複製を解消し、1Password master の欠落に受け皿を戻す
+- [#1932](https://github.com/Dayopt/dayopt/pull/1932) - docs(env): CRON_SECRET のコメントを実装に合わせる
+- [#1931](https://github.com/Dayopt/dayopt/pull/1931) - fix(auth): 設定画面の再認証から公開 Auth endpoint 依存を除去する
+- [#1927](https://github.com/Dayopt/dayopt/pull/1927) - feat(external-calendar): Step 7 — hardening と project 完了処理
+- [#1922](https://github.com/Dayopt/dayopt/pull/1922) - docs(secrets): API 経由の設定読戻しに jq 射影を必須化する
+- [#1921](https://github.com/Dayopt/dayopt/pull/1921) - docs(operations,supabase): credential 露出の incident と preview branch の仕様を記録する
+- [#1919](https://github.com/Dayopt/dayopt/pull/1919) - docs: GitHub ラベル SSOT を実態に揃え、教訓コメント方式を追加する
+- [#1918](https://github.com/Dayopt/dayopt/pull/1918) - refactor(settings): MCP connection 一覧を UI が処理できる単位でページングする
+- [#1916](https://github.com/Dayopt/dayopt/pull/1916) - docs: marketing ドメインを business へ統合し strategy.md をルートへ昇格
+- [#1914](https://github.com/Dayopt/dayopt/pull/1914) - 指揮台オーケストレーション運用の正文化(orchestration.md 新設 + dispatch/gardening 二層構造化)
+- [#1913](https://github.com/Dayopt/dayopt/pull/1913) - fix(settings,db): service-role 専用テーブルの grant を閉じ、接続一覧の dialog を行数から切り離す
+- [#1907](https://github.com/Dayopt/dayopt/pull/1907) - fix: 検査が素通りしていた 3 箇所を塞ぐ（i18n キー実在 / rls-snapshot / scripts 型検査）
+- [#1906](https://github.com/Dayopt/dayopt/pull/1906) - feat(mcp): OAuth retention の cleanup RPC と connection 一覧の切り捨てを閉じる
+- [#1904](https://github.com/Dayopt/dayopt/pull/1904) - chore: strengthen Codex review guardrails
+- [#1902](https://github.com/Dayopt/dayopt/pull/1902) - feat(mcp): Settings の connection 一覧 / revoke、shim 解消、rls-snapshot の private 対応
+- [#1901](https://github.com/Dayopt/dayopt/pull/1901) - fix(i18n): 多要素認証設定の a11y 文言を翻訳キー化し、private schema の GRANT を drift 検出網へ入れる
+- [#1891](https://github.com/Dayopt/dayopt/pull/1891) - test(auth): MFA client UI 層の component/hook test を追加（useMFA / MFAVerifyForm / MFASection）
+- [#1890](https://github.com/Dayopt/dayopt/pull/1890) - fix(billing)/test: 決済復帰の表示ラグ修正と test 品質 3 件の束ね対応
+- [#1888](https://github.com/Dayopt/dayopt/pull/1888) - feat(mcp): 候補8観測窓の直接計測をDB trigger と legacy route の両経路へ配置
+- [#1885](https://github.com/Dayopt/dayopt/pull/1885) - docs: docs 整合性の一斉手入れと未使用 Slack 通知の撤去
+- [#1884](https://github.com/Dayopt/dayopt/pull/1884) - fix(docs-guard): 凍結 log の既知リンク切れを棚卸しし未登録分だけ報告する
+- [#1882](https://github.com/Dayopt/dayopt/pull/1882) - test(e2e): 課金導線とアカウント削除の E2E を追加し、決済後の白紙ページを直す
+- [#1880](https://github.com/Dayopt/dayopt/pull/1880) - docs: 反脆弱性・脱固定化・可逆性のスタンスを技術選定ルールと出口コスト台帳として明文化する
+- [#1878](https://github.com/Dayopt/dayopt/pull/1878) - feat(mcp): 候補8 scope設計とconformance harnessのv1 SDK復活
+
+---
+
+**Full Changelog**: https://github.com/Dayopt/dayopt/compare/v0.33.0...v0.34.0


### PR DESCRIPTION
runbook.md 第4部の規約（バージョン別リリースノートを `docs/operations/log/` に日付プレフィックス付きで保存）の実施。GitHub Release v0.34.0 に反映済みの本文と同一（全128 PRリスト入り + frontmatter）。

Refs #2265