### PR TITLE
feat(mobile): モバイル UI の細部を磨く

### DIFF
--- a/apps/product/src/features/calendar/components/views/shared/components/ScrollableCalendarLayout.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/components/ScrollableCalendarLayout.tsx
@@ -14,9 +14,10 @@ import React, { useCallback, useRef } from 'react';
 import { cn } from '@dayopt/components';
 
 import { formatTimeString } from '@/lib/date';
+import { useIsMobile } from '@/lib/hooks/useIsMobile';
 import { useUserPreferences } from '@/lib/hooks/useUserPreferences';
 
-import { TIME_COLUMN_WIDTH } from '../constants/grid.constants';
+import { MOBILE_TIME_COLUMN_WIDTH, TIME_COLUMN_WIDTH } from '../constants/grid.constants';
 import { CurrentTimeLine } from '../grid/CurrentTimeLine';
 import { TimeColumn } from '../grid/TimeColumn/TimeColumn';
 import { useContainerHeight } from '../hooks/useContainerHeight';
@@ -55,17 +56,29 @@ interface CalendarDateHeaderProps {
 }
 
 /**
+ * 時間列のデフォルト幅。モバイルでは短い時刻ラベルの左側余白を抑えるため縮小する。
+ * timeColumnWidth を明示指定しない呼び出し元（CalendarDateHeader / ScrollableCalendarLayout
+ * 共通）が同じ値源を見るための共有 hook。
+ */
+function useDefaultTimeColumnWidth(): number {
+  const isMobile = useIsMobile();
+  return isMobile ? MOBILE_TIME_COLUMN_WIDTH : TIME_COLUMN_WIDTH;
+}
+
+/**
  * カレンダー日付ヘッダー（固定）
  */
 export const CalendarDateHeader = ({
   header,
   showTimeColumn = true,
   showTimezone = true,
-  timeColumnWidth = TIME_COLUMN_WIDTH,
+  timeColumnWidth,
   weekNumber,
   className,
 }: CalendarDateHeaderProps) => {
   const showWeekNumbers = useUserPreferences((s) => s.showWeekNumbers);
+  const defaultTimeColumnWidth = useDefaultTimeColumnWidth();
+  const resolvedTimeColumnWidth = timeColumnWidth ?? defaultTimeColumnWidth;
 
   // 設定がオンで週番号が渡されている場合のみ表示
   const shouldShowWeekNumber = showWeekNumbers && weekNumber != null;
@@ -85,7 +98,7 @@ export const CalendarDateHeader = ({
         {showTimeColumn ? (
           <div
             className="flex h-8 shrink-0 flex-col items-center justify-center"
-            style={{ width: timeColumnWidth }}
+            style={{ width: resolvedTimeColumnWidth }}
           >
             {/* 週番号バッジ（Googleカレンダースタイル） - モバイルのみ表示 */}
             {shouldShowWeekNumber ? (
@@ -116,13 +129,16 @@ export const ScrollableCalendarLayout = ({
   showTimeColumn = true,
   showCurrentTime = true,
   showTimezone: _showTimezone = true,
-  timeColumnWidth = TIME_COLUMN_WIDTH,
+  timeColumnWidth,
   onTimeClick,
   displayDates = [],
   viewMode = 'week',
   enableKeyboardNavigation = true,
   onScrollPositionChange,
 }: ScrollableCalendarLayoutProps) => {
+  const defaultTimeColumnWidth = useDefaultTimeColumnWidth();
+  const resolvedTimeColumnWidth = timeColumnWidth ?? defaultTimeColumnWidth;
+
   // scroll container の ref を先に確保し、実測高の観測と useScrollableCalendar 双方で共有する
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const containerHeight = useContainerHeight(scrollContainerRef);
@@ -173,7 +189,7 @@ export const ScrollableCalendarLayout = ({
       const x = e.clientX - rect.left;
 
       // 時間列以外の領域のクリックのみ処理
-      if (showTimeColumn && x < timeColumnWidth) return;
+      if (showTimeColumn && x < resolvedTimeColumnWidth) return;
 
       // 15分単位でスナップ
       const totalMinutes = Math.max(0, Math.floor((y / HOUR_HEIGHT) * 60));
@@ -184,7 +200,7 @@ export const ScrollableCalendarLayout = ({
         onTimeClick(hours, minutes);
       }
     },
-    [onTimeClick, HOUR_HEIGHT, showTimeColumn, timeColumnWidth, scrollContainerRef],
+    [onTimeClick, HOUR_HEIGHT, showTimeColumn, resolvedTimeColumnWidth, scrollContainerRef],
   );
 
   // 現在時刻線を表示するか判定
@@ -209,7 +225,7 @@ export const ScrollableCalendarLayout = ({
         {showTimeColumn && (
           <div
             className="border-border sticky left-0 z-10 shrink-0 border-r"
-            style={{ width: timeColumnWidth }}
+            style={{ width: resolvedTimeColumnWidth }}
           >
             <div className="relative h-full overflow-hidden">
               <TimeColumn
@@ -218,6 +234,7 @@ export const ScrollableCalendarLayout = ({
                 hourHeight={HOUR_HEIGHT}
                 format={timeFormat}
                 className="h-full"
+                width={resolvedTimeColumnWidth}
               />
               {/* 現在時刻ラベル（Apple Calendar風） */}
               {shouldShowCurrentTimeLine && hasToday && (

--- a/apps/product/src/features/calendar/components/views/shared/constants/grid.constants.ts
+++ b/apps/product/src/features/calendar/components/views/shared/constants/grid.constants.ts
@@ -14,6 +14,13 @@ export { DENSITY_FACTOR, MIN_LEGIBLE_HOUR_HEIGHT } from '../../../../lib/constan
 /** 時間列の幅（px） */
 export const TIME_COLUMN_WIDTH = 56; // 時間列の幅(px)
 
+/**
+ * モバイル版時間列の幅（px）
+ * ラベルは右詰めのため、PC と同じ 56px だと短いラベル（"9:00" 等）の
+ * 左側に余白が溜まる。8px グリッド準拠で縮小する。
+ */
+export const MOBILE_TIME_COLUMN_WIDTH = 40;
+
 /** 現在時刻ドットのサイズ（px） */
 export const CURRENT_TIME_DOT_SIZE = 6; // 現在時刻のドットサイズ(px)
 

--- a/apps/product/src/features/calendar/components/views/shared/grid/TimeColumn/TimeColumn.tsx
+++ b/apps/product/src/features/calendar/components/views/shared/grid/TimeColumn/TimeColumn.tsx
@@ -31,6 +31,7 @@ export const TimeColumn = memo<TimeColumnProps>(function TimeColumn({
   hourHeight = 72,
   format = '24h',
   className = '',
+  width = TIME_COLUMN_WIDTH,
 }) {
   // グリッド高さ
   const gridHeight = (endHour - startHour) * hourHeight;
@@ -66,7 +67,7 @@ export const TimeColumn = memo<TimeColumnProps>(function TimeColumn({
     <div
       className={cn('sticky left-0 z-10 flex flex-col', className)}
       style={{
-        width: `${TIME_COLUMN_WIDTH}px`,
+        width: `${width}px`,
         height: `${gridHeight}px`,
       }}
     >

--- a/apps/product/src/features/calendar/types/grid.types.ts
+++ b/apps/product/src/features/calendar/types/grid.types.ts
@@ -5,6 +5,8 @@ export interface TimeColumnProps {
   hourHeight?: number | undefined;
   format?: '12h' | '24h' | undefined; // 時刻表示形式
   className?: string | undefined;
+  /** 列の幅（px）。未指定時は TIME_COLUMN_WIDTH（PC 既定値）にフォールバック */
+  width?: number | undefined;
 }
 
 /** 現在時刻線コンポーネントのプロパティ */

--- a/apps/product/src/lib/styles/globals.css
+++ b/apps/product/src/lib/styles/globals.css
@@ -32,6 +32,7 @@
  * ============================================ */
 @import './vendor/time-input.css';
 @import './vendor/sonner.css';
+@import './vendor/vaul.css';
 
 /* ============================================
  * Mobile & Accessibility

--- a/apps/product/src/lib/styles/mobile.css
+++ b/apps/product/src/lib/styles/mobile.css
@@ -153,6 +153,12 @@ button,
   .calendar-scrollbar::-webkit-scrollbar {
     display: none !important;
   }
+
+  /* Radix ScrollArea（自前描画のスクロールバー）もモバイルでは非表示 */
+  [data-slot='scroll-area-scrollbar'],
+  [data-slot='scroll-area-corner'] {
+    display: none;
+  }
 }
 
 /* 画像のドラッグ防止（モバイル操作時の誤操作防止） */

--- a/apps/product/src/lib/styles/vendor/vaul.css
+++ b/apps/product/src/lib/styles/vendor/vaul.css
@@ -1,0 +1,34 @@
+/* ============================================
+ * vaul Drawer ドラッグハンドル
+ *
+ * vaul は視覚バー・タッチヒット領域の CSS を `vaul/style.css` として
+ * パッケージ本体と別配布しており、このリポジトリでは未 import。
+ * そのため `DrawerPrimitive.Handle` は data-vaul-handle 属性のみ持つ
+ * 無スタイルの div になり、高さ0に潰れてドラッグの起点にならない
+ * （@dayopt/components の DrawerHandle / Dialog drawer モード共通の問題）。
+ * デザイントークンで再定義し、両者に共通のドラッグハンドルを持たせる。
+ * @see node_modules/vaul/style.css の [data-vaul-handle] 相当
+ * ============================================ */
+
+[data-vaul-handle] {
+  display: block;
+  position: relative;
+  margin-left: auto;
+  margin-right: auto;
+  height: 4px; /* h-1 相当 */
+  width: 40px; /* w-10 相当 */
+  border-radius: 9999px;
+  background: var(--border);
+  touch-action: pan-y;
+}
+
+/* タップ・ドラッグのヒット領域はタッチターゲット最小値（44px）を確保する */
+[data-vaul-handle-hitarea] {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: max(100%, 2.75rem);
+  height: max(100%, 2.75rem);
+  touch-action: inherit;
+}

--- a/packages/components/src/actions/command.tsx
+++ b/packages/components/src/actions/command.tsx
@@ -35,6 +35,7 @@ const CommandDialog = ({
   className,
   showCloseButton = true,
   mobilePresentation = 'sheet',
+  handleOnly,
   ...props
 }: React.ComponentProps<typeof Dialog> & {
   title?: string;
@@ -43,8 +44,12 @@ const CommandDialog = ({
   showCloseButton?: boolean;
   mobilePresentation?: DialogMobilePresentation;
 }) => {
+  // full-height（内部スクロール主体）は既定でハンドルのみでスワイプ dismiss させ、
+  // リスト内のスクロールが誤って閉じるのを防ぐ。呼び出し側で明示指定した場合はそちらを優先。
+  const resolvedHandleOnly = handleOnly ?? mobilePresentation === 'full-height';
+
   return (
-    <Dialog {...props}>
+    <Dialog handleOnly={resolvedHandleOnly} {...props}>
       <DialogHeader className="sr-only">
         <DialogTitle>{title}</DialogTitle>
         <DialogDescription>{description}</DialogDescription>

--- a/packages/components/src/layout/scroll-area.tsx
+++ b/packages/components/src/layout/scroll-area.tsx
@@ -25,7 +25,7 @@ function ScrollArea({
         {children}
       </ScrollAreaPrimitive.Viewport>
       <ScrollBar />
-      <ScrollAreaPrimitive.Corner />
+      <ScrollAreaPrimitive.Corner data-slot="scroll-area-corner" />
     </ScrollAreaPrimitive.Root>
   );
 }

--- a/packages/components/src/overlays/dialog.stories.tsx
+++ b/packages/components/src/overlays/dialog.stories.tsx
@@ -267,7 +267,9 @@ export const ForceDrawer: Story = {
 /** 入力や長い一覧を扱うモバイル向けの全高Drawer。 */
 export const FullHeightDrawer: Story = {
   render: () => (
-    <Dialog responsive="drawer">
+    // handleOnly: 検索結果一覧のスクロールが誤って dismiss を誘発しないよう、
+    // ハンドルのみでスワイプ dismiss させる（full-height の既定パターン）
+    <Dialog responsive="drawer" handleOnly>
       <DialogTrigger asChild>
         <Button variant="outline">全高Drawer</Button>
       </DialogTrigger>
@@ -337,7 +339,7 @@ export const AllPatterns: Story = {
         </DialogContent>
       </Dialog>
 
-      <Dialog responsive="drawer">
+      <Dialog responsive="drawer" handleOnly>
         <DialogTrigger asChild>
           <Button variant="outline">全高Drawer</Button>
         </DialogTrigger>

--- a/packages/components/src/overlays/dialog.tsx
+++ b/packages/components/src/overlays/dialog.tsx
@@ -37,9 +37,20 @@ type DialogMobilePresentation = 'sheet' | 'full-height';
 interface DialogProps extends React.ComponentProps<typeof DialogPrimitive.Root> {
   /** レスポンシブ制御。'auto' = PC:Dialog / モバイル:Drawer。default: 'auto' */
   responsive?: DialogResponsive;
+  /**
+   * drawer モードで、ハンドルのみでスワイプ dismiss を許可するか。
+   * true にすると本文（内部スクロール領域）のドラッグでは閉じなくなる。
+   * 内部スクロール主体の mobilePresentation="full-height" 等で使う。default: false
+   */
+  handleOnly?: boolean;
 }
 
-const Dialog = ({ responsive = 'auto', modal = true, ...props }: DialogProps) => {
+const Dialog = ({
+  responsive = 'auto',
+  modal = true,
+  handleOnly = false,
+  ...props
+}: DialogProps) => {
   const isMobile = useIsMobile();
   const mounted = useHasMounted();
 
@@ -60,7 +71,12 @@ const Dialog = ({ responsive = 'auto', modal = true, ...props }: DialogProps) =>
     return (
       <DialogModeContext.Provider value="drawer">
         <DialogModalContext.Provider value={resolvedModal}>
-          <DrawerPrimitive.Root data-slot="dialog" modal={resolvedModal} {...props} />
+          <DrawerPrimitive.Root
+            data-slot="dialog"
+            modal={resolvedModal}
+            handleOnly={handleOnly}
+            {...props}
+          />
         </DialogModalContext.Provider>
       </DialogModeContext.Provider>
     );
@@ -214,10 +230,8 @@ const DialogContent = ({
           )}
           {...(props as React.ComponentProps<typeof DrawerPrimitive.Content>)}
         >
-          {/* ドラッグハンドル */}
-          <div className="flex h-6 w-full shrink-0 items-center justify-center" aria-hidden="true">
-            <div className="bg-border h-1 w-10 rounded-full" />
-          </div>
+          {/* ドラッグハンドル（vaul Handle: handleOnly 時はここのみでスワイプ dismiss。drawer.tsx の DrawerHandle と同じ見た目） */}
+          <DrawerPrimitive.Handle data-slot="dialog-handle" className="mt-2 shrink-0" />
           {children}
         </DrawerPrimitive.Content>
       </DrawerPortalInternal>


### PR DESCRIPTION
## Summary

モバイル UI 磨き束（3 issue、指揮台 2026-08-23 dispatch）。

- **#2310**: Radix `ScrollArea` の自前描画スクロールバーをモバイルで非表示にする（既存の `mobile.css` の `@media (hover: none) and (pointer: coarse)` ブロックへ `[data-slot='scroll-area-scrollbar']` / `[data-slot='scroll-area-corner']` の非表示ルールを追加）
- **#2311**: `Dialog` の drawer モードに `vaul` の `DrawerPrimitive.Handle` を接続し、ボトムシートをスワイプで閉じられるようにする。`mobilePresentation="full-height"` はハンドルのみで閉じ（`handleOnly`）、内部スクロールと競合しない
- **#2312**: モバイルの時間列幅を 56px→40px に縮小（`MOBILE_TIME_COLUMN_WIDTH`）。ラベル右詰めによる左余白の肥大を抑える。ヘッダー左スペーサー・スティッキー列ラッパー・`TimeColumn` 本体の 3 箇所が同じ値源（`useDefaultTimeColumnWidth`）を見るように統一

### 実装中に判明した前提バグ（#2311 の一部として修正）

`vaul` パッケージは視覚バー/タッチヒット領域用の CSS を `vaul/style.css` として本体と別配布しており、このリポジトリではどこにも import されていなかった。そのため既存の `packages/components/src/overlays/drawer.tsx` の `DrawerHandle`（`CalendarLayout` / `TimeblockInspector` / `ActivityQuickSelector` が使用）も、ハンドルバーが 0 サイズで描画されドラッグの起点にならない状態だった。design token（`var(--border)`）で再定義した `apps/product/src/lib/styles/vendor/vaul.css` を新規追加し、`dialog.tsx` / `drawer.tsx` の両系統で共通に効くようにした。

### モバイル判定の使い分け

- #2310: CSS media query（`@media (hover: none) and (pointer: coarse)`）
- #2311: `@dayopt/components` 内部の `useIsMobile`（既存の `Dialog` の responsive 判定を流用）
- #2312: `apps/product/src/lib/hooks/useIsMobile`（calendar feature の他ファイルと同じ app 側 hook）

判定手段が異なるのは、各修正が触る層（グローバル CSS / 共有パッケージ内部 / app feature）にすでに存在する仕組みを踏襲したため。

### デスクトップへの影響

なし。3 issue とも既定値・分岐条件はモバイル（`pointer: coarse` かつ狭幅）にのみ効き、デスクトップの見た目・挙動は変更していない（Storybook で実測確認）。

## Test plan

- [x] `pnpm exec tsc --noEmit`（`packages/components` / `apps/product` 個別実行、両方 green）
- [x] `pnpm exec eslint`（両パッケージ個別実行、`--max-warnings 0` green）
- [x] `pnpm lint:boundaries`（cross=0 self=0）
- [x] `pnpm check:workspace`（typecheck + lint + build:packages + build-storybook、green）
- [x] `pnpm exec prettier --check`（対象ファイル全て）
- [x] Storybook 視覚確認（`storybook-worktree` サーバー、mobile viewport 375x812 + `pointer: coarse` エミュレーション）
  - Dialog `ForceDrawer`（sheet）: ドラッグハンドルバーが正しく表示・スタイル適用（40x4px、`var(--border)`）
  - Dialog `FullHeightDrawer`（`handleOnly`）: 開いた状態でハンドルが上部に表示、vaul source 確認で `handleOnly=true` 時は body 側の `onPointerDown` が early return し Handle のみがドラッグ起点になることを確認
  - DayView（mobile viewport）: 時間列 3 箇所（TimeColumn 本体 / ヘッダー左スペーサー / スティッキー列ラッパー）すべて `width: 40px` で揃っている
  - DayView（desktop viewport）: 同 3 箇所すべて `width: 56px`（従来値）で不変
- [x] `pnpm test:run`: 78 件失敗があるが、`git stash` で clean baseline（main HEAD）を実測し同一エラーが再現することを確認（Node 26 ローカル環境での zustand persist `localStorage` 関連の既知の pre-existing 問題、`docs/engineering/diagnostics.md` の誤診断防止プロトコルに従って検証）。今回変更したコンポーネントに対する unit test は存在せず（Storybook 視覚確認が正本）

Closes #2310
Closes #2311
Closes #2312