### PR TITLE
fix(ops): night-watch のrun-scoped判定を実測遅延に対応させる

### DIFF
--- a/.claude/skills/night-watch/SKILL.md
+++ b/.claude/skills/night-watch/SKILL.md
@@ -65,7 +65,7 @@ wrapper 内部の処理（引数は取らない。判定・組み立てはすべ
 
 次の 7 check-id を判定する。各項目は「実行コマンド + 判定」の対で、裁量の余地はない。
 
-**fail-closed 原則（v2 追加）**: いずれかの観測コマンドが非 0 exit で終了する、またはレスポンスがパース不能なら、**緑と判定しない**。`<check-id>: 取得失敗` として Step 5 の運行記録へ必ず記録し、その run を「all green」と報告しない（§異常があれば起票または追記する の dedup 検索 fail-closed と対称の扱い。取得失敗は「異常なし」の代わりに「観測できず」として扱う）。
+**fail-closed 原則（v2 追加）**: いずれかの観測コマンドが非 0 exit で終了する、またはレスポンスがパース不能なら、**緑と判定しない**。`<check-id>: 取得失敗` として Step 5 の運行記録へ必ず記録し、その run を「all green」と報告しない（§異常があれば起票または追記する の dedup 検索 fail-closed と対称の扱い。取得失敗は「異常なし」の代わりに「観測できず」として扱う）。**heavy-red / integration-red は、コマンド自体が成功（exit 0・パース可能）でも直近 run が未完了（`in_progress` / `queued`）なら同じ経路（`<check-id>: 取得失敗`）へ倒す**（#2341。詳細は下記 heavy-red 参照。赤とは判定せず、alert-issue.mjs も呼ばない）。
 
 **checklist v1**（[checklist.md](checklist.md) の 4 項目、番号順に実行。判定規約は不変）:
 
@@ -73,9 +73,9 @@ wrapper 内部の処理（引数は取らない。判定・組み立てはすべ
 - actual < baseline の場合は正常だが、Step 5 の運行記録に「baseline 更新推奨（`<check-id>`: 現在値 N、baseline M）」を1行残す。baseline.json の更新は行わない（通常の PR レビューでのみ更新する review-gated ratchet）
 - `docs-check` / `deadcode` は exit code のみで判定（baseline 不要、閾値は常に 0）
 
-**heavy-post-merge 赤確認（check-id: `heavy-red`、v2 追加）**: `gh run list --workflow=heavy-post-merge.yml --limit 3 --json conclusion,status,headSha,createdAt,url` を実行する。**判定は「直近 run に success 以外（`cancelled` / `timed_out` / `action_required` 等の終了状態、または `status` が未完了）が含まれれば赤、または直近 24h に `conclusion=success` の run が 1 件も無ければ赤」**。baseline 不要。heavy-post-merge は schedule（nightly 04:00 JST）と push:main が同一 concurrency group（`cancel-in-progress: true`）のため、nightly が main push で cancel され `conclusion=cancelled` になりうる（`conclusion=failure` だけを見ると緑と誤読する）。実行中の run は `conclusion` が空で `status` が `in_progress`/`queued` になるため、`status` も判定に含める。対象 workflow は nightly・push:main・手動 dispatch のすべての run を含む。異常検出時は該当 run の `url` を起票本文の再現手がかりとして使う
+**heavy-post-merge 赤確認（check-id: `heavy-red`、v2 追加）**: `gh run list --workflow=heavy-post-merge.yml --limit 3 --json conclusion,status,headSha,createdAt,url` を実行する。**判定はまず直近 run（応答配列の先頭、gh run list は新しい順）の `status` を見る。`in_progress` / `queued`（未完了）なら判定を保留し、赤とはせず `heavy-red: 取得失敗` として §fail-closed 原則 の経路へ倒す**（#2341。GitHub Actions の scheduled workflow は数十分規模の遅延が日常的に起きるため、05:00 時点で直近 run がまだ実行中なだけのケースを、旧規約は無条件で赤と誤判定していた。判定境界の正本は `isLatestWorkflowRunPending`、`scripts/night-watch/lib.mjs`）。**直近 run が完了（`status: completed`）している場合のみ**、「直近 run に success 以外（`cancelled` / `timed_out` / `action_required` 等の終了状態）が含まれれば赤、または直近 24h に `conclusion=success` の run が 1 件も無ければ赤」と判定する。baseline 不要。heavy-post-merge は schedule（nightly 04:00 JST）と push:main が同一 concurrency group（`cancel-in-progress: true`）のため、nightly が main push で cancel され `conclusion=cancelled` になりうる（`conclusion=failure` だけを見ると緑と誤読する。この `cancelled` は `status: completed` の terminal conclusion であり、上記の未完了判定とは別物）。対象 workflow は nightly・push:main・手動 dispatch のすべての run を含む。異常検出時は該当 run の `url` を起票本文の再現手がかりとして使う
 
-**integration 赤確認（check-id: `integration-red`、[#2333](https://github.com/Dayopt/dayopt/issues/2333) 追加）**: `gh run list --workflow=integration.yml --branch main --limit 3 --json conclusion,status,headSha,createdAt,url` を実行する。判定規約は heavy-red と同一（`integration.yml` も schedule（nightly 04:30 JST）と push:main が同一 concurrency group `cancel-in-progress: true` のため、cancelled/timed_out/action_required も赤、直近 24h に success が無ければ赤）。**`--branch main` は必須**（push前反証レビュー risk-reviewer 指摘、P2）: `integration.yml` は `heavy-post-merge.yml` と異なり `pull_request` trigger も持つ（migration-safety job 用）ため、branch 指定が無いと直近 3 run に PR run が混入し、cancel-in-progress による誤起票・nightly success の窓外押し出し・本物の失敗の見逃しが同時に起こり得る。CI 4層再設計（[#2269](https://github.com/Dayopt/dayopt/issues/2269)）で `integration.yml` が per-PR から nightly + push:main 後の層3へ移った後、夜勤が heavy-post-merge の赤しか観測しておらず integration 単独の失敗が無通知のまま朝を迎える穴があった（非ブロッキング Codex レビュー指摘、P2）。異常検出時は該当 run の `url` を起票本文の再現手がかりとして使う
+**integration 赤確認（check-id: `integration-red`、[#2333](https://github.com/Dayopt/dayopt/issues/2333) 追加）**: `gh run list --workflow=integration.yml --branch main --limit 3 --json conclusion,status,headSha,createdAt,url` を実行する。判定規約は heavy-red と同一（未完了時の取得失敗扱いを含む。`integration.yml` も schedule（nightly 04:30 JST）と push:main が同一 concurrency group `cancel-in-progress: true` のため、cancelled/timed_out/action_required も赤、直近 24h に success が無ければ赤）。**integration.yml は heavy-post-merge.yml（60分の余裕）と異なり schedule〜夜勤起動の余裕が 30 分しかなく、未完了判定の実益が heavy-red より大きい**（#2341、実測の誤起票シナリオ）。**`--branch main` は必須**（push前反証レビュー risk-reviewer 指摘、P2）: `integration.yml` は `heavy-post-merge.yml` と異なり `pull_request` trigger も持つ（migration-safety job 用）ため、branch 指定が無いと直近 3 run に PR run が混入し、cancel-in-progress による誤起票・nightly success の窓外押し出し・本物の失敗の見逃しが同時に起こり得る。CI 4層再設計（[#2269](https://github.com/Dayopt/dayopt/issues/2269)）で `integration.yml` が per-PR から nightly + push:main 後の層3へ移った後、夜勤が heavy-post-merge の赤しか観測しておらず integration 単独の失敗が無通知のまま朝を迎える穴があった（非ブロッキング Codex レビュー指摘、P2）。異常検出時は該当 run の `url` を起票本文の再現手がかりとして使う
 
 **Sentry 新規 issue スキャン（check-id: `sentry-new`、v2 追加）**: `sentry issue list dayopt --query "is:unresolved age:-24h"` を実行し、直近 24h に新規発生した unresolved production issue の件数を数える。**この cloud 互換形（env の `SENTRY_AUTH_TOKEN` を直接使う）が夜勤 Routine（Cloud Environment 実行）の既定形**（[#2334](https://github.com/Dayopt/dayopt/issues/2334) コメント、scope 追加5点目）。1Password が使えない Cloud Environment では `op run --` ラッパー自体が不要かつ実行不可能なため、Cloud Environment 側の env として `SENTRY_AUTH_TOKEN` を直接注入する（層1/2 と同じ、本 skill の実装 scope 外の登録前提）。`SENTRY_AUTH_TOKEN="op://agent/sentry-cli-readonly/credential" op run -- sentry issue list dayopt --query "is:unresolved age:-24h"`（旧形）は 1Password が使えるローカル環境（指揮台の手動代行）専用として allowlist に残す。**件数 > 0 のみ異常**（baseline 不要、閾値は常に 0）。**個別 triage はしない** — 列挙して Step 3 で起票し、朝のレーンへ渡すだけ。**public repo への raw データ露出を禁止する**（high、v2 で明記。repo は 2026-09 private 化まで public のまま）: Sentry issue の title / culprit / message には user email・OAuth callback query・Supabase エラー詳細等が混入しうる。Step 3 の起票本文へ転記してよいのは **件数・short ID（`DAYOPT-XXX`）・Sentry issue URL のみ**。title / culprit / message の生テキストは issue へ書かない
 
@@ -142,12 +142,14 @@ JSON の形（wrapper 内部で厳密に検証する。既知 check-id 以外・
     | { "checkId": "<check-id>", "outcome": "skipped", "reason": "dedup-search-failed" | "run-cap-reached" }
   ],
   "baselineRecommend": ["<check-id>", ...],
-  "board": { "status": "success", "issueNumber": 1234 } | { "status": "skip" } | { "status": "fail", "reason": "auth-error" | "rate-limited" | "network-error" | "invalid-response" | "unknown" },
-  "dod": { "status": "candidate", "prNumber": 1234 } | { "status": "none" }
+  "board": { "status": "success", "issueNumber": 1234 } | { "status": "skip" } | { "status": "weekend" } | { "status": "fail", "reason": "auth-error" | "rate-limited" | "network-error" | "invalid-response" | "unknown" },
+  "dod": { "status": "candidate", "prNumber": 1234 } | { "status": "none" } | { "status": "weekend" }
 }
 ```
 
 **`board.reason`（Step 1 の盤面起票が失敗した時の理由）は既知 enum のみで、gh CLI の生エラーメッセージをそのまま渡してはいけない**（push 前反証レビュー risk-reviewer / behavior-verifier + 非ブロッキング Codex レビューが独立に検出、P1）。旧設計は自由文字列（文字集合の denylist で検証）だったが、prompt injection を受けたセッションが Sentry issue の raw title/message（user email 等を含みうる）を 300 文字ずつ小分けにして public な常設運行記録 issue へ書く経路になり得た。自由文字列である限り、安全な文字だけで構成された機微情報の断片は文字集合の denylist では塞げない。実際に発生した gh CLI エラーを `auth-error` / `rate-limited` / `network-error` / `invalid-response` / `unknown` のいずれかへ分類してから渡す。`results` の `outcome: "skipped"` の `reason` も同様に既知 enum（`dedup-search-failed` / `run-cap-reached`）のみ。
+
+**`board.status` / `dod.status` の `"weekend"` は JST 土日専用**（#2342）。Step 1（盤面起票）・Step 4（DoD候補選定）は `isJstWeekend` 判定で土日に gh を一切呼ばず skip する（§Step 1・§Step 4 参照）。この skip は `board.status: "skip"`（起票済み・重複回避）や `dod.status: "none"`（前日merge PR無し）とは意味が異なるため、Claude は土日の運行記録でこれらへ丸めず `"weekend"` を渡す（丸めると「盤面起票: skip（起票済み）」「DoD監査候補: 前日merge PR無し」という事実と異なる文言が毎週2回残る）。
 
 wrapper はこの JSON から、以下と同じ内容のコメント本文を組み立てて投稿する:
 
@@ -158,8 +160,8 @@ wrapper はこの JSON から、以下と同じ内容のコメント本文を組
 - 取得失敗: <check-id> があれば列挙（コマンド非0 exit / パース不能）、無ければ「なし」
 - all green | 起票/追記: #NNNN（<check-id>）, ... | 見送り: <check-id>（<reason>）, ... | 取得失敗のみ（起票/追記なし）
 - baseline 更新推奨: <check-id> があれば列挙、無ければ「なし」
-- 盤面起票: 成功（#NNNN）| skip（起票済み）| 失敗（<reason>）
-- DoD監査候補: #NNNN | 前日merge PR無し
+- 盤面起票: 成功（#NNNN）| skip（起票済み）| skip（土日）| 失敗（<reason>）
+- DoD監査候補: #NNNN | 前日merge PR無し | skip（土日）
 - 起票予算 state: 有効（新規起票 N/3、対応済み check-id M件）| 利用不可（fail-open、無制限扱いで実行）
 ```
 

--- a/scripts/night-watch/lib.mjs
+++ b/scripts/night-watch/lib.mjs
@@ -123,6 +123,30 @@ export function extractTrailingNumber(url) {
 }
 
 /**
+ * heavy-red / integration-red（`gh run list ... --json conclusion,status,...`）の
+ * 判定規約の正本。**直近 run（配列先頭、gh run list は新しい順）が未完了
+ * （`status` が `in_progress` / `queued`）なら、判定を保留すべきかを返す**。
+ *
+ * GitHub Actions の scheduled workflow は数十分規模の遅延が日常的に起きる。
+ * 旧判定規約は status を無条件で赤判定へ含めており、単に実行中というだけの
+ * run を赤と誤検出していた（#2341、integration.yml の schedule-run margin が
+ * 30分しかなく実際に誤起票しうると判明）。true を返した check-id は §Step2
+ * fail-closed 原則と同じ経路（`<check-id>: 取得失敗`、Step 5 の `failed` へ
+ * 記録）へ倒し、赤とは判定しない・alert-issue.mjs を呼ばない。
+ *
+ * 過去の run（配列 2 件目以降）が in_progress のまま止まっている場合まで
+ * 拾わない（そのような状態は通常発生せず、拾おうとすると「実行中」の通常
+ * 判定と区別できなくなる）。
+ * @param {{ status: string }[]} runs
+ * @returns {boolean}
+ */
+export function isLatestWorkflowRunPending(runs) {
+  if (!Array.isArray(runs) || runs.length === 0) return false;
+  const status = runs[0]?.status;
+  return status === 'in_progress' || status === 'queued';
+}
+
+/**
  * 当日 JST タイトルの盤面 issue を探す。無ければ null。
  * dod-candidate.mjs（Step 4）・run-log.mjs（Step 5 の当日盤面 issue への 1 行
  * コメント）の両方が使う共通ルックアップ。

--- a/scripts/night-watch/lib.test.ts
+++ b/scripts/night-watch/lib.test.ts
@@ -10,6 +10,7 @@ import {
   findTodayBoardIssue,
   isJstMonday,
   isJstWeekend,
+  isLatestWorkflowRunPending,
   jstDateString,
   jstDayRange,
   jstWeekdayIndex,
@@ -93,6 +94,29 @@ describe('jstWeekdayIndex / isJstWeekend / isJstMonday', () => {
     } finally {
       spy.mockRestore();
     }
+  });
+});
+
+// #2341: scheduled workflow の遅延で直近 run がまだ in_progress/queued の時、
+// 旧判定規約（status も無条件で赤判定に含める）は誤って赤と判定していた。
+describe('isLatestWorkflowRunPending', () => {
+  it.each(['in_progress', 'queued'])('直近 run が status: %s なら true', (status) => {
+    expect(isLatestWorkflowRunPending([{ status }, { status: 'completed' }])).toBe(true);
+  });
+
+  it('直近 run が completed（terminal）なら false（赤判定を進めてよい）', () => {
+    expect(isLatestWorkflowRunPending([{ status: 'completed' }])).toBe(false);
+  });
+
+  it('過去の run が in_progress でも直近 run が completed なら false', () => {
+    // 配列先頭（最新）だけを見る。2件目以降の in_progress は拾わない。
+    expect(isLatestWorkflowRunPending([{ status: 'completed' }, { status: 'in_progress' }])).toBe(
+      false,
+    );
+  });
+
+  it('run が 0 件なら false（別途 fail-closed の取得失敗パスで扱われる想定）', () => {
+    expect(isLatestWorkflowRunPending([])).toBe(false);
   });
 });
 

--- a/scripts/night-watch/run-log.mjs
+++ b/scripts/night-watch/run-log.mjs
@@ -123,8 +123,8 @@ function isPositiveInt(value) {
  *     | { checkId: string, outcome: 'skipped', reason: string }
  *   >,
  *   baselineRecommend: string[],
- *   board: { status: 'success', issueNumber: number } | { status: 'skip' } | { status: 'fail', reason: string },
- *   dod: { status: 'candidate', prNumber: number } | { status: 'none' },
+ *   board: { status: 'success', issueNumber: number } | { status: 'skip' } | { status: 'weekend' } | { status: 'fail', reason: string },
+ *   dod: { status: 'candidate', prNumber: number } | { status: 'none' } | { status: 'weekend' },
  * }} OpsLogReport
  */
 
@@ -172,8 +172,10 @@ export function validateOpsLogReport(report) {
   }
   if (board.status === 'success') {
     if (!isPositiveInt(board.issueNumber)) throw new Error('board.issueNumber が不正です');
-  } else if (board.status === 'skip') {
-    // 追加フィールド不要
+  } else if (board.status === 'skip' || board.status === 'weekend') {
+    // 追加フィールド不要。'weekend' は #2342: JST 土日（Step 1 が isJstWeekend
+    // 判定で gh を一切呼ばず skip する日）専用の値。'skip'（起票済み・重複回避）
+    // と意味が異なるため区別する。
   } else if (board.status === 'fail') {
     if (!BOARD_FAIL_REASONS.has(board.reason)) {
       throw new Error(
@@ -181,7 +183,7 @@ export function validateOpsLogReport(report) {
       );
     }
   } else {
-    throw new Error('board.status は success/skip/fail のいずれかである必要があります');
+    throw new Error('board.status は success/skip/fail/weekend のいずれかである必要があります');
   }
   const dod = r.dod;
   if (typeof dod !== 'object' || dod === null) {
@@ -189,8 +191,10 @@ export function validateOpsLogReport(report) {
   }
   if (dod.status === 'candidate') {
     if (!isPositiveInt(dod.prNumber)) throw new Error('dod.prNumber が不正です');
-  } else if (dod.status !== 'none') {
-    throw new Error('dod.status は candidate/none のいずれかである必要があります');
+  } else if (dod.status !== 'none' && dod.status !== 'weekend') {
+    // 'weekend' は #2342: JST 土日（Step 4 が isJstWeekend 判定で skip する日）
+    // 専用の値。'none'（前日merge PR無し）と意味が異なるため区別する。
+    throw new Error('dod.status は candidate/none/weekend のいずれかである必要があります');
   }
 }
 
@@ -229,9 +233,15 @@ export function buildOpsLogComment(report) {
       ? `成功（#${report.board.issueNumber}）`
       : report.board.status === 'skip'
         ? 'skip（起票済み）'
-        : `失敗（${report.board.reason}）`;
+        : report.board.status === 'weekend'
+          ? 'skip（土日）'
+          : `失敗（${report.board.reason}）`;
   const dodLine =
-    report.dod.status === 'candidate' ? `#${report.dod.prNumber}` : '前日merge PR無し';
+    report.dod.status === 'candidate'
+      ? `#${report.dod.prNumber}`
+      : report.dod.status === 'weekend'
+        ? 'skip（土日）'
+        : '前日merge PR無し';
 
   return `**night-watch 運行記録 ${today}**
 

--- a/scripts/night-watch/run-log.test.ts
+++ b/scripts/night-watch/run-log.test.ts
@@ -121,6 +121,22 @@ describe('validateOpsLogReport', () => {
     );
   });
 
+  // #2342: JST 土日は Step 1（盤面起票）・Step 4（DoD候補選定）が
+  // isJstWeekend 判定で skip する。旧 schema は 'skip'（起票済み・重複回避）/
+  // 'none'（前日merge PR無し）しか持たず、「土日につき skip」という別の意味を
+  // 表現できなかった（buildOpsLogComment の文言が事実と異なる形で残る）。
+  it('board.status=weekend を通す（追加フィールド不要）', () => {
+    expect(() =>
+      validateOpsLogReport({ ...GREEN_REPORT, board: { status: 'weekend' } }),
+    ).not.toThrow();
+  });
+
+  it('dod.status=weekend を通す（追加フィールド不要）', () => {
+    expect(() =>
+      validateOpsLogReport({ ...GREEN_REPORT, dod: { status: 'weekend' } }),
+    ).not.toThrow();
+  });
+
   // Codex 実測指摘（P2）: 旧 schema は results の outcome に "green"/"issue"
   // しか許さず、Step 3 の dedup 検索失敗（fail closed で起票見送り）という
   // 正当な状態を運行記録で表現できなかった。
@@ -192,6 +208,18 @@ describe('buildOpsLogComment', () => {
       board: { status: 'fail', reason: 'rate-limited' },
     });
     expect(comment).toContain('- 盤面起票: 失敗（rate-limited）');
+  });
+
+  // #2342: 土日は 'skip（起票済み）' / '前日merge PR無し' ではなく
+  // 'skip（土日）' と書き分ける（事実と異なる文言が毎週2回残る回帰の是正）。
+  it('土日（board.status=weekend / dod.status=weekend）は「skip（土日）」と書き分ける', () => {
+    const comment = buildOpsLogComment({
+      ...GREEN_REPORT,
+      board: { status: 'weekend' },
+      dod: { status: 'weekend' },
+    });
+    expect(comment).toContain('- 盤面起票: skip（土日）');
+    expect(comment).toContain('- DoD監査候補: skip（土日）');
   });
 
   // Codex 実測指摘（P2）: failed が非空でも results に issue/skipped が


### PR DESCRIPTION
## 概要

night-watch follow-up 束（#2340 + #2341 + #2342、いずれも PR #2343 の push前反証レビュー risk-reviewer 指摘の切り出し）。

- **#2341**: `heavy-red` / `integration-red` の判定が、直近 run が `in_progress`/`queued`（未完了）のままでも無条件で赤判定に含めており、GitHub Actions scheduled workflow の実測レベルの遅延（integration.yml は 05:00 JST 起動まで30分の余裕しかない）で誤起票しうる問題を修正。未完了時は「取得失敗（観測できず）」パスへ倒す新しい判定境界を `isLatestWorkflowRunPending`（`scripts/night-watch/lib.mjs`）として実装し、SKILL.md §Step2 の該当記述を更新
- **#2342**: JST 土日の Step1（盤面起票）・Step4（DoD候補選定）skip を、`OpsLogReport` の `board.status`/`dod.status` に `'weekend'` を追加して表現。従来は `skip`（起票済み）や `none`（前日merge PR無し）へ丸めていたため、土日の運行記録に事実と異なる文言が毎週2回残っていた
- **#2340**: 実装せず close（[コメント](https://github.com/Dayopt/dayopt/issues/2340#issuecomment-5392403196)）。Anthropic 公式ドキュメントで、night-watch の実行系（Claude Code Cloud）がセッションごとに隔離された VM を割り当てる設計だと一次資料で確認できたため、run-scoped state file の run 識別子紐付けは不要と判断

## 設計の安全性

明朝 05:02 JST に夜勤 Routine の初回運行が走るため、本 PR の変更は additive / fail-safe:

- `isLatestWorkflowRunPending` は新規追加の純関数で、まだどの実行パスにも wiring されていない（SKILL.md の判定境界の正本として参照されるのみ）
- `weekend` enum 値の追加は既存の `success`/`skip`/`fail`（board）・`candidate`/`none`（dod）の受理を変えない

## 検証

- `npx vitest run --config vitest.scripts.config.ts scripts/night-watch/` — 138 tests pass
- `pnpm exec tsc --noEmit -p tsconfig.scripts.json` — no errors

Closes #2341
Closes #2342
