### PR TITLE
chore(deps): zod v3/v4 分裂の方針を明文化し supabase CLI pin の二重定義を解消する

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -64,6 +64,18 @@ Server Component をデフォルト。useState / useEffect / イベントハン�
 - `ctx.userId` でデータアクセスを制限
 - `dangerouslySetInnerHTML` 禁止
 
+## zod v3/v4 分裂（意図的トレードオフ）
+
+策定日: 2026-08-23（[#2307](https://github.com/Dayopt/dayopt/issues/2307)、epic #2165 の follow-up）
+
+`apps/product` は zod `^3.25.76`、`apps/web` は zod `4.3.6` を使う。**この分裂は意図的に維持する。統一（v4 へ寄せる）は見送り済み。**
+
+- **障壁の実測**: `apps/product/src` で zod を直接 import するファイルは 37（`grep -rl "from ['\"]zod['\"]" apps/product/src | wc -l`）。issue の撤退条件（変更ファイル 20 超）を超過
+- **決定打は typecheck では検出できない実行時破壊**: `apps/product` の `@hookform/resolvers@^3.10.0`（`zodResolver`）は内部で `Array.isArray(error?.errors)` によって `ZodError` を判定するが、zod v4 の `ZodError` は `.errors` を持たず `.issues` のみを持つ。zod だけを v4 へ上げると、`tsc --noEmit` は 0 エラーで通過する一方、`LoginForm.test.tsx` の実行時テストが未捕捉の `ZodError` throw で fail する（実測済み）。apps/web は既に `@hookform/resolvers@^5.1.1` で zod v4 と揃えている
+- **意味すること**: 統一には zod 本体だけでなく `@hookform/resolvers` を含む依存 chain 全体の協調アップグレードと、全 37 ファイルの実行時再検証が要る。typecheck green は安全の証拠にならない
+- **新規コードのルール**: `apps/product` 配下は zod v3 系（`^3.x`）に留める。`apps/web` 配下は zod v4 系（`4.x`）に留める。app 間で zod スキーマを共有しない（`features/ -> lib/` の依存方向とも整合し、そもそも app 境界を跨ぐ共有はしない）
+- **再検討条件**: `@hookform/resolvers` を v4/v5 系へ先行アップグレードし、`apps/product` の全 zod 消費箇所（フォーム・tRPC input・外部 API レスポンス検証）を実行時テストで再検証できる見込みが立った時
+
 ## Tailwind v4 既知の落とし穴
 
 - `@theme` で `--spacing-xs/sm/md/lg/xl/2xl` を定義すると `max-w-sm/md/lg` 等が壊れる

--- a/apps/product/package.json
+++ b/apps/product/package.json
@@ -155,7 +155,6 @@
     "prettier": "^3.9.5",
     "sharp": "^0.35.3",
     "storybook": "^10.5.2",
-    "supabase": "2.109.1",
     "tailwindcss": "^4.3.3",
     "tsx": "^4.23.1",
     "tw-animate-css": "^1.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -462,9 +462,6 @@ importers:
       storybook:
         specifier: ^10.5.2
         version: 10.5.2(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.7)
-      supabase:
-        specifier: 2.109.1
-        version: 2.109.1
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -5982,6 +5979,7 @@ packages:
   eslint@9.39.5:
     resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'


### PR DESCRIPTION
## 概要

epic #2165 の follow-up。2 点を整理する。

1. **zod v3/v4 統一**: 実測の結果、統一は見送り。分裂維持の方針を `.claude/rules/code-style.md` に明文化した
2. **supabase CLI exact pin の二重定義**: root と `apps/product` の両方にあった `"supabase": "2.109.1"` を root のみへ寄せた

## 判断根拠

詳細は #2307 のコメントに実測ログ込みで記録済み。要点:

- `apps/product/src` で zod を直接 import するファイルは 37 で、issue の撤退条件（20 超）を超過
- `@hookform/resolvers@^3.10.0`（apps/product が使用中）の `zodResolver` は `ZodError` を `.errors`（v3 のみ）で判定しており、zod v4 の `.issues` のみの構造とは非互換。zod だけを v4 へ上げると **typecheck は 0 エラーで通過するが、`LoginForm.test.tsx` は実行時に未捕捉の throw で fail する**（実測済み）
- apps/web は既に `@hookform/resolvers@^5.1.1` で zod v4 と揃えており非互換なし
- supabase CLI pin は削除後も `pnpm --filter @dayopt/product exec supabase --version` が pnpm workspace の PATH 解決で引き続き成功することを実測確認

Closes #2307
Refs #2165

## 検証

- `pnpm --filter @dayopt/product exec tsc --noEmit -p .` green
- `pnpm typecheck` / `pnpm lint` / `pnpm lint:boundaries` / `pnpm secrets:check` / `pnpm check:static` / `pnpm quality:deadcode:ci` 全て green
- `pnpm test:run`: node v26.5.0 環境依存の localStorage/zustand persist 系 11 ファイル fail（既知問題 #2198）。`git stash` で変更退避した clean baseline でも同一失敗を再現し pre-existing であることを実測確認済み（この diff は zod/supabase 周りのみで対象テストと無関係）