### PR TITLE
fix(external-calendar): settle cron の generic dispatch failure に実エラーの code/message を伝搬する

### DIFF
--- a/apps/product/src/app/api/cron/calendar-account-deletion-settle/__tests__/route.test.ts
+++ b/apps/product/src/app/api/cron/calendar-account-deletion-settle/__tests__/route.test.ts
@@ -28,7 +28,10 @@ vi.mock('@/lib/logger', () => ({
 vi.mock('@/lib/ops/write-fence', () => ({ isWriteFenceEnabled }));
 vi.mock('@/lib/supabase/oauth', () => ({ createServiceRoleClient: vi.fn(() => ({})) }));
 
-import { SETTLE_WORST_CASE_MS } from '../_composition/settle-dispatcher';
+import {
+  CalendarAccountDeletionSettleError,
+  SETTLE_WORST_CASE_MS,
+} from '../_composition/settle-dispatcher';
 import { GET, maxDuration, TIME_BUDGET_MS } from '../route';
 
 const URL = 'https://app.dayopt.app/api/cron/calendar-account-deletion-settle';
@@ -149,7 +152,7 @@ describe('calendar account deletion settle cron', () => {
     );
   });
 
-  it('dispatcher失敗は安全な500とSentry通知に変換する', async () => {
+  it('dispatcher失敗は安全な500とSentry通知に変換する（未分類の raw error は context を持たない）', async () => {
     const error = new Error('v1.secret-ciphertext');
     dispatchCalendarAccountDeletionSettle.mockRejectedValue(error);
 
@@ -166,5 +169,48 @@ describe('calendar account deletion settle cron', () => {
     expect(captured).not.toBe(error);
     expect(JSON.stringify(captureUnexpectedError.mock.calls)).not.toContain(error.message);
     expect(loggerError).toHaveBeenCalledWith('[calendar-account-deletion-settle] dispatch failed');
+  });
+
+  // DAYOPT-V（#2305）: generic dispatch failure で真因が観測不能だった穴を塞ぐ回帰。
+  // dispatcher が CalendarAccountDeletionSettleError で reject した時、原因の code/message
+  // が errorCode/errorMessage として captureUnexpectedError の context へ伝搬することを固定する。
+  it('CalendarAccountDeletionSettleError は原因の code/message を Sentry context へ伝搬する', async () => {
+    const error = new CalendarAccountDeletionSettleError('normalize', {
+      code: '55P03',
+      message: 'could not obtain lock on row in relation "timeblock_supported_writer_v1"',
+    });
+    dispatchCalendarAccountDeletionSettle.mockRejectedValue(error);
+
+    const response = await GET(request('Bearer super-secret-cron'));
+
+    expect(response.status).toBe(500);
+    expect(captureUnexpectedError).toHaveBeenCalledWith(expect.any(Error), {
+      feature: 'external_calendar',
+      operation: 'cron_dispatch',
+      route: '/api/cron/calendar-account-deletion-settle',
+      errorCode: '55P03',
+      errorMessage: 'could not obtain lock on row in relation "timeblock_supported_writer_v1"',
+    });
+    const captured = captureUnexpectedError.mock.calls[0]?.[0] as Error;
+    expect(captured).not.toBe(error);
+  });
+
+  // causeCode が無い場合（例: client 生成失敗）は stage 自身の code へフォールバックする。
+  it('causeCode が無い CalendarAccountDeletionSettleError は自身の stage code を errorCode に使う', async () => {
+    const error = new CalendarAccountDeletionSettleError('client', {
+      message: 'missing SUPABASE_SERVICE_ROLE_KEY',
+    });
+    dispatchCalendarAccountDeletionSettle.mockRejectedValue(error);
+
+    const response = await GET(request('Bearer super-secret-cron'));
+
+    expect(response.status).toBe(500);
+    expect(captureUnexpectedError).toHaveBeenCalledWith(expect.any(Error), {
+      feature: 'external_calendar',
+      operation: 'cron_dispatch',
+      route: '/api/cron/calendar-account-deletion-settle',
+      errorCode: 'ACCOUNT_DELETION_SETTLE_CLIENT_FAILED',
+      errorMessage: 'missing SUPABASE_SERVICE_ROLE_KEY',
+    });
   });
 });

--- a/apps/product/src/app/api/cron/calendar-account-deletion-settle/__tests__/settle-dispatcher.test.ts
+++ b/apps/product/src/app/api/cron/calendar-account-deletion-settle/__tests__/settle-dispatcher.test.ts
@@ -174,4 +174,93 @@ describe('dispatchCalendarAccountDeletionSettle', () => {
     expect(SETTLE_WORST_CASE_MS).toBeGreaterThan(0);
     expect(SETTLE_WORST_CASE_MS).toBeLessThan(50_000);
   });
+
+  // DAYOPT-V（#2305）: 原因の code/message が CalendarAccountDeletionSettleError へ載ることを
+  // stage ごとに固定する。route.ts はこれを errorCode/errorMessage として Sentry へ伝搬する。
+  describe('CalendarAccountDeletionSettleError への cause 伝搬', () => {
+    it('list RPC の error は code/message を cause として持つ', async () => {
+      rpc.mockImplementation((operation: string) => {
+        if (operation === 'get_external_lifecycle_app_version_v2') {
+          return { abortSignal: vi.fn(async () => ({ data: 1, error: null })) };
+        }
+        if (operation === 'list_expired_calendar_account_deletion_intents_v1') {
+          return {
+            abortSignal: vi.fn(async () => ({
+              data: null,
+              error: { code: '57014', message: 'canceling statement due to statement timeout' },
+            })),
+          };
+        }
+        return { abortSignal: vi.fn(async () => ({ data: [], error: null })) };
+      });
+
+      await expect(
+        dispatchCalendarAccountDeletionSettle({ deadlineAt: FAR_DEADLINE }),
+      ).rejects.toMatchObject({
+        name: 'CalendarAccountDeletionSettleError',
+        code: 'ACCOUNT_DELETION_SETTLE_LIST_FAILED',
+        causeCode: '57014',
+        causeMessage: 'canceling statement due to statement timeout',
+      });
+    });
+
+    it('normalize RPC の error は code/message を cause として持つ', async () => {
+      const candidates = [{ user_id: 'user-1', deletion_id: 'del-1' }];
+      rpc.mockImplementation((operation: string) => {
+        if (operation === 'get_external_lifecycle_app_version_v2') {
+          return { abortSignal: vi.fn(async () => ({ data: 1, error: null })) };
+        }
+        if (operation === 'list_expired_calendar_account_deletion_intents_v1') {
+          return { abortSignal: vi.fn(async () => ({ data: candidates, error: null })) };
+        }
+        if (operation === 'normalize_calendar_account_deletion_intent_v1') {
+          return {
+            abortSignal: vi.fn(async () => ({
+              data: null,
+              error: {
+                code: '55P03',
+                message: 'could not obtain lock on row in relation "timeblock_supported_writer_v1"',
+              },
+            })),
+          };
+        }
+        return { abortSignal: vi.fn(async () => ({ data: null, error: null })) };
+      });
+
+      await expect(
+        dispatchCalendarAccountDeletionSettle({ deadlineAt: FAR_DEADLINE }),
+      ).rejects.toMatchObject({
+        name: 'CalendarAccountDeletionSettleError',
+        code: 'ACCOUNT_DELETION_SETTLE_NORMALIZE_FAILED',
+        causeCode: '55P03',
+      });
+    });
+
+    it('未分類の例外（abortSignal タイムアウト等）は message だけを cause として引き継ぐ', async () => {
+      const candidates = [{ user_id: 'user-1', deletion_id: 'del-1' }];
+      rpc.mockImplementation((operation: string) => {
+        if (operation === 'get_external_lifecycle_app_version_v2') {
+          return { abortSignal: vi.fn(async () => ({ data: 1, error: null })) };
+        }
+        if (operation === 'list_expired_calendar_account_deletion_intents_v1') {
+          return { abortSignal: vi.fn(async () => ({ data: candidates, error: null })) };
+        }
+        if (operation === 'normalize_calendar_account_deletion_intent_v1') {
+          return {
+            abortSignal: vi.fn(async () => Promise.reject(new Error('The operation was aborted'))),
+          };
+        }
+        return { abortSignal: vi.fn(async () => ({ data: null, error: null })) };
+      });
+
+      await expect(
+        dispatchCalendarAccountDeletionSettle({ deadlineAt: FAR_DEADLINE }),
+      ).rejects.toMatchObject({
+        name: 'CalendarAccountDeletionSettleError',
+        code: 'ACCOUNT_DELETION_SETTLE_NORMALIZE_FAILED',
+        causeCode: undefined,
+        causeMessage: 'The operation was aborted',
+      });
+    });
+  });
 });

--- a/apps/product/src/app/api/cron/calendar-account-deletion-settle/_composition/settle-dispatcher.ts
+++ b/apps/product/src/app/api/cron/calendar-account-deletion-settle/_composition/settle-dispatcher.ts
@@ -71,13 +71,27 @@ const NO_ACCOUNT_DELETION_SETTLE: Omit<AccountDeletionSettleSummary, 'durationMs
   skipped: false,
 };
 
-class CalendarAccountDeletionSettleError extends Error {
+/**
+ * `causeCode`/`causeMessage` は #2289（DAYOPT-X）と同型の診断可能性の穴（DAYOPT-V、#2305）を
+ * 塞ぐために持たせる。以前はここで原因（DB / provider の raw error）を握りつぶし、stage 名
+ * だけの `code` に丸めていたため、route.ts 側で generic dispatch failure としか観測できず
+ * 真因が Sentry 上で完全に不可視だった。`route.ts` はこれを `errorCode`/`errorMessage` として
+ * `captureUnexpectedError` へ伝搬し、`packages/observability/src/sanitize.ts` の
+ * `sanitizeErrorMessage`（default-closed allowlist）を通してから送信する。allowlist 外の
+ * 内容は `[UNRECOGNIZED_ERROR_MESSAGE]` に落ちるため、ここで raw message を保持しても
+ * 送信経路の安全性は sanitizer 側が担保する。
+ */
+export class CalendarAccountDeletionSettleError extends Error {
   readonly code: string;
+  readonly causeCode: string | undefined;
+  readonly causeMessage: string | undefined;
 
-  constructor(operation: string) {
+  constructor(operation: string, cause?: { code?: string; message?: string }) {
     super('Calendar account deletion settle failed');
     this.name = 'CalendarAccountDeletionSettleError';
     this.code = `ACCOUNT_DELETION_SETTLE_${operation.toUpperCase()}_FAILED`;
+    this.causeCode = cause?.code;
+    this.causeMessage = cause?.message;
   }
 }
 
@@ -95,8 +109,11 @@ export async function dispatchCalendarAccountDeletionSettle(params: {
   let db: SupabaseClient<Database>;
   try {
     db = createServiceRoleClient();
-  } catch {
-    throw new CalendarAccountDeletionSettleError('client');
+  } catch (error) {
+    throw new CalendarAccountDeletionSettleError(
+      'client',
+      error instanceof Error ? { message: error.message } : undefined,
+    );
   }
 
   const lifecycleVersion = await getExternalLifecycleAppVersion(db);
@@ -133,7 +150,10 @@ export async function dispatchCalendarAccountDeletionSettle(params: {
     if (isPredecessorMissingFunction(listError)) {
       return { ...NO_ACCOUNT_DELETION_SETTLE, durationMs: Date.now() - startedAt };
     }
-    throw new CalendarAccountDeletionSettleError('list');
+    throw new CalendarAccountDeletionSettleError('list', {
+      code: listError.code,
+      message: listError.message,
+    });
   }
 
   const result = { ...NO_ACCOUNT_DELETION_SETTLE };
@@ -158,7 +178,10 @@ export async function dispatchCalendarAccountDeletionSettle(params: {
 
       if (error) {
         if (isPredecessorMissingFunction(error)) continue;
-        throw new CalendarAccountDeletionSettleError('normalize');
+        throw new CalendarAccountDeletionSettleError('normalize', {
+          code: error.code,
+          message: error.message,
+        });
       }
 
       if (data === 'normalized') {
@@ -169,12 +192,15 @@ export async function dispatchCalendarAccountDeletionSettle(params: {
         result.other += 1;
       }
     } catch (error) {
-      // raw error（DB / provider）を Sentry / ログへ通さない。既存の
-      // CalendarAccountDeletionSettleError はそのまま、それ以外は固定メッセージへ置き換える。
+      // CalendarAccountDeletionSettleError はそのまま（cause 情報は既に載っている）。
+      // 未分類の例外（abortSignal タイムアウト等）は message を cause として引き継ぐ。
       firstError ??=
         error instanceof CalendarAccountDeletionSettleError
           ? error
-          : new CalendarAccountDeletionSettleError('normalize');
+          : new CalendarAccountDeletionSettleError(
+              'normalize',
+              error instanceof Error ? { message: error.message } : undefined,
+            );
     }
   }
 

--- a/apps/product/src/app/api/cron/calendar-account-deletion-settle/route.ts
+++ b/apps/product/src/app/api/cron/calendar-account-deletion-settle/route.ts
@@ -8,7 +8,10 @@ import { isWriteFenceEnabled } from '@/lib/ops/write-fence';
 import { captureUnexpectedError } from '@/lib/sentry';
 import { createServiceRoleClient } from '@/lib/supabase/oauth';
 
-import { dispatchCalendarAccountDeletionSettle } from './_composition/settle-dispatcher';
+import {
+  CalendarAccountDeletionSettleError,
+  dispatchCalendarAccountDeletionSettle,
+} from './_composition/settle-dispatcher';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -78,12 +81,24 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     }
 
     return noStoreJson({ ok: true, ...summary });
-  } catch {
-    // dispatcher の将来変更でも raw DB error を Sentry の cause へ通さない。
+  } catch (error) {
+    // 常に新しい generic Error で capture する（raw error インスタンス自体は Sentry の
+    // cause へ通さない）。原因の code/message は #2289 と同型の default-closed
+    // errorMessage sanitizer（packages/observability/src/sanitize.ts）経由で
+    // context へ伝搬し、generic dispatch failure の真因を診断可能にする（DAYOPT-V、#2305）。
+    const causeCode =
+      error instanceof CalendarAccountDeletionSettleError
+        ? (error.causeCode ?? error.code)
+        : undefined;
+    const causeMessage =
+      error instanceof CalendarAccountDeletionSettleError ? error.causeMessage : undefined;
+
     captureUnexpectedError(new Error('Calendar account deletion settle dispatch failed'), {
       feature: 'external_calendar',
       operation: 'cron_dispatch',
       route: '/api/cron/calendar-account-deletion-settle',
+      ...(causeCode !== undefined ? { errorCode: causeCode } : {}),
+      ...(causeMessage !== undefined ? { errorMessage: causeMessage } : {}),
     });
     logger.error('[calendar-account-deletion-settle] dispatch failed');
     return noStoreJson({ error: 'Settle dispatch failed' }, 500);


### PR DESCRIPTION
## 背景

DAYOPT-V（[#2305](https://github.com/Dayopt/dayopt/issues/2305)）: `calendar-account-deletion-settle` cron の失敗が Sentry 上で `Error: [REDACTED]` + `operation: cron_dispatch` のみとなり、真因が完全に不可視だった。#2289（DAYOPT-X）と同型の診断可能性の穴。

Sentry CLI（`sentry issue view DAYOPT-V --json`）でイベント実体を確認した結果、`tags`/`extra` に `errorCode`/`errorMessage` が一切無く、`exception.value` も sanitizer により常に `[REDACTED]` になることを確認済み（issue コメント参照）。

## やったこと

1. `settle-dispatcher.ts` — `CalendarAccountDeletionSettleError` に原因（client 生成失敗 / list RPC / normalize RPC の code・message）を `causeCode`/`causeMessage` として持たせる。従来は stage 名だけの `code` に丸めて raw error を握りつぶしていた
2. `route.ts` — catch 節で `causeCode`/`causeMessage` を `errorCode`/`errorMessage` として `captureUnexpectedError` の context へ伝搬する。既存の default-closed `errorMessage` sanitizer（`packages/observability/src/sanitize.ts`、#2289 で導入済み）を通すため、未知の内容は `[UNRECOGNIZED_ERROR_MESSAGE]` へ安全側に倒れる

## 検証

- `pnpm exec tsc --noEmit -p apps/product/tsconfig.json` — pass
- `pnpm --filter @dayopt/product exec eslint` 対象 4 ファイル — pass
- `pnpm lint:boundaries` — pass
- `pnpm --filter @dayopt/product exec vitest run src/app/api/cron/calendar-account-deletion-settle` — 24/24 pass（settle-dispatcher.test.ts に stage 別 cause 伝搬 3 件、route.test.ts に Sentry context 伝搬 2 件を追加）
- `pnpm --filter @dayopt/observability exec vitest run src/sanitize.test.ts` — 45/45 pass（無変更、回帰なし確認）
- `pnpm check` の localStorage/zustand persist 系 test 失敗（11 ファイル）と `pnpm quality:deadcode` の `integration-setup.ts` 検出は、変更前の clean tree でも同一に再現する pre-existing の環境依存問題（node26 ローカル / node24 CI）。本 PR の変更とは無関係

production での新規イベント停止の確認は promote 後の後続観測（issue #2305 の DoD どおり）。

Closes #2305

---

*レーンB、指揮台 Fable dispatch（2026-08-23）*
