### PR TITLE
fix(storage): account-closing fence を迂回する legacy RLS policy を削除

### DIFF
--- a/supabase/migrations/20260823063536_drop_legacy_storage_object_policies.sql
+++ b/supabase/migrations/20260823063536_drop_legacy_storage_object_policies.sql
@@ -1,0 +1,97 @@
+-- Drop legacy Storage RLS policies that coexist with the hardened
+-- authorize_owned_storage_*_v1 policies on storage.objects (#2316).
+--
+-- Root cause: `_archive/20251024022910_remote_schema.sql` (avatar, role
+-- `public`) and `_archive/20251218072948_create_attachments_bucket.sql`
+-- (attachments, role `authenticated`) created 8 policies whose names were
+-- never dropped by any later migration. `20260730090027_fence_account_storage.sql`
+-- only dropped/recreated the "own" (not "their own") names, so both sets
+-- coexist as PERMISSIVE policies on the same commands and get OR-combined.
+-- The legacy predicates check ownership only — not
+-- authorize_owned_storage_write_v1() / read_v1() — so a request that fails
+-- the account-closing fence can still succeed through the legacy policy.
+-- Confirmed present in production by direct inspection (issue #2316 body).
+--
+-- storage.objects has no other application-defined policies (see
+-- STORAGE_OBJECTS_APP_POLICY_NAMES in scripts/generate-rls-snapshot.ts and
+-- docs/engineering/data/db/rls-snapshot.md), so the guards below use a
+-- simple named-policy count rather than parsing predicate text.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '60s';
+
+-- Fail closed if the hardened policies are somehow not all present yet.
+-- Dropping the legacy policies first would remove the only remaining
+-- access path for avatar/attachment operations.
+DO $$
+DECLARE
+  v_hardened_count INT;
+BEGIN
+  SELECT count(*) INTO v_hardened_count
+  FROM pg_policies
+  WHERE schemaname = 'storage' AND tablename = 'objects'
+    AND policyname IN (
+      'Users can upload own avatar',
+      'Users can update own avatar',
+      'Users can delete own avatar',
+      'Users can view own avatar',
+      'Users can upload own attachments',
+      'Users can update own attachments',
+      'Users can delete own attachments',
+      'Users can view own attachments'
+    );
+
+  IF v_hardened_count <> 8 THEN
+    RAISE EXCEPTION
+      'Expected 8 hardened storage.objects policies before dropping legacy '
+      'ones, found %. Aborting to avoid removing the only remaining access '
+      'path for avatar/attachment operations.',
+      v_hardened_count;
+  END IF;
+END $$;
+
+DROP POLICY IF EXISTS "Users can upload their own avatar" ON storage.objects;
+DROP POLICY IF EXISTS "Users can update their own avatar" ON storage.objects;
+DROP POLICY IF EXISTS "Users can delete their own avatar" ON storage.objects;
+DROP POLICY IF EXISTS "Users can view their own avatar" ON storage.objects;
+DROP POLICY IF EXISTS "Users can upload attachments to their folder" ON storage.objects;
+DROP POLICY IF EXISTS "Users can update their own attachments" ON storage.objects;
+DROP POLICY IF EXISTS "Users can delete their own attachments" ON storage.objects;
+DROP POLICY IF EXISTS "Users can view their own attachments" ON storage.objects;
+
+-- Fail closed if anything other than exactly the 8 hardened policies
+-- remains (a 9th orphan, or a hardened policy unexpectedly missing).
+DO $$
+DECLARE
+  v_total_count INT;
+  v_hardened_count INT;
+BEGIN
+  SELECT count(*) INTO v_total_count
+  FROM pg_policies
+  WHERE schemaname = 'storage' AND tablename = 'objects';
+
+  SELECT count(*) INTO v_hardened_count
+  FROM pg_policies
+  WHERE schemaname = 'storage' AND tablename = 'objects'
+    AND policyname IN (
+      'Users can upload own avatar',
+      'Users can update own avatar',
+      'Users can delete own avatar',
+      'Users can view own avatar',
+      'Users can upload own attachments',
+      'Users can update own attachments',
+      'Users can delete own attachments',
+      'Users can view own attachments'
+    );
+
+  IF v_total_count <> 8 OR v_hardened_count <> 8 THEN
+    RAISE EXCEPTION
+      'Expected exactly the 8 hardened storage.objects policies after '
+      'dropping legacy ones, found % total (% hardened).',
+      v_total_count, v_hardened_count;
+  END IF;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
## Summary

production の `storage.objects` に、avatar/attachments 操作の legacy 命名 permissive RLS policy（ownership チェックのみ）が hardened な `authorize_owned_storage_write_v1()`/`read_v1()` policy と共存していた。PostgreSQL の permissive policy は同一 command で OR 結合されるため、legacy policy が真なら account-closing fence（stale JWT 拒否・account closing 中の write 拒否・削除処理との serialization）を迂回できていた（cross-user access は成立しない）。

root cause: `_archive/20251024022910_remote_schema.sql`（avatar）と `_archive/20251218072948_create_attachments_bucket.sql`（attachments）が作った8つの legacy-named policy が、どの migration でも `DROP POLICY` されていない。

Closes #2316

## 変更内容

- `supabase/migrations/20260823063536_drop_legacy_storage_object_policies.sql`
  - 8つの legacy policy を `DROP POLICY IF EXISTS` で削除
  - DROP 前後に fail-closed guard（`DO` ブロック + `RAISE EXCEPTION`）: hardened 8 policy が揃っていない状態で legacy を先に消して全ユーザーの storage 操作を止める事故を防ぐ（pre-check）、9件目の混入や意図しない欠落を検知する（post-check）

ローカルでは `baseline.sql` が最初から hardened 命名のみで構築されるため本 migration は no-op（`_archive/` は `db reset` の対象外）。**production 専用の historical drift 修正。**

## ⚠️ merge 前に必須: production の read-only 実測確認

risk-reviewer のレビューで `EXPLICIT AUTHORITY` 相当と判定された（merge → Supabase GitHub integration 経由で production に自動適用されるため）。post-check guard の `v_total_count <> 8` が production の未知の drift（想定外の9件目等）を前提にしており、**local の検証だけでは production への適用結果を保証できない**。merge 前に以下を実施すること:

```sql
SELECT tablename, policyname, cmd, roles, qual, with_check
FROM pg_policies
WHERE schemaname = 'storage'
ORDER BY tablename, policyname;
```

（`.claude/rules/mcp-usage.md` §`supabase`(cloud) はオンデマンド登録する の手順で read-only MCP を一時登録するか、Dashboard SQL Editor で実行）

- **期待値**: `storage.objects` に 16 件（hardened 8 + legacy 8）、`storage.buckets`/`storage.prefixes` に想定外の policy が無いこと
- 8つの hardened policy の `qual`/`with_check` が `authorize_owned_storage_write_v1()`/`read_v1()` を含んだままであること（Dashboard 経由の改変が無いか）を `docs/engineering/data/db/rls-snapshot.md` の該当行と突き合わせる
- 件数が一致しない場合は migration の guard が `RAISE EXCEPTION` で deploy を止める（fail-closed、データは壊れない）が、原因を特定してから migration を書き直す必要がある
- merge 後、同じクエリを再実行して 8 件（hardened のみ）になったことを確認し、結果を本 issue へ証跡として貼る

## 検証

- `pnpm db:reset` — 8つの DROP は全て `NOTICE: ... does not exist, skipping`（no-op確認）、両 guard は pass
- `pnpm rls:snapshot:check` — drift 0件
- `pnpm vitest run --config vitest.config.integration.ts src/lib/test/integration/account-deletion-gate-concurrency.integration.test.ts` — 14 tests pass（account-closing 中の Storage write 拒否・serialization を含む既存カバレッジが本 migration で壊れていないことを確認）
- 両 guard の `RAISE EXCEPTION` をローカルで rolled-back transaction 内で実際に発火させ、メッセージ整形を確認済み（risk-reviewer 指摘: 通常経路では未実行のコードパスだったため）

## スコープ外（別 issue化）

production 側の継続的な RLS drift 検出の常設化は #2323 へ切り出した（`rls:snapshot:check` は local DB しか見ないため、production だけの drift は本 PR のような一回性の手動発見に頼っている）。

## 既存カバレッジとの対応

`account-deletion-gate-concurrency.integration.test.ts` が account-closing 中の Storage write 拒否と `begin_account_deletion_v1` との serialization を既にテスト済み（attachments bucket の INSERT のみ、既存範囲）。avatar bucket・他コマンドへの新規テスト追加はしていない（本 PR は既存 hardened policy の内容を変更せず、迂回経路である legacy policy を除去するだけのため）。

新規 catalog assertion integration test は追加していない（plan-review で `pnpm rls:snapshot:check` との二重管理と判断し見送り。詳細は issue コメント参照）。
